### PR TITLE
Add tinygo version subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -455,6 +455,8 @@ func Run(pkgName, target string, config *BuildConfig) error {
 }
 
 func usage() {
+	fmt.Fprintln(os.Stderr, "TinyGo is a Go compiler for small places.")
+	fmt.Fprintln(os.Stderr, displayversion())
 	fmt.Fprintf(os.Stderr, "usage: %s command [-printir] [-target=<target>] -o <output> <input>\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "\ncommands:")
 	fmt.Fprintln(os.Stderr, "  build: compile packages and dependencies")
@@ -601,6 +603,9 @@ func main() {
 		}
 	case "help":
 		usage()
+	case "version":
+		fmt.Fprintln(os.Stderr, displayversion())
+		version()
 	default:
 		fmt.Fprintln(os.Stderr, "Unknown command:", command)
 		usage()

--- a/main.go
+++ b/main.go
@@ -605,7 +605,7 @@ func main() {
 	case "help":
 		usage()
 	case "version":
-		fmt.Printf("TinyGo version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("tinygo version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
 	default:
 		fmt.Fprintln(os.Stderr, "Unknown command:", command)
 		usage()

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -456,7 +457,7 @@ func Run(pkgName, target string, config *BuildConfig) error {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "TinyGo is a Go compiler for small places.")
-	fmt.Fprintln(os.Stderr, displayversion())
+	fmt.Fprintln(os.Stderr, "version:", version)
 	fmt.Fprintf(os.Stderr, "usage: %s command [-printir] [-target=<target>] -o <output> <input>\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "\ncommands:")
 	fmt.Fprintln(os.Stderr, "  build: compile packages and dependencies")
@@ -604,8 +605,7 @@ func main() {
 	case "help":
 		usage()
 	case "version":
-		fmt.Fprintln(os.Stderr, displayversion())
-		version()
+		fmt.Printf("TinyGo version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
 	default:
 		fmt.Fprintln(os.Stderr, "Unknown command:", command)
 		usage()

--- a/version.go
+++ b/version.go
@@ -1,15 +1,5 @@
 package main
 
-// tinyGoVersion of this package.
+// version of this package.
 // Update this value before release of new version of software.
-const tinyGoVersion = "0.1.0"
-
-// version returns the current TinyGo version
-func version() string {
-	return tinyGoVersion
-}
-
-// displayversion returns the current TinyGo full version description for display purposes.
-func displayversion() string {
-	return "TinyGo compiler v" + tinyGoVersion
-}
+const version = "0.1.0"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,15 @@
+package main
+
+// tinyGoVersion of this package.
+// Update this value before release of new version of software.
+const tinyGoVersion = "0.1.0"
+
+// version returns the current TinyGo version
+func version() string {
+	return tinyGoVersion
+}
+
+// displayversion returns the current TinyGo full version description for display purposes.
+func displayversion() string {
+	return "TinyGo compiler v" + tinyGoVersion
+}


### PR DESCRIPTION
This PR adds a `tinygo version` subcommand to display the current version of the TinyGo compiler:

```shell
tinygo version
TinyGo compiler v0.1.0
```

The same info is displayed alongside the usage info.