### PR TITLE
samd21: define and use hardware pin numbers

### DIFF
--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -4,30 +4,30 @@ package machine
 
 // GPIO Pins
 const (
-	D0  = 11 // UART0 RX
-	D1  = 10 // UART0 TX
-	D2  = 14
-	D3  = 9  // PWM available
-	D4  = 8  // PWM available
-	D5  = 15 // PWM available
-	D6  = 20 // PWM available
-	D7  = 21 // PWM available
-	D8  = 6  // PWM available
-	D9  = 7  // PWM available
-	D10 = 18 // can be used for PWM or UART1 TX
-	D11 = 16 // can be used for PWM or UART1 RX
-	D12 = 19 // PWM available
-	D13 = 17 // PWM available
+	D0  = PA11 // UART0 RX
+	D1  = PA10 // UART0 TX
+	D2  = PA14
+	D3  = PA09 // PWM available
+	D4  = PA08 // PWM available
+	D5  = PA15 // PWM available
+	D6  = PA20 // PWM available
+	D7  = PA21 // PWM available
+	D8  = PA06 // PWM available
+	D9  = PA07 // PWM available
+	D10 = PA18 // can be used for PWM or UART1 TX
+	D11 = PA16 // can be used for PWM or UART1 RX
+	D12 = PA19 // PWM available
+	D13 = PA17 // PWM available
 )
 
 // Analog pins
 const (
-	A0 = 2 // ADC/AIN[0]
-	// A1 = 8 // ADC/AIN[2] TODO: requires PORTB
-	// A2 = 9 // ADC/AIN[3] TODO: requires PORTB
-	A3 = 4 // ADC/AIN[4]
-	A4 = 5 // ADC/AIN[5]
-	//A5 = 2 // ADC/AIN[10] TODO: requires PORTB
+	A0 = PA02 // ADC/AIN[0]
+	A1 = PB08 // ADC/AIN[2]
+	A2 = PB09 // ADC/AIN[3]
+	A3 = PA04 // ADC/AIN[4]
+	A4 = PA05 // ADC/AIN[5]
+	A5 = PB02 // ADC/AIN[10]
 )
 
 const (
@@ -36,8 +36,8 @@ const (
 
 // UART0 aka USBCDC pins
 const (
-	USBCDC_DM_PIN = 24
-	USBCDC_DP_PIN = 25
+	USBCDC_DM_PIN = PA24
+	USBCDC_DP_PIN = PA25
 )
 
 // UART1 pins
@@ -48,6 +48,6 @@ const (
 
 // I2C pins
 const (
-	SDA_PIN = 22 // SDA: SERCOM3/PAD[0]
-	SCL_PIN = 23 // SCL: SERCOM3/PAD[1]
+	SDA_PIN = PA22 // SDA: SERCOM3/PAD[0]
+	SCL_PIN = PA23 // SCL: SERCOM3/PAD[1]
 )

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -36,6 +36,74 @@ const (
 	GPIO_PWM_ALT      = GPIO_TIMER_ALT
 )
 
+// Hardware pins
+const (
+	PA00 = 0
+	PA01 = 1
+	PA02 = 2
+	PA03 = 3
+	PA04 = 4
+	PA05 = 5
+	PA06 = 6
+	PA07 = 7
+	PA08 = 8
+	PA09 = 9
+	PA10 = 10
+	PA11 = 11
+	PA12 = 12
+	PA13 = 13
+	PA14 = 14
+	PA15 = 15
+	PA16 = 16
+	PA17 = 17
+	PA18 = 18
+	PA19 = 19
+	PA20 = 20
+	PA21 = 21
+	PA22 = 22
+	PA23 = 23
+	PA24 = 24
+	PA25 = 25
+	PA26 = 26
+	PA27 = 27
+	PA28 = 28
+	PA29 = 29
+	PA30 = 30
+	PA31 = 31
+	PB00 = 32
+	PB01 = 33
+	PB02 = 34
+	PB03 = 35
+	PB04 = 36
+	PB05 = 37
+	PB06 = 38
+	PB07 = 39
+	PB08 = 40
+	PB09 = 41
+	PB10 = 42
+	PB11 = 43
+	PB12 = 44
+	PB13 = 45
+	PB14 = 46
+	PB15 = 47
+	PB16 = 48
+	PB17 = 49
+	PB18 = 50
+	PB19 = 51
+	PB20 = 52
+	PB21 = 53
+	PB22 = 54
+	PB23 = 55
+	PB24 = 56
+	PB25 = 57
+	PB26 = 58
+	PB27 = 59
+	PB28 = 60
+	PB29 = 61
+	PB30 = 62
+	PB31 = 63
+)
+
 // Configure this pin with the given configuration.
 func (p GPIO) Configure(config GPIOConfig) {
 	switch config.Mode {


### PR DESCRIPTION
Now that port B is available, define them. Also, define all hardware pins for easy access (e.g. `PB23` instead of `55`).