### PR TITLE
main: fix linker script includes when running outside TINYGOROOT

### DIFF
--- a/linker-builtin.go
+++ b/linker-builtin.go
@@ -22,7 +22,7 @@ import "C"
 // Link invokes a linker with the given name and flags.
 //
 // This version uses the built-in linker when trying to use lld.
-func Link(dir, linker string, flags ...string) error {
+func Link(linker string, flags ...string) error {
 	switch linker {
 	case "ld.lld", commands["ld.lld"]:
 		flags = append([]string{"tinygo:" + linker}, flags...)
@@ -60,7 +60,6 @@ func Link(dir, linker string, flags ...string) error {
 		cmd := exec.Command(linker, flags...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		cmd.Dir = dir
 		return cmd.Run()
 	}
 }

--- a/linker-external.go
+++ b/linker-external.go
@@ -13,10 +13,9 @@ import (
 // Link invokes a linker with the given name and arguments.
 //
 // This version always runs the linker as an external command.
-func Link(dir, linker string, flags ...string) error {
+func Link(linker string, flags ...string) error {
 	cmd := exec.Command(linker, flags...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Dir = dir
 	return cmd.Run()
 }

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		// Prepare link command.
 		executable := filepath.Join(dir, "main")
 		tmppath := executable // final file
-		ldflags := append(spec.LDFlags, "-o", executable, objfile)
+		ldflags := append(spec.LDFlags, "-o", executable, objfile, "-L", sourceDir())
 		if spec.RTLib == "compiler-rt" {
 			ldflags = append(ldflags, librt)
 		}
@@ -229,9 +229,9 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 
 		// Link the object files together.
 		if linker, ok := commands[spec.Linker]; ok {
-			err = Link(sourceDir(), linker, ldflags...)
+			err = Link(linker, ldflags...)
 		} else {
-			err = Link(sourceDir(), spec.Linker, ldflags...)
+			err = Link(spec.Linker, ldflags...)
 		}
 		if err != nil {
 			return &commandError{"failed to link", executable, err}


### PR DESCRIPTION
This commit adds the TinyGo root directory (`TINYGOROOT`) to the linker script `-L` search path, so that linker scripts can be found when running `tinygo` outside of the TinyGo root.

This was already working before when using an external linker by setting the working directory, but this is not possible when using the internal linker. However, by adding the root directory to the linker search path (`-L`), it can now find these linker scripts.

fixes #265