### PR TITLE
Fix escapes due to nil checks

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -379,6 +379,11 @@ func (c *Compiler) Compile(mainPath string) error {
 		c.mod.NamedFunction("runtime.alloc").AddAttributeAtIndex(0, attr)
 	}
 
+	// See emitNilCheck in asserts.go.
+	attrKind := llvm.AttributeKindID("nocapture")
+	attr := c.ctx.CreateEnumAttribute(attrKind, 0)
+	c.mod.NamedFunction("runtime.isnil").AddAttributeAtIndex(1, attr)
+
 	// see: https://reviews.llvm.org/D18355
 	if c.Debug {
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -27,6 +27,14 @@ func _recover() interface{} {
 	return nil
 }
 
+// See emitNilCheck in compiler/asserts.go.
+// This function is a dummy function that has its first and only parameter
+// marked 'nocapture' to work around a limitation in LLVM: a regular pointer
+// comparison captures the pointer.
+func isnil(ptr *uint8) bool {
+	return ptr == nil
+}
+
 // Panic when trying to dereference a nil pointer.
 func nilpanic() {
 	runtimePanic("nil pointer dereference")


### PR DESCRIPTION
Some tests get bigger, most get smaller. However, all tested driver
examples get smaller in size showing that this is a good change in the
real world.
