### PR TITLE
Fix uintptr handling for AVR

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -51,6 +51,11 @@ func (c *Compiler) emitLookupBoundsCheck(frame *Frame, arrayLen, index llvm.Valu
 
 // emitSliceBoundsCheck emits a bounds check before a slicing operation to make
 // sure it is within bounds.
+//
+// This function is both used for slicing a slice (low and high have their
+// normal meaning) and for creating a new slice, where 'capacity' means the
+// biggest possible slice capacity, 'low' means len and 'high' means cap. The
+// logic is the same in both cases.
 func (c *Compiler) emitSliceBoundsCheck(frame *Frame, capacity, low, high llvm.Value, lowType, highType *types.Basic) {
 	if frame.fn.IsNoBounds() {
 		// The //go:nobounds pragma was added to the function to avoid bounds

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1917,8 +1917,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 				}
 			}
 		} else {
-			lowType = types.Typ[types.Int]
-			low = llvm.ConstInt(c.intType, 0, false)
+			lowType = types.Typ[types.Uintptr]
+			low = llvm.ConstInt(c.uintptrType, 0, false)
 		}
 
 		if expr.High != nil {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1752,37 +1752,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		}
 
 		// Bounds checking.
-		if !frame.fn.IsNoBounds() {
-			checkFunc := "sliceBoundsCheckMake"
-			capacityType := c.uintptrType
-			capacityTypeWidth := capacityType.IntTypeWidth()
-			if sliceLen.Type().IntTypeWidth() > capacityTypeWidth || sliceCap.Type().IntTypeWidth() > capacityTypeWidth {
-				// System that is less than 64bit, meaning that the slice make
-				// params are bigger than uintptr.
-				checkFunc = "sliceBoundsCheckMake64"
-				capacityType = c.ctx.Int64Type()
-				capacityTypeWidth = capacityType.IntTypeWidth()
-			}
-			if sliceLen.Type().IntTypeWidth() < capacityTypeWidth {
-				if expr.Len.Type().(*types.Basic).Info()&types.IsUnsigned != 0 {
-					sliceLen = c.builder.CreateZExt(sliceLen, capacityType, "")
-				} else {
-					sliceLen = c.builder.CreateSExt(sliceLen, capacityType, "")
-				}
-			}
-			if sliceCap.Type().IntTypeWidth() < capacityTypeWidth {
-				if expr.Cap.Type().(*types.Basic).Info()&types.IsUnsigned != 0 {
-					sliceCap = c.builder.CreateZExt(sliceCap, capacityType, "")
-				} else {
-					sliceCap = c.builder.CreateSExt(sliceCap, capacityType, "")
-				}
-			}
-			maxSliceSize := maxSize
-			if elemSize != 0 { // avoid divide by zero
-				maxSliceSize = llvm.ConstSDiv(maxSize, llvm.ConstInt(c.uintptrType, elemSize, false))
-			}
-			c.createRuntimeCall(checkFunc, []llvm.Value{sliceLen, sliceCap, maxSliceSize}, "")
-		}
+		c.emitSliceBoundsCheck(frame, maxSize, sliceLen, sliceCap, expr.Len.Type().(*types.Basic), expr.Cap.Type().(*types.Basic))
 
 		// Allocate the backing array.
 		// TODO: escape analysis
@@ -1794,9 +1764,15 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		slicePtr := c.createRuntimeCall("alloc", []llvm.Value{sliceSize}, "makeslice.buf")
 		slicePtr = c.builder.CreateBitCast(slicePtr, llvm.PointerType(llvmElemType, 0), "makeslice.array")
 
