### PR TITLE
all: support interface asserts in interp

### DIFF
--- a/compiler/interface-lowering.go
+++ b/compiler/interface-lowering.go
@@ -4,7 +4,6 @@ package compiler
 // form, optimizing them in the process.
 //
 // During SSA construction, the following pseudo-calls are created:
-//     runtime.makeInterface(typecode, methodSet)
 //     runtime.typeAssert(typecode, assertedType)
 //     runtime.interfaceImplements(typecode, interfaceMethodSet)
 //     runtime.interfaceMethod(typecode, interfaceMethodSet, signature)
@@ -14,16 +13,13 @@ package compiler
 //
 // This pass lowers the above functions to their final form:
 //
-// makeInterface:
-//     Replaced with a constant typecode.
-//
 // typeAssert:
 //     Replaced with an icmp instruction so it can be directly used in a type
 //     switch. This is very easy to optimize for LLVM: it will often translate a
 //     type switch into a regular switch statement.
 //     When this type assert is not possible (the type is never used in an
-//     interface with makeInterface), this call is replaced with a constant
-//     false to optimize the type assert away completely.
+//     interface), this call is replaced with a constant false to optimize the
+//     type assert away completely.
 //
 // interfaceImplements:
 //     This call is translated into a call that checks whether the underlying
