### PR TITLE
macos: display SHA256 values used for homebrew packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ commands:
           command: |
             make release -j3
             cp -p build/release.tar.gz /tmp/tinygo.darwin-amd64.tar.gz
+            openssl sha256 < /tmp/tinygo.darwin-amd64.tar.gz
       - store_artifacts:
           path: /tmp/tinygo.darwin-amd64.tar.gz
       - run:

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ release: static gen-device
 	./build/tinygo build-builtins -target=armv7em-none-eabi -o build/release/tinygo/pkg/armv7em-none-eabi/compiler-rt.a
 	tar -czf build/release.tar.gz -C build/release tinygo
 
+homebrew: release
+	@echo "Use the following SHA256 for the release build:"
+	openssl sha256 < build/release.tar.gz
+
 # Binary that can run on the host.
 build/%: src/examples/% src/examples/%/*.go build/tinygo src/runtime/*.go
 	./build/tinygo build $(TGOFLAGS) -size=short -o $@ $(subst src/,,$<)


### PR DESCRIPTION
This PR helps prepare a release of TinyGo for distribution using Homebrew, in two ways:

- Display the SHA256 value that match the release package created as build artifact by CircleCI in the build log.
- create a `make homebrew` task that creates a release build, and then also displays the SHA256 value needed to create the Homebrew brew.