### PR TITLE
Refactor function pointers

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -9,7 +9,6 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1342,120 +1341,15 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 
 	// Try to call the function directly for trivially static calls.
 	if fn := instr.StaticCallee(); fn != nil {
-		if fn.RelString(nil) == "device/arm.Asm" || fn.RelString(nil) == "device/avr.Asm" {
-			// Magic function: insert inline assembly instead of calling it.
-			fnType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{}, false)
-			asm := constant.StringVal(instr.Args[0].(*ssa.Const).Value)
-			target := llvm.InlineAsm(fnType, asm, "", true, false, 0)
-			return c.builder.CreateCall(target, nil, ""), nil
-		}
-
-		if fn.RelString(nil) == "device/arm.ReadRegister" {
-			// Magic function: return the given register.
-			fnType := llvm.FunctionType(c.uintptrType, []llvm.Type{}, false)
-			regname := constant.StringVal(instr.Args[0].(*ssa.Const).Value)
-			target := llvm.InlineAsm(fnType, "mov $0, "+regname, "=r", false, false, 0)
-			return c.builder.CreateCall(target, nil, ""), nil
-		}
-
-		if strings.HasPrefix(fn.RelString(nil), "device/arm.SVCall") {
-			// Magic function: inline this call as a SVC instruction.
-			num, _ := constant.Uint64Val(instr.Args[0].(*ssa.Const).Value)
-			args := []llvm.Value{}
-			argTypes := []llvm.Type{}
-			asm := "svc #" + strconv.FormatUint(num, 10)
-			constraints := "={r0}"
-			for i, arg := range instr.Args[1:] {
-				arg = arg.(*ssa.MakeInterface).X
-				if i == 0 {
-					constraints += ",0"
-				} else {
-					constraints += ",{r" + strconv.Itoa(i) + "}"
-				}
-				llvmValue, err := c.parseExpr(frame, arg)
-				if err != nil {
-					return llvm.Value{}, err
-				}
-				args = append(args, llvmValue)
-				argTypes = append(argTypes, llvmValue.Type())
-			}
-			// Implement the ARM calling convention by marking r1-r3 as
-			// clobbered. r0 is used as an output register so doesn't have to be
-			// marked as clobbered.
-			constraints += ",~{r1},~{r2},~{r3}"
-			fnType := llvm.FunctionType(c.uintptrType, argTypes, false)
-			target := llvm.InlineAsm(fnType, asm, constraints, true, false, 0)
-			return c.builder.CreateCall(target, args, ""), nil
-		}
-
-		if fn.RelString(nil) == "device/arm.AsmFull" || fn.RelString(nil) == "device/avr.AsmFull" {
-			asmString := constant.StringVal(instr.Args[0].(*ssa.Const).Value)
-			registers := map[string]llvm.Value{}
-			registerMap := instr.Args[1].(*ssa.MakeMap)
-			for _, r := range *registerMap.Referrers() {
-				switch r := r.(type) {
-				case *ssa.DebugRef:
-					// ignore
-				case *ssa.MapUpdate:
-					if r.Block() != registerMap.Block() {
-						return llvm.Value{}, c.makeError(instr.Pos(), "register value map must be created in the same basic block")
-					}
-					key := constant.StringVal(r.Key.(*ssa.Const).Value)
-					//println("value:", r.Value.(*ssa.MakeInterface).X.String())
-					value, err := c.parseExpr(frame, r.Value.(*ssa.MakeInterface).X)
-					if err != nil {
-						return llvm.Value{}, err
-					}
-					registers[key] = value
-				case *ssa.Call:
-					if r.Common() == instr {
-						break
-					}
-				default:
-					return llvm.Value{}, c.makeError(instr.Pos(), "don't know how to handle argument to inline assembly: "+r.String())
-				}
-			}
-			// TODO: handle dollar signs in asm string
-			registerNumbers := map[string]int{}
-			var err error
-			argTypes := []llvm.Type{}
-			args := []llvm.Value{}
-			constraints := []string{}
-			asmString = regexp.MustCompile("\\{[a-zA-Z]+\\}").ReplaceAllStringFunc(asmString, func(s string) string {
-				// TODO: skip strings like {r4} etc. that look like ARM push/pop
-				// instructions.
-				name := s[1 : len(s)-1]
-				if _, ok := registers[name]; !ok {
-					if err == nil {
-						err = c.makeError(instr.Pos(), "unknown register name: "+name)
-					}
-					return s
-				}
-				if _, ok := registerNumbers[name]; !ok {
-					registerNumbers[name] = len(registerNumbers)
-					argTypes = append(argTypes, registers[name].Type())
-					args = append(args, registers[name])
-					switch registers[name].Type().TypeKind() {
-					case llvm.IntegerTypeKind:
-						constraints = append(constraints, "r")
-					case llvm.PointerTypeKind:
-						constraints = append(constraints, "*m")
-					default:
-						err = c.makeError(instr.Pos(), "unknown type in inline assembly for value: "+name)
-						return s
-					}
-				}
-				return fmt.Sprintf("${%v}", registerNumbers[name])
-			})
-			if err != nil {
-				return llvm.Value{}, err
-			}
-			fnType := llvm.FunctionType(c.ctx.VoidType(), argTypes, false)
-			target := llvm.InlineAsm(fnType, asmString, strings.Join(constraints, ","), true, false, 0)
-			return c.builder.CreateCall(target, args, ""), nil
-		}
-
 		switch fn.RelString(nil) {
+		case "device/arm.ReadRegister":
+			return c.emitReadRegister(instr.Args)
+		case "device/arm.Asm", "device/avr.Asm":
+			return c.emitAsm(instr.Args)
+		case "device/arm.AsmFull", "device/avr.AsmFull":
+			return c.emitAsmFull(frame, instr)
+		case "device/arm.SVCall0", "device/arm.SVCall1", "device/arm.SVCall2", "device/arm.SVCall3", "device/arm.SVCall4":
+			return c.emitSVCall(frame, instr.Args)
 		case "syscall.Syscall", "syscall.Syscall6", "syscall.Syscall9":
 			return c.emitSyscall(frame, instr)
 		}

