### PR TITLE
compiler: support function pointers outside of addrspace 0

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -203,7 +203,7 @@ func (c *Compiler) getTypeMethodSet(typ types.Type) (llvm.Value, error) {
 		}
 		methodInfo := llvm.ConstNamedStruct(interfaceMethodInfoType, []llvm.Value{
 			signatureGlobal,
-			llvm.ConstBitCast(fn, c.i8ptrType),
+			llvm.ConstPtrToInt(fn, c.uintptrType),
 		})
 		methods[i] = methodInfo
 	}
@@ -400,7 +400,7 @@ func (c *Compiler) getInvokeCall(frame *Frame, instr *ssa.CallCommon) (llvm.Valu
 		c.getMethodSignature(instr.Method),
 	}
 	fn := c.createRuntimeCall("interfaceMethod", values, "invoke.func")
-	fnCast := c.builder.CreateBitCast(fn, llvmFnType, "invoke.func.cast")
+	fnCast := c.builder.CreateIntToPtr(fn, llvmFnType, "invoke.func.cast")
 	receiverValue := c.builder.CreateExtractValue(itf, 1, "invoke.func.receiver")
 
 	args := []llvm.Value{receiverValue}

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -39,8 +39,8 @@ func interfaceTypeAssert(ok bool) {
 // See compiler/interface-lowering.go for details.
 
 type interfaceMethodInfo struct {
-	signature *uint8 // external *i8 with a name identifying the Go function signature
-	funcptr   *uint8 // bitcast from the actual function pointer
+	signature *uint8  // external *i8 with a name identifying the Go function signature
+	funcptr   uintptr // bitcast from the actual function pointer
 }
 
 // Pseudo function call used while putting a concrete value in an interface,
@@ -59,4 +59,4 @@ func interfaceImplements(typecode uintptr, interfaceMethodSet **uint8) bool
 
 // Pseudo function that returns a function pointer to the method to call.
 // See the interface lowering pass for how this is lowered to a real call.
-func interfaceMethod(typecode uintptr, interfaceMethodSet **uint8, signature *uint8) *uint8
+func interfaceMethod(typecode uintptr, interfaceMethodSet **uint8, signature *uint8) uintptr


### PR DESCRIPTION
In LLVM 8, the AVR backend has moved all function pointers to address space 1 by default. Much of the code still assumes function pointers live in address space 0, leading to assertion failures.

This commit fixes this problem by autodetecting function pointers and avoiding them in interface pseudo-calls.