### PR TITLE
runtime: implement memmove intrinsic

### DIFF
--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -46,10 +46,16 @@ func abort() {
 	}
 }
 
-// Implement memset for compiler-rt.
+// Implement memset for LLVM and compiler-rt.
 //go:export memset
-func memset(ptr unsafe.Pointer, c byte, size uintptr) {
+func libc_memset(ptr unsafe.Pointer, c byte, size uintptr) {
 	for i := uintptr(0); i < size; i++ {
 		*(*byte)(unsafe.Pointer(uintptr(ptr) + i)) = c
 	}
+}
+
+// Implement memmove for LLVM and compiler-rt.
+//go:export memmove
+func libc_memmove(dst, src unsafe.Pointer, size uintptr) {
+	memmove(dst, src, size)
 }


### PR DESCRIPTION
This should improve the following issue:
https://github.com/tinygo-org/tinygo/issues/252