--- a/compiler/func-lowering.go
+++ b/compiler/func-lowering.go
@@ -1,0 +1,269 @@
+package compiler
+
+// This file lowers func values into their final form. This is necessary for
+// funcValueSwitch, which needs full program analysis.
+
+import (
+	"sort"
+	"strconv"
+
+	"tinygo.org/x/go-llvm"
+)
+
+// funcSignatureInfo keeps information about a single signature and its uses.
+type funcSignatureInfo struct {
+	sig                     llvm.Value   // *uint8 to identify the signature
+	funcValueWithSignatures []llvm.Value // slice of runtime.funcValueWithSignature
+}
+
+// funcWithUses keeps information about a single function used as func value and
+// the assigned function ID. More commonly used functions are assigned a lower
+// ID.
+type funcWithUses struct {
+	funcPtr  llvm.Value
+	useCount int // how often this function is used in a func value
+	id       int // assigned ID
+}
+
+// Slice to sort functions by their use counts, or else their name if they're
+// used equally often.
+type funcWithUsesList []*funcWithUses
+
+func (l funcWithUsesList) Len() int { return len(l) }
+func (l funcWithUsesList) Less(i, j int) bool {
+	if l[i].useCount != l[j].useCount {
+		// return the reverse: we want the highest use counts sorted first
+		return l[i].useCount > l[j].useCount
+	}
+	iName := l[i].funcPtr.Name()
+	jName := l[j].funcPtr.Name()
+	return iName < jName
+}
+func (l funcWithUsesList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+// LowerFuncValue lowers the runtime.funcValueWithSignature type and
+// runtime.getFuncPtr function to their final form.
+func (c *Compiler) LowerFuncValues() {
+	if c.funcImplementation() != funcValueSwitch {
+		return
+	}
+
+	// Find all func values used in the program with their signatures.
+	funcValueWithSignaturePtr := llvm.PointerType(c.mod.GetTypeByName("runtime.funcValueWithSignature"), 0)
+	signatures := map[string]*funcSignatureInfo{}
+	for global := c.mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
+		if global.Type() != funcValueWithSignaturePtr {
+			continue
+		}
+		sig := llvm.ConstExtractValue(global.Initializer(), []uint32{1})
+		name := sig.Name()
+		if info, ok := signatures[name]; ok {
+			info.funcValueWithSignatures = append(info.funcValueWithSignatures, global)
+		} else {
+			signatures[name] = &funcSignatureInfo{
+				sig:                     sig,
+				funcValueWithSignatures: []llvm.Value{global},
+			}
+		}
+	}
+
+	// Sort the signatures, for deterministic execution.
+	names := make([]string, 0, len(signatures))
+	for name := range signatures {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		info := signatures[name]
+		functions := make(funcWithUsesList, len(info.funcValueWithSignatures))
+		for i, use := range info.funcValueWithSignatures {
+			var useCount int
+			for _, use2 := range getUses(use) {
+				useCount += len(getUses(use2))
+			}
+			functions[i] = &funcWithUses{
+				funcPtr:  llvm.ConstExtractValue(use.Initializer(), []uint32{0}).Operand(0),
+				useCount: useCount,
+			}
+		}
+		sort.Sort(functions)
+
+		for i, fn := range functions {
+			fn.id = i + 1
+			for _, ptrtoint := range getUses(fn.funcPtr) {
+				if ptrtoint.IsAConstantExpr().IsNil() || ptrtoint.Opcode() != llvm.PtrToInt {
+					continue
+				}
+				for _, funcValueWithSignatureConstant := range getUses(ptrtoint) {
+					for _, funcValueWithSignatureGlobal := range getUses(funcValueWithSignatureConstant) {
+						for _, use := range getUses(funcValueWithSignatureGlobal) {
+							if ptrtoint.IsAConstantExpr().IsNil() || ptrtoint.Opcode() != llvm.PtrToInt {
+								panic("expected const ptrtoint")
+							}
+							use.ReplaceAllUsesWith(llvm.ConstInt(c.uintptrType, uint64(fn.id), false))
+						}
+					}
+				}
+			}
+		}
+
+		for _, getFuncPtrCall := range getUses(info.sig) {
+			if getFuncPtrCall.IsACallInst().IsNil() {
+				continue
+			}
+			if getFuncPtrCall.CalledValue().Name() != "runtime.getFuncPtr" {
+				panic("expected all call uses to be runtime.getFuncPtr")
+			}
+			funcID := getFuncPtrCall.Operand(1)
+			switch len(functions) {
+			case 0:
+				// There are no functions used in a func value that implement
+				// this signature. The only possible value is a nil value.
+				for _, inttoptr := range getUses(getFuncPtrCall) {
+					if inttoptr.IsAIntToPtrInst().IsNil() {
+						panic("expected inttoptr")
+					}
+					nilptr := llvm.ConstPointerNull(inttoptr.Type())
+					inttoptr.ReplaceAllUsesWith(nilptr)
+					inttoptr.EraseFromParentAsInstruction()
+				}
+				getFuncPtrCall.EraseFromParentAsInstruction()
+			case 1:
+				// There is exactly one function with this signature that is
+				// used in a func value. The func value itself can be either nil
+				// or this one function.
+				c.builder.SetInsertPointBefore(getFuncPtrCall)
+				zero := llvm.ConstInt(c.uintptrType, 0, false)
+				isnil := c.builder.CreateICmp(llvm.IntEQ, funcID, zero, "")
+				funcPtrNil := llvm.ConstPointerNull(functions[0].funcPtr.Type())
+				funcPtr := c.builder.CreateSelect(isnil, funcPtrNil, functions[0].funcPtr, "")
+				for _, inttoptr := range getUses(getFuncPtrCall) {
+					if inttoptr.IsAIntToPtrInst().IsNil() {
+						panic("expected inttoptr")
+					}
+					inttoptr.ReplaceAllUsesWith(funcPtr)
+					inttoptr.EraseFromParentAsInstruction()
+				}
+				getFuncPtrCall.EraseFromParentAsInstruction()
+			default:
+				// There are multiple functions used in a func value that
+				// implement this signature.
+				// What we'll do is transform the following:
+				//     rawPtr := runtime.getFuncPtr(fn)
+				//     if func.rawPtr == nil {
+				//         runtime.nilpanic()
+				//     }
+				//     result := func.rawPtr(...args, func.context)
+				// into this:
+				//     if false {
+				//         runtime.nilpanic()
+				//     }
+				//     var result // Phi
+				//     switch fn.id {
+				//     case 0:
+				//         runtime.nilpanic()
+				//     case 1:
+				//         result = call first implementation...
+				//     case 2:
+				//         result = call second implementation...
+				//     default:
+				//         unreachable
+				//     }
+
+				// Remove some casts, checks, and the old call which we're going
+				// to replace.
+				var funcCall llvm.Value
+				for _, inttoptr := range getUses(getFuncPtrCall) {
+					if inttoptr.IsAIntToPtrInst().IsNil() {
+						panic("expected inttoptr")
+					}
+					for _, ptrUse := range getUses(inttoptr) {
+						if !ptrUse.IsABitCastInst().IsNil() {
+							for _, bitcastUse := range getUses(ptrUse) {
+								if bitcastUse.IsACallInst().IsNil() || bitcastUse.CalledValue().Name() != "runtime.isnil" {
+									panic("expected a call to runtime.isnil")
+								}
+								bitcastUse.ReplaceAllUsesWith(llvm.ConstInt(c.ctx.Int1Type(), 0, false))
+								bitcastUse.EraseFromParentAsInstruction()
+							}
+							ptrUse.EraseFromParentAsInstruction()
+						} else if !ptrUse.IsACallInst().IsNil() && ptrUse.CalledValue() == inttoptr {
+							if !funcCall.IsNil() {
+								panic("multiple calls on a single runtime.getFuncPtr")
+							}
+							funcCall = ptrUse
+						} else {
+							panic("unexpected getFuncPtrCall")
+						}
+					}
+				}
+				if funcCall.IsNil() {
+					panic("expected exactly one call use of a runtime.getFuncPtr")
+				}
+
+				// The block that cannot be reached with correct funcValues (to
+				// help the optimizer).
+				c.builder.SetInsertPointBefore(funcCall)
+				defaultBlock := llvm.AddBasicBlock(funcCall.InstructionParent().Parent(), "func.default")
+				c.builder.SetInsertPointAtEnd(defaultBlock)
+				c.builder.CreateUnreachable()
+
+				// Create the switch.
+				c.builder.SetInsertPointBefore(funcCall)
+				sw := c.builder.CreateSwitch(funcID, defaultBlock, len(functions)+1)
+
+				// Split right after the switch. We will need to insert a few
+				// basic blocks in this gap.
+				nextBlock := c.splitBasicBlock(sw, llvm.NextBasicBlock(sw.InstructionParent()), "func.next")
+
+				// The 0 case, which is actually a nil check.
+				nilBlock := llvm.InsertBasicBlock(nextBlock, "func.nil")
+				c.builder.SetInsertPointAtEnd(nilBlock)
+				c.createRuntimeCall("nilpanic", nil, "")
+				c.builder.CreateUnreachable()
+				sw.AddCase(llvm.ConstInt(c.uintptrType, 0, false), nilBlock)
+
+				// Gather the list of parameters for every call we're going to
+				// make.
+				callParams := make([]llvm.Value, funcCall.OperandsCount()-1)
+				for i := range callParams {
+					callParams[i] = funcCall.Operand(i)
+				}
+
+				// If the call produces a value, we need to get it using a PHI
+				// node.
+				phiBlocks := make([]llvm.BasicBlock, len(functions))
+				phiValues := make([]llvm.Value, len(functions))
+				for i, fn := range functions {
+					// Insert a switch case.
+					bb := llvm.InsertBasicBlock(nextBlock, "func.call"+strconv.Itoa(fn.id))
+					c.builder.SetInsertPointAtEnd(bb)
+					result := c.builder.CreateCall(fn.funcPtr, callParams, "")
+					c.builder.CreateBr(nextBlock)
+					sw.AddCase(llvm.ConstInt(c.uintptrType, uint64(fn.id), false), bb)
+					phiBlocks[i] = bb
+					phiValues[i] = result
+				}
+				// Create the PHI node so that the call result flows into the
+				// next block (after the split). This is only necessary when the
+				// call produced a value.
+				if funcCall.Type().TypeKind() != llvm.VoidTypeKind {
+					c.builder.SetInsertPointBefore(nextBlock.FirstInstruction())
+					phi := c.builder.CreatePHI(funcCall.Type(), "")
+					phi.AddIncoming(phiValues, phiBlocks)
+					funcCall.ReplaceAllUsesWith(phi)
+				}
+
+				// Finally, remove the old instructions.
+				funcCall.EraseFromParentAsInstruction()
+				for _, inttoptr := range getUses(getFuncPtrCall) {
+					inttoptr.EraseFromParentAsInstruction()
+				}
+				getFuncPtrCall.EraseFromParentAsInstruction()
+			}
+		}
+	}
+}

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -1,0 +1,189 @@
+package compiler
+
+// This file implements function values and closures. A func value is
+// implemented as a pair of pointers: {context, function pointer}, where the
+// context may be a pointer to a heap-allocated struct containing the free
+// variables, or it may be undef if the function being pointed to doesn't need a
+// context.
+
+import (
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+	"tinygo.org/x/go-llvm"
+)
+
+// createFuncValue creates a function value from a raw function pointer with no
+// context.
+func (c *Compiler) createFuncValue(funcPtr llvm.Value) (llvm.Value, error) {
+	// Closure is: {context, function pointer}
+	return c.ctx.ConstStruct([]llvm.Value{
+		llvm.Undef(c.i8ptrType),
+		funcPtr,
+	}, false), nil
+}
+
+// extractFuncScalar returns some scalar that can be used in comparisons. It is
+// a cheap operation.
+func (c *Compiler) extractFuncScalar(funcValue llvm.Value) llvm.Value {
+	return c.builder.CreateExtractValue(funcValue, 1, "")
+}
+
+// extractFuncContext extracts the context pointer from this function value. It
+// is a cheap operation.
+func (c *Compiler) extractFuncContext(funcValue llvm.Value) llvm.Value {
+	return c.builder.CreateExtractValue(funcValue, 0, "")
+}
+
+// decodeFuncValue extracts the context and the function pointer from this func
+// value. This may be an expensive operation.
+func (c *Compiler) decodeFuncValue(funcValue llvm.Value) (funcPtr, context llvm.Value) {
+	context = c.builder.CreateExtractValue(funcValue, 0, "")
+	funcPtr = c.builder.CreateExtractValue(funcValue, 1, "")
+	return
+}
+
+// getFuncType returns the type of a func value given a signature.
+func (c *Compiler) getFuncType(typ *types.Signature) (llvm.Type, error) {
+	rawPtr, err := c.getRawFuncType(typ)
+	if err != nil {
+		return llvm.Type{}, err
+	}
+	return c.ctx.StructType([]llvm.Type{c.i8ptrType, rawPtr}, false), nil
+}
+
+// getRawFuncType returns a LLVM function pointer type for a given signature.
+func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
+	// Get the return type.
+	var err error
+	var returnType llvm.Type
+	switch typ.Results().Len() {
+	case 0:
+		// No return values.
+		returnType = c.ctx.VoidType()
+	case 1:
+		// Just one return value.
+		returnType, err = c.getLLVMType(typ.Results().At(0).Type())
+		if err != nil {
+			return llvm.Type{}, err
+		}
+	default:
+		// Multiple return values. Put them together in a struct.
+		// This appears to be the common way to handle multiple return values in
+		// LLVM.
+		members := make([]llvm.Type, typ.Results().Len())
+		for i := 0; i < typ.Results().Len(); i++ {
+			returnType, err := c.getLLVMType(typ.Results().At(i).Type())
+			if err != nil {
+				return llvm.Type{}, err
+			}
+			members[i] = returnType
+		}
+		returnType = c.ctx.StructType(members, false)
+	}
+
+	// Get the parameter types.
+	var paramTypes []llvm.Type
+	if typ.Recv() != nil {
+		recv, err := c.getLLVMType(typ.Recv().Type())
+		if err != nil {
+			return llvm.Type{}, err
+		}
+		if recv.StructName() == "runtime._interface" {
+			// This is a call on an interface, not a concrete type.
+			// The receiver is not an interface, but a i8* type.
+			recv = c.i8ptrType
+		}
+		paramTypes = append(paramTypes, c.expandFormalParamType(recv)...)
+	}
+	for i := 0; i < typ.Params().Len(); i++ {
+		subType, err := c.getLLVMType(typ.Params().At(i).Type())
+		if err != nil {
+			return llvm.Type{}, err
+		}
+		paramTypes = append(paramTypes, c.expandFormalParamType(subType)...)
+	}
+	// All functions take these parameters at the end.
+	paramTypes = append(paramTypes, c.i8ptrType) // context
+	paramTypes = append(paramTypes, c.i8ptrType) // parent coroutine
+
+	// Make a func type out of the signature.
+	return llvm.PointerType(llvm.FunctionType(returnType, paramTypes, false), c.funcPtrAddrSpace), nil
+}
+
+// parseMakeClosure makes a function value (with context) from the given
+// closure expression.
+func (c *Compiler) parseMakeClosure(frame *Frame, expr *ssa.MakeClosure) (llvm.Value, error) {
+	if len(expr.Bindings) == 0 {
+		panic("unexpected: MakeClosure without bound variables")
+	}
+	f := c.ir.GetFunction(expr.Fn.(*ssa.Function))
+
+	// Collect all bound variables.
+	boundVars := make([]llvm.Value, 0, len(expr.Bindings))
+	boundVarTypes := make([]llvm.Type, 0, len(expr.Bindings))
+	for _, binding := range expr.Bindings {
+		// The context stores the bound variables.
+		llvmBoundVar, err := c.parseExpr(frame, binding)
+		if err != nil {
+			return llvm.Value{}, err
+		}
+		boundVars = append(boundVars, llvmBoundVar)
+		boundVarTypes = append(boundVarTypes, llvmBoundVar.Type())
+	}
+	contextType := c.ctx.StructType(boundVarTypes, false)
+
+	// Allocate memory for the context.
+	contextAlloc := llvm.Value{}
+	contextHeapAlloc := llvm.Value{}
+	if c.targetData.TypeAllocSize(contextType) <= c.targetData.TypeAllocSize(c.i8ptrType) {
+		// Context fits in a pointer - e.g. when it is a pointer. Store it
+		// directly in the stack after a convert.
+		// Because contextType is a struct and we have to cast it to a *i8,
+		// store it in an alloca first for bitcasting (store+bitcast+load).
+		contextAlloc = c.builder.CreateAlloca(contextType, "")
+	} else {
+		// Context is bigger than a pointer, so allocate it on the heap.
+		size := c.targetData.TypeAllocSize(contextType)
+		sizeValue := llvm.ConstInt(c.uintptrType, size, false)
+		contextHeapAlloc = c.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "")
+		contextAlloc = c.builder.CreateBitCast(contextHeapAlloc, llvm.PointerType(contextType, 0), "")
+	}
+
+	// Store all bound variables in the alloca or heap pointer.
+	for i, boundVar := range boundVars {
+		indices := []llvm.Value{
+			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+			llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false),
+		}
+		gep := c.builder.CreateInBoundsGEP(contextAlloc, indices, "")
+		c.builder.CreateStore(boundVar, gep)
+	}
+
+	context := llvm.Value{}
+	if c.targetData.TypeAllocSize(contextType) <= c.targetData.TypeAllocSize(c.i8ptrType) {
+		// Load value (as *i8) from the alloca.
+		contextAlloc = c.builder.CreateBitCast(contextAlloc, llvm.PointerType(c.i8ptrType, 0), "")
+		context = c.builder.CreateLoad(contextAlloc, "")
+	} else {
+		// Get the original heap allocation pointer, which already is an
+		// *i8.
+		context = contextHeapAlloc
+	}
+
+	// Get the function signature type, which is a closure type.
+	// A closure is a tuple of {context, function pointer}.
+	typ, err := c.getFuncType(f.Signature)
+	if err != nil {
+		return llvm.Value{}, err
+	}
+
+	// Create the closure, which is a struct: {context, function pointer}.
+	closure, err := c.getZeroValue(typ)
+	if err != nil {
+		return llvm.Value{}, err
+	}
+	closure = c.builder.CreateInsertValue(closure, f.LLVMFn, 1, "")
+	closure = c.builder.CreateInsertValue(closure, context, 0, "")
+	return closure, nil
+}

