### PR TITLE
Add default pin mappings for BBC:Microbit SPI bus

### DIFF
--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -38,9 +38,9 @@ const (
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = 23
-	SPI0_MOSI_PIN = 21
-	SPI0_MISO_PIN = 22
+	SPI0_SCK_PIN  = 23 // P13 on the board
+	SPI0_MOSI_PIN = 21 // P15 on the board
+	SPI0_MISO_PIN = 22 // P14 on the board
 )
 
 // LED matrix pins


### PR DESCRIPTION
This PR adds the BBC:Microbit default pin mappings for the SPI bus.