### PR TITLE
arm: provide intrinsics to disable/enable interrupts

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -118,3 +118,21 @@ func SetPriority(irq uint32, priority uint32) {
 	priority = priority << (regpos * 8)  // bits to set
 	NVIC.IPR[regnum] = RegValue((uint32(NVIC.IPR[regnum]) &^ mask) | priority)
 }
+
+// DisableInterrupts disables all interrupts, and returns the old state.
+//
+// TODO: it doesn't actually return the old state, meaning that it cannot be
+// nested.
+func DisableInterrupts() uintptr {
+	Asm("cpsid if")
+	return 0
+}
+
+// EnableInterrupts enables all interrupts again. The value passed in must be
+// the mask returned by DisableInterrupts.
+//
+// TODO: it doesn't actually use the old state, meaning that it cannot be
+// nested.
+func EnableInterrupts(mask uintptr) {
+	Asm("cpsie if")
+}


### PR DESCRIPTION
These intrinsics aren't complete yet. Perhaps I should make them complete, but that will require some more compiler support. But I think they're useful as-is, to be made more complete in the future.