### PR TITLE
compiler: improve escape analysis to allow icmp

### DIFF
--- a/compiler/optimizer.go
+++ b/compiler/optimizer.go
@@ -281,6 +281,9 @@ func (c *Compiler) doesEscape(value llvm.Value) bool {
 			if !c.hasFlag(use, value, "nocapture") {
 				return true
 			}
+		} else if use.IsAICmpInst() != nilValue {
+			// Comparing pointers don't let the pointer escape.
+			// This is often a compiler-inserted nil check.
 		} else {
 			// Unknown instruction, might escape.
 			return true


### PR DESCRIPTION
The icmp instruction is often used in nil checks, so this instruction
happens very frequently now that TinyGo automatically inserts nil checks
everywhere. Escape analysis would conservatively mark such pointers as
escaping, which they obviously don't.
This commit improves escape analysis to allow icmp instructions.

---

I found this optimization opportunity while working on #249. It reduces code size for the following test cases:

  * testdata/map.go
  * testdata/math.go
  * testdata/print.go
  * testdata/reflect.go
  * testdata/stdlib.go

The savings aren't big but the biggest advantage of this is not code size reduction but avoiding heap allocations.