### PR TITLE
machine/itsybitsy-m0: set pins and pin mode mapping for i2c0 bus

### DIFF
--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -56,7 +56,10 @@ const (
 
 // I2C on the ItsyBitsy M0.
 var (
-	I2C0 = I2C{Bus: sam.SERCOM3_I2CM}
+	I2C0 = I2C{Bus: sam.SERCOM3_I2CM,
+		SDA:     SDA_PIN,
+		SCL:     SCL_PIN,
+		PinMode: GPIO_SERCOM}
 )
 
 // SPI pins


### PR DESCRIPTION
This PR sets the pin and pin mode mapping for i2c0 bus on the Adafruit ItsyBitsy-M0 board.