### PR TITLE
Improve bounds checking

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -4,8 +4,81 @@ package compiler
 // required by the Go programming language.
 
 import (
+	"go/types"
+
 	"tinygo.org/x/go-llvm"
 )
+
+// emitLookupBoundsCheck emits a bounds check before doing a lookup into a
+// slice. This is required by the Go language spec: an index out of bounds must
+// cause a panic.
+func (c *Compiler) emitLookupBoundsCheck(frame *Frame, arrayLen, index llvm.Value, indexType types.Type) {
+	if frame.fn.IsNoBounds() {
+		// The //go:nobounds pragma was added to the function to avoid bounds
+		// checking.
+		return
+	}
+
+	// Sometimes, the index can be e.g. an uint8 or int8, and we have to
+	// correctly extend that type.
+	if index.Type().IntTypeWidth() < arrayLen.Type().IntTypeWidth() {
+		if indexType.(*types.Basic).Info()&types.IsUnsigned == 0 {
+			index = c.builder.CreateZExt(index, arrayLen.Type(), "")
+		} else {
+			index = c.builder.CreateSExt(index, arrayLen.Type(), "")
+		}
+	}
+
+	// Optimize away trivial cases.
+	// LLVM would do this anyway with interprocedural optimizations, but it
+	// helps to see cases where bounds check elimination would really help.
+	if index.IsConstant() && arrayLen.IsConstant() && !arrayLen.IsUndef() {
+		index := index.SExtValue()
+		arrayLen := arrayLen.SExtValue()
+		if index >= 0 && index < arrayLen {
+			return
+		}
+	}
+
+	if index.Type().IntTypeWidth() > c.intType.IntTypeWidth() {
+		// Index is too big for the regular bounds check. Use the one for int64.
+		c.createRuntimeCall("lookupBoundsCheckLong", []llvm.Value{arrayLen, index}, "")
+	} else {
+		c.createRuntimeCall("lookupBoundsCheck", []llvm.Value{arrayLen, index}, "")
+	}
+}
+
+// emitSliceBoundsCheck emits a bounds check before a slicing operation to make
+// sure it is within bounds.
+func (c *Compiler) emitSliceBoundsCheck(frame *Frame, capacity, low, high llvm.Value, lowType, highType *types.Basic) {
+	if frame.fn.IsNoBounds() {
+		// The //go:nobounds pragma was added to the function to avoid bounds
+		// checking.
+		return
+	}
+
+	uintptrWidth := c.uintptrType.IntTypeWidth()
+	if low.Type().IntTypeWidth() > uintptrWidth || high.Type().IntTypeWidth() > uintptrWidth {
+		if low.Type().IntTypeWidth() < 64 {
+			if lowType.Info()&types.IsUnsigned != 0 {
+				low = c.builder.CreateZExt(low, c.ctx.Int64Type(), "")
+			} else {
+				low = c.builder.CreateSExt(low, c.ctx.Int64Type(), "")
+			}
+		}
+		if high.Type().IntTypeWidth() < 64 {
+			if highType.Info()&types.IsUnsigned != 0 {
+				high = c.builder.CreateZExt(high, c.ctx.Int64Type(), "")
+			} else {
+				high = c.builder.CreateSExt(high, c.ctx.Int64Type(), "")
+			}
+		}
+		// TODO: 32-bit or even 16-bit slice bounds checks for 8-bit platforms
+		c.createRuntimeCall("sliceBoundsCheck64", []llvm.Value{capacity, low, high}, "")
+	} else {
+		c.createRuntimeCall("sliceBoundsCheck", []llvm.Value{capacity, low, high}, "")
+	}
+}
 
 // emitNilCheck checks whether the given pointer is nil, and panics if it is. It
 // has no effect in well-behaved programs, but makes sure no uncaught nil

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1603,7 +1603,6 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		}
 
 		// Bounds check.
-		// LLVM optimizes this away in most cases.
 		c.emitLookupBoundsCheck(frame, buflen, index, expr.Index.Type())
 
 		switch expr.X.Type().Underlying().(type) {
@@ -1635,7 +1634,6 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			}
 
 			// Bounds check.
-			// LLVM optimizes this away in most cases.
 			length := c.builder.CreateExtractValue(value, 1, "len")
 			c.emitLookupBoundsCheck(frame, length, index, expr.Index.Type())
 
@@ -1883,7 +1881,6 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 				low,
 			}
 
-			// This check is optimized away in most cases.
 			c.emitSliceBoundsCheck(frame, llvmLen, low, high, lowType, highType)
 
 			if c.targetData.TypeAllocSize(high.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -32,33 +32,14 @@ func nilpanic() {
 	runtimePanic("nil pointer dereference")
 }
 
-// Check for bounds in *ssa.Index, *ssa.IndexAddr and *ssa.Lookup.
-func lookupBoundsCheck(length uintptr, index int) {
-	if index < 0 || index >= int(length) {
-		runtimePanic("index out of range")
-	}
+// Panic when trying to acces an array or slice out of bounds.
+func lookuppanic() {
+	runtimePanic("index out of range")
 }
 
-// Check for bounds in *ssa.Index, *ssa.IndexAddr and *ssa.Lookup.
-// Supports 64-bit indexes.
-func lookupBoundsCheckLong(length uintptr, index int64) {
-	if index < 0 || index >= int64(length) {
-		runtimePanic("index out of range")
-	}
-}
-
-// Check for bounds in *ssa.Slice.
-func sliceBoundsCheck(capacity, low, high uintptr) {
-	if !(0 <= low && low <= high && high <= capacity) {
-		runtimePanic("slice out of range")
-	}
-}
-
-// Check for bounds in *ssa.Slice. Supports 64-bit indexes.
-func sliceBoundsCheck64(capacity uintptr, low, high uint64) {
-	if !(0 <= low && low <= high && high <= uint64(capacity)) {
-		runtimePanic("slice out of range")
-	}
+// Panic when trying to slice a slice out of bounds.
+func slicepanic() {
+	runtimePanic("slice out of range")
 }
 
 // Check for bounds in *ssa.MakeSlice.


### PR DESCRIPTION
Depends on #222.

This PR improves slice/string/array bounds checking by inlining the checks. This has the result of reduced code size of around 1% and likely increased performance as well.
Unfortunately, LLVM is not smart enough to do bounds check elimination even in trivial cases like iterating over a slice. This should be added in the future to reduce code size even further (up to around 1%).