### PR TITLE
machine/stm32f103xx: correct convertion for fractional timing of RTC …

### DIFF
--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -124,8 +124,8 @@ func ticks() timeUnit {
 	// convert RTC counter from seconds to microseconds
 	timerCounter := uint64(stm32.RTC.CNTH<<16|stm32.RTC.CNTL) * 1000 * 1000
 
-	// add the fractional part of current time using DIV registers
-	timerCounter += (uint64(stm32.RTC.DIVH<<16|stm32.RTC.DIVL) / 1024 * 32 * 32) * 1000 * 1000
+	// add the fractional part of current time using DIV register
+	timerCounter += uint64(0x8000-stm32.RTC.DIVL) * 31
 
 	// change since last measurement
 	offset := (timerCounter - timerLastCounter)


### PR DESCRIPTION
This PR implements the correct conversion on STM32F103XX for fractional timing of RTC as used in ticks() function.

It corrects #149 for the stm32, the samd21 was already been corrected in #197 