### PR TITLE
Portability improvements

### DIFF
--- a/buildcache.go
+++ b/buildcache.go
@@ -9,9 +9,11 @@ import (
 
 // Get the cache directory, usually ~/.cache/tinygo
 func cacheDir() string {
-	home := getHomeDir()
-	dir := filepath.Join(home, ".cache", "tinygo")
-	return dir
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		panic("could not find cache dir: " + err.Error())
+	}
+	return filepath.Join(dir, "tinygo")
 }
 
 // Return the newest timestamp of all the file paths passed in. Used to check

--- a/builtins.go
+++ b/builtins.go
@@ -294,5 +294,6 @@ func compileBuiltins(target string, callback func(path string) error) error {
 
 	// Give the caller the resulting file. The callback must copy the file,
 	// because after it returns the temporary directory will be removed.
+	arfile.Close()
 	return callback(arpath)
 }

--- a/main.go
+++ b/main.go
@@ -201,7 +201,11 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		// Compile extra files.
 		for i, path := range spec.ExtraFiles {
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			cmd := exec.Command(spec.Compiler, append(spec.CFlags, "-c", "-o", outpath, path)...)
+			cmdName := spec.Compiler
+			if name, ok := commands[cmdName]; ok {
+				cmdName = name
+			}
+			cmd := exec.Command(cmdName, append(spec.CFlags, "-c", "-o", outpath, path)...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			cmd.Dir = sourceDir()
@@ -217,7 +221,11 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 			for _, file := range pkg.CFiles {
 				path := filepath.Join(pkg.Package.Dir, file)
 				outpath := filepath.Join(dir, "pkg"+strconv.Itoa(i)+"-"+file+".o")
-				cmd := exec.Command(spec.Compiler, append(spec.CFlags, "-c", "-o", outpath, path)...)
+				cmdName := spec.Compiler
+				if name, ok := commands[cmdName]; ok {
+					cmdName = name
+				}
+				cmd := exec.Command(cmdName, append(spec.CFlags, "-c", "-o", outpath, path)...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				cmd.Dir = sourceDir()

--- a/main_test.go
+++ b/main_test.go
@@ -20,12 +20,12 @@ import (
 const TESTDATA = "testdata"
 
 func TestCompiler(t *testing.T) {
-	matches, err := filepath.Glob(TESTDATA + "/*.go")
+	matches, err := filepath.Glob(filepath.Join(TESTDATA, "*.go"))
 	if err != nil {
 		t.Fatal("could not read test files:", err)
 	}
 
-	dirMatches, err := filepath.Glob(TESTDATA + "/*/main.go")
+	dirMatches, err := filepath.Glob(filepath.Join(TESTDATA, "*", "main.go"))
 	if err != nil {
 		t.Fatal("could not read test packages:", err)
 	}
@@ -66,7 +66,7 @@ func TestCompiler(t *testing.T) {
 	if runtime.GOOS == "linux" {
 		t.Log("running tests for linux/arm...")
 		for _, path := range matches {
-			if path == "testdata/cgo/" {
+			if path == filepath.Join("testdata", "cgo")+string(filepath.Separator) {
 				continue // TODO: improve CGo
 			}
 			t.Run(path, func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestCompiler(t *testing.T) {
 
 		t.Log("running tests for linux/arm64...")
 		for _, path := range matches {
-			if path == "testdata/cgo/" {
+			if path == filepath.Join("testdata", "cgo")+string(filepath.Separator) {
 				continue // TODO: improve CGo
 			}
 			t.Run(path, func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestCompiler(t *testing.T) {
 
 		t.Log("running tests for WebAssembly...")
 		for _, path := range matches {
-			if path == "testdata/gc.go" {
+			if path == filepath.Join("testdata", "gc.go") {
 				continue // known to fail
 			}
 			t.Run(path, func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestCompiler(t *testing.T) {
 func runTest(path, tmpdir string, target string, t *testing.T) {
 	// Get the expected output for this test.
 	txtpath := path[:len(path)-3] + ".txt"
-	if path[len(path)-1] == '/' {
+	if path[len(path)-1] == os.PathSeparator {
 		txtpath = path + "out.txt"
 	}
 	f, err := os.Open(txtpath)

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -2,7 +2,7 @@
 	"build-tags": ["cortexm", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
-	"compiler": "clang-8",
+	"compiler": "clang",
 	"gc": "marksweep",
 	"linker": "ld.lld",
 	"rtlib": "compiler-rt",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -3,7 +3,7 @@
 	"build-tags":    ["js", "wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
-	"compiler":      "clang-8",
+	"compiler":      "clang",
 	"linker":        "wasm-ld",
 	"cflags": [
 		"--target=wasm32",


### PR DESCRIPTION
A set of commits that improve portability to Windows. They do not add Windows support, but will be required if we add Windows support in the future.

For reference, this originally came from the appveyor branch, which adds some Windows support (but is not finished). These are the bits that seem to be an improvement in general.