### PR TITLE
cgo: improve diagnostics

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -299,9 +299,9 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 			fileErrs = append(fileErrs, err)
 			continue
 		}
-		err = p.processCgo(path, f, append(p.CFlags, "-I"+p.Package.Dir))
-		if err != nil {
-			fileErrs = append(fileErrs, err)
+		errs := p.processCgo(path, f, append(p.CFlags, "-I"+p.Package.Dir))
+		if errs != nil {
+			fileErrs = append(fileErrs, errs...)
 			continue
 		}
 		files = append(files, f)


### PR DESCRIPTION
This makes CGo-emitted diagnostics very similar to regular errors emitted while parsing/typechecking a package, and thus more readable.
It's not perfect yet, but after introducing some errors in testdata/cgo, this is the resulting output:

    # ./testdata/cgo/
    testdata/cgo/main.h:18:11: error: a parameter list without types is only allowed in a function definition
    testdata/cgo/main.go:5:10: note: in file included from testdata/cgo/main.go!cgo.c:2:
    testdata/cgo/main.go:6:19: error: expected identifier or '('

Previously, this was the output:

    /home/ayke/src/github.com/tinygo-org/tinygo/testdata/cgo/main.h:18:11: error: a parameter list without types is only allowed in a function definition
    cgo-fake.c:3:19: error: expected identifier or '('
    # ./testdata/cgo/
    cgo: libclang cannot parse fragment