### PR TITLE
build: correct Makefile to build tinygo executable correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ gen-device-stm32:
 	go fmt ./src/device/stm32
 
 # Build the Go compiler.
-tinygo:
+build/tinygo:
 	@mkdir -p build
 	go build -o build/tinygo .
 


### PR DESCRIPTION
If you try to run `make tinygo` after running `make clean` you get the following error:

```shell
make: *** No rule to make target 'build/tinygo', needed by 'tinygo'.  Stop.
```

This very small change corrects that issue.