### PR TITLE
all: add macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ matrix:
   include:
   - dist: xenial
     go: "1.11"
+  - os: osx
+    go: "1.11"
+    env: PATH="/usr/local/opt/llvm/bin:$PATH"
 
 addons:
   apt:
@@ -24,8 +27,16 @@ addons:
     - qemu-user
     - gcc-avr
     - avr-libc
+  homebrew:
+    update: true
+    taps: ArmMbed/homebrew-formulae
+    packages:
+    - llvm@7
+    - qemu
+    - arm-none-eabi-gcc
 
 install:
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then mkdir -p /Users/travis/gopath/bin; fi
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - dep ensure --vendor-only
 
@@ -35,14 +46,14 @@ script:
   - make gen-device
   - tinygo build -size short -o blinky1.nrf.elf    -target=pca10040     examples/blinky1
   - tinygo build -size short -o blinky2.nrf.elf    -target=pca10040     examples/blinky2
-  - tinygo build -size short -o blinky2                                 examples/blinky2
+  - tinygo build             -o blinky2                                 examples/blinky2 # TODO: re-enable -size flag with MachO support
   - tinygo build -size short -o test.nrf.elf       -target=pca10040     examples/test
   - tinygo build -size short -o blinky1.nrf51.elf  -target=microbit     examples/echo
   - tinygo build -size short -o test.nrf.elf       -target=nrf52840-mdk examples/blinky1
   - tinygo build -size short -o blinky1.nrf51d.elf -target=pca10031     examples/blinky1
   - tinygo build -size short -o blinky1.stm32.elf  -target=bluepill     examples/blinky1
-  - tinygo build -size short -o blinky1.avr.elf    -target=arduino      examples/blinky1
-  - tinygo build -size short -o blinky1.avr.elf    -target=digispark    examples/blinky1
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tinygo build -size short -o blinky1.avr.elf    -target=arduino      examples/blinky1; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tinygo build -size short -o blinky1.avr.elf    -target=digispark    examples/blinky1; fi
   - tinygo build -size short -o blinky1.reel.elf   -target=reelboard    examples/blinky1
   - tinygo build -size short -o blinky2.reel.elf   -target=reelboard    examples/blinky2
   - tinygo build -size short -o blinky1.pca10056.elf    -target=pca10056     examples/blinky1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,15 +11,15 @@
     "go/types/typeutil",
   ]
   pruneopts = "UT"
-  revision = "40960b6deb8ecdb8bcde6a8f44722731939b8ddc"
+  revision = "3744606dbb67b99c60d3f11cb10bd3f9e6dad472"
 
 [[projects]]
   branch = "master"
-  digest = "1:3611159788efdd4e0cfae18b6ebcccbad25a2815968b0e4323b42647d201031a"
+  digest = "1:a6a25fd8906c74978f1ed811bc9fd3422da8093be863b458874b02a782b6ae3e"
   name = "tinygo.org/x/go-llvm"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f420620d1a0f54417a5712260153fe861780d030"
+  revision = "d5f730401f5069618b275a5241c6417eb0c38a65"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1353,7 +1353,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 		}
 
 		switch fn.RelString(nil) {
-		case "syscall.Syscall", "syscall.Syscall6":
+		case "syscall.Syscall", "syscall.Syscall6", "syscall.Syscall9":
 			return c.emitSyscall(frame, instr)
 		}
 

--- a/loader/libclang_config.go
+++ b/loader/libclang_config.go
@@ -3,7 +3,9 @@
 package loader
 
 /*
-#cgo CFLAGS: -I/usr/lib/llvm-7/include
-#cgo LDFLAGS: -L/usr/lib/llvm-7/lib -lclang
+#cgo linux  CFLAGS: -I/usr/lib/llvm-7/include
+#cgo darwin CFLAGS: -I/usr/local/opt/llvm/include
+#cgo linux  LDFLAGS: -L/usr/lib/llvm-7/lib -lclang
+#cgo darwin LDFLAGS: -L/usr/local/opt/llvm/lib -lclang -lffi
 */
 import "C"

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 var commands = map[string]string{
-	"ar":      "ar",
+	"ar":      "llvm-ar",
 	"clang":   "clang-7",
 	"ld.lld":  "ld.lld-7",
 	"wasm-ld": "wasm-ld-7",
@@ -102,7 +102,9 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		return errors.New("verification error after interpreting runtime.initAll")
 	}
 
-	c.ApplyFunctionSections() // -ffunction-sections
+	if spec.GOOS != "darwin" {
+		c.ApplyFunctionSections() // -ffunction-sections
+	}
 	if err := c.Verify(); err != nil {
 		return errors.New("verification error after applying function sections")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"testing"
 )
@@ -53,31 +54,33 @@ func TestCompiler(t *testing.T) {
 		return
 	}
 
-	t.Log("running tests for linux/arm...")
-	for _, path := range matches {
-		if path == "testdata/cgo/" {
-			continue // TODO: improve CGo
-		}
-		t.Run(path, func(t *testing.T) {
-			runTest(path, tmpdir, "arm--linux-gnueabi", t)
-		})
-	}
-
-	t.Log("running tests for linux/arm64...")
-	for _, path := range matches {
-		if path == "testdata/cgo/" {
-			continue // TODO: improve CGo
-		}
-		t.Run(path, func(t *testing.T) {
-			runTest(path, tmpdir, "aarch64--linux-gnueabi", t)
-		})
-	}
-
 	t.Log("running tests for emulated cortex-m3...")
 	for _, path := range matches {
 		t.Run(path, func(t *testing.T) {
 			runTest(path, tmpdir, "qemu", t)
 		})
+	}
+
+	if runtime.GOOS == "linux" {
+		t.Log("running tests for linux/arm...")
+		for _, path := range matches {
+			if path == "testdata/cgo/" {
+				continue // TODO: improve CGo
+			}
+			t.Run(path, func(t *testing.T) {
+				runTest(path, tmpdir, "arm--linux-gnueabi", t)
+			})
+		}
+
+		t.Log("running tests for linux/arm64...")
+		for _, path := range matches {
+			if path == "testdata/cgo/" {
+				continue // TODO: improve CGo
+			}
+			t.Run(path, func(t *testing.T) {
+				runTest(path, tmpdir, "aarch64--linux-gnueabi", t)
+			})
+		}
 	}
 }
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build darwin linux
 
 package os
 

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -1,0 +1,5 @@
+// +build darwin
+
+package runtime
+
+const GOOS = "darwin"

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build darwin linux
 
 package runtime
 


### PR DESCRIPTION
WARNING: this PR depends on https://github.com/tinygo-org/go-llvm/pull/3, and after that one is merged `dep` should be run again to update the branch etc.

This PR adds macOS support, and automatically tests its support in Travis. I needed to disable linux/arm and linux/aarch64 tests in macOS because it tries to use the GNU toolchains, but that support is tested in Linux anyway so there is no big loss.