### PR TITLE
machine/atsamd21: select internal ground for ADC and scale result correctly

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -343,6 +343,12 @@ func (a ADC) Get() uint16 {
 	sam.ADC.INPUTCTRL |= sam.RegValue(ch << sam.ADC_INPUTCTRL_MUXPOS_Pos)
 	waitADCSync()
 
+	// Select internal ground for ADC input
+	sam.ADC.INPUTCTRL &^= sam.ADC_INPUTCTRL_MUXNEG_Msk
+	waitADCSync()
+	sam.ADC.INPUTCTRL |= sam.RegValue(sam.ADC_INPUTCTRL_MUXNEG_GND << sam.ADC_INPUTCTRL_MUXNEG_Pos)
+	waitADCSync()
+
 	// Enable ADC
 	sam.ADC.CTRLA |= sam.ADC_CTRLA_ENABLE
 	waitADCSync()
@@ -368,7 +374,7 @@ func (a ADC) Get() uint16 {
 	sam.ADC.CTRLA &^= sam.ADC_CTRLA_ENABLE
 	waitADCSync()
 
-	return uint16(val)
+	return uint16(val) << 4 // scales from 12 to 16-bit result
 }
 
 func (a ADC) getADCChannel() uint8 {


### PR DESCRIPTION
This PR corrects the readings from the ADC by selecting internal ground for the ADC and scale result correctly to 16-bit.