### PR TITLE
goland: autoupdate TinyGo version number and bin/go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/go
 build
 docs/_build
 src/device/avr/*.go

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,14 @@ llvm-build: llvm-build/build.ninja
 
 # Build the Go compiler.
 build/tinygo:
-	@if [ ! -f llvm-build/bin/llvm-config ]; then echo "Fetch and build LLVM first by running:\n  make llvm-source\n  make llvm-build"; exit 1; fi
+	@if [ ! -f $(LLVM_BUILDDIR)/bin/llvm-config ]; then echo "Fetch and build LLVM first by running:\n  make llvm-source\n  make llvm-build"; exit 1; fi
+	# Generate src/runtime/internal/sys/zversion.go with TinyGo version number, for GoLand and IDEA
+	echo 'package sys' > src/runtime/internal/sys/zversion.go
+	echo >> src/runtime/internal/sys/zversion.go
+	echo "const TheVersion = \`go`grep '^const version' version.go|sed 's/const version = "//'|sed 's/"//'`\`" >> src/runtime/internal/sys/zversion.go
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go build -o build/tinygo -tags byollvm .
+	# GoLand and IDEA expect a "go" binary under bin
+	ln -s "../build/tinygo" bin/go
 
 test:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" go test -v -tags byollvm .

--- a/src/runtime/internal/sys/.gitignore
+++ b/src/runtime/internal/sys/.gitignore
@@ -1,0 +1,1 @@
+zversion.go


### PR DESCRIPTION
This automatically generates `zversion.go` with the correct TinyGo version number, and copies the TinyGo binary to `bin/go` where GoLand and JetBrains IDEA expect it.

For GoLand to recognise the TinyGo GOROOT, the version number piece is optional (some file + version string needs to be there though), but the `bin/go` binary definitely needs to be there.  For now at least. :smile: