### PR TITLE
Refactor error handling

### DIFF
--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -123,10 +123,7 @@ func (c *Compiler) collapseFormalParamInternal(t llvm.Type, fields []llvm.Value)
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
 		if len(c.flattenAggregateType(t)) <= MaxFieldsPerParam {
-			value, err := c.getZeroValue(t)
-			if err != nil {
-				panic("could not get zero value of struct: " + err.Error())
-			}
+			value := c.getZeroValue(t)
 			for i, subtyp := range t.StructElementTypes() {
 				structField, remaining := c.collapseFormalParamInternal(subtyp, fields)
 				fields = remaining

--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -12,10 +12,7 @@ import (
 
 // emitMakeChan returns a new channel value for the given channel type.
 func (c *Compiler) emitMakeChan(expr *ssa.MakeChan) (llvm.Value, error) {
-	valueType, err := c.getLLVMType(expr.Type().(*types.Chan).Elem())
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	valueType := c.getLLVMType(expr.Type().(*types.Chan).Elem())
 	if c.targetData.TypeAllocSize(valueType) > c.targetData.TypeAllocSize(c.intType) {
 		// Values bigger than int overflow the data part of the coroutine.
 		// TODO: make the coroutine data part big enough to hold these bigger
@@ -33,10 +30,7 @@ func (c *Compiler) emitMakeChan(expr *ssa.MakeChan) (llvm.Value, error) {
 // emitChanSend emits a pseudo chan send operation. It is lowered to the actual
 // channel send operation during goroutine lowering.
 func (c *Compiler) emitChanSend(frame *Frame, instr *ssa.Send) error {
-	valueType, err := c.getLLVMType(instr.Chan.Type().(*types.Chan).Elem())
-	if err != nil {
-		return err
-	}
+	valueType := c.getLLVMType(instr.Chan.Type().(*types.Chan).Elem())
 	ch, err := c.parseExpr(frame, instr.Chan)
 	if err != nil {
 		return err
@@ -56,10 +50,7 @@ func (c *Compiler) emitChanSend(frame *Frame, instr *ssa.Send) error {
 // emitChanRecv emits a pseudo chan receive operation. It is lowered to the
 // actual channel receive operation during goroutine lowering.
 func (c *Compiler) emitChanRecv(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
-	valueType, err := c.getLLVMType(unop.X.Type().(*types.Chan).Elem())
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	valueType := c.getLLVMType(unop.X.Type().(*types.Chan).Elem())
 	valueSize := llvm.ConstInt(c.uintptrType, c.targetData.TypeAllocSize(valueType), false)
 	ch, err := c.parseExpr(frame, unop.X)
 	if err != nil {
@@ -83,11 +74,8 @@ func (c *Compiler) emitChanRecv(frame *Frame, unop *ssa.UnOp) (llvm.Value, error
 
 // emitChanClose closes the given channel.
 func (c *Compiler) emitChanClose(frame *Frame, param ssa.Value) error {
-	valueType, err := c.getLLVMType(param.Type().(*types.Chan).Elem())
+	valueType := c.getLLVMType(param.Type().(*types.Chan).Elem())
 	valueSize := llvm.ConstInt(c.uintptrType, c.targetData.TypeAllocSize(valueType), false)
-	if err != nil {
-		return err
-	}
 	ch, err := c.parseExpr(frame, param)
 	if err != nil {
 		return err

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -272,10 +272,7 @@ func (c *Compiler) Compile(mainPath string) error {
 	for _, t := range c.ir.NamedTypes {
 		if named, ok := t.Type.Type().(*types.Named); ok {
 			if st, ok := named.Underlying().(*types.Struct); ok {
-				llvmType, err := c.getLLVMType(st)
-				if err != nil {
-					return err
-				}
+				llvmType := c.getLLVMType(st)
 				t.LLVMType.StructSetBody(llvmType.StructElementTypes(), false)
 			}
 		}
@@ -284,10 +281,7 @@ func (c *Compiler) Compile(mainPath string) error {
 	// Declare all globals.
 	for _, g := range c.ir.Globals {
 		typ := g.Type().(*types.Pointer).Elem()
-		llvmType, err := c.getLLVMType(typ)
-		if err != nil {
-			return err
-		}
+		llvmType := c.getLLVMType(typ)
 		global := c.mod.NamedGlobal(g.LinkName())
 		if global.IsNil() {
 			global = llvm.AddGlobal(c.mod, llvmType, g.LinkName())
@@ -301,11 +295,7 @@ func (c *Compiler) Compile(mainPath string) error {
 
 	// Declare all functions.
 	for _, f := range c.ir.Functions {
-		frame, err := c.parseFuncDecl(f)
-		if err != nil {
-			return err
-		}
-		frames = append(frames, frame)
+		frames = append(frames, c.parseFuncDecl(f))
 	}
 
 	// Add definitions to declarations.
@@ -328,10 +318,7 @@ func (c *Compiler) Compile(mainPath string) error {
 	// Define the already declared functions that wrap methods for use in
 	// interfaces.
 	for _, state := range c.interfaceInvokeWrappers {
-		err = c.createInterfaceInvokeWrapper(state)
-		if err != nil {
-			return err
-		}
+		c.createInterfaceInvokeWrapper(state)
 	}
 
 	// After all packages are imported, add a synthetic initializer function
@@ -340,10 +327,7 @@ func (c *Compiler) Compile(mainPath string) error {
 	initFn.LLVMFn.SetLinkage(llvm.InternalLinkage)
 	initFn.LLVMFn.SetUnnamedAddr(true)
 	if c.Debug {
-		difunc, err := c.attachDebugInfo(initFn)
-		if err != nil {
-			return err
-		}
+		difunc := c.attachDebugInfo(initFn)
 		pos := c.ir.Program.Fset.Position(initFn.Pos())
 		c.builder.SetCurrentDebugLocation(uint(pos.Line), uint(pos.Column), difunc, llvm.Metadata{})
 	}
@@ -409,87 +393,74 @@ func (c *Compiler) Compile(mainPath string) error {
 	return nil
 }
 
-func (c *Compiler) getLLVMType(goType types.Type) (llvm.Type, error) {
+func (c *Compiler) getLLVMType(goType types.Type) llvm.Type {
 	switch typ := goType.(type) {
 	case *types.Array:
-		elemType, err := c.getLLVMType(typ.Elem())
-		if err != nil {
-			return llvm.Type{}, err
-		}
-		return llvm.ArrayType(elemType, int(typ.Len())), nil
+		elemType := c.getLLVMType(typ.Elem())
+		return llvm.ArrayType(elemType, int(typ.Len()))
 	case *types.Basic:
 		switch typ.Kind() {
 		case types.Bool, types.UntypedBool:
-			return c.ctx.Int1Type(), nil
+			return c.ctx.Int1Type()
 		case types.Int8, types.Uint8:
-			return c.ctx.Int8Type(), nil
+			return c.ctx.Int8Type()
 		case types.Int16, types.Uint16:
-			return c.ctx.Int16Type(), nil
+			return c.ctx.Int16Type()
 		case types.Int32, types.Uint32:
-			return c.ctx.Int32Type(), nil
+			return c.ctx.Int32Type()
 		case types.Int, types.Uint:
-			return c.intType, nil
+			return c.intType
 		case types.Int64, types.Uint64:
-			return c.ctx.Int64Type(), nil
+			return c.ctx.Int64Type()
 		case types.Float32:
-			return c.ctx.FloatType(), nil
+			return c.ctx.FloatType()
 		case types.Float64:
-			return c.ctx.DoubleType(), nil
+			return c.ctx.DoubleType()
 		case types.Complex64:
-			return c.ctx.StructType([]llvm.Type{c.ctx.FloatType(), c.ctx.FloatType()}, false), nil
+			return c.ctx.StructType([]llvm.Type{c.ctx.FloatType(), c.ctx.FloatType()}, false)
 		case types.Complex128:
-			return c.ctx.StructType([]llvm.Type{c.ctx.DoubleType(), c.ctx.DoubleType()}, false), nil
+			return c.ctx.StructType([]llvm.Type{c.ctx.DoubleType(), c.ctx.DoubleType()}, false)
 		case types.String, types.UntypedString:
-			return c.mod.GetTypeByName("runtime._string"), nil
+			return c.mod.GetTypeByName("runtime._string")
 		case types.Uintptr:
-			return c.uintptrType, nil
+			return c.uintptrType
 		case types.UnsafePointer:
-			return c.i8ptrType, nil
+			return c.i8ptrType
 		default:
-			return llvm.Type{}, errors.New("todo: unknown basic type: " + typ.String())
+			panic("unknown basic type: " + typ.String())
 		}
 	case *types.Chan:
-		return llvm.PointerType(c.mod.GetTypeByName("runtime.channel"), 0), nil
+		return llvm.PointerType(c.mod.GetTypeByName("runtime.channel"), 0)
 	case *types.Interface:
-		return c.mod.GetTypeByName("runtime._interface"), nil
+		return c.mod.GetTypeByName("runtime._interface")
 	case *types.Map:
-		return llvm.PointerType(c.mod.GetTypeByName("runtime.hashmap"), 0), nil
+		return llvm.PointerType(c.mod.GetTypeByName("runtime.hashmap"), 0)
 	case *types.Named:
 		if _, ok := typ.Underlying().(*types.Struct); ok {
 			llvmType := c.mod.GetTypeByName(typ.Obj().Pkg().Path() + "." + typ.Obj().Name())
 			if llvmType.IsNil() {
-				return llvm.Type{}, errors.New("type not found: " + typ.Obj().Pkg().Path() + "." + typ.Obj().Name())
+				panic("underlying type not found: " + typ.Obj().Pkg().Path() + "." + typ.Obj().Name())
 			}
-			return llvmType, nil
+			return llvmType
 		}
 		return c.getLLVMType(typ.Underlying())
 	case *types.Pointer:
-		ptrTo, err := c.getLLVMType(typ.Elem())
-		if err != nil {
-			return llvm.Type{}, err
-		}
-		return llvm.PointerType(ptrTo, 0), nil
+		ptrTo := c.getLLVMType(typ.Elem())
+		return llvm.PointerType(ptrTo, 0)
 	case *types.Signature: // function value
 		return c.getFuncType(typ)
 	case *types.Slice:
-		elemType, err := c.getLLVMType(typ.Elem())
-		if err != nil {
-			return llvm.Type{}, err
-		}
+		elemType := c.getLLVMType(typ.Elem())
 		members := []llvm.Type{
 			llvm.PointerType(elemType, 0),
 			c.uintptrType, // len
 			c.uintptrType, // cap
 		}
-		return c.ctx.StructType(members, false), nil
+		return c.ctx.StructType(members, false)
 	case *types.Struct:
 		members := make([]llvm.Type, typ.NumFields())
 		for i := 0; i < typ.NumFields(); i++ {
-			member, err := c.getLLVMType(typ.Field(i).Type())
-			if err != nil {
-				return llvm.Type{}, err
-			}
-			members[i] = member
+			members[i] = c.getLLVMType(typ.Field(i).Type())
 		}
 		if len(members) > 2 && typ.Field(0).Name() == "C union" {
 			// Not a normal struct but a C union emitted by cgo.
@@ -518,19 +489,15 @@ func (c *Compiler) getLLVMType(goType types.Type) (llvm.Type, error) {
 				members = append(members, llvm.ArrayType(c.ctx.Int8Type(), int(maxSize-mainTypeSize)))
 			}
 		}
-		return c.ctx.StructType(members, false), nil
+		return c.ctx.StructType(members, false)
 	case *types.Tuple:
 		members := make([]llvm.Type, typ.Len())
 		for i := 0; i < typ.Len(); i++ {
-			member, err := c.getLLVMType(typ.At(i).Type())
-			if err != nil {
-				return llvm.Type{}, err
-			}
-			members[i] = member
+			members[i] = c.getLLVMType(typ.At(i).Type())
 		}
-		return c.ctx.StructType(members, false), nil
+		return c.ctx.StructType(members, false)
 	default:
-		return llvm.Type{}, errors.New("todo: unknown type: " + goType.String())
+		panic("unknown type: " + goType.String())
 	}
 }
 
@@ -582,15 +549,12 @@ func isPointer(typ types.Type) bool {
 }
 
 // Get the DWARF type for this Go type.
-func (c *Compiler) getDIType(typ types.Type) (llvm.Metadata, error) {
+func (c *Compiler) getDIType(typ types.Type) llvm.Metadata {
 	name := typ.String()
 	if dityp, ok := c.ditypes[name]; ok {
-		return dityp, nil
+		return dityp
 	} else {
-		llvmType, err := c.getLLVMType(typ)
-		if err != nil {
-			return llvm.Metadata{}, err
-		}
+		llvmType := c.getLLVMType(typ)
 		sizeInBytes := c.targetData.TypeAllocSize(llvmType)
 		var encoding llvm.DwarfTypeEncoding
 		switch typ := typ.(type) {
@@ -618,11 +582,11 @@ func (c *Compiler) getDIType(typ types.Type) (llvm.Metadata, error) {
 			Encoding:   encoding,
 		})
 		c.ditypes[name] = dityp
-		return dityp, nil
+		return dityp
 	}
 }
 
-func (c *Compiler) parseFuncDecl(f *ir.Function) (*Frame, error) {
+func (c *Compiler) parseFuncDecl(f *ir.Function) *Frame {
 	frame := &Frame{
 		fn:           f,
 		locals:       make(map[ssa.Value]llvm.Value),
@@ -634,29 +598,18 @@ func (c *Compiler) parseFuncDecl(f *ir.Function) (*Frame, error) {
 	if f.Signature.Results() == nil {
 		retType = c.ctx.VoidType()
 	} else if f.Signature.Results().Len() == 1 {
-		var err error
-		retType, err = c.getLLVMType(f.Signature.Results().At(0).Type())
-		if err != nil {
-			return nil, err
-		}
+		retType = c.getLLVMType(f.Signature.Results().At(0).Type())
 	} else {
 		results := make([]llvm.Type, 0, f.Signature.Results().Len())
 		for i := 0; i < f.Signature.Results().Len(); i++ {
-			typ, err := c.getLLVMType(f.Signature.Results().At(i).Type())
-			if err != nil {
-				return nil, err
-			}
-			results = append(results, typ)
+			results = append(results, c.getLLVMType(f.Signature.Results().At(i).Type()))
 		}
 		retType = c.ctx.StructType(results, false)
 	}
 
 	var paramTypes []llvm.Type
 	for _, param := range f.Params {
-		paramType, err := c.getLLVMType(param.Type())
-		if err != nil {
-			return nil, err
-		}
+		paramType := c.getLLVMType(param.Type())
 		paramTypeFragments := c.expandFormalParamType(paramType)
 		paramTypes = append(paramTypes, paramTypeFragments...)
 	}
@@ -676,15 +629,15 @@ func (c *Compiler) parseFuncDecl(f *ir.Function) (*Frame, error) {
 		frame.fn.LLVMFn = llvm.AddFunction(c.mod, name, fnType)
 	}
 
-	return frame, nil
+	return frame
 }
 
-func (c *Compiler) attachDebugInfo(f *ir.Function) (llvm.Metadata, error) {
+func (c *Compiler) attachDebugInfo(f *ir.Function) llvm.Metadata {
 	pos := c.ir.Program.Fset.Position(f.Syntax().Pos())
 	return c.attachDebugInfoRaw(f, f.LLVMFn, "", pos.Filename, pos.Line)
 }
 
-func (c *Compiler) attachDebugInfoRaw(f *ir.Function, llvmFn llvm.Value, suffix, filename string, line int) (llvm.Metadata, error) {
+func (c *Compiler) attachDebugInfoRaw(f *ir.Function, llvmFn llvm.Value, suffix, filename string, line int) llvm.Metadata {
 	if _, ok := c.difiles[filename]; !ok {
 		dir, file := filepath.Split(filename)
 		if dir != "" {
@@ -696,11 +649,7 @@ func (c *Compiler) attachDebugInfoRaw(f *ir.Function, llvmFn llvm.Value, suffix,
 	// Debug info for this function.
 	diparams := make([]llvm.Metadata, 0, len(f.Params))
 	for _, param := range f.Params {
-		ditype, err := c.getDIType(param.Type())
-		if err != nil {
-			return llvm.Metadata{}, err
-		}
-		diparams = append(diparams, ditype)
+		diparams = append(diparams, c.getDIType(param.Type()))
 	}
 	diFuncType := c.dibuilder.CreateSubroutineType(llvm.DISubroutineType{
 		File:       c.difiles[filename],
@@ -720,7 +669,7 @@ func (c *Compiler) attachDebugInfoRaw(f *ir.Function, llvmFn llvm.Value, suffix,
 		Optimized:    true,
 	})
 	llvmFn.SetSubprogram(difunc)
-	return difunc, nil
+	return difunc
 }
 
 func (c *Compiler) parseFunc(frame *Frame) error {
@@ -740,18 +689,10 @@ func (c *Compiler) parseFunc(frame *Frame) error {
 		if frame.fn.Synthetic == "package initializer" {
 			// Package initializers have no debug info. Create some fake debug
 			// info to at least have *something*.
-			difunc, err := c.attachDebugInfoRaw(frame.fn, frame.fn.LLVMFn, "", "", 0)
-			if err != nil {
-				return err
-			}
-			frame.difunc = difunc
+			frame.difunc = c.attachDebugInfoRaw(frame.fn, frame.fn.LLVMFn, "", "", 0)
 		} else if frame.fn.Syntax() != nil {
 			// Create debug info file if needed.
-			difunc, err := c.attachDebugInfo(frame.fn)
-			if err != nil {
-				return err
-			}
-			frame.difunc = difunc
+			frame.difunc = c.attachDebugInfo(frame.fn)
 		}
 		pos := c.ir.Program.Fset.Position(frame.fn.Pos())
 		c.builder.SetCurrentDebugLocation(uint(pos.Line), uint(pos.Column), frame.difunc, llvm.Metadata{})
@@ -769,10 +710,7 @@ func (c *Compiler) parseFunc(frame *Frame) error {
 	// Load function parameters
 	llvmParamIndex := 0
 	for i, param := range frame.fn.Params {
-		llvmType, err := c.getLLVMType(param.Type())
-		if err != nil {
-			return err
-		}
+		llvmType := c.getLLVMType(param.Type())
 		fields := make([]llvm.Value, 0, 1)
 		for range c.expandFormalParamType(llvmType) {
 			fields = append(fields, frame.fn.LLVMFn.Param(llvmParamIndex))
@@ -783,15 +721,11 @@ func (c *Compiler) parseFunc(frame *Frame) error {
 		// Add debug information to this parameter (if available)
 		if c.Debug && frame.fn.Syntax() != nil {
 			pos := c.ir.Program.Fset.Position(frame.fn.Syntax().Pos())
-			dityp, err := c.getDIType(param.Type())
-			if err != nil {
-				return err
-			}
 			c.dibuilder.CreateParameterVariable(frame.difunc, llvm.DIParameterVariable{
 				Name:           param.Name(),
 				File:           c.difiles[pos.Filename],
 				Line:           pos.Line,
-				Type:           dityp,
+				Type:           c.getDIType(param.Type()),
 				AlwaysPreserve: true,
 				ArgNo:          i + 1,
 			})
@@ -812,11 +746,7 @@ func (c *Compiler) parseFunc(frame *Frame) error {
 		// Determine the context type. It's a struct containing all variables.
 		freeVarTypes := make([]llvm.Type, 0, len(frame.fn.FreeVars))
 		for _, freeVar := range frame.fn.FreeVars {
-			typ, err := c.getLLVMType(freeVar.Type())
-			if err != nil {
-				return err
-			}
-			freeVarTypes = append(freeVarTypes, typ)
+			freeVarTypes = append(freeVarTypes, c.getLLVMType(freeVar.Type()))
 		}
 		contextType := c.ctx.StructType(freeVarTypes, false)
 
@@ -1344,10 +1274,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 	switch expr := expr.(type) {
 	case *ssa.Alloc:
-		typ, err := c.getLLVMType(expr.Type().Underlying().(*types.Pointer).Elem())
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		typ := c.getLLVMType(expr.Type().Underlying().(*types.Pointer).Elem())
 		var buf llvm.Value
 		if expr.Heap {
 			size := c.targetData.TypeAllocSize(typ)
@@ -1398,10 +1325,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if err != nil {
 			return llvm.Value{}, err
 		}
-		llvmType, err := c.getLLVMType(expr.Type())
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmType := c.getLLVMType(expr.Type())
 		if x.Type() == llvmType {
 			// Different Go type but same LLVM type (for example, named int).
 			// This is the common case.
@@ -1450,10 +1374,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			// Extract a field from a CGo union.
 			// This could be done directly, but as this is a very infrequent
 			// operation it's much easier to bitcast it through an alloca.
-			resultType, err := c.getLLVMType(expr.Type())
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			resultType := c.getLLVMType(expr.Type())
 			alloca := c.builder.CreateAlloca(value.Type(), "")
 			c.builder.CreateStore(value, alloca)
 			bitcast := c.builder.CreateBitCast(alloca, llvm.PointerType(resultType, 0), "")
@@ -1475,10 +1396,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			// This is not a regular struct but actually an union.
 			// That simplifies things, as we can just bitcast the pointer to the
 			// right type.
-			ptrType, err := c.getLLVMType(expr.Type())
-			if err != nil {
-				return llvm.Value{}, nil
-			}
+			ptrType := c.getLLVMType(expr.Type())
 			return c.builder.CreateBitCast(val, ptrType, ""), nil
 		} else {
 			// Do a GEP on the pointer to get the field address.
@@ -1493,7 +1411,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if fn.IsExported() {
 			return llvm.Value{}, c.makeError(expr.Pos(), "cannot use an exported function as value")
 		}
-		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature)
+		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature), nil
 	case *ssa.Global:
 		value := c.ir.GetGlobal(expr).LLVMGlobal
 		if value.IsNil() {
@@ -1618,14 +1536,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		return c.parseMakeInterface(val, expr.X.Type(), expr.Pos())
 	case *ssa.MakeMap:
 		mapType := expr.Type().Underlying().(*types.Map)
-		llvmKeyType, err := c.getLLVMType(mapType.Key().Underlying())
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		llvmValueType, err := c.getLLVMType(mapType.Elem().Underlying())
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmKeyType := c.getLLVMType(mapType.Key().Underlying())
+		llvmValueType := c.getLLVMType(mapType.Elem().Underlying())
 		keySize := c.targetData.TypeAllocSize(llvmKeyType)
 		valueSize := c.targetData.TypeAllocSize(llvmValueType)
 		llvmKeySize := llvm.ConstInt(c.ctx.Int8Type(), keySize, false)
@@ -1642,10 +1554,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return llvm.Value{}, nil
 		}
 		sliceType := expr.Type().Underlying().(*types.Slice)
-		llvmElemType, err := c.getLLVMType(sliceType.Elem())
-		if err != nil {
-			return llvm.Value{}, nil
-		}
+		llvmElemType := c.getLLVMType(sliceType.Elem())
 		elemSize := c.targetData.TypeAllocSize(llvmElemType)
 		elemSizeValue := llvm.ConstInt(c.uintptrType, elemSize, false)
 
@@ -1705,14 +1614,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if expr.IsString {
 			return c.createRuntimeCall("stringNext", []llvm.Value{llvmRangeVal, it}, "range.next"), nil
 		} else { // map
-			llvmKeyType, err := c.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Key())
-			if err != nil {
-				return llvm.Value{}, err
-			}
-			llvmValueType, err := c.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Elem())
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			llvmKeyType := c.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Key())
+			llvmValueType := c.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Elem())
 
 			mapKeyAlloca := c.builder.CreateAlloca(llvmKeyType, "range.key")
 			mapKeyPtr := c.builder.CreateBitCast(mapKeyAlloca, c.i8ptrType, "range.keyptr")
@@ -1727,11 +1630,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return tuple, nil
 		}
 	case *ssa.Phi:
-		t, err := c.getLLVMType(expr.Type())
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		phi := c.builder.CreatePHI(t, "")
+		phi := c.builder.CreatePHI(c.getLLVMType(expr.Type()), "")
 		frame.phis = append(frame.phis, Phi{expr, phi})
 		return phi, nil
 	case *ssa.Range:
@@ -1750,10 +1649,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.Select:
 		if len(expr.States) == 0 {
 			// Shortcuts for some simple selects.
-			llvmType, err := c.getLLVMType(expr.Type())
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			llvmType := c.getLLVMType(expr.Type())
 			if expr.Blocking {
 				// Blocks forever:
 				//     select {}
@@ -2223,10 +2119,7 @@ func (c *Compiler) parseBinOp(op token.Token, typ types.Type, x, y llvm.Value, p
 func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error) {
 	switch typ := expr.Type().Underlying().(type) {
 	case *types.Basic:
-		llvmType, err := c.getLLVMType(typ)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmType := c.getLLVMType(typ)
 		if typ.Info()&types.IsBoolean != 0 {
 			b := constant.BoolVal(expr.Value)
 			n := uint64(0)
@@ -2292,20 +2185,12 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 			return llvm.Value{}, errors.New("todo: unknown constant: " + expr.String())
 		}
 	case *types.Chan:
-		sig, err := c.getLLVMType(expr.Type())
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		return c.getZeroValue(sig), nil
+		return c.getZeroValue(c.getLLVMType(expr.Type())), nil
 	case *types.Signature:
 		if expr.Value != nil {
 			return llvm.Value{}, errors.New("non-nil signature constant")
 		}
-		sig, err := c.getLLVMType(expr.Type())
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		return c.getZeroValue(sig), nil
+		return c.getZeroValue(c.getLLVMType(expr.Type())), nil
 	case *types.Interface:
 		if expr.Value != nil {
 			return llvm.Value{}, errors.New("non-nil interface constant")
@@ -2321,19 +2206,12 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 		if expr.Value != nil {
 			return llvm.Value{}, errors.New("non-nil pointer constant")
 		}
-		llvmType, err := c.getLLVMType(typ)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		return llvm.ConstPointerNull(llvmType), nil
+		return llvm.ConstPointerNull(c.getLLVMType(typ)), nil
 	case *types.Slice:
 		if expr.Value != nil {
 			return llvm.Value{}, errors.New("non-nil slice constant")
 		}
-		elemType, err := c.getLLVMType(typ.Elem())
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		elemType := c.getLLVMType(typ.Elem())
 		llvmPtr := llvm.ConstPointerNull(llvm.PointerType(elemType, 0))
 		llvmLen := llvm.ConstInt(c.uintptrType, 0, false)
 		slice := c.ctx.ConstStruct([]llvm.Value{
@@ -2347,10 +2225,7 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 			// I believe this is not allowed by the Go spec.
 			panic("non-nil map constant")
 		}
-		llvmType, err := c.getLLVMType(typ)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmType := c.getLLVMType(typ)
 		return c.getZeroValue(llvmType), nil
 	default:
 		return llvm.Value{}, errors.New("todo: unknown constant: " + expr.String())
@@ -2359,10 +2234,7 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 
 func (c *Compiler) parseConvert(typeFrom, typeTo types.Type, value llvm.Value, pos token.Pos) (llvm.Value, error) {
 	llvmTypeFrom := value.Type()
-	llvmTypeTo, err := c.getLLVMType(typeTo)
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	llvmTypeTo := c.getLLVMType(typeTo)
 
 	// Conversion between unsafe.Pointer and uintptr.
 	isPtrFrom := isPointer(typeFrom.Underlying())

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -816,10 +816,7 @@ func (c *Compiler) parseFunc(frame *Frame) error {
 	for _, phi := range frame.phis {
 		block := phi.ssa.Block()
 		for i, edge := range phi.ssa.Edges {
-			llvmVal, err := c.parseExpr(frame, edge)
-			if err != nil {
-				return err
-			}
+			llvmVal := c.getValue(frame, edge)
 			llvmBlock := frame.blockExits[block.Preds[i]]
 			phi.llvm.AddIncoming([]llvm.Value{llvmVal}, []llvm.BasicBlock{llvmBlock})
 		}
@@ -864,11 +861,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 		// Get all function parameters to pass to the goroutine.
 		var params []llvm.Value
 		for _, param := range instr.Call.Args {
-			val, err := c.parseExpr(frame, param)
-			if err != nil {
-				return err
-			}
-			params = append(params, val)
+			params = append(params, c.getValue(frame, param))
 		}
 		if !calleeFn.IsExported() {
 			params = append(params, llvm.Undef(c.i8ptrType)) // context parameter
@@ -878,10 +871,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 		c.createCall(calleeValue, params, "")
 		return nil
 	case *ssa.If:
-		cond, err := c.parseExpr(frame, instr.Cond)
-		if err != nil {
-			return err
-		}
+		cond := c.getValue(frame, instr.Cond)
 		block := instr.Block()
 		blockThen := frame.blockEntries[block.Succs[0]]
 		blockElse := frame.blockEntries[block.Succs[1]]
@@ -892,25 +882,13 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 		c.builder.CreateBr(blockJump)
 		return nil
 	case *ssa.MapUpdate:
-		m, err := c.parseExpr(frame, instr.Map)
-		if err != nil {
-			return err
-		}
-		key, err := c.parseExpr(frame, instr.Key)
-		if err != nil {
-			return err
-		}
-		value, err := c.parseExpr(frame, instr.Value)
-		if err != nil {
-			return err
-		}
+		m := c.getValue(frame, instr.Map)
+		key := c.getValue(frame, instr.Key)
+		value := c.getValue(frame, instr.Value)
 		mapType := instr.Map.Type().Underlying().(*types.Map)
 		return c.emitMapUpdate(mapType.Key(), m, key, value, instr.Pos())
 	case *ssa.Panic:
-		value, err := c.parseExpr(frame, instr.X)
-		if err != nil {
-			return err
-		}
+		value := c.getValue(frame, instr.X)
 		c.createRuntimeCall("_panic", []llvm.Value{value}, "")
 		c.builder.CreateUnreachable()
 		return nil
@@ -919,20 +897,13 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 			c.builder.CreateRetVoid()
 			return nil
 		} else if len(instr.Results) == 1 {
-			val, err := c.parseExpr(frame, instr.Results[0])
-			if err != nil {
-				return err
-			}
-			c.builder.CreateRet(val)
+			c.builder.CreateRet(c.getValue(frame, instr.Results[0]))
 			return nil
 		} else {
 			// Multiple return values. Put them all in a struct.
 			retVal := c.getZeroValue(frame.fn.LLVMFn.Type().ElementType().ReturnType())
 			for i, result := range instr.Results {
-				val, err := c.parseExpr(frame, result)
-				if err != nil {
-					return err
-				}
+				val := c.getValue(frame, result)
 				retVal = c.builder.CreateInsertValue(retVal, val, i, "")
 			}
 			c.builder.CreateRet(retVal)
@@ -941,16 +912,11 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 	case *ssa.RunDefers:
 		return c.emitRunDefers(frame)
 	case *ssa.Send:
-		return c.emitChanSend(frame, instr)
+		c.emitChanSend(frame, instr)
+		return nil
 	case *ssa.Store:
-		llvmAddr, err := c.parseExpr(frame, instr.Addr)
-		if err != nil {
-			return err
-		}
-		llvmVal, err := c.parseExpr(frame, instr.Val)
-		if err != nil {
-			return err
-		}
+		llvmAddr := c.getValue(frame, instr.Addr)
+		llvmVal := c.getValue(frame, instr.Val)
 		if c.targetData.TypeAllocSize(llvmVal.Type()) == 0 {
 			// nothing to store
 			return nil
@@ -970,14 +936,8 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) error {
 func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string, pos token.Pos) (llvm.Value, error) {
 	switch callName {
 	case "append":
-		src, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		elems, err := c.parseExpr(frame, args[1])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		src := c.getValue(frame, args[0])
+		elems := c.getValue(frame, args[1])
 		srcBuf := c.builder.CreateExtractValue(src, 0, "append.srcBuf")
 		srcPtr := c.builder.CreateBitCast(srcBuf, c.i8ptrType, "append.srcPtr")
 		srcLen := c.builder.CreateExtractValue(src, 1, "append.srcLen")
@@ -998,10 +958,7 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		newSlice = c.builder.CreateInsertValue(newSlice, newCap, 2, "")
 		return newSlice, nil
 	case "cap":
-		value, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, args[0])
 		var llvmCap llvm.Value
 		switch args[0].Type().(type) {
 		case *types.Chan:
@@ -1018,16 +975,11 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		}
 		return llvmCap, nil
 	case "close":
-		return llvm.Value{}, c.emitChanClose(frame, args[0])
+		c.emitChanClose(frame, args[0])
+		return llvm.Value{}, nil
 	case "complex":
-		r, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		i, err := c.parseExpr(frame, args[1])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		r := c.getValue(frame, args[0])
+		i := c.getValue(frame, args[1])
 		t := args[0].Type().Underlying().(*types.Basic)
 		var cplx llvm.Value
 		switch t.Kind() {
@@ -1042,14 +994,8 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		cplx = c.builder.CreateInsertValue(cplx, i, 1, "")
 		return cplx, nil
 	case "copy":
-		dst, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		src, err := c.parseExpr(frame, args[1])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		dst := c.getValue(frame, args[0])
+		src := c.getValue(frame, args[1])
 		dstLen := c.builder.CreateExtractValue(dst, 1, "copy.dstLen")
 		srcLen := c.builder.CreateExtractValue(src, 1, "copy.srcLen")
 		dstBuf := c.builder.CreateExtractValue(dst, 0, "copy.dstArray")
@@ -1060,26 +1006,14 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		elemSize := llvm.ConstInt(c.uintptrType, c.targetData.TypeAllocSize(elemType), false)
 		return c.createRuntimeCall("sliceCopy", []llvm.Value{dstBuf, srcBuf, dstLen, srcLen, elemSize}, "copy.n"), nil
 	case "delete":
-		m, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		key, err := c.parseExpr(frame, args[1])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		m := c.getValue(frame, args[0])
+		key := c.getValue(frame, args[1])
 		return llvm.Value{}, c.emitMapDelete(args[1].Type(), m, key, pos)
 	case "imag":
-		cplx, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		cplx := c.getValue(frame, args[0])
 		return c.builder.CreateExtractValue(cplx, 1, "imag"), nil
 	case "len":
-		value, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, args[0])
 		var llvmLen llvm.Value
 		switch args[0].Type().Underlying().(type) {
 		case *types.Basic, *types.Slice:
@@ -1103,10 +1037,7 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 			if i >= 1 && callName == "println" {
 				c.createRuntimeCall("printspace", nil, "")
 			}
-			value, err := c.parseExpr(frame, arg)
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			value := c.getValue(frame, arg)
 			typ := arg.Type().Underlying()
 			switch typ := typ.(type) {
 			case *types.Basic:
@@ -1159,29 +1090,22 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		}
 		return llvm.Value{}, nil // print() or println() returns void
 	case "real":
-		cplx, err := c.parseExpr(frame, args[0])
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		cplx := c.getValue(frame, args[0])
 		return c.builder.CreateExtractValue(cplx, 0, "real"), nil
 	case "recover":
 		return c.createRuntimeCall("_recover", nil, ""), nil
 	case "ssa:wrapnilchk":
 		// TODO: do an actual nil check?
-		return c.parseExpr(frame, args[0])
+		return c.getValue(frame, args[0]), nil
 	default:
 		return llvm.Value{}, c.makeError(pos, "todo: builtin: "+callName)
 	}
 }
 
-func (c *Compiler) parseFunctionCall(frame *Frame, args []ssa.Value, llvmFn, context llvm.Value, exported bool) (llvm.Value, error) {
+func (c *Compiler) parseFunctionCall(frame *Frame, args []ssa.Value, llvmFn, context llvm.Value, exported bool) llvm.Value {
 	var params []llvm.Value
 	for _, param := range args {
-		val, err := c.parseExpr(frame, param)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		params = append(params, val)
+		params = append(params, c.getValue(frame, param))
 	}
 
 	if !exported {
@@ -1193,15 +1117,12 @@ func (c *Compiler) parseFunctionCall(frame *Frame, args []ssa.Value, llvmFn, con
 		params = append(params, llvm.Undef(c.i8ptrType))
 	}
 
-	return c.createCall(llvmFn, params, ""), nil
+	return c.createCall(llvmFn, params, "")
 }
 
 func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
 	if instr.IsInvoke() {
-		fnCast, args, err := c.getInvokeCall(frame, instr)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		fnCast, args := c.getInvokeCall(frame, instr)
 		return c.createCall(fnCast, args, ""), nil
 	}
 
@@ -1232,15 +1153,12 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 		case *ssa.MakeClosure:
 			// A call on a func value, but the callee is trivial to find. For
 			// example: immediately applied functions.
-			funcValue, err := c.parseExpr(frame, value)
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			funcValue := c.getValue(frame, value)
 			context = c.extractFuncContext(funcValue)
 		default:
 			panic("StaticCallee returned an unexpected value")
 		}
-		return c.parseFunctionCall(frame, instr.Args, targetFunc.LLVMFn, context, targetFunc.IsExported())
+		return c.parseFunctionCall(frame, instr.Args, targetFunc.LLVMFn, context, targetFunc.IsExported()), nil
 	}
 
 	// Builtin or function pointer.
@@ -1248,10 +1166,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 	case *ssa.Builtin:
 		return c.parseBuiltin(frame, instr.Args, call.Name(), instr.Pos())
 	default: // function pointer
-		value, err := c.parseExpr(frame, instr.Value)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, instr.Value)
 		// This is a func value, which cannot be called directly. We have to
 		// extract the function pointer and context first from the func value.
 		funcPtr, context, err := c.decodeFuncValue(value, instr.Value.Type().(*types.Signature))
@@ -1259,17 +1174,46 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 			return llvm.Value{}, err
 		}
 		c.emitNilCheck(frame, funcPtr, "fpcall")
-		return c.parseFunctionCall(frame, instr.Args, funcPtr, context, false)
+		return c.parseFunctionCall(frame, instr.Args, funcPtr, context, false), nil
 	}
 }
 
-func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
-	if value, ok := frame.locals[expr]; ok {
-		// Value is a local variable that has already been computed.
-		if value.IsNil() {
-			return llvm.Value{}, c.makeError(expr.Pos(), "undefined local var (from cgo?)")
+// getValue returns the LLVM value of a constant, function value, global, or
+// already processed SSA expression.
+func (c *Compiler) getValue(frame *Frame, expr ssa.Value) llvm.Value {
+	switch expr := expr.(type) {
+	case *ssa.Const:
+		return c.parseConst(frame.fn.LinkName(), expr)
+	case *ssa.Function:
+		fn := c.ir.GetFunction(expr)
+		if fn.IsExported() {
+			// TODO: report this as a compiler diagnostic
+			panic("cannot use an exported function as value: " + expr.String())
 		}
-		return value, nil
+		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature)
+	case *ssa.Global:
+		value := c.ir.GetGlobal(expr).LLVMGlobal
+		if value.IsNil() {
+			// TODO: report this as a compiler diagnostic
+			panic("global not found: " + c.ir.GetGlobal(expr).LinkName())
+		}
+		return value
+	default:
+		// other (local) SSA value
+		if value, ok := frame.locals[expr]; ok {
+			return value
+		} else {
+			// indicates a compiler bug
+			panic("local has not been parsed: " + expr.String())
+		}
+	}
+}
+
+// parseExpr translates a Go SSA expression to a LLVM instruction.
+func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
+	if _, ok := frame.locals[expr]; ok {
+		// sanity check
+		panic("local has already been parsed: " + expr.String())
 	}
 
 	switch expr := expr.(type) {
@@ -1296,14 +1240,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		}
 		return buf, nil
 	case *ssa.BinOp:
-		x, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		y, err := c.parseExpr(frame, expr.Y)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		x := c.getValue(frame, expr.X)
+		y := c.getValue(frame, expr.Y)
 		return c.parseBinOp(expr.Op, expr.X.Type(), x, y, expr.Pos())
 	case *ssa.Call:
 		// Passing the current task here to the subroutine. It is only used when
@@ -1316,15 +1254,12 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		// This is different from how the official Go compiler works, because of
 		// heap allocation and because it's easier to implement, see:
 		// https://research.swtch.com/interfaces
-		return c.parseExpr(frame, expr.X)
+		return c.getValue(frame, expr.X), nil
 	case *ssa.ChangeType:
 		// This instruction changes the type, but the underlying value remains
 		// the same. This is often a no-op, but sometimes we have to change the
 		// LLVM type as well.
-		x, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		x := c.getValue(frame, expr.X)
 		llvmType := c.getLLVMType(expr.Type())
 		if x.Type() == llvmType {
 			// Different Go type but same LLVM type (for example, named int).
@@ -1351,25 +1286,16 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return llvm.Value{}, errors.New("todo: unknown ChangeType type: " + expr.X.Type().String())
 		}
 	case *ssa.Const:
-		return c.parseConst(frame.fn.LinkName(), expr)
+		panic("const is not an expression")
 	case *ssa.Convert:
-		x, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		x := c.getValue(frame, expr.X)
 		return c.parseConvert(expr.X.Type(), expr.Type(), x, expr.Pos())
 	case *ssa.Extract:
-		value, err := c.parseExpr(frame, expr.Tuple)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, expr.Tuple)
 		result := c.builder.CreateExtractValue(value, expr.Index, "")
 		return result, nil
 	case *ssa.Field:
-		value, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, expr.X)
 		if s := expr.X.Type().Underlying().(*types.Struct); s.NumFields() > 2 && s.Field(0).Name() == "C union" {
 			// Extract a field from a CGo union.
 			// This could be done directly, but as this is a very infrequent
@@ -1383,10 +1309,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		result := c.builder.CreateExtractValue(value, expr.Field, "")
 		return result, nil
 	case *ssa.FieldAddr:
-		val, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		val := c.getValue(frame, expr.X)
 		// Check for nil pointer before calculating the address, from the spec:
 		// > For an operand x of type T, the address operation &x generates a
 		// > pointer of type *T to x. [...] If the evaluation of x would cause a
@@ -1407,26 +1330,12 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return c.builder.CreateGEP(val, indices, ""), nil
 		}
 	case *ssa.Function:
-		fn := c.ir.GetFunction(expr)
-		if fn.IsExported() {
-			return llvm.Value{}, c.makeError(expr.Pos(), "cannot use an exported function as value")
-		}
-		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature), nil
+		panic("function is not an expression")
 	case *ssa.Global:
-		value := c.ir.GetGlobal(expr).LLVMGlobal
-		if value.IsNil() {
-			return llvm.Value{}, c.makeError(expr.Pos(), "global not found: "+c.ir.GetGlobal(expr).LinkName())
-		}
-		return value, nil
+		panic("global is not an expression")
 	case *ssa.Index:
-		array, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		index, err := c.parseExpr(frame, expr.Index)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		array := c.getValue(frame, expr.X)
+		index := c.getValue(frame, expr.Index)
 
 		// Check bounds.
 		arrayLen := expr.X.Type().(*types.Array).Len()
@@ -1441,14 +1350,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		ptr := c.builder.CreateGEP(alloca, []llvm.Value{zero, index}, "index.gep")
 		return c.builder.CreateLoad(ptr, "index.load"), nil
 	case *ssa.IndexAddr:
-		val, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		index, err := c.parseExpr(frame, expr.Index)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		val := c.getValue(frame, expr.X)
+		index := c.getValue(frame, expr.Index)
 
 		// Get buffer pointer and length
 		var bufptr, buflen llvm.Value
@@ -1492,14 +1395,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			panic("unreachable")
 		}
 	case *ssa.Lookup:
-		value, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, nil
-		}
-		index, err := c.parseExpr(frame, expr.Index)
-		if err != nil {
-			return llvm.Value{}, nil
-		}
+		value := c.getValue(frame, expr.X)
+		index := c.getValue(frame, expr.Index)
 		switch xType := expr.X.Type().Underlying().(type) {
 		case *types.Basic:
 			// Value type must be a string, which is a basic type.
@@ -1529,10 +1426,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.MakeClosure:
 		return c.parseMakeClosure(frame, expr)
 	case *ssa.MakeInterface:
-		val, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		val := c.getValue(frame, expr.X)
 		return c.parseMakeInterface(val, expr.X.Type(), expr.Pos())
 	case *ssa.MakeMap:
 		mapType := expr.Type().Underlying().(*types.Map)
@@ -1545,14 +1439,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		hashmap := c.createRuntimeCall("hashmapMake", []llvm.Value{llvmKeySize, llvmValueSize}, "")
 		return hashmap, nil
 	case *ssa.MakeSlice:
-		sliceLen, err := c.parseExpr(frame, expr.Len)
-		if err != nil {
-			return llvm.Value{}, nil
-		}
-		sliceCap, err := c.parseExpr(frame, expr.Cap)
-		if err != nil {
-			return llvm.Value{}, nil
-		}
+		sliceLen := c.getValue(frame, expr.Len)
+		sliceCap := c.getValue(frame, expr.Cap)
 		sliceType := expr.Type().Underlying().(*types.Slice)
 		llvmElemType := c.getLLVMType(sliceType.Elem())
 		elemSize := c.targetData.TypeAllocSize(llvmElemType)
@@ -1603,14 +1491,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		return slice, nil
 	case *ssa.Next:
 		rangeVal := expr.Iter.(*ssa.Range).X
-		llvmRangeVal, err := c.parseExpr(frame, rangeVal)
-		if err != nil {
-			return llvm.Value{}, err
-		}
-		it, err := c.parseExpr(frame, expr.Iter)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmRangeVal := c.getValue(frame, rangeVal)
+		it := c.getValue(frame, expr.Iter)
 		if expr.IsString {
 			return c.createRuntimeCall("stringNext", []llvm.Value{llvmRangeVal, it}, "range.next"), nil
 		} else { // map
@@ -1670,20 +1552,14 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		if expr.Max != nil {
 			return llvm.Value{}, c.makeError(expr.Pos(), "todo: full slice expressions (with max): "+expr.Type().String())
 		}
-		value, err := c.parseExpr(frame, expr.X)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		value := c.getValue(frame, expr.X)
 
 		var lowType, highType *types.Basic
 		var low, high llvm.Value
 
 		if expr.Low != nil {
 			lowType = expr.Low.Type().Underlying().(*types.Basic)
-			low, err = c.parseExpr(frame, expr.Low)
-			if err != nil {
-				return llvm.Value{}, nil
-			}
+			low = c.getValue(frame, expr.Low)
 			if low.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 				if lowType.Info()&types.IsUnsigned != 0 {
 					low = c.builder.CreateZExt(low, c.uintptrType, "")
@@ -1698,10 +1574,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 		if expr.High != nil {
 			highType = expr.High.Type().Underlying().(*types.Basic)
-			high, err = c.parseExpr(frame, expr.High)
-			if err != nil {
-				return llvm.Value{}, nil
-			}
+			high = c.getValue(frame, expr.High)
 			if high.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 				if highType.Info()&types.IsUnsigned != 0 {
 					high = c.builder.CreateZExt(high, c.uintptrType, "")
@@ -1817,7 +1690,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return llvm.Value{}, c.makeError(expr.Pos(), "unknown slice type: "+typ.String())
 		}
 	case *ssa.TypeAssert:
-		return c.parseTypeAssert(frame, expr)
+		return c.parseTypeAssert(frame, expr), nil
 	case *ssa.UnOp:
 		return c.parseUnOp(frame, expr)
 	default:
@@ -2116,7 +1989,7 @@ func (c *Compiler) parseBinOp(op token.Token, typ types.Type, x, y llvm.Value, p
 	}
 }
 
-func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error) {
+func (c *Compiler) parseConst(prefix string, expr *ssa.Const) llvm.Value {
 	switch typ := expr.Type().Underlying().(type) {
 	case *types.Basic:
 		llvmType := c.getLLVMType(typ)
@@ -2126,7 +1999,7 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 			if b {
 				n = 1
 			}
-			return llvm.ConstInt(llvmType, n, false), nil
+			return llvm.ConstInt(llvmType, n, false)
 		} else if typ.Info()&types.IsString != 0 {
 			str := constant.StringVal(expr.Value)
 			strLen := llvm.ConstInt(c.uintptrType, uint64(len(str)), false)
@@ -2139,77 +2012,67 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
 			strPtr := c.builder.CreateInBoundsGEP(global, []llvm.Value{zero, zero}, "")
 			strObj := llvm.ConstNamedStruct(c.mod.GetTypeByName("runtime._string"), []llvm.Value{strPtr, strLen})
-			return strObj, nil
+			return strObj
 		} else if typ.Kind() == types.UnsafePointer {
 			if !expr.IsNil() {
 				value, _ := constant.Uint64Val(expr.Value)
-				return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, value, false), c.i8ptrType), nil
+				return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, value, false), c.i8ptrType)
 			}
-			return llvm.ConstNull(c.i8ptrType), nil
+			return llvm.ConstNull(c.i8ptrType)
 		} else if typ.Info()&types.IsUnsigned != 0 {
 			n, _ := constant.Uint64Val(expr.Value)
-			return llvm.ConstInt(llvmType, n, false), nil
+			return llvm.ConstInt(llvmType, n, false)
 		} else if typ.Info()&types.IsInteger != 0 { // signed
 			n, _ := constant.Int64Val(expr.Value)
-			return llvm.ConstInt(llvmType, uint64(n), true), nil
+			return llvm.ConstInt(llvmType, uint64(n), true)
 		} else if typ.Info()&types.IsFloat != 0 {
 			n, _ := constant.Float64Val(expr.Value)
-			return llvm.ConstFloat(llvmType, n), nil
+			return llvm.ConstFloat(llvmType, n)
 		} else if typ.Kind() == types.Complex64 {
-			r, err := c.parseConst(prefix, ssa.NewConst(constant.Real(expr.Value), types.Typ[types.Float32]))
-			if err != nil {
-				return llvm.Value{}, err
-			}
-			i, err := c.parseConst(prefix, ssa.NewConst(constant.Imag(expr.Value), types.Typ[types.Float32]))
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			r := c.parseConst(prefix, ssa.NewConst(constant.Real(expr.Value), types.Typ[types.Float32]))
+			i := c.parseConst(prefix, ssa.NewConst(constant.Imag(expr.Value), types.Typ[types.Float32]))
 			cplx := llvm.Undef(c.ctx.StructType([]llvm.Type{c.ctx.FloatType(), c.ctx.FloatType()}, false))
 			cplx = c.builder.CreateInsertValue(cplx, r, 0, "")
 			cplx = c.builder.CreateInsertValue(cplx, i, 1, "")
-			return cplx, nil
+			return cplx
 		} else if typ.Kind() == types.Complex128 {
-			r, err := c.parseConst(prefix, ssa.NewConst(constant.Real(expr.Value), types.Typ[types.Float64]))
-			if err != nil {
-				return llvm.Value{}, err
-			}
-			i, err := c.parseConst(prefix, ssa.NewConst(constant.Imag(expr.Value), types.Typ[types.Float64]))
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			r := c.parseConst(prefix, ssa.NewConst(constant.Real(expr.Value), types.Typ[types.Float64]))
+			i := c.parseConst(prefix, ssa.NewConst(constant.Imag(expr.Value), types.Typ[types.Float64]))
 			cplx := llvm.Undef(c.ctx.StructType([]llvm.Type{c.ctx.DoubleType(), c.ctx.DoubleType()}, false))
 			cplx = c.builder.CreateInsertValue(cplx, r, 0, "")
 			cplx = c.builder.CreateInsertValue(cplx, i, 1, "")
-			return cplx, nil
+			return cplx
 		} else {
-			return llvm.Value{}, errors.New("todo: unknown constant: " + expr.String())
+			panic("unknown constant of basic type: " + expr.String())
 		}
 	case *types.Chan:
-		return c.getZeroValue(c.getLLVMType(expr.Type())), nil
+		if expr.Value != nil {
+			panic("expected nil chan constant")
+		}
+		return c.getZeroValue(c.getLLVMType(expr.Type()))
 	case *types.Signature:
 		if expr.Value != nil {
-			return llvm.Value{}, errors.New("non-nil signature constant")
+			panic("expected nil signature constant")
 		}
-		return c.getZeroValue(c.getLLVMType(expr.Type())), nil
+		return c.getZeroValue(c.getLLVMType(expr.Type()))
 	case *types.Interface:
 		if expr.Value != nil {
-			return llvm.Value{}, errors.New("non-nil interface constant")
+			panic("expected nil interface constant")
 		}
 		// Create a generic nil interface with no dynamic type (typecode=0).
 		fields := []llvm.Value{
 			llvm.ConstInt(c.uintptrType, 0, false),
 			llvm.ConstPointerNull(c.i8ptrType),
 		}
-		itf := llvm.ConstNamedStruct(c.mod.GetTypeByName("runtime._interface"), fields)
-		return itf, nil
+		return llvm.ConstNamedStruct(c.mod.GetTypeByName("runtime._interface"), fields)
 	case *types.Pointer:
 		if expr.Value != nil {
-			return llvm.Value{}, errors.New("non-nil pointer constant")
+			panic("expected nil pointer constant")
 		}
-		return llvm.ConstPointerNull(c.getLLVMType(typ)), nil
+		return llvm.ConstPointerNull(c.getLLVMType(typ))
 	case *types.Slice:
 		if expr.Value != nil {
-			return llvm.Value{}, errors.New("non-nil slice constant")
+			panic("expected nil slice constant")
 		}
 		elemType := c.getLLVMType(typ.Elem())
 		llvmPtr := llvm.ConstPointerNull(llvm.PointerType(elemType, 0))
@@ -2219,16 +2082,16 @@ func (c *Compiler) parseConst(prefix string, expr *ssa.Const) (llvm.Value, error
 			llvmLen, // len
 			llvmLen, // cap
 		}, false)
-		return slice, nil
+		return slice
 	case *types.Map:
 		if !expr.IsNil() {
 			// I believe this is not allowed by the Go spec.
 			panic("non-nil map constant")
 		}
 		llvmType := c.getLLVMType(typ)
-		return c.getZeroValue(llvmType), nil
+		return c.getZeroValue(llvmType)
 	default:
-		return llvm.Value{}, errors.New("todo: unknown constant: " + expr.String())
+		panic("unknown constant: " + expr.String())
 	}
 }
 
@@ -2390,10 +2253,7 @@ func (c *Compiler) parseConvert(typeFrom, typeTo types.Type, value llvm.Value, p
 }
 
 func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
-	x, err := c.parseExpr(frame, unop.X)
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	x := c.getValue(frame, unop.X)
 	switch unop.Op {
 	case token.NOT: // !x
 		return c.builder.CreateNot(x, ""), nil
@@ -2439,7 +2299,7 @@ func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
 	case token.XOR: // ^x, toggle all bits in integer
 		return c.builder.CreateXor(x, llvm.ConstInt(x.Type(), ^uint64(0), false), ""), nil
 	case token.ARROW: // <-x, receive from channel
-		return c.emitChanRecv(frame, unop)
+		return c.emitChanRecv(frame, unop), nil
 	default:
 		return llvm.Value{}, c.makeError(unop.Pos(), "todo: unknown unop")
 	}

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -217,11 +217,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			// Get the real defer struct type and cast to it.
 			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0), c.i8ptrType}
 			for _, arg := range callback.Args {
-				llvmType, err := c.getLLVMType(arg.Type())
-				if err != nil {
-					return err
-				}
-				valueTypes = append(valueTypes, llvmType)
+				valueTypes = append(valueTypes, c.getLLVMType(arg.Type()))
 			}
 			deferFrameType := c.ctx.StructType(valueTypes, false)
 			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
@@ -255,11 +251,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			// Get the real defer struct type and cast to it.
 			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
 			for _, param := range callback.Params {
-				llvmType, err := c.getLLVMType(param.Type())
-				if err != nil {
-					return err
-				}
-				valueTypes = append(valueTypes, llvmType)
+				valueTypes = append(valueTypes, c.getLLVMType(param.Type()))
 			}
 			deferFrameType := c.ctx.StructType(valueTypes, false)
 			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
@@ -289,11 +281,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
 			params := fn.Signature.Params()
 			for i := 0; i < params.Len(); i++ {
-				llvmType, err := c.getLLVMType(params.At(i).Type())
-				if err != nil {
-					return err
-				}
-				valueTypes = append(valueTypes, llvmType)
+				valueTypes = append(valueTypes, c.getLLVMType(params.At(i).Type()))
 			}
 			valueTypes = append(valueTypes, c.i8ptrType) // closure
 			deferFrameType := c.ctx.StructType(valueTypes, false)

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -136,10 +136,7 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) error {
 
 	// Make a struct out of the collected values to put in the defer frame.
 	deferFrameType := c.ctx.StructType(valueTypes, false)
-	deferFrame, err := c.getZeroValue(deferFrameType)
-	if err != nil {
-		return err
-	}
+	deferFrame := c.getZeroValue(deferFrameType)
 	for i, value := range values {
 		deferFrame = c.builder.CreateInsertValue(deferFrame, value, i, "")
 	}

--- a/compiler/errors.go
+++ b/compiler/errors.go
@@ -12,3 +12,7 @@ func (c *Compiler) makeError(pos token.Pos, msg string) types.Error {
 		Msg:  msg,
 	}
 }
+
+func (c *Compiler) addError(pos token.Pos, msg string) {
+	c.diagnostics = append(c.diagnostics, c.makeError(pos, msg))
+}

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -190,10 +190,7 @@ func (c *Compiler) parseMakeClosure(frame *Frame, expr *ssa.MakeClosure) (llvm.V
 	boundVarTypes := make([]llvm.Type, 0, len(expr.Bindings))
 	for _, binding := range expr.Bindings {
 		// The context stores the bound variables.
-		llvmBoundVar, err := c.parseExpr(frame, binding)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmBoundVar := c.getValue(frame, binding)
 		boundVars = append(boundVars, llvmBoundVar)
 		boundVarTypes = append(boundVarTypes, llvmBoundVar.Type())
 	}

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -41,7 +41,7 @@ func (c *Compiler) funcImplementation() funcValueImplementation {
 
 // createFuncValue creates a function value from a raw function pointer with no
 // context.
-func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) (llvm.Value, error) {
+func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
 	var funcValueScalar llvm.Value
 	switch c.funcImplementation() {
 	case funcValueDoubleword:
@@ -66,14 +66,11 @@ func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signa
 	default:
 		panic("unimplemented func value variant")
 	}
-	funcValueType, err := c.getFuncType(sig)
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	funcValueType := c.getFuncType(sig)
 	funcValue := llvm.Undef(funcValueType)
 	funcValue = c.builder.CreateInsertValue(funcValue, context, 0, "")
 	funcValue = c.builder.CreateInsertValue(funcValue, funcValueScalar, 1, "")
-	return funcValue, nil
+	return funcValue
 }
 
 // getFuncSignature returns a global for identification of a particular function
@@ -112,10 +109,7 @@ func (c *Compiler) decodeFuncValue(funcValue llvm.Value, sig *types.Signature) (
 	case funcValueDoubleword:
 		funcPtr = c.builder.CreateExtractValue(funcValue, 1, "")
 	case funcValueSwitch:
-		llvmSig, err := c.getRawFuncType(sig)
-		if err != nil {
-			return llvm.Value{}, llvm.Value{}, err
-		}
+		llvmSig := c.getRawFuncType(sig)
 		sigGlobal := c.getFuncSignature(sig)
 		funcPtr = c.createRuntimeCall("getFuncPtr", []llvm.Value{funcValue, sigGlobal}, "")
 		funcPtr = c.builder.CreateIntToPtr(funcPtr, llvmSig, "")
@@ -126,25 +120,21 @@ func (c *Compiler) decodeFuncValue(funcValue llvm.Value, sig *types.Signature) (
 }
 
 // getFuncType returns the type of a func value given a signature.
-func (c *Compiler) getFuncType(typ *types.Signature) (llvm.Type, error) {
+func (c *Compiler) getFuncType(typ *types.Signature) llvm.Type {
 	switch c.funcImplementation() {
 	case funcValueDoubleword:
-		rawPtr, err := c.getRawFuncType(typ)
-		if err != nil {
-			return llvm.Type{}, err
-		}
-		return c.ctx.StructType([]llvm.Type{c.i8ptrType, rawPtr}, false), nil
+		rawPtr := c.getRawFuncType(typ)
+		return c.ctx.StructType([]llvm.Type{c.i8ptrType, rawPtr}, false)
 	case funcValueSwitch:
-		return c.mod.GetTypeByName("runtime.funcValue"), nil
+		return c.mod.GetTypeByName("runtime.funcValue")
 	default:
 		panic("unimplemented func value variant")
 	}
 }
 
 // getRawFuncType returns a LLVM function pointer type for a given signature.
-func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
+func (c *Compiler) getRawFuncType(typ *types.Signature) llvm.Type {
 	// Get the return type.
-	var err error
 	var returnType llvm.Type
 	switch typ.Results().Len() {
 	case 0:
@@ -152,21 +142,14 @@ func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
 		returnType = c.ctx.VoidType()
 	case 1:
 		// Just one return value.
-		returnType, err = c.getLLVMType(typ.Results().At(0).Type())
-		if err != nil {
-			return llvm.Type{}, err
-		}
+		returnType = c.getLLVMType(typ.Results().At(0).Type())
 	default:
 		// Multiple return values. Put them together in a struct.
 		// This appears to be the common way to handle multiple return values in
 		// LLVM.
 		members := make([]llvm.Type, typ.Results().Len())
 		for i := 0; i < typ.Results().Len(); i++ {
-			returnType, err := c.getLLVMType(typ.Results().At(i).Type())
-			if err != nil {
-				return llvm.Type{}, err
-			}
-			members[i] = returnType
+			members[i] = c.getLLVMType(typ.Results().At(i).Type())
 		}
 		returnType = c.ctx.StructType(members, false)
 	}
@@ -174,10 +157,7 @@ func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
 	// Get the parameter types.
 	var paramTypes []llvm.Type
 	if typ.Recv() != nil {
-		recv, err := c.getLLVMType(typ.Recv().Type())
-		if err != nil {
-			return llvm.Type{}, err
-		}
+		recv := c.getLLVMType(typ.Recv().Type())
 		if recv.StructName() == "runtime._interface" {
 			// This is a call on an interface, not a concrete type.
 			// The receiver is not an interface, but a i8* type.
@@ -186,10 +166,7 @@ func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
 		paramTypes = append(paramTypes, c.expandFormalParamType(recv)...)
 	}
 	for i := 0; i < typ.Params().Len(); i++ {
-		subType, err := c.getLLVMType(typ.Params().At(i).Type())
-		if err != nil {
-			return llvm.Type{}, err
-		}
+		subType := c.getLLVMType(typ.Params().At(i).Type())
 		paramTypes = append(paramTypes, c.expandFormalParamType(subType)...)
 	}
 	// All functions take these parameters at the end.
@@ -197,7 +174,7 @@ func (c *Compiler) getRawFuncType(typ *types.Signature) (llvm.Type, error) {
 	paramTypes = append(paramTypes, c.i8ptrType) // parent coroutine
 
 	// Make a func type out of the signature.
-	return llvm.PointerType(llvm.FunctionType(returnType, paramTypes, false), c.funcPtrAddrSpace), nil
+	return llvm.PointerType(llvm.FunctionType(returnType, paramTypes, false), c.funcPtrAddrSpace)
 }
 
 // parseMakeClosure makes a function value (with context) from the given
@@ -261,5 +238,5 @@ func (c *Compiler) parseMakeClosure(frame *Frame, expr *ssa.MakeClosure) (llvm.V
 	}
 
 	// Create the closure.
-	return c.createFuncValue(f.LLVMFn, context, f.Signature)
+	return c.createFuncValue(f.LLVMFn, context, f.Signature), nil
 }

--- a/compiler/inlineasm.go
+++ b/compiler/inlineasm.go
@@ -68,11 +68,7 @@ func (c *Compiler) emitAsmFull(frame *Frame, instr *ssa.CallCommon) (llvm.Value,
 			}
 			key := constant.StringVal(r.Key.(*ssa.Const).Value)
 			//println("value:", r.Value.(*ssa.MakeInterface).X.String())
-			value, err := c.parseExpr(frame, r.Value.(*ssa.MakeInterface).X)
-			if err != nil {
-				return llvm.Value{}, err
-			}
-			registers[key] = value
+			registers[key] = c.getValue(frame, r.Value.(*ssa.MakeInterface).X)
 		case *ssa.Call:
 			if r.Common() == instr {
 				break
@@ -145,10 +141,7 @@ func (c *Compiler) emitSVCall(frame *Frame, args []ssa.Value) (llvm.Value, error
 		} else {
 			constraints += ",{r" + strconv.Itoa(i) + "}"
 		}
-		llvmValue, err := c.parseExpr(frame, arg)
-		if err != nil {
-			return llvm.Value{}, err
-		}
+		llvmValue := c.getValue(frame, arg)
 		llvmArgs = append(llvmArgs, llvmValue)
 		argTypes = append(argTypes, llvmValue.Type())
 	}

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -279,10 +279,7 @@ func (c *Compiler) parseTypeAssert(frame *Frame, expr *ssa.TypeAssert) (llvm.Val
 	if err != nil {
 		return llvm.Value{}, err
 	}
-	assertedType, err := c.getLLVMType(expr.AssertedType)
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	assertedType := c.getLLVMType(expr.AssertedType)
 
 	actualTypeNum := c.builder.CreateExtractValue(itf, 0, "interface.type")
 	commaOk := llvm.Value{}
@@ -389,10 +386,7 @@ func (c *Compiler) getInvokeCall(frame *Frame, instr *ssa.CallCommon) (llvm.Valu
 		return llvm.Value{}, nil, err
 	}
 
-	llvmFnType, err := c.getRawFuncType(instr.Method.Type().(*types.Signature))
-	if err != nil {
-		return llvm.Value{}, nil, err
-	}
+	llvmFnType := c.getRawFuncType(instr.Method.Type().(*types.Signature))
 
 	typecode := c.builder.CreateExtractValue(itf, 0, "invoke.typecode")
 	values := []llvm.Value{
@@ -443,10 +437,7 @@ func (c *Compiler) getInterfaceInvokeWrapper(f *ir.Function) (llvm.Value, error)
 	}
 
 	// Get the expanded receiver type.
-	receiverType, err := c.getLLVMType(f.Params[0].Type())
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	receiverType := c.getLLVMType(f.Params[0].Type())
 	expandedReceiverType := c.expandFormalParamType(receiverType)
 
 	// Does this method even need any wrapping?
@@ -473,7 +464,7 @@ func (c *Compiler) getInterfaceInvokeWrapper(f *ir.Function) (llvm.Value, error)
 
 // createInterfaceInvokeWrapper finishes the work of getInterfaceInvokeWrapper,
 // see that function for details.
-func (c *Compiler) createInterfaceInvokeWrapper(state interfaceInvokeWrapper) error {
+func (c *Compiler) createInterfaceInvokeWrapper(state interfaceInvokeWrapper) {
 	wrapper := state.wrapper
 	fn := state.fn
 	receiverType := state.receiverType
@@ -483,10 +474,7 @@ func (c *Compiler) createInterfaceInvokeWrapper(state interfaceInvokeWrapper) er
 	// add debug info if needed
 	if c.Debug {
 		pos := c.ir.Program.Fset.Position(fn.Pos())
-		difunc, err := c.attachDebugInfoRaw(fn, wrapper, "$invoke", pos.Filename, pos.Line)
-		if err != nil {
-			return err
-		}
+		difunc := c.attachDebugInfoRaw(fn, wrapper, "$invoke", pos.Filename, pos.Line)
 		c.builder.SetCurrentDebugLocation(uint(pos.Line), uint(pos.Column), difunc, llvm.Metadata{})
 	}
 
@@ -524,6 +512,4 @@ func (c *Compiler) createInterfaceInvokeWrapper(state interfaceInvokeWrapper) er
 		ret := c.builder.CreateCall(fn.LLVMFn, params, "ret")
 		c.builder.CreateRet(ret)
 	}
-
-	return nil
 }

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -39,7 +39,7 @@ func (c *Compiler) emitMapLookup(keyType, valueType types.Type, m, key llvm.Valu
 	}
 }
 
-func (c *Compiler) emitMapUpdate(keyType types.Type, m, key, value llvm.Value, pos token.Pos) error {
+func (c *Compiler) emitMapUpdate(keyType types.Type, m, key, value llvm.Value, pos token.Pos) {
 	valueAlloca := c.builder.CreateAlloca(value.Type(), "hashmap.value")
 	c.builder.CreateStore(value, valueAlloca)
 	valuePtr := c.builder.CreateBitCast(valueAlloca, c.i8ptrType, "hashmap.valueptr")
@@ -48,7 +48,6 @@ func (c *Compiler) emitMapUpdate(keyType types.Type, m, key, value llvm.Value, p
 		// key is a string
 		params := []llvm.Value{m, key, valuePtr}
 		c.createRuntimeCall("hashmapStringSet", params, "")
-		return nil
 	} else if hashmapIsBinaryKey(keyType) {
 		// key can be compared with runtime.memequal
 		keyAlloca := c.builder.CreateAlloca(key.Type(), "hashmap.key")
@@ -56,9 +55,8 @@ func (c *Compiler) emitMapUpdate(keyType types.Type, m, key, value llvm.Value, p
 		keyPtr := c.builder.CreateBitCast(keyAlloca, c.i8ptrType, "hashmap.keyptr")
 		params := []llvm.Value{m, keyPtr, valuePtr}
 		c.createRuntimeCall("hashmapBinarySet", params, "")
-		return nil
 	} else {
-		return c.makeError(pos, "only strings, bools, ints or structs of bools/ints are supported as map keys, but got: "+keyType.String())
+		c.addError(pos, "only strings, bools, ints or structs of bools/ints are supported as map keys, but got: "+keyType.String())
 	}
 }
 

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -10,10 +10,7 @@ import (
 )
 
 func (c *Compiler) emitMapLookup(keyType, valueType types.Type, m, key llvm.Value, commaOk bool, pos token.Pos) (llvm.Value, error) {
-	llvmValueType, err := c.getLLVMType(valueType)
-	if err != nil {
-		return llvm.Value{}, err
-	}
+	llvmValueType := c.getLLVMType(valueType)
 	mapValueAlloca := c.builder.CreateAlloca(llvmValueType, "hashmap.value")
 	mapValuePtr := c.builder.CreateBitCast(mapValueAlloca, c.i8ptrType, "hashmap.valueptr")
 	var commaOkValue llvm.Value

--- a/compiler/optimizer.go
+++ b/compiler/optimizer.go
@@ -249,7 +249,7 @@ func (c *Compiler) OptimizeAllocs() {
 			sizeInWords := (size + uint64(alignment) - 1) / uint64(alignment)
 			allocaType := llvm.ArrayType(c.ctx.IntType(alignment*8), int(sizeInWords))
 			alloca := c.builder.CreateAlloca(allocaType, "stackalloc.alloca")
-			zero, _ := c.getZeroValue(alloca.Type().ElementType())
+			zero := c.getZeroValue(alloca.Type().ElementType())
 			c.builder.CreateStore(zero, alloca)
 			stackalloc := c.builder.CreateBitCast(alloca, bitcast.Type(), "stackalloc")
 			bitcast.ReplaceAllUsesWith(stackalloc)

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -51,10 +51,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{r12}",
 				"{r13}",
 			}[i]
-			llvmValue, err := c.parseExpr(frame, arg)
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			llvmValue := c.getValue(frame, arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -80,10 +77,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{r5}",
 				"{r6}",
 			}[i]
-			llvmValue, err := c.parseExpr(frame, arg)
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			llvmValue := c.getValue(frame, arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -113,10 +107,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{x4}",
 				"{x5}",
 			}[i]
-			llvmValue, err := c.parseExpr(frame, arg)
-			if err != nil {
-				return llvm.Value{}, err
-			}
+			llvmValue := c.getValue(frame, arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}


### PR DESCRIPTION
This PR refactors error handling. The primary motivation is to be able to show multiple compiler errors to the user at the same time. For example, if you have this code:

```go
    c64 := complex(f32, 1.2)
    c64 += 2
    c64 *= 2
    c64 /= 2
    println(c64)
```

Before this PR, it would result in the following error because these operations have not yet been implemented on complex numbers:

```
testdata/float.go:56:2: todo: binop on complex number: +
```

After this change, it will show all the errors:

```
testdata/float.go:56:2: todo: binop on complex number: +
testdata/float.go:57:2: todo: binop on complex number: *
testdata/float.go:58:2: todo: binop on complex number: /
```

But the main part of this PR (the first 3 commits) is a huge refactor of large parts of the compiler to make error handling much easier. These changes may be controversial: they convert a few errors into panics. However, I think the simplicity in other parts of the compiler is worth it and perhaps a panic would be the best way to deal with it anyway: they happen when unknown types are used in the code and as far as I'm aware all Go types have at least a partial/stub implementation and new types get added very infrequently to Go (and would only need to be implemented by TinyGo after updating the x/tools/go/ssa dependency).