--- a/compiler/inlineasm.go
+++ b/compiler/inlineasm.go
@@ -1,0 +1,162 @@
+package compiler
+
+// This file implements inline asm support by calling special functions.
+
+import (
+	"fmt"
+	"go/constant"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/ssa"
+	"tinygo.org/x/go-llvm"
+)
+
+// This is a compiler builtin, which reads the given register by name:
+//
+//     func ReadRegister(name string) uintptr
+//
+// The register name must be a constant, for example "sp".
+func (c *Compiler) emitReadRegister(args []ssa.Value) (llvm.Value, error) {
+	fnType := llvm.FunctionType(c.uintptrType, []llvm.Type{}, false)
+	regname := constant.StringVal(args[0].(*ssa.Const).Value)
+	target := llvm.InlineAsm(fnType, "mov $0, "+regname, "=r", false, false, 0)
+	return c.builder.CreateCall(target, nil, ""), nil
+}
+
+// This is a compiler builtin, which emits a piece of inline assembly with no
+// operands or return values. It is useful for trivial instructions, like wfi in
+// ARM or sleep in AVR.
+//
+//     func Asm(asm string)
+//
+// The provided assembly must be a constant.
+func (c *Compiler) emitAsm(args []ssa.Value) (llvm.Value, error) {
+	// Magic function: insert inline assembly instead of calling it.
+	fnType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{}, false)
+	asm := constant.StringVal(args[0].(*ssa.Const).Value)
+	target := llvm.InlineAsm(fnType, asm, "", true, false, 0)
+	return c.builder.CreateCall(target, nil, ""), nil
+}
+
+// This is a compiler builtin, which allows assembly to be called in a flexible
+// way.
+//
+//     func AsmFull(asm string, regs map[string]interface{})
+//
+// The asm parameter must be a constant string. The regs parameter must be
+// provided immediately. For example:
+//
+//     arm.AsmFull(
+//         "str {value}, {result}",
+//         map[string]interface{}{
+//             "value":  1
+//             "result": &dest,
+//         })
+func (c *Compiler) emitAsmFull(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
+	asmString := constant.StringVal(instr.Args[0].(*ssa.Const).Value)
+	registers := map[string]llvm.Value{}
+	registerMap := instr.Args[1].(*ssa.MakeMap)
+	for _, r := range *registerMap.Referrers() {
+		switch r := r.(type) {
+		case *ssa.DebugRef:
+			// ignore
+		case *ssa.MapUpdate:
+			if r.Block() != registerMap.Block() {
+				return llvm.Value{}, c.makeError(instr.Pos(), "register value map must be created in the same basic block")
+			}
+			key := constant.StringVal(r.Key.(*ssa.Const).Value)
+			//println("value:", r.Value.(*ssa.MakeInterface).X.String())
+			value, err := c.parseExpr(frame, r.Value.(*ssa.MakeInterface).X)
+			if err != nil {
+				return llvm.Value{}, err
+			}
+			registers[key] = value
+		case *ssa.Call:
+			if r.Common() == instr {
+				break
+			}
+		default:
+			return llvm.Value{}, c.makeError(instr.Pos(), "don't know how to handle argument to inline assembly: "+r.String())
+		}
+	}
+	// TODO: handle dollar signs in asm string
+	registerNumbers := map[string]int{}
+	var err error
+	argTypes := []llvm.Type{}
+	args := []llvm.Value{}
+	constraints := []string{}
+	asmString = regexp.MustCompile("\\{[a-zA-Z]+\\}").ReplaceAllStringFunc(asmString, func(s string) string {
+		// TODO: skip strings like {r4} etc. that look like ARM push/pop
+		// instructions.
+		name := s[1 : len(s)-1]
+		if _, ok := registers[name]; !ok {
+			if err == nil {
+				err = c.makeError(instr.Pos(), "unknown register name: "+name)
+			}
+			return s
+		}
+		if _, ok := registerNumbers[name]; !ok {
+			registerNumbers[name] = len(registerNumbers)
+			argTypes = append(argTypes, registers[name].Type())
+			args = append(args, registers[name])
+			switch registers[name].Type().TypeKind() {
+			case llvm.IntegerTypeKind:
+				constraints = append(constraints, "r")
+			case llvm.PointerTypeKind:
+				constraints = append(constraints, "*m")
+			default:
+				err = c.makeError(instr.Pos(), "unknown type in inline assembly for value: "+name)
+				return s
+			}
+		}
+		return fmt.Sprintf("${%v}", registerNumbers[name])
+	})
+	if err != nil {
+		return llvm.Value{}, err
+	}
+	fnType := llvm.FunctionType(c.ctx.VoidType(), argTypes, false)
+	target := llvm.InlineAsm(fnType, asmString, strings.Join(constraints, ","), true, false, 0)
+	return c.builder.CreateCall(target, args, ""), nil
+}
+
+// This is a compiler builtin which emits an inline SVCall instruction. It can
+// be one of:
+//
+//     func SVCall0(num uintptr) uintptr
+//     func SVCall1(num uintptr, a1 interface{}) uintptr
+//     func SVCall2(num uintptr, a1, a2 interface{}) uintptr
+//     func SVCall3(num uintptr, a1, a2, a3 interface{}) uintptr
+//     func SVCall4(num uintptr, a1, a2, a3, a4 interface{}) uintptr
+//
+// The num parameter must be a constant. All other parameters may be any scalar
+// value supported by LLVM inline assembly.
+func (c *Compiler) emitSVCall(frame *Frame, args []ssa.Value) (llvm.Value, error) {
+	num, _ := constant.Uint64Val(args[0].(*ssa.Const).Value)
+	llvmArgs := []llvm.Value{}
+	argTypes := []llvm.Type{}
+	asm := "svc #" + strconv.FormatUint(num, 10)
+	constraints := "={r0}"
+	for i, arg := range args[1:] {
+		arg = arg.(*ssa.MakeInterface).X
+		if i == 0 {
+			constraints += ",0"
+		} else {
+			constraints += ",{r" + strconv.Itoa(i) + "}"
+		}
+		llvmValue, err := c.parseExpr(frame, arg)
+		if err != nil {
+			return llvm.Value{}, err
+		}
+		llvmArgs = append(llvmArgs, llvmValue)
+		argTypes = append(argTypes, llvmValue.Type())
+	}
+	// Implement the ARM calling convention by marking r1-r3 as
+	// clobbered. r0 is used as an output register so doesn't have to be
+	// marked as clobbered.
+	constraints += ",~{r1},~{r2},~{r3}"
+	fnType := llvm.FunctionType(c.uintptrType, argTypes, false)
+	target := llvm.InlineAsm(fnType, asm, constraints, true, false, 0)
+	return c.builder.CreateCall(target, llvmArgs, ""), nil
+}

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -396,14 +396,10 @@ func (c *Compiler) getInvokeCall(frame *Frame, instr *ssa.CallCommon) (llvm.Valu
 		return llvm.Value{}, nil, err
 	}
 
