### PR TITLE
Makefile: build static binaries only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
             - go-cache-{{ checksum "Gopkg.lock" }}
       - dep
       - run: go install .
-      - run: make test
+      - run: go test -v
       - run: make gen-device -j4
       - smoketest
       - save_cache:
@@ -162,7 +162,7 @@ commands:
       - dep
       - run:
           name: "Test TinyGo"
-          command: make static-test
+          command: make test
       - run:
           name: "Build TinyGo release"
           command: |
@@ -227,7 +227,7 @@ commands:
           command: dep ensure --vendor-only
       - run:
           name: "Test TinyGo"
-          command: make static-test
+          command: make test
       - run:
           name: "Build TinyGo release"
           command: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -92,7 +92,7 @@ Now that you have a working version of LLVM, build TinyGo using it. You need to
 specify the directories to the LLVM build directory and to the Clang and LLD source.
 
     cd $HOME/go/src/github.com/tinygo-org/tinygo
-    make static LLVM_BUILDDIR=$HOME/src/llvm-build CLANG_SRC=$HOME/src/llvm/tools/clang LLD_SRC=$HOME/src/llvm/tools/lld
+    make LLVM_BUILDDIR=$HOME/src/llvm-build CLANG_SRC=$HOME/src/llvm/tools/clang LLD_SRC=$HOME/src/llvm/tools/lld
 
 ## Verify TinyGo
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,9 +2,9 @@
 
 TinyGo depends on LLVM and libclang, which are both big C++ libraries. It can
 also optionally use a built-in lld to ease cross compiling. There are two ways
-these can be linked: dynamically and statically. The default is dynamic linking
-because it is fast and works almost out of the box on Debian-based systems with
-the right libraries installed.
+these can be linked: dynamically and statically. An install with `go install` is
+dynamic linking because it is fast and works almost out of the box on
+Debian-based systems with the right packages installed.
 
 This guide describes how to statically link TinyGo against LLVM, libclang and
 lld so that the binary can be easily moved between systems. It also shows how to
