### PR TITLE
machine/atsamd21: correct pad/pin handling when using both UART and USBCDC

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -546,6 +546,33 @@ func (c *Compiler) getLLVMType(goType types.Type) (llvm.Type, error) {
 			}
 			members[i] = member
 		}
+		if len(members) > 2 && typ.Field(0).Name() == "C union" {
+			// Not a normal struct but a C union emitted by cgo.
+			// Such a field name cannot be entered in regular Go code, this must
+			// be manually inserted in the AST so this is safe.
+			maxAlign := 0
+			maxSize := uint64(0)
+			mainType := members[0]
+			for _, member := range members {
+				align := c.targetData.ABITypeAlignment(member)
+				size := c.targetData.TypeAllocSize(member)
+				if align > maxAlign {
+					maxAlign = align
+					mainType = member
+				} else if align == maxAlign && size > maxSize {
+					maxAlign = align
+					maxSize = size
+					mainType = member
+				} else if size > maxSize {
+					maxSize = size
+				}
+			}
+			members = []llvm.Type{mainType}
+			mainTypeSize := c.targetData.TypeAllocSize(mainType)
+			if mainTypeSize < maxSize {
+				members = append(members, llvm.ArrayType(c.ctx.Int8Type(), int(maxSize-mainTypeSize)))
+			}
+		}
 		return c.ctx.StructType(members, false), nil
 	case *types.Tuple:
 		members := make([]llvm.Type, typ.Len())
@@ -1592,6 +1619,19 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if err != nil {
 			return llvm.Value{}, err
 		}
+		if s := expr.X.Type().Underlying().(*types.Struct); s.NumFields() > 2 && s.Field(0).Name() == "C union" {
+			// Extract a field from a CGo union.
+			// This could be done directly, but as this is a very infrequent
+			// operation it's much easier to bitcast it through an alloca.
+			resultType, err := c.getLLVMType(expr.Type())
+			if err != nil {
+				return llvm.Value{}, err
+			}
+			alloca := c.builder.CreateAlloca(value.Type(), "")
+			c.builder.CreateStore(value, alloca)
+			bitcast := c.builder.CreateBitCast(alloca, llvm.PointerType(resultType, 0), "")
+			return c.builder.CreateLoad(bitcast, ""), nil
+		}
 		result := c.builder.CreateExtractValue(value, expr.Field, "")
 		return result, nil
 	case *ssa.FieldAddr:
@@ -1599,16 +1639,28 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if err != nil {
 			return llvm.Value{}, err
 		}
-		indices := []llvm.Value{
-			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
-			llvm.ConstInt(c.ctx.Int32Type(), uint64(expr.Field), false),
-		}
 		// Check for nil pointer before calculating the address, from the spec:
 		// > For an operand x of type T, the address operation &x generates a
 		// > pointer of type *T to x. [...] If the evaluation of x would cause a
 		// > run-time panic, then the evaluation of &x does too.
 		c.emitNilCheck(frame, val, "gep")
