### PR TITLE
compiler: fix interface lowering pass

### DIFF
--- a/compiler/interface-lowering.go
+++ b/compiler/interface-lowering.go
@@ -440,10 +440,16 @@ func (p *lowerInterfacesPass) run() {
 	// numbers.
 	for _, typ := range p.types {
 		for _, use := range getUses(typ.typecode) {
-			if use.IsConstant() && use.Opcode() == llvm.PtrToInt {
+			if !use.IsAConstantExpr().IsNil() && use.Opcode() == llvm.PtrToInt {
 				use.ReplaceAllUsesWith(llvm.ConstInt(p.uintptrType, typ.num, false))
 			}
 		}
+	}
+
+	// Remove stray runtime.typeInInterface globals. Required for the following
+	// cleanup.
+	for _, global := range typesInInterfaces {
+		global.EraseFromParentAsGlobal()
 	}
 
 	// Remove method sets of types. Unnecessary, but cleans up the IR for


### PR DESCRIPTION
It was removing some globals that still had uses left.

This bug was introduced by #277 but I didn't notice it because an optimization pass would hide it.