### PR TITLE
build: display output file sizes for target smoke test builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,18 @@ script:
   - go install github.com/tinygo-org/tinygo
   - go test -v .
   - make gen-device
-  - tinygo build -o blinky1.nrf.elf    -target=pca10040     examples/blinky1
-  - tinygo build -o blinky2.nrf.elf    -target=pca10040     examples/blinky2
-  - tinygo build -o blinky2                                 examples/blinky2
-  - tinygo build -o test.nrf.elf       -target=pca10040     examples/test
-  - tinygo build -o blinky1.nrf51.elf  -target=microbit     examples/echo
-  - tinygo build -o test.nrf.elf       -target=nrf52840-mdk examples/blinky1
-  - tinygo build -o blinky1.nrf51d.elf -target=pca10031     examples/blinky1
-  - tinygo build -o blinky1.stm32.elf  -target=bluepill     examples/blinky1
-  - tinygo build -o blinky1.avr.elf    -target=arduino      examples/blinky1
-  - tinygo build -o blinky1.avr.elf    -target=digispark    examples/blinky1
-  - tinygo build -o blinky1.reel.elf   -target=reelboard    examples/blinky1
-  - tinygo build -o blinky2.reel.elf   -target=reelboard    examples/blinky2
-  - tinygo build -o blinky1.pca10056.elf    -target=pca10056     examples/blinky1
-  - tinygo build -o blinky2.pca10056.elf    -target=pca10056     examples/blinky2
-  - tinygo build -o blinky1.samd21.elf    -target=itsybitsy-m0     examples/blinky1
+  - tinygo build -size short -o blinky1.nrf.elf    -target=pca10040     examples/blinky1
+  - tinygo build -size short -o blinky2.nrf.elf    -target=pca10040     examples/blinky2
+  - tinygo build -size short -o blinky2                                 examples/blinky2
+  - tinygo build -size short -o test.nrf.elf       -target=pca10040     examples/test
+  - tinygo build -size short -o blinky1.nrf51.elf  -target=microbit     examples/echo
+  - tinygo build -size short -o test.nrf.elf       -target=nrf52840-mdk examples/blinky1
+  - tinygo build -size short -o blinky1.nrf51d.elf -target=pca10031     examples/blinky1
+  - tinygo build -size short -o blinky1.stm32.elf  -target=bluepill     examples/blinky1
+  - tinygo build -size short -o blinky1.avr.elf    -target=arduino      examples/blinky1
+  - tinygo build -size short -o blinky1.avr.elf    -target=digispark    examples/blinky1
+  - tinygo build -size short -o blinky1.reel.elf   -target=reelboard    examples/blinky1
+  - tinygo build -size short -o blinky2.reel.elf   -target=reelboard    examples/blinky2
+  - tinygo build -size short -o blinky1.pca10056.elf    -target=pca10056     examples/blinky1
+  - tinygo build -size short -o blinky2.pca10056.elf    -target=pca10056     examples/blinky2
+  - tinygo build -size short -o blinky1.samd21.elf    -target=itsybitsy-m0     examples/blinky1


### PR DESCRIPTION
This PR displays the output file sizes for target smoke test builds on Travis, as a simple way we can determine if the build sizes are changing, and just general informational purposes.