### PR TITLE
arm: use the lld linker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ commands:
                 libclang<<parameters.llvm>>-dev \
                 lld<<parameters.llvm>> \
                 gcc-arm-linux-gnueabihf \
-                binutils-arm-none-eabi \
                 libc6-dev-armel-cross \
                 gcc-aarch64-linux-gnu \
                 libc6-dev-arm64-cross \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ commands:
       - run: tinygo build -size short -o test.elf -target=pca10056            examples/blinky2
       - run: tinygo build -size short -o test.elf -target=itsybitsy-m0        examples/blinky1
       - run: tinygo build -size short -o test.elf -target=circuitplay-express examples/blinky1
+      - run: tinygo build             -o wasm.wasm -target=wasm               examples/wasm
   test-linux:
     parameters:
       llvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ matrix:
 addons:
   homebrew:
     update: true
-    taps: ArmMbed/homebrew-formulae
     packages:
     - llvm@8
     - qemu
-    - arm-none-eabi-gcc
 
 install:
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ script:
   - tinygo build -size short -o blinky1.pca10056.elf    -target=pca10056     examples/blinky1
   - tinygo build -size short -o blinky2.pca10056.elf    -target=pca10056     examples/blinky2
   - tinygo build -size short -o blinky1.samd21.elf    -target=itsybitsy-m0     examples/blinky1
+  - tinygo build             -o wasm.wasm          -target=wasm         examples/wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=tinygo-base /go/src/github.com/tinygo-org/tinygo/lib /go/src/github.
 
 RUN cd /go/src/github.com/tinygo-org/tinygo/ && \
     apt-get update && \
-    apt-get install -y apt-utils python3 make binutils-arm-none-eabi clang-8 && \
+    apt-get install -y apt-utils python3 make clang-8 && \
     make gen-device-nrf && make gen-device-stm32 && \
     apt-get remove -y python3 make && \
     apt-get autoremove -y && \
@@ -74,7 +74,7 @@ COPY --from=tinygo-base /go/src/github.com/tinygo-org/tinygo/lib /go/src/github.
 
 RUN cd /go/src/github.com/tinygo-org/tinygo/ && \
     apt-get update && \
-    apt-get install -y apt-utils python3 make binutils-arm-none-eabi clang-8 binutils-avr gcc-avr avr-libc && \
+    apt-get install -y apt-utils python3 make clang-8 binutils-avr gcc-avr avr-libc && \
     make gen-device && \
     apt-get remove -y python3 make && \
     apt-get autoremove -y && \

--- a/commands_macos.go
+++ b/commands_macos.go
@@ -7,5 +7,5 @@ var commands = map[string]string{
 	"ar":      "llvm-ar",
 	"clang":   "clang-8",
 	"ld.lld":  "ld.lld-8",
-	"wasm-ld": "wasm-ld-8",
+	"wasm-ld": "wasm-ld",
 }

--- a/commands_macos.go
+++ b/commands_macos.go
@@ -6,6 +6,6 @@ package main
 var commands = map[string]string{
 	"ar":      "llvm-ar",
 	"clang":   "clang-8",
-	"ld.lld":  "ld.lld-8",
+	"ld.lld":  "ld.lld",
 	"wasm-ld": "wasm-ld",
 }

--- a/main.go
+++ b/main.go
@@ -228,7 +228,11 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		}
 
 		// Link the object files together.
-		err = Link(sourceDir(), spec.Linker, ldflags...)
+		if linker, ok := commands[spec.Linker]; ok {
+			err = Link(sourceDir(), linker, ldflags...)
+		} else {
+			err = Link(sourceDir(), spec.Linker, ldflags...)
+		}
 		if err != nil {
 			return &commandError{"failed to link", executable, err}
 		}

--- a/targets/arm.ld
+++ b/targets/arm.ld
@@ -54,6 +54,7 @@ SECTIONS
 
     /DISCARD/ :
     {
+        *(.ARM.exidx)      /* causes 'no memory region specified' error in lld */
         *(.ARM.exidx.*)    /* causes spurious 'undefined reference' errors */
     }
 }

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -4,7 +4,7 @@
 	"goarch": "arm",
 	"compiler": "clang-8",
 	"gc": "marksweep",
-	"linker": "arm-none-eabi-ld",
+	"linker": "ld.lld",
 	"rtlib": "compiler-rt",
 	"cflags": [
 		"-Oz",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -4,7 +4,7 @@
 	"goos":          "js",
 	"goarch":        "wasm",
 	"compiler":      "clang-8",
-	"linker":        "wasm-ld-8",
+	"linker":        "wasm-ld",
 	"cflags": [
 		"--target=wasm32",
 		"-Oz"


### PR DESCRIPTION
LLD version 8 has added support for armv6m: https://reviews.llvm.org/D55555
This means we can use LLD instead of `arm-none-eabi-ld`, eliminating our dependency on GNU binutils.

There are small differences in code size, but never more than a few bytes.

---

I have tested the following devices:

  * nrf51 (microbit)
  * nrf52 (pca10040)
  * samd21 (circuitplay-express)

It all works perfectly in my tests.