### PR TITLE
examples: add microbit blink example

### DIFF
--- a/src/examples/microbit-blink/microbit-blink.go
+++ b/src/examples/microbit-blink/microbit-blink.go
@@ -1,0 +1,19 @@
+// blink program for the BBC micro:bit that uses the entire LED matrix
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+func main() {
+	machine.InitLEDMatrix()
+
+	for {
+		machine.ClearLEDMatrix()
+		time.Sleep(time.Millisecond * 500)
+
+		machine.SetEntireLEDMatrixOn()
+		time.Sleep(time.Millisecond * 500)
+	}
+}


### PR DESCRIPTION
This PR adds a micro:bit blink example that uses the entire LED array. The reason for adding this to the built-in examples is really to provide a basic "hello, world" example for the very common micro:bit board.