### PR TITLE
 main: drop the dependency on llvm-ar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,6 @@ commands:
           name: "Create LLVM symlinks"
           command: |
             ln -s $PWD/llvm-build/bin/clang-8 /go/bin/clang-8
-            ln -s $PWD/llvm-build/bin/llvm-ar /go/bin/llvm-ar-8
             ln -s $PWD/llvm-build/bin/ld.lld  /go/bin/ld.lld-8
             ln -s $PWD/llvm-build/bin/wasm-ld /go/bin/wasm-ld-8
       - dep
@@ -220,7 +219,6 @@ commands:
           name: "Create LLVM symlinks"
           command: |
             ln -s $PWD/llvm-build/bin/clang-8 /usr/local/bin/clang-8
-            ln -s $PWD/llvm-build/bin/llvm-ar /usr/local/bin/llvm-ar
       - run:
           name: "Install Go dependencies"
           command: dep ensure --vendor-only

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:06519a2ec1d59040eaccec40206f9d0b59dc662db2a032f974d6d6b9a2bcb839"
+  name = "github.com/blakesmith/ar"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8bd4349a67f2533b078dbc524689d15dba0f4659"
+
+[[projects]]
+  branch = "master"
   digest = "1:00b45e06c7843541372fc17d982242bd6adfc2fc382b6f2e9ef9ce53d87a50b9"
   name = "github.com/marcinbor85/gohex"
   packages = ["."]
@@ -33,6 +41,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/blakesmith/ar",
     "github.com/marcinbor85/gohex",
     "golang.org/x/tools/go/ast/astutil",
     "golang.org/x/tools/go/ssa",

--- a/commands.go
+++ b/commands.go
@@ -4,7 +4,6 @@ package main
 
 // commands used by the compilation process might have different file names on Linux than those used on macOS.
 var commands = map[string]string{
-	"ar":      "llvm-ar-8",
 	"clang":   "clang-8",
 	"ld.lld":  "ld.lld-8",
 	"wasm-ld": "wasm-ld-8",

--- a/commands_macos.go
+++ b/commands_macos.go
@@ -4,7 +4,6 @@ package main
 
 // commands used by the compilation process might have different file names on macOS than those used on Linux.
 var commands = map[string]string{
-	"ar":      "llvm-ar",
 	"clang":   "clang-8",
 	"ld.lld":  "ld.lld",
 	"wasm-ld": "wasm-ld",


### PR DESCRIPTION
The ar file format is pretty simple and can be implemented by using a Go package. Use that instead of calling out to `llvm-ar`.

There are a few limitations to the used package, but that doesn't seem to matter for our use case (linking compiler-rt for use with `ld.lld`):

  * no index is created
  * long filenames are truncated
  * no support for archives bigger than 4GB