@@ -18,81 +18,49 @@ build tools to be built. Go is of course necessary to build TinyGo itself.
   * Go (1.11+)
   * [dep](https://golang.github.io/dep/)
   * Standard build tools (gcc/clang)
-  * git or subversion
+  * git
   * CMake
-  * [Ninja](https://ninja-build.org/) or make (preferably Ninja)
+  * [Ninja](https://ninja-build.org/)
 
 The rest of this guide assumes you're running Linux, but it should be equivalent
 on a different system like Mac.
 
 ## Download the source
 
-The first step is to get the source code. Place it in some directory, assuming
-`$HOME/src` here, but you can pick a different one of course:
+The first step is to download the TinyGo sources. Then, inside the directory,
+perform these steps:
 
-    git clone -b release_80 https://github.com/llvm-mirror/llvm.git $HOME/src/llvm
-    git clone -b release_80 https://github.com/llvm-mirror/clang.git $HOME/src/llvm/tools/clang
-    git clone -b release_80 https://github.com/llvm-mirror/lld.git $HOME/src/llvm/tools/lld
-    go get -d github.com/tinygo-org/tinygo
-    cd $HOME/go/src/github.com/tinygo-org/tinygo
-    dep ensure -vendor-only # download dependencies
+    dep ensure -vendor-only # download Go dependencies
+    make llvm-source        # download LLVM
 
-Note that Clang and LLD must be placed inside the tools subdirectory of LLVM to
-be automatically built with the rest of the system.
+You can also store LLVM outside of the TinyGo root directory by setting the
+`LLVM_BUILDDIR`, `CLANG_SRC` and `LLD_SRC` make variables, but that is not
+covered by this guide.
 
 ## Build LLVM, Clang, LLD
 
-Building LLVM is quite easy compared to some other software packages. However,
-the default configuration is _not_ optimized for distribution. It is optimized
-for development, meaning that binaries produce accurate error messages at the
-cost of huge binaries and slow compiles.
-
-Before configuring, you may want to set the following environment variables to
-speed up the build. Most Linux distributions ship with GCC as the default
-compiler, but Clang is significantly faster and uses much less memory while
-producing binaries that are about as fast.
+Before starting the build, you may want to set the following environment
+variables to speed up the build. Most Linux distributions ship with GCC as the
+default compiler, but Clang is significantly faster and uses much less memory
+while producing binaries that are about as fast.
 
     export CC=clang
     export CXX=clang++
 
-Make a build directory. LLVM requires out-of-tree builds:
+The Makefile includes a default configuration that is good for most users. It
+builds a release version of LLVM (optimized, no asserts) and includes all
+targets supported by TinyGo:
 
-    mkdir $HOME/src/llvm-build
-    cd $HOME/src/llvm-build
-
-Configure LLVM with CMake:
-
-    cmake -G Ninja ../llvm "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;WebAssembly" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLIBCLANG_BUILD_STATIC=ON
-
-You can also choose a different build system than Ninja, but Ninja is fast.
-
-There are various options you can tune here, but the options given above are
-preferable for releases. Here is what they do:
-
-  * `LLVM_TARGETS_TO_BUILD` and `LLVM_EXPERIMENTAL_TARGETS_TO_BUILD`: the
-    targets that are natively supported by the LLVM code generators. The targets
-    listed here are the ones supported by TinyGo. Note that LLVM is a cross
-    compiler by default, unlike some other compilers.
-  * `CMAKE_BUILD_TYPE`: the default is Debug, which produces large inefficient
-    binaries that are easy to debug. We want small and fast binaries.
-  * `LLVM_ENABLE_ASSERTIONS`: the default is ON, which greatly slows down LLVM
-    and is only really useful during development. Disable them here.
-  * `LIBCLANG_BUILD_STATIC`: unlike LLVM, libclang is built as a shared library
-    by default. We want a static library for easy distribution.
-
-Now build it:
-
-    ninja # or make, if you choose make in the previous step
+    make llvm-build
 
 This can take over an hour depending on the speed of your system.
 
 ## Build TinyGo
 
-Now that you have a working version of LLVM, build TinyGo using it. You need to
-specify the directories to the LLVM build directory and to the Clang and LLD source.
+The last step of course is to build TinyGo itself. This can again be done with
+make:
 
-    cd $HOME/go/src/github.com/tinygo-org/tinygo
-    make LLVM_BUILDDIR=$HOME/src/llvm-build CLANG_SRC=$HOME/src/llvm/tools/clang LLD_SRC=$HOME/src/llvm/tools/lld
+    make
 
 ## Verify TinyGo
 
@@ -109,14 +77,12 @@ The result should not contain libclang or libLLVM.
 
 ## Make a release tarball
 
-Now that we have a working static build, it's time to make a release tarball.
-This is just a slight change from the command to build TinyGo:
+Now that we have a working static build, it's time to make a release tarball:
 
-    cd $HOME/go/src/github.com/tinygo-org/tinygo
-    make release LLVM_BUILDDIR=$HOME/src/llvm-build CLANG_SRC=$HOME/src/llvm/tools/clang LLD_SRC=$HOME/src/llvm/tools/lld
+    make release
 
 The release tarball is stored in build/release.tar.gz, and can be extracted with
-the following command:
+the following command (for example in ~/lib):
 
     tar -xvf path/to/release.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: tinygo
 tinygo: build/tinygo
 
-.PHONY: all tinygo llvm-build llvm-source static run-test clean fmt gen-device gen-device-nrf gen-device-avr
+.PHONY: all tinygo build/tinygo test llvm-build llvm-source clean fmt gen-device gen-device-nrf gen-device-avr
 
 # Default build and source directories, as created by `make llvm-build`.
 LLVM_BUILDDIR ?= llvm-build
@@ -37,9 +37,6 @@ fmt:
 	@gofmt -l -w $(FMT_PATHS)
 fmt-check:
 	@unformatted=$$(gofmt -l $(FMT_PATHS)); [ -z "$$unformatted" ] && exit 0; echo "Unformatted:"; for fn in $$unformatted; do echo "  $$fn"; done; exit 1
-
-test:
-	@go test -v .
 
 gen-device: gen-device-avr gen-device-nrf gen-device-sam gen-device-stm32
 
@@ -81,17 +78,13 @@ llvm-build: llvm-build/build.ninja
 
 # Build the Go compiler.
 build/tinygo:
-	@mkdir -p build
-	go build -o build/tinygo .
-
-static:
 	@if [ ! -f llvm-build/bin/llvm-config ]; then echo "Fetch and build LLVM first by running:\n  make llvm-source\n  make llvm-build"; exit 1; fi
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go build -o build/tinygo -tags byollvm .
 
-static-test:
+test:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -v -tags byollvm .
 
-release: static gen-device
+release: build/tinygo gen-device
 	@mkdir -p build/release/tinygo/bin
 	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
 	@mkdir -p build/release/tinygo/lib/compiler-rt/lib


### PR DESCRIPTION
This replaces the older way which just does the following:

    go install .

and

    go test -v .

Instead, `make` and `make test` will now build TinyGo statically linked against LLVM, so that `go install` and `go test -v` should be used manually.

(Warning: conflicts with #281 but it should be trivial to resolve).