### PR TITLE
compiler: mark all GEPs as inbounds

### DIFF
--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -190,13 +190,13 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 	//     stack = stack.next
 	//     switch stack.callback {
 	c.builder.SetInsertPointAtEnd(loop)
-	nextStackGEP := c.builder.CreateGEP(deferData, []llvm.Value{
+	nextStackGEP := c.builder.CreateInBoundsGEP(deferData, []llvm.Value{
 		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 		llvm.ConstInt(c.ctx.Int32Type(), 1, false), // .next field
 	}, "stack.next.gep")
 	nextStack := c.builder.CreateLoad(nextStackGEP, "stack.next")
 	c.builder.CreateStore(nextStack, frame.deferPtr)
-	gep := c.builder.CreateGEP(deferData, []llvm.Value{
+	gep := c.builder.CreateInBoundsGEP(deferData, []llvm.Value{
 		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 		llvm.ConstInt(c.ctx.Int32Type(), 0, false), // .callback field
 	}, "callback.gep")
@@ -233,7 +233,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			forwardParams := []llvm.Value{}
 			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
 			for i := 2; i < len(valueTypes); i++ {
-				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "gep")
+				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "gep")
 				forwardParam := c.builder.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}
@@ -271,7 +271,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			forwardParams := []llvm.Value{}
 			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
 			for i := range callback.Params {
-				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+2), false)}, "gep")
+				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+2), false)}, "gep")
 				forwardParam := c.builder.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}
@@ -306,7 +306,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) error {
 			forwardParams := []llvm.Value{}
 			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
 			for i := 2; i < len(valueTypes); i++ {
-				gep := c.builder.CreateGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "")
+				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "")
 				forwardParam := c.builder.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -485,7 +485,7 @@ func (c *Compiler) markAsyncFunctions() (needsScheduler bool, err error) {
 			llvm.ConstInt(c.ctx.Int1Type(), 0, false),
 		}, "task.promise.raw")
 		promise := c.builder.CreateBitCast(promiseRaw, llvm.PointerType(promiseType, 0), "task.promise")
-		dataPtr := c.builder.CreateGEP(promise, []llvm.Value{
+		dataPtr := c.builder.CreateInBoundsGEP(promise, []llvm.Value{
 			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 			llvm.ConstInt(c.ctx.Int32Type(), 2, false),
 		}, "task.promise.data")
@@ -546,13 +546,13 @@ func (c *Compiler) markAsyncFunctions() (needsScheduler bool, err error) {
 			llvm.ConstInt(c.ctx.Int1Type(), 0, false),
 		}, "task.promise.raw")
 		promise := c.builder.CreateBitCast(promiseRaw, llvm.PointerType(promiseType, 0), "task.promise")
-		dataPtr := c.builder.CreateGEP(promise, []llvm.Value{
+		dataPtr := c.builder.CreateInBoundsGEP(promise, []llvm.Value{
 			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 			llvm.ConstInt(c.ctx.Int32Type(), 2, false),
 		}, "task.promise.data")
 		valueAlloca.ReplaceAllUsesWith(c.builder.CreateBitCast(dataPtr, valueAlloca.Type(), ""))
 		valueAlloca.EraseFromParentAsInstruction()
-		commaOkPtr := c.builder.CreateGEP(promise, []llvm.Value{
+		commaOkPtr := c.builder.CreateInBoundsGEP(promise, []llvm.Value{
 			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 			llvm.ConstInt(c.ctx.Int32Type(), 1, false),
 		}, "task.promise.comma-ok")


### PR DESCRIPTION
In Go, it is not possible to construct pointers that are out of bounds (and not null), so let LLVM know about this fact.

This leads to a significant code size reduction, around 3% in many cases.