@@ -166,25 +162,36 @@ func (c *Compiler) LowerInterfaces() {
 
 // run runs the pass itself.
 func (p *lowerInterfacesPass) run() {
-	// Count per type how often it is put in an interface. Also, collect all
-	// methods this type has (if it is named).
-	makeInterface := p.mod.NamedFunction("runtime.makeInterface")
-	makeInterfaceUses := getUses(makeInterface)
-	for _, use := range makeInterfaceUses {
-		typecode := use.Operand(0)
-		name := typecode.Name()
-		if t, ok := p.types[name]; !ok {
-			// This is the first time this type has been seen, add it to the
-			// list of types.
-			t = p.addType(typecode)
-			p.addTypeMethods(t, use.Operand(1))
-		} else {
-			p.addTypeMethods(t, use.Operand(1))
-		}
+	// Collect all type codes.
+	typecodeIDPtr := llvm.PointerType(p.mod.GetTypeByName("runtime.typecodeID"), 0)
+	typeInInterfacePtr := llvm.PointerType(p.mod.GetTypeByName("runtime.typeInInterface"), 0)
+	var typesInInterfaces []llvm.Value
+	for global := p.mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
+		switch global.Type() {
+		case typecodeIDPtr:
+			// Retrieve Go type information based on an opaque global variable.
+			// Only the name of the global is relevant, the object itself is
+			// discarded afterwards.
+			name := global.Name()
+			t := &typeInfo{
+				name:     name,
+				typecode: global,
+			}
+			p.types[name] = t
+		case typeInInterfacePtr:
+			// Count per type how often it is put in an interface. Also, collect
+			// all methods this type has (if it is named).
+			typesInInterfaces = append(typesInInterfaces, global)
+			initializer := global.Initializer()
+			typecode := llvm.ConstExtractValue(initializer, []uint32{0})
+			methodSet := llvm.ConstExtractValue(initializer, []uint32{1})
+			t := p.types[typecode.Name()]
+			p.addTypeMethods(t, methodSet)
 
-		// Count the number of MakeInterface instructions, for sorting the
-		// typecodes later.
-		p.types[name].countMakeInterfaces++
+			// Count the number of MakeInterface instructions, for sorting the
+			// typecodes later.
+			t.countMakeInterfaces += len(getUses(global))
+		}
 	}
 
 	// Count per type how often it is type asserted on (e.g. in a switch
@@ -194,9 +201,6 @@ func (p *lowerInterfacesPass) run() {
 	for _, use := range typeAssertUses {
 		typecode := use.Operand(1)
 		name := typecode.Name()
-		if _, ok := p.types[name]; !ok {
-			p.addType(typecode)
-		}
 		p.types[name].countTypeAsserts++
 	}
 
@@ -286,16 +290,6 @@ func (p *lowerInterfacesPass) run() {
 		typecode := use.Operand(0)
 		signature := p.signatures[use.Operand(2).Name()]
 
-		// If the interface was created in the same function, we can insert a
-		// direct call. This may not happen often but it is an easy
-		// optimization so let's do it anyway.
-		if !typecode.IsACallInst().IsNil() && typecode.CalledValue() == makeInterface {
-			name := typecode.Operand(0).Name()
-			typ := p.types[name]
-			p.replaceInvokeWithCall(use, typ, signature)
-			continue
-		}
-
 		methodSet := use.Operand(1).Operand(0) // global variable
 		itf := p.interfaces[methodSet.Name()]
 		if len(itf.types) == 0 {
@@ -356,20 +350,6 @@ func (p *lowerInterfacesPass) run() {
 	// types, if possible.
 	for _, use := range interfaceImplementsUses {
 		actualType := use.Operand(0)
-		if !actualType.IsACallInst().IsNil() && actualType.CalledValue() == makeInterface {
-			// Type assert is in the same function that creates the interface
-			// value. This means the underlying type is already known so match
-			// on that.
-			// This may not happen often but it is an easy optimization.
-			name := actualType.Operand(0).Name()
-			typ := p.types[name]
-			p.builder.SetInsertPointBefore(use)
-			assertedType := p.builder.CreatePtrToInt(typ.typecode, p.uintptrType, "typeassert.typecode")
-			commaOk := p.builder.CreateICmp(llvm.IntEQ, assertedType, actualType, "typeassert.ok")
-			use.ReplaceAllUsesWith(commaOk)
-			use.EraseFromParentAsInstruction()
-			continue
-		}
 
 		methodSet := use.Operand(1).Operand(0) // global variable
 		itf := p.interfaces[methodSet.Name()]
@@ -416,12 +396,14 @@ func (p *lowerInterfacesPass) run() {
 	// Assign a type code for each type.
 	p.assignTypeCodes(typeSlice)
 
-	// Replace each call to runtime.makeInterface with the constant type code.
-	for _, use := range makeInterfaceUses {
-		global := use.Operand(0)
-		t := p.types[global.Name()]
-		use.ReplaceAllUsesWith(llvm.ConstPtrToInt(t.typecode, p.uintptrType))
-		use.EraseFromParentAsInstruction()
+	// Replace each use of a runtime.typeInInterface with the constant type
+	// code.
+	for _, global := range typesInInterfaces {
+		for _, use := range getUses(global) {
+			t := p.types[llvm.ConstExtractValue(global.Initializer(), []uint32{0}).Name()]
+			typecode := llvm.ConstInt(p.uintptrType, t.num, false)
+			use.ReplaceAllUsesWith(typecode)
+		}
 	}
 
 	// Replace each type assert with an actual type comparison or (if the type
@@ -472,19 +454,6 @@ func (p *lowerInterfacesPass) run() {
 			typ.methodSet = llvm.Value{}
 		}
 	}
-}
-
-// addType retrieves Go type information based on a i16 global variable.
-// Only the name of the i16 is relevant, the object itself is const-propagated
-// and discared afterwards.
-func (p *lowerInterfacesPass) addType(typecode llvm.Value) *typeInfo {
-	name := typecode.Name()
-	t := &typeInfo{
-		name:     name,
-		typecode: typecode,
-	}
-	p.types[name] = t
-	return t
 }
 
 // addTypeMethods reads the method set of the given type info struct. It

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -33,6 +33,8 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 		return &sideEffectResult{severity: sideEffectNone}
 	case "runtime._panic":
 		return &sideEffectResult{severity: sideEffectLimited}
+	case "runtime.interfaceImplements":
+		return &sideEffectResult{severity: sideEffectNone}
 	}
 	if e.sideEffectFuncs == nil {
 		e.sideEffectFuncs = make(map[llvm.Value]*sideEffectResult)
@@ -84,11 +86,6 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 					continue
 				}
 				if child.IsDeclaration() {
-					switch child.Name() {
-					case "runtime.makeInterface":
-						// Can be interpreted so does not have side effects.
-						continue
-					}
 					// External function call. Assume only limited side effects
 					// (no affected globals, etc.).
 					if e.hasLocalSideEffects(dirtyLocals, inst) {

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -43,15 +43,22 @@ type interfaceMethodInfo struct {
 	funcptr   uintptr // bitcast from the actual function pointer
 }
 
-// Pseudo function call used while putting a concrete value in an interface,
-// that must be lowered to a constant uintptr.
-func makeInterface(typecode *uint8, methodSet *interfaceMethodInfo) uintptr
+type typecodeID struct{}
+
+// Pseudo type used before interface lowering. By using a struct instead of a
+// function call, this is simpler to reason about during init interpretation
+// than a function call. Also, by keeping the method set around it is easier to
+// implement interfaceImplements in the interp package.
+type typeInInterface struct {
+	typecode  *typecodeID
+	methodSet *interfaceMethodInfo // nil or a GEP of an array
+}
 
 // Pseudo function call used during a type assert. It is used during interface
 // lowering, to assign the lowest type numbers to the types with the most type
 // asserts. Also, it is replaced with const false if this type assert can never
 // happen.
-func typeAssert(actualType uintptr, assertedType *uint8) bool
+func typeAssert(actualType uintptr, assertedType *typecodeID) bool
 
 // Pseudo function call that returns whether a given type implements all methods
 // of the given interface.

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 )
 
@@ -9,4 +10,6 @@ func main() {
 	fmt.Println("stdin: ", os.Stdin.Fd())
 	fmt.Println("stdout:", os.Stdout.Fd())
 	fmt.Println("stderr:", os.Stderr.Fd())
+
+	fmt.Println("pseudorandom number:", rand.Int31())
 }

--- a/testdata/stdlib.txt
+++ b/testdata/stdlib.txt
@@ -1,3 +1,4 @@
 stdin:  0
 stdout: 1
 stderr: 2
+pseudorandom number: 1298498081


### PR DESCRIPTION
This adds support for the math/rand package.

There are small differences in code size when testing on a micro:bit: testdata/interface.go got slightly smaller and testdata/reflect.go got slightly bigger. testdata/stdlib.go also got slightly bigger but that's because it tests more: when removing the extra code the size is the same.