### PR TITLE
Makefile: check whether LLVM was build before making a static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ build/tinygo:
 	go build -o build/tinygo .
 
 static:
+	@if [ ! -f llvm-build/bin/llvm-config ]; then echo "Fetch and build LLVM first by running:\n  make llvm-source\n  make llvm-build"; exit 1; fi
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go build -o build/tinygo -tags byollvm .
 
 static-test:


### PR DESCRIPTION
This is just a small hint to users that may not know where the error is coming from.