### PR TITLE
Implement nil checks

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -1,0 +1,31 @@
+package compiler
+
+// This file implements functions that do certain safety checks that are
+// required by the Go programming language.
+
+import (
+	"tinygo.org/x/go-llvm"
+)
+
+// emitNilCheck checks whether the given pointer is nil, and panics if it is. It
+// has no effect in well-behaved programs, but makes sure no uncaught nil
+// pointer dereferences exist in valid Go code.
+func (c *Compiler) emitNilCheck(frame *Frame, ptr llvm.Value, blockPrefix string) {
+	// Check whether this is a nil pointer.
+	faultBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".nil")
+	nextBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".next")
+	frame.blockExits[frame.currentBlock] = nextBlock // adjust outgoing block for phi nodes
+
+	// Compare against nil.
+	nilptr := llvm.ConstPointerNull(ptr.Type())
+	isnil := c.builder.CreateICmp(llvm.IntEQ, ptr, nilptr, "")
+	c.builder.CreateCondBr(isnil, faultBlock, nextBlock)
+
+	// Fail: this is a nil pointer, exit with a panic.
+	c.builder.SetInsertPointAtEnd(faultBlock)
+	c.createRuntimeCall("nilpanic", nil, "")
+	c.builder.CreateUnreachable()
+
+	// Ok: this is a valid pointer.
+	c.builder.SetInsertPointAtEnd(nextBlock)
+}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -115,11 +115,7 @@ func (e *Eval) function(fn llvm.Value, params []Value, pkgName, indent string) (
 // getValue determines what kind of LLVM value it gets and returns the
 // appropriate Value type.
 func (e *Eval) getValue(v llvm.Value) Value {
-	if !v.IsAGlobalVariable().IsNil() {
-		return &GlobalValue{e, v}
-	} else {
-		return &LocalValue{e, v}
-	}
+	return &LocalValue{e, v}
 }
 
 // markDirty marks the passed-in LLVM value dirty, recursively. For example,

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -27,6 +27,11 @@ func _recover() interface{} {
 	return nil
 }
 
+// Panic when trying to dereference a nil pointer.
+func nilpanic() {
+	runtimePanic("nil pointer dereference")
+}
+
 // Check for bounds in *ssa.Index, *ssa.IndexAddr and *ssa.Lookup.
 func lookupBoundsCheck(length uintptr, index int) {
 	if index < 0 || index >= int(length) {


### PR DESCRIPTION
Make sure we never dereference a nil pointer without panic. The code size impact is around 5%, but I think the added safety (and Go language spec compliance!) is worth it. We can eliminate most of this for systems with MMU (Linux etc.) if needed.

The first commit also refactors the interp package and eliminates lots of repetitive code but does not affect the generated code. It makes the second commit easier to implement.

Fixes #180.