### PR TITLE
circleci: don't install the llvm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ commands:
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
             sudo apt-get update
             sudo apt-get install \
-                llvm \
                 python3 \
                 llvm<<parameters.llvm>>-dev \
                 clang<<parameters.llvm>> \


### PR DESCRIPTION
This is not necessary anymore since d6c2d6e301: llvm-ar has been replaced with llvm-ar-8. It will speed up CircleCI tests a tiny bit.