### PR TITLE
main: only run WebAssembly tests on Linux

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -81,16 +81,16 @@ func TestCompiler(t *testing.T) {
 				runTest(path, tmpdir, "aarch64--linux-gnu", t)
 			})
 		}
-	}
 
-	t.Log("running tests for WebAssembly...")
-	for _, path := range matches {
-		if path == "testdata/gc.go" {
-			continue // known to fail
+		t.Log("running tests for WebAssembly...")
+		for _, path := range matches {
+			if path == "testdata/gc.go" {
+				continue // known to fail
+			}
+			t.Run(path, func(t *testing.T) {
+				runTest(path, tmpdir, "wasm", t)
+			})
 		}
-		t.Run(path, func(t *testing.T) {
-			runTest(path, tmpdir, "wasm", t)
-		})
 	}
 }
 


### PR DESCRIPTION
The WebAssembly target is not yet considered stable in LLVM 7, but has
been enabled in the Debian builds so tests can run on Debian. However,
the Homebrew builds don't have it enabled which results in test
failures.

Temporarily run WebAssembly tests only on Linux to fix this. This can be
reverted after a switch to LLVM 8, which has WebAssembly enabled by
default.