### PR TITLE
machine/samd21: move definitions for I2C interfaces into board files

### DIFF
--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -2,6 +2,8 @@
 
 package machine
 
+import "device/sam"
+
 // GPIO Pins
 const (
 	D0  = PB09
@@ -67,4 +69,10 @@ const (
 const (
 	SDA_PIN = PA00 // SDA: SERCOM3/PAD[0]
 	SCL_PIN = PA01 // SCL: SERCOM3/PAD[1]
+)
+
+// I2C on the Circuit Playground Express.
+var (
+	I2C0 = I2C{Bus: sam.SERCOM5_I2CM} // external device
+	I2C1 = I2C{Bus: sam.SERCOM1_I2CM} // internal device
 )

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -2,6 +2,8 @@
 
 package machine
 
+import "device/sam"
+
 // GPIO Pins
 const (
 	D0  = PA11 // UART0 RX
@@ -50,4 +52,9 @@ const (
 const (
 	SDA_PIN = PA22 // SDA: SERCOM3/PAD[0]
 	SCL_PIN = PA23 // SCL: SERCOM3/PAD[1]
+)
+
+// I2C on the ItsyBitsy M0.
+var (
+	I2C0 = I2C{Bus: sam.SERCOM3_I2CM}
 )

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -420,12 +420,6 @@ type I2C struct {
 	Bus *sam.SERCOM_I2CM_Type
 }
 
-// Since the I2C interfaces on the SAMD21 use the SERCOMx peripherals,
-// you can have multiple ones. we currently only implement one.
-var (
-	I2C0 = I2C{Bus: sam.SERCOM3_I2CM}
-)
-
 // I2CConfig is used to store config info for I2C.
 type I2CConfig struct {
 	Frequency uint32


### PR DESCRIPTION
This PR move definitions for I2C interfaces into board files, since pin connections on each SAMD21-based board implementation can differ between boards.