### PR TITLE
main: use tool command naming to ensure that llvm7 toolchain works on both Linux/macOS

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,11 @@
+// +build !darwin
+
+package main
+
+// commands used by the compilation process might have different file names on Linux than those used on macOS.
+var commands = map[string]string{
+	"ar":      "llvm-ar-7",
+	"clang":   "clang-7",
+	"ld.lld":  "ld.lld-7",
+	"wasm-ld": "wasm-ld-7",
+}

--- a/commands_macos.go
+++ b/commands_macos.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package main
+
+// commands used by the compilation process might have different file names on macOS than those used on Linux.
+var commands = map[string]string{
+	"ar":      "llvm-ar",
+	"clang":   "clang-7",
+	"ld.lld":  "ld.lld-7",
+	"wasm-ld": "wasm-ld-7",
+}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 var commands = map[string]string{
-	"ar":      "llvm-ar",
+	"ar":      "llvm-ar-7",
 	"clang":   "clang-7",
 	"ld.lld":  "ld.lld-7",
 	"wasm-ld": "wasm-ld-7",

--- a/main.go
+++ b/main.go
@@ -21,13 +21,6 @@ import (
 	"github.com/tinygo-org/tinygo/loader"
 )
 
-var commands = map[string]string{
-	"ar":      "llvm-ar-7",
-	"clang":   "clang-7",
-	"ld.lld":  "ld.lld-7",
-	"wasm-ld": "wasm-ld-7",
-}
-
 // commandError is an error type to wrap os/exec.Command errors. This provides
 // some more information regarding what went wrong while running a command.
 type commandError struct {


### PR DESCRIPTION
This PR makes sure that the compiler uses correct toll command naming for llvm-ar-7 tool to ensure that llvm7 toolchain works as expected in Docker container builds as well as on macOS.