### PR TITLE
circleci: replace Linux tests on Travis CI with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,91 @@
+version: 2.1
+
+commands:
+  submodules:
+    steps:
+      - run:
+          name: "Pull submodules"
+          command: git submodule update --init
+  apt-dependencies:
+    parameters:
+      llvm:
+        type: string
+    steps:
+      - run:
+          name: "Install apt dependencies"
+          command: |
+            echo 'deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch<<parameters.llvm>> main' | sudo tee /etc/apt/sources.list.d/llvm.list
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+            sudo apt-get update
+            sudo apt-get install \
+                llvm \
+                python3 \
+                llvm<<parameters.llvm>>-dev \
+                clang<<parameters.llvm>> \
+                libclang<<parameters.llvm>>-dev \
+                gcc-arm-linux-gnueabihf \
+                binutils-arm-none-eabi \
+                libc6-dev-armel-cross \
+                gcc-aarch64-linux-gnu \
+                libc6-dev-arm64-cross \
+                qemu-system-arm \
+                qemu-user \
+                gcc-avr \
+                avr-libc
+  dep:
+    steps:
+      - run:
+          name: "Install Go dependencies"
+          command: |
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure --vendor-only
+  smoketest:
+    steps:
+      - run: tinygo build -size short -o test.elf -target=pca10040            examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=pca10040            examples/blinky2
+      - run: tinygo build -size short -o blinky2                              examples/blinky2
+      - run: tinygo build -size short -o test.elf -target=pca10040            examples/test
+      - run: tinygo build -size short -o test.elf -target=microbit            examples/echo
+      - run: tinygo build -size short -o test.elf -target=nrf52840-mdk        examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=pca10031            examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=bluepill            examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=arduino             examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=digispark           examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=reelboard           examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=reelboard           examples/blinky2
+      - run: tinygo build -size short -o test.elf -target=pca10056            examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=pca10056            examples/blinky2
+      - run: tinygo build -size short -o test.elf -target=itsybitsy-m0        examples/blinky1
+      - run: tinygo build -size short -o test.elf -target=circuitplay-express examples/blinky1
+
+
+jobs:
+  test-llvm7-go111:
+    docker:
+      - image: circleci/golang:1.11
+
+    working_directory: /go/src/github.com/tinygo-org/tinygo
+    steps:
+      - checkout
+      - submodules
+      - apt-dependencies:
+          llvm: "-7"
+      - restore_cache:
+          keys:
+            - go-cache-{{ checksum "Gopkg.lock" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+            - go-cache-{{ checksum "Gopkg.lock" }}
+      - dep
+      - run: go install .
+      - run: make test
+      - run: make gen-device -j4
+      - smoketest
+      - save_cache:
+          key: go-cache-{{ checksum "Gopkg.lock" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+            - ~/.cache/go-build
+            - ~/.cache/tinygo
+
+workflows:
+  test-all:
+    jobs:
+      - test-llvm7-go111

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,13 @@ language: go
 
 matrix:
   include:
-  - dist: xenial
-    go: "1.11"
   - os: osx
     go: "1.11"
     env: PATH="/usr/local/opt/llvm/bin:$PATH"
+    before_install:
+    - mkdir -p /Users/travis/gopath/bin
 
 addons:
-  apt:
-    sources:
-    - sourceline: 'ppa:ubuntu-toolchain-r'
-    - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-      key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-    packages:
-    - llvm-7-dev
-    - clang-7
-    - libclang-7-dev
-    - gcc-arm-linux-gnueabihf
-    - binutils-arm-none-eabi
-    - libc6-dev-armhf-cross
-    - gcc-aarch64-linux-gnu
-    - libc6-dev-arm64-cross
-    - qemu-system-arm
-    - qemu-user
-    - gcc-avr
-    - avr-libc
   homebrew:
     update: true
     taps: ArmMbed/homebrew-formulae
@@ -36,7 +18,6 @@ addons:
     - arm-none-eabi-gcc
 
 install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then mkdir -p /Users/travis/gopath/bin; fi
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - dep ensure --vendor-only
 
@@ -52,8 +33,6 @@ script:
   - tinygo build -size short -o test.nrf.elf       -target=nrf52840-mdk examples/blinky1
   - tinygo build -size short -o blinky1.nrf51d.elf -target=pca10031     examples/blinky1
   - tinygo build -size short -o blinky1.stm32.elf  -target=bluepill     examples/blinky1
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tinygo build -size short -o blinky1.avr.elf    -target=arduino      examples/blinky1; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tinygo build -size short -o blinky1.avr.elf    -target=digispark    examples/blinky1; fi
   - tinygo build -size short -o blinky1.reel.elf   -target=reelboard    examples/blinky1
   - tinygo build -size short -o blinky2.reel.elf   -target=reelboard    examples/blinky2
   - tinygo build -size short -o blinky1.pca10056.elf    -target=pca10056     examples/blinky1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TinyGo - Go compiler for small places
 
-[![Build Status](https://travis-ci.com/tinygo-org/tinygo.svg?branch=dev)](https://travis-ci.com/tinygo-org/tinygo)
+[![Travis CI](https://travis-ci.com/tinygo-org/tinygo.svg?branch=dev)](https://travis-ci.com/tinygo-org/tinygo)
+[![CircleCI](https://circleci.com/gh/tinygo-org/tinygo/tree/dev.svg?style=svg)](https://circleci.com/gh/tinygo-org/tinygo/tree/dev)
 
 TinyGo is a Go compiler intended for use in small places such as microcontrollers, WebAssembly (WASM), and command-line tools.
 


### PR DESCRIPTION
End goal: replace Travis CI with CircleCI. CircleCI is much faster and doesn't have an uncertain future like Travis CI.

For now, let's just replace the Linux tests with CircleCI.