### PR TITLE
cgo: add pointer types

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1325,7 +1325,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 			return nil
 		}
 		store := c.builder.CreateStore(llvmVal, llvmAddr)
-		valType := instr.Addr.Type().(*types.Pointer).Elem()
+		valType := instr.Addr.Type().Underlying().(*types.Pointer).Elem()
 		if c.ir.IsVolatile(valType) {
 			// Volatile store, for memory-mapped registers.
 			store.SetVolatile(true)
@@ -1957,7 +1957,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		var bufptr, buflen llvm.Value
 		switch ptrTyp := expr.X.Type().Underlying().(type) {
 		case *types.Pointer:
-			typ := expr.X.Type().(*types.Pointer).Elem().Underlying()
+			typ := expr.X.Type().Underlying().(*types.Pointer).Elem().Underlying()
 			switch typ := typ.(type) {
 			case *types.Array:
 				bufptr = val
@@ -2986,7 +2986,7 @@ func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
 			return llvm.Value{}, c.makeError(unop.Pos(), "todo: unknown type for negate: "+unop.X.Type().Underlying().String())
 		}
 	case token.MUL: // *x, dereference pointer
-		valType := unop.X.Type().(*types.Pointer).Elem()
+		valType := unop.X.Type().Underlying().(*types.Pointer).Elem()
 		if c.targetData.TypeAllocSize(x.Type().ElementType()) == 0 {
 			// zero-length data
 			return c.getZeroValue(x.Type().ElementType())

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -9,3 +9,7 @@ int fortytwo() {
 int add(int a, int b) {
 	return a + b;
 }
+
+void store(int value, int *ptr) {
+	*ptr = value;
+}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -10,6 +10,10 @@ int add(int a, int b) {
 	return a + b;
 }
 
+int doCallback(int a, int b, binop_t callback) {
+	return callback(a, b);
+}
+
 void store(int value, int *ptr) {
 	*ptr = value;
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -3,6 +3,7 @@ package main
 /*
 int fortytwo(void);
 #include "main.h"
+int mul(int, int);
 */
 import "C"
 
@@ -23,4 +24,13 @@ func main() {
 	println("15:", *ptr)
 	C.store(25, &n)
 	println("25:", *ptr)
+	cb := C.binop_t(C.add)
+	println("callback 1:", C.doCallback(20, 30, cb))
+	cb = C.binop_t(C.mul)
+	println("callback 2:", C.doCallback(20, 30, cb))
+}
+
+//export mul
+func mul(a, b C.int) C.int {
+	return a * b
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -17,4 +17,10 @@ func main() {
 	var y C.longlong = -(1 << 40)
 	println("longlong:", y)
 	println("global:", C.global)
+	var ptr C.intPointer
+	var n C.int = 15
+	ptr = C.intPointer(&n)
+	println("15:", *ptr)
+	C.store(25, &n)
+	println("25:", *ptr)
 }

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,5 +1,7 @@
 typedef short myint;
 int add(int a, int b);
+typedef int (*binop_t) (int, int);
+int doCallback(int a, int b, binop_t cb);
 typedef int * intPointer;
 extern int global;
 void store(int value, int *ptr);

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,3 +1,9 @@
 typedef short myint;
 int add(int a, int b);
+typedef int * intPointer;
+extern int global;
+void store(int value, int *ptr);
+
+// test duplicate definitions
+int add(int a, int b);
 extern int global;

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -6,3 +6,5 @@ longlong: -1099511627776
 global: 3
 15: 15
 25: 25
+callback 1: 50
+callback 2: 600

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -4,3 +4,5 @@ myint: 3 5
 myint size: 2
 longlong: -1099511627776
 global: 3
+15: 15
+25: 25


### PR DESCRIPTION
This builds upon #173. It adds support for pointer types and function pointer types in CGo.