-		if c.targetData.TypeAllocSize(sliceLen.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {
-			sliceLen = c.builder.CreateTrunc(sliceLen, c.uintptrType, "")
-			sliceCap = c.builder.CreateTrunc(sliceCap, c.uintptrType, "")
+		// Extend or truncate if necessary. This is safe as we've already done
+		// the bounds check.
+		sliceLen, err = c.parseConvert(expr.Len.Type(), types.Typ[types.Uintptr], sliceLen, expr.Pos())
+		if err != nil {
+			return llvm.Value{}, err
+		}
+		sliceCap, err = c.parseConvert(expr.Cap.Type(), types.Typ[types.Uintptr], sliceCap, expr.Pos())
+		if err != nil {
+			return llvm.Value{}, err
 		}
 
 		// Create the slice.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2539,7 +2539,7 @@ func (c *Compiler) parseConvert(typeFrom, typeTo types.Type, value llvm.Value, p
 			// Conversion between two integers.
 			if sizeFrom > sizeTo {
 				return c.builder.CreateTrunc(value, llvmTypeTo, ""), nil
-			} else if typeTo.Info()&types.IsUnsigned != 0 { // if unsigned
+			} else if typeFrom.Info()&types.IsUnsigned != 0 { // if unsigned
 				return c.builder.CreateZExt(value, llvmTypeTo, ""), nil
 			} else { // if signed
 				return c.builder.CreateSExt(value, llvmTypeTo, ""), nil

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1953,6 +1953,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 			c.emitSliceBoundsCheck(frame, llvmLen, low, high, lowType, highType)
 
+			// Truncate ints bigger than uintptr. This is after the bounds
+			// check so it's safe.
 			if c.targetData.TypeAllocSize(high.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {
 				high = c.builder.CreateTrunc(high, c.uintptrType, "")
 			}
@@ -1985,6 +1987,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 			c.emitSliceBoundsCheck(frame, oldCap, low, high, lowType, highType)
 
+			// Truncate ints bigger than uintptr. This is after the bounds
+			// check so it's safe.
 			if c.targetData.TypeAllocSize(low.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {
 				low = c.builder.CreateTrunc(low, c.uintptrType, "")
 			}
@@ -2017,6 +2021,15 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			}
 
 			c.emitSliceBoundsCheck(frame, oldLen, low, high, lowType, highType)
+
+			// Truncate ints bigger than uintptr. This is after the bounds
+			// check so it's safe.
+			if c.targetData.TypeAllocSize(low.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {
+				low = c.builder.CreateTrunc(low, c.uintptrType, "")
+			}
+			if c.targetData.TypeAllocSize(high.Type()) > c.targetData.TypeAllocSize(c.uintptrType) {
+				high = c.builder.CreateTrunc(high, c.uintptrType, "")
+			}
 
 			newPtr := c.builder.CreateGEP(oldPtr, []llvm.Value{low}, "")
 			newLen := c.builder.CreateSub(high, low, "")

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -49,17 +49,3 @@ func lookuppanic() {
 func slicepanic() {
 	runtimePanic("slice out of range")
 }
-
-// Check for bounds in *ssa.MakeSlice.
-func sliceBoundsCheckMake(length, capacity uintptr, max uintptr) {
-	if length > capacity || capacity > max {
-		runtimePanic("slice size out of range")
-	}
-}
-
-// Check for bounds in *ssa.MakeSlice. Supports 64-bit indexes.
-func sliceBoundsCheckMake64(length, capacity uint64, max uintptr) {
-	if length > capacity || capacity > uint64(max) {
-		runtimePanic("slice size out of range")
-	}
-}

--- a/src/runtime/print.go
+++ b/src/runtime/print.go
@@ -39,7 +39,7 @@ func printuint16(n uint16) {
 	printuint32(uint32(n))
 }
 
-func printint16(n uint16) {
+func printint16(n int16) {
 	printint32(int32(n))
 }
 


### PR DESCRIPTION
This is a collection of bug fixes that together get testdata/stdlib.go to compile for AVR (at least to IR, compiling to machine code causes a crash in the backend). It also fixes a more serious (and subtle!) issue where it gets casting wrong when casting between signed and unsigned integers.