### PR TITLE
Support Go 1.12 for most targets

### DIFF
--- a/interp/frame.go
+++ b/interp/frame.go
@@ -310,6 +310,8 @@ func (fr *frame) evalBasicBlock(bb, incoming llvm.BasicBlock, indent string) (re
 			case callee.Name() == "runtime.makeInterface":
 				uintptrType := callee.Type().Context().IntType(fr.TargetData.PointerSize() * 8)
 				fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstPtrToInt(inst.Operand(0), uintptrType)}
+			case callee.Name() == "runtime.nanotime":
+				fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstInt(fr.Mod.Context().Int64Type(), 0, false)}
 			case strings.HasPrefix(callee.Name(), "runtime.print") || callee.Name() == "runtime._panic":
 				// This are all print instructions, which necessarily have side
 				// effects but no results.

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -28,6 +28,9 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 	case "runtime.alloc":
 		// Cannot be scanned but can be interpreted.
 		return &sideEffectResult{severity: sideEffectNone}
+	case "runtime.nanotime":
+		// Fixed value at compile time.
+		return &sideEffectResult{severity: sideEffectNone}
 	case "runtime._panic":
 		return &sideEffectResult{severity: sideEffectLimited}
 	}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -365,6 +365,25 @@ func (v Value) MapIndex(key Value) Value {
 	panic("unimplemented: (reflect.Value).MapIndex()")
 }
 
+func (v Value) MapRange() *MapIter {
+	panic("unimplemented: (reflect.Value).MapRange()")
+}
+
+type MapIter struct {
+}
+
+func (it *MapIter) Key() Value {
+	panic("unimplemented: (*reflect.MapIter).Key()")
+}
+
+func (it *MapIter) Value() Value {
+	panic("unimplemented: (*reflect.MapIter).Value()")
+}
+
+func (it *MapIter) Next() bool {
+	panic("unimplemented: (*reflect.MapIter).Next()")
+}
+
 func (v Value) Set(x Value) {
 	if !v.indirect {
 		panic("reflect: value is not addressable")

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -41,6 +41,7 @@ const (
 
 func chanSendStub(caller *coroutine, ch *channel, _ unsafe.Pointer, size uintptr)
 func chanRecvStub(caller *coroutine, ch *channel, _ unsafe.Pointer, _ *bool, size uintptr)
+func deadlockStub()
 
 // chanSend sends a single value over the channel. If this operation can
 // complete immediately (there is a goroutine waiting for a value), it sends the

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -84,9 +84,13 @@ func sleep(d int64) {
 	sleepTicks(timeUnit(d / tickMicros))
 }
 
+func nanotime() int64 {
+	return int64(ticks()) * tickMicros
+}
+
 //go:linkname now time.now
 func now() (sec int64, nsec int32, mono int64) {
-	mono = int64(ticks()) * tickMicros
+	mono = nanotime()
 	sec = mono / (1000 * 1000 * 1000)
 	nsec = int32(mono - sec*(1000*1000*1000))
 	return

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -37,6 +37,11 @@ func putchar(c byte) {
 	resource_write(stdout, &c, 1)
 }
 
+//go:linkname setEventHandler syscall/js.setEventHandler
+func setEventHandler(fn func()) {
+	// TODO
+}
+
 //go:export go_scheduler
 func go_scheduler() {
 	scheduler()

--- a/testdata/channel.go
+++ b/testdata/channel.go
@@ -43,6 +43,10 @@ func main() {
 	}
 	println("sum(100):", sum)
 
+	// Test select
+	go selectDeadlock()
+	go selectNoOp()
+
 	// Allow goroutines to exit.
 	time.Sleep(time.Microsecond)
 }
@@ -92,4 +96,18 @@ func iterator(ch chan int, top int) {
 		ch <- i
 	}
 	close(ch)
+}
+
+func selectDeadlock() {
+	println("deadlocking")
+	select {}
+	println("unreachable")
+}
+
+func selectNoOp() {
+	println("select no-op")
+	select {
+	default:
+	}
+	println("after no-op")
 }

--- a/testdata/channel.txt
+++ b/testdata/channel.txt
@@ -19,3 +19,6 @@ sum: 25
 sum: 29
 sum: 33
 sum(100): 4950
+deadlocking
+select no-op
+after no-op


### PR DESCRIPTION
This PR contains almost all changes of #211, but leaves out testing on Go 1.12 because bare-metal targets are not yet supported.
This PR is still useful, because it supports the updated syscall/js package used in the WebAssembly target. Go 1.11 is still supported.

fixes #216