-	llvmFnType, err := c.getLLVMType(instr.Method.Type())
+	llvmFnType, err := c.getRawFuncType(instr.Method.Type().(*types.Signature))
 	if err != nil {
 		return llvm.Value{}, nil, err
 	}
-	// getLLVMType() has created a closure type for us, but we don't actually
-	// want a closure type as an interface call can never be a closure call. So
-	// extract the function pointer type from the closure.
-	llvmFnType = llvmFnType.Subtypes()[1]
 
 	typecode := c.builder.CreateExtractValue(itf, 0, "invoke.typecode")
 	values := []llvm.Value{

--- a/compiler/optimizer.go
+++ b/compiler/optimizer.go
@@ -43,6 +43,7 @@ func (c *Compiler) Optimize(optLevel, sizeLevel int, inlinerThreshold uint) erro
 		c.OptimizeStringToBytes()
 		c.OptimizeAllocs()
 		c.LowerInterfaces()
+		c.LowerFuncValues()
 
 		// After interfaces are lowered, there are many more opportunities for
 		// interprocedural optimizations. To get them to work, function
@@ -76,6 +77,7 @@ func (c *Compiler) Optimize(optLevel, sizeLevel int, inlinerThreshold uint) erro
 	} else {
 		// Must be run at any optimization level.
 		c.LowerInterfaces()
+		c.LowerFuncValues()
 		err := c.LowerGoroutines()
 		if err != nil {
 			return err

--- a/src/runtime/func.go
+++ b/src/runtime/func.go
@@ -1,0 +1,28 @@
+package runtime
+
+// This file implements some data types that may be useful for some
+// implementations of func values.
+
+import (
+	"unsafe"
+)
+
+// funcValue is the underlying type of func values, depending on which func
+// value representation was used.
+type funcValue struct {
+	context unsafe.Pointer // function context, for closures and bound methods
+	id      uintptr        // ptrtoint of *funcValueWithSignature before lowering, opaque index (non-0) after lowering
+}
+
+// funcValueWithSignature is used before the func lowering pass.
+type funcValueWithSignature struct {
+	funcPtr   uintptr // ptrtoint of the actual function pointer
+	signature *uint8  // pointer to identify this signature (the value is undef)
+}
+
+// getFuncPtr is a dummy function that may be used if the func lowering pass is
+// not used. It is generally too slow but may be a useful fallback to debug the
+// func lowering pass.
+func getFuncPtr(val funcValue, signature *uint8) uintptr {
+	return (*funcValueWithSignature)(unsafe.Pointer(val.id)).funcPtr
+}


### PR DESCRIPTION
This PR refactors func value handling, making multiple implementations possible. It also eliminates all function pointers from the WebAssembly output, replacing them with numeric indices per function signature and a switch on them. This is very useful for goroutines lowered using LLVM coroutines, which don't support function pointers (yet).