### PR TITLE
cgo: improve C types support

### DIFF
--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -9,10 +9,6 @@ import "C"
 
 import "unsafe"
 
-func (s C.myint) Int() int {
-	return int(s)
-}
-
 func main() {
 	println("fortytwo:", C.fortytwo())
 	println("add:", C.add(C.int(3), 5))
@@ -32,6 +28,10 @@ func main() {
 	println("callback 1:", C.doCallback(20, 30, cb))
 	cb = C.binop_t(C.mul)
 	println("callback 2:", C.doCallback(20, 30, cb))
+
+	// equivalent types
+	var goInt8 int8 = 5
+	var _ C.int8_t = goInt8
 
 	// more globals
 	println("bool:", C.globalBool, C.globalBool2 == true)
@@ -57,10 +57,14 @@ func main() {
 	C.unionSetData(5, 8, 1)
 	println("union global data:", C.globalUnion.data[0], C.globalUnion.data[1], C.globalUnion.data[2])
 	println("union field:", printUnion(C.globalUnion).f)
+	var _ C.union_joined = C.globalUnion
+
+	// elaborated type
+	p := C.struct_point{x: 3, y: 5}
+	println("struct:", p.x, p.y)
 
 	// recursive types, test using a linked list
-	lastElement := &C.list_t{n: 7, next: nil}
-	list := &C.list_t{n: 3, next: &C.struct_list_t{n: 6, next: (*C.struct_list_t)(lastElement)}}
+	list := &C.list_t{n: 3, next: &C.struct_list_t{n: 6, next: &C.list_t{n: 7, next: nil}}}
 	for list != nil {
 		println("n in chain:", list.n)
 		list = (*C.list_t)(list.next)
@@ -70,7 +74,7 @@ func main() {
 func printUnion(union C.joined_t) C.joined_t {
 	println("union local data: ", union.data[0], union.data[1], union.data[2])
 	union.s = -33
-	println("union s method:", union.s.Int(), union.data[0] == 5)
+	println("union s:", union.data[0] == -33)
 	union.f = 6.28
 	println("union f:", union.f)
 	return union

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -2,11 +2,16 @@
 #include <stdint.h>
 
 typedef short myint;
+typedef short unusedTypedef;
 int add(int a, int b);
+int unusedFunction(void);
 typedef int (*binop_t) (int, int);
 int doCallback(int a, int b, binop_t cb);
 typedef int * intPointer;
 void store(int value, int *ptr);
+
+// this signature should not be included by CGo
+void unusedFunction2(int x, __builtin_va_list args);
 
 typedef struct collection {
 	short         s;
@@ -37,6 +42,7 @@ void unionSetData(short f0, short f1, short f2);
 
 // test globals and datatypes
 extern int global;
+extern int unusedGlobal;
 extern bool globalBool;
 extern bool globalBool2;
 extern float globalFloat;

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -15,6 +15,11 @@ typedef struct collection {
 	unsigned char c;
 } collection_t;
 
+struct point {
+	int x;
+	int y;
+};
+
 // linked list
 typedef struct list_t {
 	int           n;

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -24,9 +24,10 @@ union s: 22
 union f: +3.140000e+000
 union global data: 5 8 1
 union local data:  5 8 1
-union s method: -33 false
+union s: true
 union f: +6.280000e+000
 union field: +6.280000e+000
+struct: 3 5
 n in chain: 3
 n in chain: 6
 n in chain: 7


### PR DESCRIPTION
This PR includes two semi-related commits that improve support for Go types. The first one reworks support for elaborated types (struct, union), the second avoids having to support unused C types.