-		return c.builder.CreateGEP(val, indices, ""), nil
+		if s := expr.X.Type().(*types.Pointer).Elem().Underlying().(*types.Struct); s.NumFields() > 2 && s.Field(0).Name() == "C union" {
+			// This is not a regular struct but actually an union.
+			// That simplifies things, as we can just bitcast the pointer to the
+			// right type.
+			ptrType, err := c.getLLVMType(expr.Type())
+			if err != nil {
+				return llvm.Value{}, nil
+			}
+			return c.builder.CreateBitCast(val, ptrType, ""), nil
+		} else {
+			// Do a GEP on the pointer to get the field address.
+			indices := []llvm.Value{
+				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+				llvm.ConstInt(c.ctx.Int32Type(), uint64(expr.Field), false),
+			}
+			return c.builder.CreateGEP(val, indices, ""), nil
+		}
 	case *ssa.Function:
 		fn := c.ir.GetFunction(expr)
 		if fn.IsExported() {

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -170,6 +170,10 @@ func getTypeCodeName(t types.Type) string {
 		return "slice:" + name + getTypeCodeName(t.Elem())
 	case *types.Struct:
 		elems := make([]string, t.NumFields())
+		if t.NumFields() > 2 && t.Field(0).Name() == "C union" {
+			// TODO: report this as a normal error instead of panicking.
+			panic("cgo unions are not allowed in interfaces")
+		}
 		for i := 0; i < t.NumFields(); i++ {
 			elems[i] = getTypeCodeName(t.Field(i).Type())
 		}

--- a/compiler/sizes.go
+++ b/compiler/sizes.go
@@ -63,6 +63,12 @@ func (s *StdSizes) Alignof(T types.Type) int64 {
 
 func (s *StdSizes) Offsetsof(fields []*types.Var) []int64 {
 	offsets := make([]int64, len(fields))
+	if len(fields) > 1 && fields[0].Name() == "C union" {
+		// This struct contains the magic "C union" field which indicates that
+		// this is actually a union from CGo.
+		// All fields in the union start at 0 so return that.
+		return offsets // all fields are still set to 0
+	}
 	var o int64
 	for i, f := range fields {
 		a := s.Alignof(f.Type())
@@ -125,11 +131,38 @@ func (s *StdSizes) Sizeof(T types.Type) int64 {
 			return 0
 		}
 		fields := make([]*types.Var, t.NumFields())
+		maxAlign := int64(1)
 		for i := range fields {
-			fields[i] = t.Field(i)
+			field := t.Field(i)
+			fields[i] = field
+			al := s.Alignof(field.Type())
+			if al > maxAlign {
+				maxAlign = al
+			}
 		}
-		offsets := s.Offsetsof(fields)
-		return offsets[n-1] + s.Sizeof(fields[n-1].Type())
+		if fields[0].Name() == "C union" {
+			// Magic field that indicates this is a CGo union and not a struct.
+			// The size is the biggest element, aligned to the element with the
+			// biggest alignment. This is not necessarily the same, for example
+			// in the following union:
+			//     union { int32_t l; int16_t s[3] }
+			maxSize := int64(0)
+			for _, field := range fields[1:] {
+				si := s.Sizeof(field.Type())
+				if si > maxSize {
+					maxSize = si
+				}
+			}
+			return align(maxSize, maxAlign)
+		} else {
+			// This is a regular struct.
+			// Pick the size that fits this struct and add some alignment. Some
+			// structs have some extra padding at the end which should also be
+			// taken care of:
+			//     struct { int32 n; byte b }
+			offsets := s.Offsetsof(fields)
+			return align(offsets[n-1]+s.Sizeof(fields[n-1].Type()), maxAlign)
+		}
 	case *types.Interface:
 		return s.PtrSize * 2
 	case *types.Pointer:

--- a/loader/libclang.go
+++ b/loader/libclang.go
@@ -268,6 +268,16 @@ func (info *fileInfo) makeASTType(typ C.CXType) ast.Expr {
 			Star: info.importCPos,
 			X:    info.makeASTType(C.clang_getPointeeType(typ)),
 		}
+	case C.CXType_ConstantArray:
+		return &ast.ArrayType{
+			Lbrack: info.importCPos,
+			Len: &ast.BasicLit{
+				ValuePos: info.importCPos,
+				Kind:     token.INT,
+				Value:    strconv.FormatInt(int64(C.clang_getArraySize(typ)), 10),
+			},
+			Elt: info.makeASTType(C.clang_getElementType(typ)),
+		}
 	case C.CXType_FunctionProto:
 		// Be compatible with gc, which uses the *[0]byte type for function
 		// pointer types.

--- a/loader/sync.go
+++ b/loader/sync.go
@@ -1,0 +1,46 @@
+package loader
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// #include <stdlib.h>
+import "C"
+
+// RefMap is a convenient way to store opaque references that can be passed to
+// C. It is useful if an API uses function pointers and you cannot pass a Go
+// pointer but only a C pointer.
+type RefMap struct {
+	refs map[unsafe.Pointer]interface{}
+	lock sync.Mutex
+}
+
+// Put stores a value in the map. It can later be retrieved using Get. It must
+// be removed using Remove to avoid memory leaks.
+func (m *RefMap) Put(v interface{}) unsafe.Pointer {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.refs == nil {
+		m.refs = make(map[unsafe.Pointer]interface{}, 1)
+	}
+	ref := C.malloc(1)
+	m.refs[ref] = v
+	return ref
+}
+
+// Get returns a stored value previously inserted with Put. Use the same
+// reference as you got from Put.
+func (m *RefMap) Get(ref unsafe.Pointer) interface{} {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.refs[ref]
+}
+
+// Remove deletes a single reference from the map.
+func (m *RefMap) Remove(ref unsafe.Pointer) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	delete(m.refs, ref)
+	C.free(ref)
+}

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -44,8 +44,8 @@ const (
 
 // UART1 pins
 const (
-	UART_TX_PIN = D1
-	UART_RX_PIN = D0
+	UART_TX_PIN = D10
+	UART_RX_PIN = D11
 )
 
 // I2C pins

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -416,7 +416,7 @@ var (
 	UART0 = USBCDC{Buffer: NewRingBuffer()}
 
 	// The first hardware serial port on the SAMD21. Uses the SERCOM0 interface.
-	UART1 = UART{Bus: sam.SERCOM0_USART, Buffer: NewRingBuffer()}
+	UART1 = UART{Bus: sam.SERCOM1_USART, Buffer: NewRingBuffer()}
 )
 
 const (
@@ -453,26 +453,26 @@ func (uart UART) Configure(config UARTConfig) {
 	// determine pads
 	var txpad, rxpad int
 	switch config.TX {
-	case UART_TX_PIN:
+	case PA10:
 		txpad = sercomTXPad2
-	case D10:
+	case PA18:
 		txpad = sercomTXPad2
-	case D11:
+	case PA16:
 		txpad = sercomTXPad0
 	default:
 		panic("Invalid TX pin for UART")
 	}
 
 	switch config.RX {
-	case UART_RX_PIN:
+	case PA11:
 		rxpad = sercomRXPad3
-	case D10:
+	case PA18:
 		rxpad = sercomRXPad2
-	case D11:
+	case PA16:
 		rxpad = sercomRXPad0
-	case D12:
+	case PA19:
 		rxpad = sercomRXPad3
-	case D13:
+	case PA17:
 		rxpad = sercomRXPad1
 	default:
 		panic("Invalid RX pin for UART")
@@ -531,11 +531,11 @@ func (uart UART) Configure(config UARTConfig) {
 	uart.Bus.INTENSET = sam.SERCOM_USART_INTENSET_RXC
 
 	// Enable RX IRQ.
-	if config.TX == UART_TX_PIN {
+	if config.TX == PA10 {
 		// UART0
 		arm.EnableIRQ(sam.IRQ_SERCOM0)
 	} else {
-		// UART1
+		// UART1 which is the normal default, since UART0 is used for USBCDC.
 		arm.EnableIRQ(sam.IRQ_SERCOM1)
 	}
 }
@@ -563,7 +563,7 @@ func (uart UART) WriteByte(c byte) error {
 	return nil
 }
 
-//go:export SERCOM0_IRQHandler
+//go:export SERCOM1_IRQHandler
 func handleUART1() {
 	// should reset IRQ
 	UART1.Receive(byte((UART1.Bus.DATA & 0xFF)))

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -8,6 +8,7 @@ double globalDouble = 3.2;
 _Complex float globalComplexFloat = 4.1+3.3i;
 _Complex double globalComplexDouble = 4.2+3.4i;
 _Complex double globalComplexLongDouble = 4.3+3.5i;
+collection_t globalStruct = {256, -123456, 3.14};
 
 int fortytwo() {
 	return 42;

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -8,8 +8,11 @@ double globalDouble = 3.2;
 _Complex float globalComplexFloat = 4.1+3.3i;
 _Complex double globalComplexDouble = 4.2+3.4i;
 _Complex double globalComplexLongDouble = 4.3+3.5i;
-collection_t globalStruct = {256, -123456, 3.14};
+collection_t globalStruct = {256, -123456, 3.14, 88};
+int globalStructSize = sizeof(globalStruct);
 short globalArray[3] = {5, 6, 7};
+joined_t globalUnion;
+int globalUnionSize = sizeof(globalUnion);
 
 int fortytwo() {
 	return 42;
@@ -25,4 +28,18 @@ int doCallback(int a, int b, binop_t callback) {
 
 void store(int value, int *ptr) {
 	*ptr = value;
+}
+
+void unionSetShort(short s) {
+	globalUnion.s = s;
+}
+
+void unionSetFloat(float f) {
+	globalUnion.f = f;
+}
+
+void unionSetData(short f0, short f1, short f2) {
+	globalUnion.data[0] = 5;
+	globalUnion.data[1] = 8;
+	globalUnion.data[2] = 1;
 }

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -9,6 +9,7 @@ _Complex float globalComplexFloat = 4.1+3.3i;
 _Complex double globalComplexDouble = 4.2+3.4i;
 _Complex double globalComplexLongDouble = 4.3+3.5i;
 collection_t globalStruct = {256, -123456, 3.14};
+short globalArray[3] = {5, 6, 7};
 
 int fortytwo() {
 	return 42;

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -9,6 +9,10 @@ import "C"
 
 import "unsafe"
 
+func (s C.myint) Int() int {
+	return int(s)
+}
+
 func main() {
 	println("fortytwo:", C.fortytwo())
 	println("add:", C.add(C.int(3), 5))
@@ -36,9 +40,28 @@ func main() {
 	println("complex float:", C.globalComplexFloat)
 	println("complex double:", C.globalComplexDouble)
 	println("complex long double:", C.globalComplexLongDouble)
-	println("struct:", C.globalStruct.s, C.globalStruct.l, C.globalStruct.f)
+
+	// complex types
+	println("struct:", C.int(unsafe.Sizeof(C.globalStruct)) == C.globalStructSize, C.globalStruct.s, C.globalStruct.l, C.globalStruct.f)
 	var _ [3]C.short = C.globalArray
 	println("array:", C.globalArray[0], C.globalArray[1], C.globalArray[2])
+	println("union:", C.int(unsafe.Sizeof(C.globalUnion)) == C.globalUnionSize)
+	C.unionSetShort(22)
+	println("union s:", C.globalUnion.s)
+	C.unionSetFloat(3.14)
+	println("union f:", C.globalUnion.f)
+	C.unionSetData(5, 8, 1)
+	println("union global data:", C.globalUnion.data[0], C.globalUnion.data[1], C.globalUnion.data[2])
+	println("union field:", printUnion(C.globalUnion).f)
+}
+
+func printUnion(union C.joined_t) C.joined_t {
+	println("union local data: ", union.data[0], union.data[1], union.data[2])
+	union.s = -33
+	println("union s method:", union.s.Int(), union.data[0] == 5)
+	union.f = 6.28
+	println("union f:", union.f)
+	return union
 }
 
 //export mul

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -36,6 +36,7 @@ func main() {
 	println("complex float:", C.globalComplexFloat)
 	println("complex double:", C.globalComplexDouble)
 	println("complex long double:", C.globalComplexLongDouble)
+	println("struct:", C.globalStruct.s, C.globalStruct.l, C.globalStruct.f)
 }
 
 //export mul

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -37,6 +37,8 @@ func main() {
 	println("complex double:", C.globalComplexDouble)
 	println("complex long double:", C.globalComplexLongDouble)
 	println("struct:", C.globalStruct.s, C.globalStruct.l, C.globalStruct.f)
+	var _ [3]C.short = C.globalArray
+	println("array:", C.globalArray[0], C.globalArray[1], C.globalArray[2])
 }
 
 //export mul

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -6,10 +6,20 @@ typedef int * intPointer;
 void store(int value, int *ptr);
 
 typedef struct collection {
-	short s;
-	long  l;
-	float f;
+	short         s;
+	long          l;
+	float         f;
+	unsigned char c;
 } collection_t;
+
+typedef union joined {
+	myint s;
+	float f;
+	short data[3];
+} joined_t;
+void unionSetShort(short s);
+void unionSetFloat(float f);
+void unionSetData(short f0, short f1, short f2);
 
 // test globals
 extern int global;
@@ -21,7 +31,10 @@ extern _Complex float globalComplexFloat;
 extern _Complex double globalComplexDouble;
 extern _Complex double globalComplexLongDouble;
 extern collection_t globalStruct;
+extern int globalStructSize;
 extern short globalArray[3];
+extern joined_t globalUnion;
+extern int globalUnionSize;
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -5,6 +5,12 @@ int doCallback(int a, int b, binop_t cb);
 typedef int * intPointer;
 void store(int value, int *ptr);
 
+typedef struct collection {
+	short s;
+	long  l;
+	float f;
+} collection_t;
+
 // test globals
 extern int global;
 extern _Bool globalBool;
@@ -14,6 +20,7 @@ extern double globalDouble;
 extern _Complex float globalComplexFloat;
 extern _Complex double globalComplexDouble;
 extern _Complex double globalComplexLongDouble;
+extern collection_t globalStruct;
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -21,6 +21,7 @@ extern _Complex float globalComplexFloat;
 extern _Complex double globalComplexDouble;
 extern _Complex double globalComplexLongDouble;
 extern collection_t globalStruct;
+extern short globalArray[3];
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -14,3 +14,13 @@ double: +3.200000e+000
 complex float: (+4.100000e+000+3.300000e+000i)
 complex double: (+4.200000e+000+3.400000e+000i)
 complex long double: (+4.300000e+000+3.500000e+000i)
+struct: true 256 -123456 +3.140000e+000
+array: 5 6 7
+union: true
+union s: 22
+union f: +3.140000e+000
+union global data: 5 8 1
+union local data:  5 8 1
+union s method: -33 false
+union f: +6.280000e+000
+union field: +6.280000e+000


### PR DESCRIPTION
This PR corrects pad/pin handling when using both UART and USBCDC interfaces at same time on SAMD21-based boards such as the ItsyBitsy-M0.