### PR TITLE
Add floating point support to CGo

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -53,7 +53,7 @@ func (c *Compiler) parseMakeInterface(val llvm.Value, typ types.Type, global str
 			itfValue = c.builder.CreateIntToPtr(val, c.i8ptrType, "makeinterface.cast.int")
 		case llvm.PointerTypeKind:
 			itfValue = c.builder.CreateBitCast(val, c.i8ptrType, "makeinterface.cast.ptr")
-		case llvm.StructTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind, llvm.VectorTypeKind:
+		case llvm.StructTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind:
 			// A bitcast would be useful here, but bitcast doesn't allow
 			// aggregate types. So we'll bitcast it using an alloca.
 			// Hopefully this will get optimized away.

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,6 +1,13 @@
 #include "main.h"
 
 int global = 3;
+_Bool globalBool = 1;
+_Bool globalBool2 = 10; // test narrowing
+float globalFloat = 3.1;
+double globalDouble = 3.2;
+_Complex float globalComplexFloat = 4.1+3.3i;
+_Complex double globalComplexDouble = 4.2+3.4i;
+_Complex double globalComplexLongDouble = 4.3+3.5i;
 
 int fortytwo() {
 	return 42;

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -28,6 +28,14 @@ func main() {
 	println("callback 1:", C.doCallback(20, 30, cb))
 	cb = C.binop_t(C.mul)
 	println("callback 2:", C.doCallback(20, 30, cb))
+
+	// more globals
+	println("bool:", C.globalBool, C.globalBool2 == true)
+	println("float:", C.globalFloat)
+	println("double:", C.globalDouble)
+	println("complex float:", C.globalComplexFloat)
+	println("complex double:", C.globalComplexDouble)
+	println("complex long double:", C.globalComplexLongDouble)
 }
 
 //export mul

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -3,8 +3,17 @@ int add(int a, int b);
 typedef int (*binop_t) (int, int);
 int doCallback(int a, int b, binop_t cb);
 typedef int * intPointer;
-extern int global;
 void store(int value, int *ptr);
+
+// test globals
+extern int global;
+extern _Bool globalBool;
+extern _Bool globalBool2;
+extern float globalFloat;
+extern double globalDouble;
+extern _Complex float globalComplexFloat;
+extern _Complex double globalComplexDouble;
+extern _Complex double globalComplexLongDouble;
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -8,3 +8,9 @@ global: 3
 25: 25
 callback 1: 50
 callback 2: 600
+bool: true true
+float: +3.100000e+000
+double: +3.200000e+000
+complex float: (+4.100000e+000+3.300000e+000i)
+complex double: (+4.200000e+000+3.400000e+000i)
+complex long double: (+4.300000e+000+3.500000e+000i)


### PR DESCRIPTION
Note that the first commit changes how `complex64` and `complex128` types are implemented, so that they follow how complex numbers are implemented in Clang and are specified by C11. Before this, they were implemented as a vector of two float types, which seemed to get a bigger alignment (up to 16 bytes) on amd64.
Code size was unchanged on amd64.