### PR TITLE
nrf: add CPU frequency

### DIFF
--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -6,6 +6,8 @@ import (
 	"device/nrf"
 )
 
+const CPU_FREQUENCY = 16000000
+
 // Get peripheral and pin number for this GPIO pin.
 func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
 	return nrf.GPIO, p.Pin

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -7,6 +7,8 @@ import (
 	"unsafe"
 )
 
+const CPU_FREQUENCY = 64000000
+
 // Get peripheral and pin number for this GPIO pin.
 func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
 	return nrf.P0, p.Pin

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -7,6 +7,8 @@ import (
 	"unsafe"
 )
 
+const CPU_FREQUENCY = 64000000
+
 // Get peripheral and pin number for this GPIO pin.
 func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
 	if p.Pin >= 32 {


### PR DESCRIPTION
I have some refactorings in mind for the ws2812 driver, but it requires these definitions. The plan is to select the driver implementation by a switch on the frequency, not compile-time on the board name. This switch should be easily optimized away but enables more flexibility in the driver (for example, all samd21 boards would be automatically supported).