### PR TITLE
loader: support global variables in CGo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:84316faef4ea12d34dde3b3e6dab682715a23b1c2bb8ab82cec9ab619766e214"
+  digest = "1:ba70784a3deee74c0ca3c87bcac3c2f93d3b2d27d8f237b768c358b45ba47da8"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -11,7 +11,7 @@
     "go/types/typeutil",
   ]
   pruneopts = "UT"
-  revision = "3e7aa9e59977626dc60433e9aeadf1bb63d28295"
+  revision = "40960b6deb8ecdb8bcde6a8f44722731939b8ddc"
 
 [[projects]]
   branch = "master"
@@ -25,6 +25,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "golang.org/x/tools/go/ast/astutil",
     "golang.org/x/tools/go/ssa",
     "tinygo.org/x/go-llvm",
   ]

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -389,11 +389,25 @@ func (g *Global) LinkName() string {
 	if g.linkName != "" {
 		return g.linkName
 	}
+	if name := g.CName(); name != "" {
+		return name
+	}
 	return g.RelString(nil)
 }
 
 func (g *Global) IsExtern() bool {
-	return g.extern
+	return g.extern || g.CName() != ""
+}
+
+// Return the name of the C global if this is a CGo wrapper. Otherwise, return a
+// zero-length string.
+func (g *Global) CName() string {
+	name := g.Name()
+	if strings.HasPrefix(name, "C.") {
+		// created by ../loader/cgo.go
+		return name[2:]
+	}
+	return ""
 }
 
 func (g *Global) Initializer() Value {

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -112,6 +112,14 @@ func tinygo_clang_visitor(c, parent C.CXCursor, client_data C.CXClientData) C.in
 			oldName: underlyingTypeName,
 			size:    int(typeSize),
 		})
+	case C.CXCursor_VarDecl:
+		name := getString(C.clang_getCursorSpelling(c))
+		cursorType := C.clang_getCursorType(c)
+		cursorTypeName := getString(C.clang_getTypeSpelling(cursorType))
+		info.globals = append(info.globals, &globalInfo{
+			name:     name,
+			typeName: cursorTypeName,
+		})
 	}
 	return C.CXChildVisit_Continue
 }

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,5 +1,7 @@
 #include "main.h"
 
+int global = 3;
+
 int fortytwo() {
 	return 42;
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -16,4 +16,5 @@ func main() {
 	println("myint size:", int(unsafe.Sizeof(x)))
 	var y C.longlong = -(1 << 40)
 	println("longlong:", y)
+	println("global:", C.global)
 }

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,2 +1,3 @@
 typedef short myint;
 int add(int a, int b);
+extern int global;

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -3,3 +3,4 @@ add: 8
 myint: 3 5
 myint size: 2
 longlong: -1099511627776
+global: 3


### PR DESCRIPTION
Global variables (like functions) must be declared in the import "C"
preamble and can then be used from Go.