### PR TITLE
Struct casting not supported by LLVM, suggest+implement struct pointer casting

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1862,7 +1862,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		// bitcast all struct types for ease of use.
 		if _, ok := expr.Type().Underlying().(*types.Struct); ok {
 			if expr.Type() != expr.X.Type() {
-				panic("converting between struct types is not yet supported; consider converting pointers as a workaround")
+				return llvm.Value{}, c.makeError(expr.Pos(),
+					"converting between struct types is not yet supported; consider converting pointers as a workaround")
 			}
 		}
 		return x, nil

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1868,13 +1868,11 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 					"converting between struct types is not yet supported; consider converting pointers as a workaround")
 			}
 		case *types.Pointer:
-			if _, ok := underlying.Elem().Underlying().(*types.Struct); ok {
-				llvmType, err := c.getLLVMType(expr.Type())
-				if err != nil {
-					return llvm.Value{}, err
-				}
-				return c.builder.CreateBitCast(x, llvmType, "changetype"), nil
+			llvmType, err := c.getLLVMType(expr.Type())
+			if err != nil {
+				return llvm.Value{}, err
 			}
+			return c.builder.CreateBitCast(x, llvmType, "changetype"), nil
 		}
 		return x, nil
 	case *ssa.Const:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1861,11 +1861,9 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		// struct types, as those are actually different in LLVM. Let's just
 		// bitcast all struct types for ease of use.
 		if _, ok := expr.Type().Underlying().(*types.Struct); ok {
-			llvmType, err := c.getLLVMType(expr.X.Type())
-			if err != nil {
-				return llvm.Value{}, err
+			if expr.Type() != expr.X.Type() {
+				panic("converting between struct types is not yet supported; consider converting pointers as a workaround")
 			}
-			return c.builder.CreateBitCast(x, llvmType, "changetype"), nil
 		}
 		return x, nil
 	case *ssa.Const:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1861,7 +1861,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		// struct types or pointers to struct types, as those are actually different in LLVM.
 		// Unfortunately, we cannod bitcast structs, as they are "aggregate types" in LLVM.
 		// See https://github.com/aykevl/tinygo/issues/161
-		switch underlying := expr.Type().Underlying().(type) {
+		switch expr.Type().Underlying().(type) {
 		case *types.Struct:
 			if expr.Type() != expr.X.Type() {
 				return llvm.Value{}, c.makeError(expr.Pos(),


### PR DESCRIPTION
A better error message for https://github.com/aykevl/tinygo/issues/161, to catch the problem before the LLVM verifier does.