### PR TITLE
cgo: support builtin #include headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,18 @@ commands:
           command: |
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure --vendor-only
+  llvm-source-linux:
+    steps:
+      - restore_cache:
+          keys:
+            - llvm-source-8-v2
+      - run:
+          name: "Fetch LLVM source"
+          command: make llvm-source
+      - save_cache:
+          key: llvm-source-8-v2
+          paths:
+            - llvm
   smoketest:
     steps:
       - smoketest-no-avr
@@ -86,6 +98,7 @@ commands:
           keys:
             - go-cache-{{ checksum "Gopkg.lock" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
             - go-cache-{{ checksum "Gopkg.lock" }}
+      - llvm-source-linux
       - dep
       - run: go install .
       - run: go test -v
@@ -121,16 +134,7 @@ commands:
           keys:
             - go-cache-{{ checksum "Gopkg.lock" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
             - go-cache-{{ checksum "Gopkg.lock" }}
-      - restore_cache:
-          keys:
-            - llvm-source-8-v2
-      - run:
-          name: "Fetch LLVM source"
-          command: make llvm-source
-      - save_cache:
-          key: llvm-source-8-v2
-          paths:
-            - llvm
+      - llvm-source-linux
       - restore_cache:
           keys:
             - llvm-build-8-v2

--- a/Makefile
+++ b/Makefile
@@ -86,13 +86,16 @@ test:
 
 release: build/tinygo gen-device
 	@mkdir -p build/release/tinygo/bin
+	@mkdir -p build/release/tinygo/lib/clang/include
 	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
 	@mkdir -p build/release/tinygo/lib/compiler-rt/lib
 	@mkdir -p build/release/tinygo/lib/nrfx
 	@mkdir -p build/release/tinygo/pkg/armv6m-none-eabi
 	@mkdir -p build/release/tinygo/pkg/armv7m-none-eabi
 	@mkdir -p build/release/tinygo/pkg/armv7em-none-eabi
+	@echo copying source files
 	@cp -p  build/tinygo                 build/release/tinygo/bin
+	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
 	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
 	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
 	@cp -rp lib/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt/lib

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -217,8 +217,9 @@ func (c *Compiler) Compile(mainPath string) error {
 				MaxAlign: int64(c.targetData.PrefTypeAlignment(c.i8ptrType)),
 			},
 		},
-		Dir:    wd,
-		CFlags: c.CFlags,
+		Dir:        wd,
+		TinyGoRoot: c.RootDir,
+		CFlags:     c.CFlags,
 	}
 	if strings.HasSuffix(mainPath, ".go") {
 		_, err = lprogram.ImportFile(mainPath)

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -45,6 +45,8 @@ CXType tinygo_clang_getTypedefDeclUnderlyingType(GoCXCursor c);
 CXType tinygo_clang_getCursorResultType(GoCXCursor c);
 int tinygo_clang_Cursor_getNumArguments(GoCXCursor c);
 GoCXCursor tinygo_clang_Cursor_getArgument(GoCXCursor c, unsigned i);
+CXSourceLocation tinygo_clang_getCursorLocation(GoCXCursor c);
+CXTranslationUnit tinygo_clang_Cursor_getTranslationUnit(GoCXCursor c);
 
 int tinygo_clang_globals_visitor(GoCXCursor c, GoCXCursor parent, CXClientData client_data);
 int tinygo_clang_struct_visitor(GoCXCursor c, GoCXCursor parent, CXClientData client_data);
@@ -162,6 +164,7 @@ func (info *fileInfo) parseFragment(fragment string, cflags []string, posFilenam
 func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClientData) C.int {
 	info := refMap.Get(unsafe.Pointer(client_data)).(*fileInfo)
 	kind := C.tinygo_clang_getCursorKind(c)
+	pos := info.getCursorPosition(c)
 	switch kind {
 	case C.CXCursor_FunctionDecl:
 		name := getString(C.tinygo_clang_getCursorSpelling(c))
@@ -181,7 +184,7 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 			}
 			fn.args = append(fn.args, paramInfo{
 				name:     argName,
-				typeExpr: info.makeASTType(argType),
+				typeExpr: info.makeASTType(argType, pos),
 			})
 		}
 		resultType := C.tinygo_clang_getCursorResultType(c)
@@ -189,7 +192,7 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 			fn.results = &ast.FieldList{
 				List: []*ast.Field{
 					&ast.Field{
-						Type: info.makeASTType(resultType),
+						Type: info.makeASTType(resultType, pos),
 					},
 				},
 			}
@@ -198,7 +201,7 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 		typedefType := C.tinygo_clang_getCursorType(c)
 		name := getString(C.clang_getTypedefName(typedefType))
 		underlyingType := C.tinygo_clang_getTypedefDeclUnderlyingType(c)
-		expr := info.makeASTType(underlyingType)
+		expr := info.makeASTType(underlyingType, pos)
 		if strings.HasPrefix(name, "_Cgo_") {
 			expr := expr.(*ast.Ident)
 			typeSize := C.clang_Type_getSizeOf(underlyingType)
@@ -247,7 +250,7 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 		name := getString(C.tinygo_clang_getCursorSpelling(c))
 		cursorType := C.tinygo_clang_getCursorType(c)
 		info.globals[name] = &globalInfo{
-			typeExpr: info.makeASTType(cursorType),
+			typeExpr: info.makeASTType(cursorType, pos),
 		}
 	}
 	return C.CXChildVisit_Continue
@@ -260,9 +263,44 @@ func getString(clangString C.CXString) (s string) {
 	return
 }
 
+// getCursorPosition returns a usable token.Pos from a libclang cursor. If the
+// file for this cursor has not been seen before, it is read from libclang
+// (which already has the file in memory) and added to the token.FileSet.
+func (info *fileInfo) getCursorPosition(cursor C.GoCXCursor) token.Pos {
+	location := C.tinygo_clang_getCursorLocation(cursor)
+	var file C.CXFile
+	var line C.unsigned
+	var column C.unsigned
+	var offset C.unsigned
+	C.clang_getExpansionLocation(location, &file, &line, &column, &offset)
+	if line == 0 {
+		// Invalid token.
+		return token.NoPos
+	}
+	filename := getString(C.clang_getFileName(file))
+	if _, ok := info.tokenFiles[filename]; !ok {
+		// File has not been seen before in this package, add line information
+		// now by reading the file from libclang.
+		tu := C.tinygo_clang_Cursor_getTranslationUnit(cursor)
+		var size C.size_t
+		sourcePtr := C.clang_getFileContents(tu, file, &size)
+		source := ((*[1 << 28]byte)(unsafe.Pointer(sourcePtr)))[:size:size]
+		lines := []int{0}
+		for i := 0; i < len(source)-1; i++ {
+			if source[i] == '\n' {
+				lines = append(lines, i+1)
+			}
+		}
+		f := info.fset.AddFile(filename, -1, int(size))
+		f.SetLines(lines)
+		info.tokenFiles[filename] = f
+	}
+	return info.tokenFiles[filename].Pos(int(offset))
+}
+
 // makeASTType return the ast.Expr for the given libclang type. In other words,
 // it converts a libclang type to a type in the Go AST.
-func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
+func (info *fileInfo) makeASTType(typ C.CXType, pos token.Pos) ast.Expr {
 	var typeName string
 	switch typ.kind {
 	case C.CXType_Char_S, C.CXType_Char_U:
@@ -312,28 +350,28 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 			// void* type is translated to Go as unsafe.Pointer
 			return &ast.SelectorExpr{
 				X: &ast.Ident{
-					NamePos: info.importCPos,
+					NamePos: pos,
 					Name:    "unsafe",
 				},
 				Sel: &ast.Ident{
-					NamePos: info.importCPos,
+					NamePos: pos,
 					Name:    "Pointer",
 				},
 			}
 		}
 		return &ast.StarExpr{
-			Star: info.importCPos,
-			X:    info.makeASTType(pointeeType),
+			Star: pos,
+			X:    info.makeASTType(pointeeType, pos),
 		}
 	case C.CXType_ConstantArray:
 		return &ast.ArrayType{
-			Lbrack: info.importCPos,
+			Lbrack: pos,
 			Len: &ast.BasicLit{
-				ValuePos: info.importCPos,
+				ValuePos: pos,
 				Kind:     token.INT,
 				Value:    strconv.FormatInt(int64(C.clang_getArraySize(typ)), 10),
 			},
-			Elt: info.makeASTType(C.clang_getElementType(typ)),
+			Elt: info.makeASTType(C.clang_getElementType(typ), pos),
 		}
 	case C.CXType_FunctionProto:
 		// Be compatible with gc, which uses the *[0]byte type for function
@@ -341,21 +379,21 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 		// Return type [0]byte because this is a function type, not a pointer to
 		// this function type.
 		return &ast.ArrayType{
-			Lbrack: info.importCPos,
+			Lbrack: pos,
 			Len: &ast.BasicLit{
-				ValuePos: info.importCPos,
+				ValuePos: pos,
 				Kind:     token.INT,
 				Value:    "0",
 			},
 			Elt: &ast.Ident{
-				NamePos: info.importCPos,
+				NamePos: pos,
 				Name:    "byte",
 			},
 		}
 	case C.CXType_Typedef:
 		typedefName := getString(C.clang_getTypedefName(typ))
 		return &ast.Ident{
-			NamePos: info.importCPos,
+			NamePos: pos,
 			Name:    "C." + typedefName,
 		}
 	case C.CXType_Elaborated:
@@ -370,10 +408,10 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 			// it is being processed, although it may not be fully defined yet.
 			if _, ok := info.elaboratedTypes[name]; !ok {
 				info.elaboratedTypes[name] = nil // predeclare (to avoid endless recursion)
-				info.elaboratedTypes[name] = info.makeASTType(underlying)
+				info.elaboratedTypes[name] = info.makeASTType(underlying, info.getCursorPosition(cursor))
 			}
 			return &ast.Ident{
-				NamePos: info.importCPos,
+				NamePos: pos,
 				Name:    "C.struct_" + name,
 			}
 		default:
@@ -382,8 +420,8 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 	case C.CXType_Record:
 		cursor := C.tinygo_clang_getTypeDeclaration(typ)
 		fieldList := &ast.FieldList{
-			Opening: info.importCPos,
-			Closing: info.importCPos,
+			Opening: pos,
+			Closing: pos,
 		}
 		ref := refMap.Put(struct {
 			fieldList *ast.FieldList
@@ -394,7 +432,7 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 		switch C.tinygo_clang_getCursorKind(cursor) {
 		case C.CXCursor_StructDecl:
 			return &ast.StructType{
-				Struct: info.importCPos,
+				Struct: pos,
 				Fields: fieldList,
 			}
 		case C.CXCursor_UnionDecl:
@@ -409,12 +447,12 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 				// unions as they're basically equivalent to a struct.
 				unionMarker := &ast.Field{
 					Type: &ast.StructType{
-						Struct: info.importCPos,
+						Struct: pos,
 					},
 				}
 				unionMarker.Names = []*ast.Ident{
 					&ast.Ident{
-						NamePos: info.importCPos,
+						NamePos: pos,
 						Name:    "C union",
 						Obj: &ast.Object{
 							Kind: ast.Var,
@@ -426,7 +464,7 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 				fieldList.List = append([]*ast.Field{unionMarker}, fieldList.List...)
 			}
 			return &ast.StructType{
-				Struct: info.importCPos,
+				Struct: pos,
 				Fields: fieldList,
 			}
 		}
@@ -437,7 +475,7 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 		typeName = "C." + getString(C.clang_getTypeSpelling(typ))
 	}
 	return &ast.Ident{
-		NamePos: info.importCPos,
+		NamePos: pos,
 		Name:    typeName,
 	}
 }
@@ -456,11 +494,11 @@ func tinygo_clang_struct_visitor(c, parent C.GoCXCursor, client_data C.CXClientD
 	name := getString(C.tinygo_clang_getCursorSpelling(c))
 	typ := C.tinygo_clang_getCursorType(c)
 	field := &ast.Field{
-		Type: info.makeASTType(typ),
+		Type: info.makeASTType(typ, info.getCursorPosition(c)),
 	}
 	field.Names = []*ast.Ident{
 		&ast.Ident{
-			NamePos: info.importCPos,
+			NamePos: info.getCursorPosition(c),
 			Name:    name,
 			Obj: &ast.Object{
 				Kind: ast.Var,

--- a/loader/libclang_stubs.c
+++ b/loader/libclang_stubs.c
@@ -44,3 +44,11 @@ int tinygo_clang_Cursor_getNumArguments(CXCursor c) {
 CXCursor tinygo_clang_Cursor_getArgument(CXCursor c, unsigned i) {
 	return clang_Cursor_getArgument(c, i);
 }
+
+CXSourceLocation tinygo_clang_getCursorLocation(CXCursor c) {
+	return clang_getCursorLocation(c);
+}
+
+CXTranslationUnit tinygo_clang_Cursor_getTranslationUnit(CXCursor c) {
+	return clang_Cursor_getTranslationUnit(c);
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -30,10 +30,11 @@ type Program struct {
 type Package struct {
 	*Program
 	*build.Package
-	Imports   map[string]*Package
-	Importing bool
-	Files     []*ast.File
-	Pkg       *types.Package
+	Imports    map[string]*Package
+	Importing  bool
+	Files      []*ast.File
+	tokenFiles map[string]*token.File
+	Pkg        *types.Package
 	types.Info
 }
 
@@ -106,6 +107,7 @@ func (p *Program) newPackage(pkg *build.Package) *Package {
 			Scopes:     make(map[ast.Node]*types.Scope),
 			Selections: make(map[*ast.SelectorExpr]*types.Selection),
 		},
+		tokenFiles: map[string]*token.File{},
 	}
 }
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,6 +22,7 @@ type Program struct {
 	fset          *token.FileSet
 	TypeChecker   types.Config
 	Dir           string // current working directory (for error reporting)
+	TinyGoRoot    string // root of the TinyGo installation or root of the source code
 	CFlags        []string
 }
 
@@ -292,6 +293,16 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		}
 		files = append(files, f)
 	}
+	clangIncludes := ""
+	if len(p.CgoFiles) != 0 {
+		if _, err := os.Stat(filepath.Join(p.TinyGoRoot, "llvm", "tools", "clang", "lib", "Headers")); !os.IsNotExist(err) {
+			// Running from the source directory.
+			clangIncludes = filepath.Join(p.TinyGoRoot, "llvm", "tools", "clang", "lib", "Headers")
+		} else {
+			// Running from the installation directory.
+			clangIncludes = filepath.Join(p.TinyGoRoot, "lib", "clang", "include")
+		}
+	}
 	for _, file := range p.CgoFiles {
 		path := filepath.Join(p.Package.Dir, file)
 		f, err := p.parseFile(path, parser.ParseComments)
@@ -299,7 +310,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 			fileErrs = append(fileErrs, err)
 			continue
 		}
-		errs := p.processCgo(path, f, append(p.CFlags, "-I"+p.Package.Dir))
+		errs := p.processCgo(path, f, append(p.CFlags, "-I"+p.Package.Dir, "-I"+clangIncludes))
 		if errs != nil {
 			fileErrs = append(fileErrs, errs...)
 			continue

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,8 @@ import (
 	"runtime"
 	"sort"
 	"testing"
+
+	"github.com/tinygo-org/tinygo/loader"
 )
 
 const TESTDATA = "testdata"
@@ -121,7 +123,13 @@ func runTest(path, tmpdir string, target string, t *testing.T) {
 	binary := filepath.Join(tmpdir, "test")
 	err = Build("./"+path, binary, target, config)
 	if err != nil {
-		t.Log("failed to build:", err)
+		if errLoader, ok := err.(loader.Errors); ok {
+			for _, err := range errLoader.Errs {
+				t.Log("failed to build:", err)
+			}
+		} else {
+			t.Log("failed to build:", err)
+		}
 		t.Fail()
 		return
 	}

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -9,7 +9,10 @@
 	"cflags": [
 		"-Oz",
 		"-mthumb",
+		"-Werror",
 		"-fshort-enums",
+		"-nostdlibinc",
+		"-Wno-macro-redefined",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -7,6 +7,8 @@
 	"linker":        "wasm-ld",
 	"cflags": [
 		"--target=wasm32",
+		"-nostdlibinc",
+		"-Wno-macro-redefined",
 		"-Oz"
 	],
 	"ldflags": [

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,8 +1,8 @@
 #include "main.h"
 
 int global = 3;
-_Bool globalBool = 1;
-_Bool globalBool2 = 10; // test narrowing
+bool globalBool = 1;
+bool globalBool2 = 10; // test narrowing
 float globalFloat = 3.1;
 double globalDouble = 3.2;
 _Complex float globalComplexFloat = 4.1+3.3i;
@@ -11,6 +11,7 @@ _Complex double globalComplexLongDouble = 4.3+3.5i;
 char globalChar = 100;
 void *globalVoidPtrSet = &global;
 void *globalVoidPtrNull;
+int64_t globalInt64 = -(2LL << 40);
 collection_t globalStruct = {256, -123456, 3.14, 88};
 int globalStructSize = sizeof(globalStruct);
 short globalArray[3] = {5, 6, 7};

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -43,6 +43,7 @@ func main() {
 	println("char match:", C.globalChar == 100)
 	var voidPtr unsafe.Pointer = C.globalVoidPtrNull
 	println("void* match:", voidPtr == nil, C.globalVoidPtrNull == nil, (*C.int)(C.globalVoidPtrSet) == &C.global)
+	println("int64_t match:", C.globalInt64 == C.int64_t(-(2<<40)))
 
 	// complex types
 	println("struct:", C.int(unsafe.Sizeof(C.globalStruct)) == C.globalStructSize, C.globalStruct.s, C.globalStruct.l, C.globalStruct.f)

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,3 +1,6 @@
+#include <stdbool.h>
+#include <stdint.h>
+
 typedef short myint;
 int add(int a, int b);
 typedef int (*binop_t) (int, int);
@@ -27,10 +30,10 @@ void unionSetShort(short s);
 void unionSetFloat(float f);
 void unionSetData(short f0, short f1, short f2);
 
-// test globals
+// test globals and datatypes
 extern int global;
-extern _Bool globalBool;
-extern _Bool globalBool2;
+extern bool globalBool;
+extern bool globalBool2;
 extern float globalFloat;
 extern double globalDouble;
 extern _Complex float globalComplexFloat;
@@ -39,6 +42,7 @@ extern _Complex double globalComplexLongDouble;
 extern char globalChar;
 extern void *globalVoidPtrSet;
 extern void *globalVoidPtrNull;
+extern int64_t globalInt64;
 extern collection_t globalStruct;
 extern int globalStructSize;
 extern short globalArray[3];

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -16,6 +16,7 @@ complex double: (+4.200000e+000+3.400000e+000i)
 complex long double: (+4.300000e+000+3.500000e+000i)
 char match: true
 void* match: true true true
+int64_t match: true
 struct: true 256 -123456 +3.140000e+000
 array: 5 6 7
 union: true


### PR DESCRIPTION
Add support for header files bundled with the compiler by copying them into the release tarball.

This turned out to be a lot simpler than expected.