### PR TITLE
Support wasm example on Safari

### DIFF
--- a/src/examples/wasm/wasm.js
+++ b/src/examples/wasm/wasm.js
@@ -13,11 +13,22 @@ function init() {
   document.querySelector('#b').oninput = updateResult;
 
   const go = new Go();
-  WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject).then(function(obj) {
+  fetch(WASM_URL).then(resp =>
+    resp.arrayBuffer()
+  ).then(bytes =>
+    WebAssembly.instantiate(bytes, go.importObject).then(function(obj) {
+      wasm = obj.instance;
+      go.run(wasm);
+      updateResult();
+    })
+  )
+  // the following code is preferred but it doesn't work on Safari at this point.
+  // https://bugs.webkit.org/show_bug.cgi?id=173105
+  /*WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject).then(function(obj) {
     wasm = obj.instance;
     go.run(wasm);
     updateResult();
-  })
+  })*/
 }
 
 init();

--- a/src/examples/wasm/wasm.js
+++ b/src/examples/wasm/wasm.js
@@ -13,22 +13,23 @@ function init() {
   document.querySelector('#b').oninput = updateResult;
 
   const go = new Go();
-  fetch(WASM_URL).then(resp =>
-    resp.arrayBuffer()
-  ).then(bytes =>
-    WebAssembly.instantiate(bytes, go.importObject).then(function(obj) {
+  if ('instantiateStreaming' in WebAssembly) {
+    WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject).then(function(obj) {
       wasm = obj.instance;
       go.run(wasm);
       updateResult();
     })
-  )
-  // the following code is preferred but it doesn't work on Safari at this point.
-  // https://bugs.webkit.org/show_bug.cgi?id=173105
-  /*WebAssembly.instantiateStreaming(fetch(WASM_URL), go.importObject).then(function(obj) {
-    wasm = obj.instance;
-    go.run(wasm);
-    updateResult();
-  })*/
+  } else {
+    fetch(WASM_URL).then(resp => 
+      resp.arrayBuffer()
+    ).then(bytes =>
+      WebAssembly.instantiate(bytes, go.importObject).then(function(obj) {
+        wasm = obj.instance;
+        go.run(wasm);
+        updateResult();
+      })
+    )
+  }
 }
 
 init();


### PR DESCRIPTION
The current example doesn't work on Safari or Mobile Safari because `WebAssembly.instantiateStreaming` is not supported yet (https://bugs.webkit.org/show_bug.cgi?id=173105).
This fix seems to be working (Live demo: https://1l0.github.io/t/tinygo/). The wasm file was built on Raspberry Pi 3 B+ and tinyGo version was 0.2.0 pre-built.