### PR TITLE
machine: refactor pins to be of Pin type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ import (
 )
 
 func main() {
-    led := machine.GPIO{machine.LED}
-    led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+    led := machine.LED
+    led.Configure(machine.PinConfig{Mode: machine.PinOutput})
     for {
         led.Low()
         time.Sleep(time.Millisecond * 1000)

--- a/src/examples/adc/adc.go
+++ b/src/examples/adc/adc.go
@@ -11,8 +11,8 @@ import (
 func main() {
 	machine.InitADC()
 
-	led := machine.GPIO{machine.LED}
-	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led := machine.LED
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	sensor := machine.ADC{machine.ADC2}
 	sensor.Configure()

--- a/src/examples/blinky1/blinky1.go
+++ b/src/examples/blinky1/blinky1.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
-	led := machine.GPIO{machine.LED}
-	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led := machine.LED
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	for {
 		led.Low()
 		time.Sleep(time.Millisecond * 500)

--- a/src/examples/blinky2/blinky2.go
+++ b/src/examples/blinky2/blinky2.go
@@ -16,8 +16,8 @@ func main() {
 }
 
 func led1() {
-	led := machine.GPIO{machine.LED}
-	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led := machine.LED1
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	for {
 		println("+")
 		led.Low()
@@ -30,8 +30,8 @@ func led1() {
 }
 
 func led2() {
-	led := machine.GPIO{machine.LED2}
-	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led := machine.LED2
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	for {
 		println("  +")
 		led.Low()

--- a/src/examples/button/button.go
+++ b/src/examples/button/button.go
@@ -7,14 +7,14 @@ import (
 
 // This example assumes that the button is connected to pin 8. Change the value
 // below to use a different pin.
-const buttonPin = 8
+const (
+	led    = machine.LED
+	button = machine.Pin(8)
+)
 
 func main() {
-	led := machine.GPIO{machine.LED}
-	led.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-
-	button := machine.GPIO{buttonPin}
-	button.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT})
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	button.Configure(machine.PinConfig{Mode: machine.PinInput})
 
 	for {
 		if button.Get() {

--- a/src/examples/button2/button2.go
+++ b/src/examples/button2/button2.go
@@ -8,29 +8,29 @@ import (
 // This example assumes that you are using the pca10040 board
 
 func main() {
-	led1 := machine.GPIO{machine.LED1}
-	led1.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led1 := machine.LED1
+	led1.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	led2 := machine.GPIO{machine.LED2}
-	led2.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led2 := machine.LED2
+	led2.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	led3 := machine.GPIO{machine.LED3}
-	led3.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led3 := machine.LED3
+	led3.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	led4 := machine.GPIO{machine.LED4}
-	led4.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	led4 := machine.LED4
+	led4.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	button1 := machine.GPIO{machine.BUTTON1}
-	button1.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+	button1 := machine.BUTTON1
+	button1.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	button2 := machine.GPIO{machine.BUTTON2}
-	button2.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+	button2 := machine.BUTTON2
+	button2.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	button3 := machine.GPIO{machine.BUTTON3}
-	button3.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+	button3 := machine.BUTTON3
+	button3.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	button4 := machine.GPIO{machine.BUTTON4}
-	button4.Configure(machine.GPIOConfig{Mode: machine.GPIO_INPUT_PULLUP})
+	button4 := machine.BUTTON4
+	button4.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
 	for {
 		led1.Set(button1.Get())

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -9,9 +9,9 @@ import (
 
 // change these to test a different UART or pins if available
 var (
-	uart       = machine.UART0
-	tx   uint8 = machine.UART_TX_PIN
-	rx   uint8 = machine.UART_RX_PIN
+	uart = machine.UART0
+	tx   = machine.UART_TX_PIN
+	rx   = machine.UART_RX_PIN
 )
 
 func main() {

--- a/src/examples/mcp3008/mcp3008.go
+++ b/src/examples/mcp3008/mcp3008.go
@@ -8,19 +8,17 @@ import (
 	"time"
 )
 
-// CS_PIN is the pin used for Chip Select (CS). Change to whatever is in use on your board.
-const CS_PIN = 3
+// cs is the pin used for Chip Select (CS). Change to whatever is in use on your board.
+const cs = machine.Pin(3)
 
 var (
 	tx          []byte
 	rx          []byte
 	val, result uint16
-	cs          machine.GPIO
 )
 
 func main() {
-	cs = machine.GPIO{CS_PIN}
-	cs.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	cs.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 4000000,

--- a/src/examples/microbit-blink/microbit-blink.go
+++ b/src/examples/microbit-blink/microbit-blink.go
@@ -9,10 +9,10 @@ import (
 // The LED matrix in the micro:bit is a multiplexed display: https://en.wikipedia.org/wiki/Multiplexed_display
 // Driver for easier control: https://github.com/tinygo-org/drivers/tree/master/microbitmatrix
 func main() {
-	ledrow := machine.GPIO{machine.LED_ROW_1}
-	ledrow.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
-	ledcol := machine.GPIO{machine.LED_COL_1}
-	ledcol.Configure(machine.GPIOConfig{Mode: machine.GPIO_OUTPUT})
+	ledrow := machine.LED_ROW_1
+	ledrow.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	ledcol := machine.LED_COL_1
+	ledcol.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	ledcol.Low()
 	for {
 		ledrow.Low()

--- a/src/machine/board_arduino.go
+++ b/src/machine/board_arduino.go
@@ -5,20 +5,20 @@ package machine
 const CPU_FREQUENCY = 16000000
 
 // LED on the Arduino
-const LED = 13
+const LED Pin = 13
 
 // ADC on the Arduino
 const (
-	ADC0 = 0
-	ADC1 = 1
-	ADC2 = 2
-	ADC3 = 3
-	ADC4 = 4 // Used by TWI for SDA
-	ADC5 = 5 // Used by TWI for SCL
+	ADC0 Pin = 0
+	ADC1 Pin = 1
+	ADC2 Pin = 2
+	ADC3 Pin = 3
+	ADC4 Pin = 4 // Used by TWI for SDA
+	ADC5 Pin = 5 // Used by TWI for SCL
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 1
-	UART_RX_PIN = 0
+	UART_TX_PIN Pin = 1
+	UART_RX_PIN Pin = 0
 )

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -17,7 +17,7 @@ const (
 	D8  = PB23
 	D9  = PA06
 	D10 = PA07
-	D11 = 0xff // does not seem to exist
+	D11 = NoPin // does not seem to exist
 	D12 = PA02
 	D13 = PA17 // PWM available
 )
@@ -80,12 +80,12 @@ var (
 	I2C0 = I2C{Bus: sam.SERCOM5_I2CM,
 		SDA:     SDA_PIN,
 		SCL:     SCL_PIN,
-		PinMode: GPIO_SERCOM}
+		PinMode: PinSERCOM}
 	// internal device
 	I2C1 = I2C{Bus: sam.SERCOM1_I2CM,
 		SDA:     SDA1_PIN,
 		SCL:     SCL1_PIN,
-		PinMode: GPIO_SERCOM_ALT}
+		PinMode: PinSERCOMAlt}
 )
 
 // SPI pins (internal flash)
@@ -104,7 +104,7 @@ var (
 const (
 	I2S_SCK_PIN = PA10
 	I2S_SD_PIN  = PA08
-	I2S_WS_PIN  = 0xff // no WS, instead uses SCK to sync
+	I2S_WS_PIN  = NoPin // no WS, instead uses SCK to sync
 )
 
 // I2S on the Circuit Playground Express.

--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -3,5 +3,5 @@
 package machine
 
 const (
-	LED = 1
+	LED Pin = 1
 )

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -6,14 +6,14 @@ import "device/sam"
 
 // GPIO Pins
 const (
-	D0  = PA11 // UART0 RX
-	D1  = PA10 // UART0 TX
-	D2  = 0xff // does not seem to exist
+	D0  = PA11  // UART0 RX
+	D1  = PA10  // UART0 TX
+	D2  = NoPin // does not seem to exist
 	D3  = PA09
 	D4  = PA08
-	D5  = PA15 // PWM available
-	D6  = PA20 // PWM available
-	D7  = 0xff // does not seem to exist
+	D5  = PA15  // PWM available
+	D6  = PA20  // PWM available
+	D7  = NoPin // does not seem to exist
 	D8  = PA06
 	D9  = PA07 // PWM available
 	D10 = PA18 // can be used for PWM or UART1 TX
@@ -59,7 +59,7 @@ var (
 	I2C0 = I2C{Bus: sam.SERCOM3_I2CM,
 		SDA:     SDA_PIN,
 		SCL:     SCL_PIN,
-		PinMode: GPIO_SERCOM}
+		PinMode: PinSERCOM}
 )
 
 // SPI pins
@@ -78,5 +78,5 @@ var (
 const (
 	I2S_SCK_PIN = PA10
 	I2S_SD_PIN  = PA08
-	I2S_WS_PIN  = 0xff // TODO: figure out what this is on Feather M0.
+	I2S_WS_PIN  = NoPin // TODO: figure out what this is on Feather M0.
 )

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -59,7 +59,7 @@ var (
 	I2C0 = I2C{Bus: sam.SERCOM3_I2CM,
 		SDA:     SDA_PIN,
 		SCL:     SCL_PIN,
-		PinMode: GPIO_SERCOM}
+		PinMode: PinSERCOM}
 )
 
 // SPI pins
@@ -78,7 +78,7 @@ var (
 const (
 	I2S_SCK_PIN = PA10
 	I2S_SD_PIN  = PA08
-	I2S_WS_PIN  = 0xff // TODO: figure out what this is on ItsyBitsy M0.
+	I2S_WS_PIN  = NoPin // TODO: figure out what this is on ItsyBitsy M0.
 )
 
 // I2S on the ItsyBitsy M0.

--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -7,70 +7,70 @@ const HasLowFrequencyCrystal = false
 
 // Buttons on the micro:bit (A and B)
 const (
-	BUTTON  = BUTTONA
-	BUTTONA = 17
-	BUTTONB = 26
+	BUTTON  Pin = BUTTONA
+	BUTTONA Pin = 17
+	BUTTONB Pin = 26
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 24
-	UART_RX_PIN = 25
+	UART_TX_PIN Pin = 24
+	UART_RX_PIN Pin = 25
 )
 
 // ADC pins
 const (
-	ADC0 = 3 // P0 on the board
-	ADC1 = 2 // P1 on the board
-	ADC2 = 1 // P2 on the board
+	ADC0 Pin = 3 // P0 on the board
+	ADC1 Pin = 2 // P1 on the board
+	ADC2 Pin = 1 // P2 on the board
 )
 
 // I2C pins
 const (
-	SDA_PIN = 30 // P20 on the board
-	SCL_PIN = 0  // P19 on the board
+	SDA_PIN Pin = 30 // P20 on the board
+	SCL_PIN Pin = 0  // P19 on the board
 )
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = 23 // P13 on the board
-	SPI0_MOSI_PIN = 21 // P15 on the board
-	SPI0_MISO_PIN = 22 // P14 on the board
+	SPI0_SCK_PIN  Pin = 23 // P13 on the board
+	SPI0_MOSI_PIN Pin = 21 // P15 on the board
+	SPI0_MISO_PIN Pin = 22 // P14 on the board
 )
 
 // GPIO/Analog pins
 const (
-	P0  = 3
-	P1  = 2
-	P2  = 1
-	P3  = 4
-	P4  = 5
-	P5  = 17
-	P6  = 12
-	P7  = 11
-	P8  = 18
-	P9  = 10
-	P10 = 6
-	P11 = 26
-	P12 = 20
-	P13 = 23
-	P14 = 22
-	P15 = 21
-	P16 = 16
+	P0  Pin = 3
+	P1  Pin = 2
+	P2  Pin = 1
+	P3  Pin = 4
+	P4  Pin = 5
+	P5  Pin = 17
+	P6  Pin = 12
+	P7  Pin = 11
+	P8  Pin = 18
+	P9  Pin = 10
+	P10 Pin = 6
+	P11 Pin = 26
+	P12 Pin = 20
+	P13 Pin = 23
+	P14 Pin = 22
+	P15 Pin = 21
+	P16 Pin = 16
 )
 
 // LED matrix pins
 const (
-	LED_COL_1 = 4
-	LED_COL_2 = 5
-	LED_COL_3 = 6
-	LED_COL_4 = 7
-	LED_COL_5 = 8
-	LED_COL_6 = 9
-	LED_COL_7 = 10
-	LED_COL_8 = 11
-	LED_COL_9 = 12
-	LED_ROW_1 = 13
-	LED_ROW_2 = 14
-	LED_ROW_3 = 15
+	LED_COL_1 Pin = 4
+	LED_COL_2 Pin = 5
+	LED_COL_3 Pin = 6
+	LED_COL_4 Pin = 7
+	LED_COL_5 Pin = 8
+	LED_COL_6 Pin = 9
+	LED_COL_7 Pin = 10
+	LED_COL_8 Pin = 11
+	LED_COL_9 Pin = 12
+	LED_ROW_1 Pin = 13
+	LED_ROW_2 Pin = 14
+	LED_ROW_3 Pin = 15
 )

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -6,27 +6,27 @@ const HasLowFrequencyCrystal = true
 
 // LEDs on the nrf52840-mdk (nRF52840 dev board)
 const (
-	LED       = LED_GREEN
-	LED_GREEN = 22
-	LED_RED   = 23
-	LED_BLUE  = 24
+	LED       Pin = LED_GREEN
+	LED_GREEN Pin = 22
+	LED_RED   Pin = 23
+	LED_BLUE  Pin = 24
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 20
-	UART_RX_PIN = 19
+	UART_TX_PIN Pin = 20
+	UART_RX_PIN Pin = 19
 )
 
 // I2C pins (unused)
 const (
-	SDA_PIN = 0xff
-	SCL_PIN = 0xff
+	SDA_PIN = NoPin
+	SCL_PIN = NoPin
 )
 
 // SPI pins (unused)
 const (
-	SPI0_SCK_PIN  = 0
-	SPI0_MOSI_PIN = 0
-	SPI0_MISO_PIN = 0
+	SPI0_SCK_PIN  = NoPin
+	SPI0_MOSI_PIN = NoPin
+	SPI0_MISO_PIN = NoPin
 )

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -10,30 +10,30 @@ const HasLowFrequencyCrystal = true
 
 // LED on the pca10031
 const (
-	LED       = LED_RED
-	LED1      = LED_RED
-	LED2      = LED_GREEN
-	LED3      = LED_BLUE
-	LED_RED   = 21
-	LED_GREEN = 22
-	LED_BLUE  = 23
+	LED       Pin = LED_RED
+	LED1      Pin = LED_RED
+	LED2      Pin = LED_GREEN
+	LED3      Pin = LED_BLUE
+	LED_RED   Pin = 21
+	LED_GREEN Pin = 22
+	LED_BLUE  Pin = 23
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 9
-	UART_RX_PIN = 11
+	UART_TX_PIN Pin = 9
+	UART_RX_PIN Pin = 11
 )
 
 // I2C pins (disabled)
 const (
-	SDA_PIN = 0xff
-	SCL_PIN = 0xff
+	SDA_PIN = NoPin
+	SCL_PIN = NoPin
 )
 
 // SPI pins (unused)
 const (
-	SPI0_SCK_PIN  = 0
-	SPI0_MOSI_PIN = 0
-	SPI0_MISO_PIN = 0
+	SPI0_SCK_PIN  = NoPin
+	SPI0_MOSI_PIN = NoPin
+	SPI0_MISO_PIN = NoPin
 )

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -7,47 +7,47 @@ const HasLowFrequencyCrystal = true
 
 // LEDs on the PCA10040 (nRF52832 dev board)
 const (
-	LED  = LED1
-	LED1 = 17
-	LED2 = 18
-	LED3 = 19
-	LED4 = 20
+	LED  Pin = LED1
+	LED1 Pin = 17
+	LED2 Pin = 18
+	LED3 Pin = 19
+	LED4 Pin = 20
 )
 
 // Buttons on the PCA10040 (nRF52832 dev board)
 const (
-	BUTTON  = BUTTON1
-	BUTTON1 = 13
-	BUTTON2 = 14
-	BUTTON3 = 15
-	BUTTON4 = 16
+	BUTTON  Pin = BUTTON1
+	BUTTON1 Pin = 13
+	BUTTON2 Pin = 14
+	BUTTON3 Pin = 15
+	BUTTON4 Pin = 16
 )
 
 // UART pins for NRF52840-DK
 const (
-	UART_TX_PIN = 6
-	UART_RX_PIN = 8
+	UART_TX_PIN Pin = 6
+	UART_RX_PIN Pin = 8
 )
 
 // ADC pins
 const (
-	ADC0 = 3
-	ADC1 = 4
-	ADC2 = 28
-	ADC3 = 29
-	ADC4 = 30
-	ADC5 = 31
+	ADC0 Pin = 3
+	ADC1 Pin = 4
+	ADC2 Pin = 28
+	ADC3 Pin = 29
+	ADC4 Pin = 30
+	ADC5 Pin = 31
 )
 
 // I2C pins
 const (
-	SDA_PIN = 26
-	SCL_PIN = 27
+	SDA_PIN Pin = 26
+	SCL_PIN Pin = 27
 )
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = 25
-	SPI0_MOSI_PIN = 23
-	SPI0_MISO_PIN = 24
+	SPI0_SCK_PIN  Pin = 25
+	SPI0_MOSI_PIN Pin = 23
+	SPI0_MISO_PIN Pin = 24
 )

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -6,47 +6,47 @@ const HasLowFrequencyCrystal = true
 
 // LEDs on the pca10056
 const (
-	LED  = LED1
-	LED1 = 13
-	LED2 = 14
-	LED3 = 15
-	LED4 = 16
+	LED  Pin = LED1
+	LED1 Pin = 13
+	LED2 Pin = 14
+	LED3 Pin = 15
+	LED4 Pin = 16
 )
 
 // Buttons on the pca10056
 const (
-	BUTTON  = BUTTON1
-	BUTTON1 = 11
-	BUTTON2 = 12
-	BUTTON3 = 24
-	BUTTON4 = 25
+	BUTTON  Pin = BUTTON1
+	BUTTON1 Pin = 11
+	BUTTON2 Pin = 12
+	BUTTON3 Pin = 24
+	BUTTON4 Pin = 25
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 6
-	UART_RX_PIN = 8
+	UART_TX_PIN Pin = 6
+	UART_RX_PIN Pin = 8
 )
 
 // ADC pins
 const (
-	ADC0 = 3
-	ADC1 = 4
-	ADC2 = 28
-	ADC3 = 29
-	ADC4 = 30
-	ADC5 = 31
+	ADC0 Pin = 3
+	ADC1 Pin = 4
+	ADC2 Pin = 28
+	ADC3 Pin = 29
+	ADC4 Pin = 30
+	ADC5 Pin = 31
 )
 
 // I2C pins
 const (
-	SDA_PIN = 26 // P0.26
-	SCL_PIN = 27 // P0.27
+	SDA_PIN Pin = 26 // P0.26
+	SCL_PIN Pin = 27 // P0.27
 )
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = 47 // P1.15
-	SPI0_MOSI_PIN = 45 // P1.13
-	SPI0_MISO_PIN = 46 // P1.14
+	SPI0_SCK_PIN  Pin = 47 // P1.15
+	SPI0_MOSI_PIN Pin = 45 // P1.13
+	SPI0_MISO_PIN Pin = 46 // P1.14
 )

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -6,37 +6,37 @@ const HasLowFrequencyCrystal = true
 
 // LEDs on the reel board
 const (
-	LED        = LED1
-	LED1       = LED_YELLOW
-	LED2       = LED_RED
-	LED3       = LED_GREEN
-	LED4       = LED_BLUE
-	LED_RED    = 11
-	LED_GREEN  = 12
-	LED_BLUE   = 41
-	LED_YELLOW = 13
+	LED        Pin = LED1
+	LED1       Pin = LED_YELLOW
+	LED2       Pin = LED_RED
+	LED3       Pin = LED_GREEN
+	LED4       Pin = LED_BLUE
+	LED_RED    Pin = 11
+	LED_GREEN  Pin = 12
+	LED_BLUE   Pin = 41
+	LED_YELLOW Pin = 13
 )
 
 // User "a" button on the reel board
 const (
-	BUTTON = 7
+	BUTTON Pin = 7
 )
 
 // UART pins
 const (
-	UART_TX_PIN = 6
-	UART_RX_PIN = 8
+	UART_TX_PIN Pin = 6
+	UART_RX_PIN Pin = 8
 )
 
 // I2C pins
 const (
-	SDA_PIN = 26
-	SCL_PIN = 27
+	SDA_PIN Pin = 26
+	SCL_PIN Pin = 27
 )
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = 47
-	SPI0_MOSI_PIN = 45
-	SPI0_MISO_PIN = 46
+	SPI0_SCK_PIN  Pin = 47
+	SPI0_MOSI_PIN Pin = 45
+	SPI0_MISO_PIN Pin = 46
 )

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -62,12 +62,12 @@ var (
 	I2C0 = I2C{Bus: sam.SERCOM2_I2CM,
 		SDA:     SDA_PIN,
 		SCL:     SCL_PIN,
-		PinMode: GPIO_SERCOM_ALT}
+		PinMode: PinSERCOMAlt}
 )
 
 // I2S pins
 const (
 	I2S_SCK_PIN = PA10
 	I2S_SD_PIN  = PA08
-	I2S_WS_PIN  = 0xff // TODO: figure out what this is on Trinket M0.
+	I2S_WS_PIN  = NoPin // TODO: figure out what this is on Trinket M0.
 )

--- a/src/machine/i2s.go
+++ b/src/machine/i2s.go
@@ -41,9 +41,9 @@ const (
 
 // All fields are optional and may not be required or used on a particular platform.
 type I2SConfig struct {
-	SCK               uint8
-	WS                uint8
-	SD                uint8
+	SCK               Pin
+	WS                Pin
+	SD                Pin
 	Mode              I2SMode
 	Standard          I2SStandard
 	ClockSource       I2SClockSource

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -1,25 +1,36 @@
 package machine
 
-type GPIOConfig struct {
-	Mode GPIOMode
+type PinConfig struct {
+	Mode PinMode
 }
 
-type GPIO struct {
-	Pin uint8
-}
+// Pin is a single pin on a chip, which may be connected to other hardware
+// devices. It can either be used directly as GPIO pin or it can be used in
+// other peripherals like ADC, I2C, etc.
+type Pin int8
 
-func (p GPIO) High() {
+// NoPin explicitly indicates "not a pin". Use this pin if you want to leave one
+// of the pins in a peripheral unconfigured (if supported by the hardware).
+const NoPin = Pin(-1)
+
+// High sets this GPIO pin to high, assuming it has been configured as an output
+// pin. It is hardware dependent (and often undefined) what happens if you set a
+// pin to high that is not configured as an output pin.
+func (p Pin) High() {
 	p.Set(true)
 }
 
-func (p GPIO) Low() {
+// Low sets this GPIO pin to low, assuming it has been configured as an output
+// pin. It is hardware dependent (and often undefined) what happens if you set a
+// pin to low that is not configured as an output pin.
+func (p Pin) Low() {
 	p.Set(false)
 }
 
 type PWM struct {
-	Pin uint8
+	Pin Pin
 }
 
 type ADC struct {
-	Pin uint8
+	Pin Pin
 }

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -7,38 +7,38 @@ import (
 )
 
 // Configure sets the pin to input or output.
-func (p GPIO) Configure(config GPIOConfig) {
-	if config.Mode == GPIO_OUTPUT { // set output bit
-		if p.Pin < 8 {
-			avr.DDRD.SetBits(1 << p.Pin)
+func (p Pin) Configure(config PinConfig) {
+	if config.Mode == PinOutput { // set output bit
+		if p < 8 {
+			avr.DDRD.SetBits(1 << uint8(p))
 		} else {
-			avr.DDRB.SetBits(1 << (p.Pin - 8))
+			avr.DDRB.SetBits(1 << uint8(p-8))
 		}
 	} else { // configure input: clear output bit
-		if p.Pin < 8 {
-			avr.DDRD.ClearBits(1 << p.Pin)
+		if p < 8 {
+			avr.DDRD.ClearBits(1 << uint8(p))
 		} else {
-			avr.DDRB.ClearBits(1 << (p.Pin - 8))
+			avr.DDRB.ClearBits(1 << uint8(p-8))
 		}
 	}
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() bool {
-	if p.Pin < 8 {
-		val := avr.PIND.Get() & (1 << p.Pin)
+func (p Pin) Get() bool {
+	if p < 8 {
+		val := avr.PIND.Get() & (1 << uint8(p))
 		return (val > 0)
 	} else {
-		val := avr.PINB.Get() & (1 << (p.Pin - 8))
+		val := avr.PINB.Get() & (1 << uint8(p-8))
 		return (val > 0)
 	}
 }
 
-func (p GPIO) getPortMask() (*avr.Register8, uint8) {
-	if p.Pin < 8 {
-		return avr.PORTD, 1 << p.Pin
+func (p Pin) getPortMask() (*avr.Register8, uint8) {
+	if p < 8 {
+		return avr.PORTD, 1 << uint8(p)
 	} else {
-		return avr.PORTB, 1 << (p.Pin - 8)
+		return avr.PORTB, 1 << uint8(p-8)
 	}
 }
 
@@ -66,9 +66,9 @@ func InitPWM() {
 // Configure configures a PWM pin for output.
 func (pwm PWM) Configure() {
 	if pwm.Pin < 8 {
-		avr.DDRD.SetBits(1 << pwm.Pin)
+		avr.DDRD.SetBits(1 << uint8(pwm.Pin))
 	} else {
-		avr.DDRB.SetBits(1 << (pwm.Pin - 8))
+		avr.DDRB.SetBits(1 << uint8(pwm.Pin-8))
 	}
 }
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -18,112 +18,92 @@ import (
 
 const CPU_FREQUENCY = 48000000
 
-type GPIOMode uint8
+type PinMode uint8
 
 const (
-	GPIO_ANALOG         = 1
-	GPIO_SERCOM         = 2
-	GPIO_SERCOM_ALT     = 3
-	GPIO_TIMER          = 4
-	GPIO_TIMER_ALT      = 5
-	GPIO_COM            = 6
-	GPIO_AC_CLK         = 7
-	GPIO_DIGITAL        = 8
-	GPIO_INPUT          = 9
-	GPIO_INPUT_PULLUP   = 10
-	GPIO_OUTPUT         = 11
-	GPIO_PWM            = GPIO_TIMER
-	GPIO_PWM_ALT        = GPIO_TIMER_ALT
-	GPIO_INPUT_PULLDOWN = 12
+	PinAnalog    PinMode = 1
+	PinSERCOM    PinMode = 2
+	PinSERCOMAlt PinMode = 3
+	PinTimer     PinMode = 4
+	PinTimerAlt  PinMode = 5
+	PinCom       PinMode = 6
+	//PinAC_CLK        PinMode = 7
+	PinDigital       PinMode = 8
+	PinInput         PinMode = 9
+	PinInputPullup   PinMode = 10
+	PinOutput        PinMode = 11
+	PinPWM           PinMode = PinTimer
+	PinPWMAlt        PinMode = PinTimerAlt
+	PinInputPulldown PinMode = 12
 )
 
 // Hardware pins
 const (
-	PA00 = 0
-	PA01 = 1
-	PA02 = 2
-	PA03 = 3
-	PA04 = 4
-	PA05 = 5
-	PA06 = 6
-	PA07 = 7
-	PA08 = 8
-	PA09 = 9
-	PA10 = 10
-	PA11 = 11
-	PA12 = 12
-	PA13 = 13
-	PA14 = 14
-	PA15 = 15
-	PA16 = 16
-	PA17 = 17
-	PA18 = 18
-	PA19 = 19
-	PA20 = 20
-	PA21 = 21
-	PA22 = 22
-	PA23 = 23
-	PA24 = 24
-	PA25 = 25
-	PA26 = 26
-	PA27 = 27
-	PA28 = 28
-	PA29 = 29
-	PA30 = 30
-	PA31 = 31
-	PB00 = 32
-	PB01 = 33
-	PB02 = 34
-	PB03 = 35
-	PB04 = 36
-	PB05 = 37
-	PB06 = 38
-	PB07 = 39
-	PB08 = 40
-	PB09 = 41
-	PB10 = 42
-	PB11 = 43
-	PB12 = 44
-	PB13 = 45
-	PB14 = 46
-	PB15 = 47
-	PB16 = 48
-	PB17 = 49
-	PB18 = 50
-	PB19 = 51
-	PB20 = 52
-	PB21 = 53
-	PB22 = 54
-	PB23 = 55
-	PB24 = 56
-	PB25 = 57
-	PB26 = 58
-	PB27 = 59
-	PB28 = 60
-	PB29 = 61
-	PB30 = 62
-	PB31 = 63
+	PA00 Pin = 0
+	PA01 Pin = 1
+	PA02 Pin = 2
+	PA03 Pin = 3
+	PA04 Pin = 4
+	PA05 Pin = 5
+	PA06 Pin = 6
+	PA07 Pin = 7
+	PA08 Pin = 8
+	PA09 Pin = 9
+	PA10 Pin = 10
+	PA11 Pin = 11
+	PA12 Pin = 12
+	PA13 Pin = 13
+	PA14 Pin = 14
+	PA15 Pin = 15
+	PA16 Pin = 16
+	PA17 Pin = 17
+	PA18 Pin = 18
+	PA19 Pin = 19
+	PA20 Pin = 20
+	PA21 Pin = 21
+	PA22 Pin = 22
+	PA23 Pin = 23
+	PA24 Pin = 24
+	PA25 Pin = 25
+	PA26 Pin = 26
+	PA27 Pin = 27
+	PA28 Pin = 28
+	PA29 Pin = 29
+	PA30 Pin = 30
+	PA31 Pin = 31
+	PB00 Pin = 32
+	PB01 Pin = 33
+	PB02 Pin = 34
+	PB03 Pin = 35
+	PB04 Pin = 36
+	PB05 Pin = 37
+	PB06 Pin = 38
+	PB07 Pin = 39
+	PB08 Pin = 40
+	PB09 Pin = 41
+	PB10 Pin = 42
+	PB11 Pin = 43
+	PB12 Pin = 44
+	PB13 Pin = 45
+	PB14 Pin = 46
+	PB15 Pin = 47
+	PB16 Pin = 48
+	PB17 Pin = 49
+	PB18 Pin = 50
+	PB19 Pin = 51
+	PB20 Pin = 52
+	PB21 Pin = 53
+	PB22 Pin = 54
+	PB23 Pin = 55
+	PB24 Pin = 56
+	PB25 Pin = 57
+	PB26 Pin = 58
+	PB27 Pin = 59
+	PB28 Pin = 60
+	PB29 Pin = 61
+	PB30 Pin = 62
+	PB31 Pin = 63
 )
-
-// getPMux returns the value for the correct PMUX register for this pin.
-func (p GPIO) getPMux() uint8 {
-	return getPMux(p.Pin)
-}
-
-// setPMux sets the value for the correct PMUX register for this pin.
-func (p GPIO) setPMux(val uint8) {
-	setPMux(p.Pin, val)
-}
-
-// getPinCfg returns the value for the correct PINCFG register for this pin.
-func (p GPIO) getPinCfg() uint8 {
-	return getPinCfg(p.Pin)
-}
-
-// setPinCfg sets the value for the correct PINCFG register for this pin.
-func (p GPIO) setPinCfg(val uint8) {
-	setPinCfg(p.Pin, val)
-}
 
 // InitADC initializes the ADC.
 func InitADC() {
@@ -184,7 +164,7 @@ func InitADC() {
 
 // Configure configures a ADCPin to be able to be used to read data.
 func (a ADC) Configure() {
-	GPIO{a.Pin}.Configure(GPIOConfig{Mode: GPIO_ANALOG})
+	a.Pin.Configure(PinConfig{Mode: PinAnalog})
 	return
 }
 
@@ -340,8 +320,8 @@ func (uart UART) Configure(config UARTConfig) {
 	}
 
 	// configure pins
-	GPIO{config.TX}.Configure(GPIOConfig{Mode: GPIO_SERCOM})
-	GPIO{config.RX}.Configure(GPIOConfig{Mode: GPIO_SERCOM})
+	config.TX.Configure(PinConfig{Mode: PinSERCOM})
+	config.RX.Configure(PinConfig{Mode: PinSERCOM})
 
 	// reset SERCOM0
 	uart.Bus.CTRLA.SetBits(sam.SERCOM_USART_CTRLA_SWRST)
@@ -434,16 +414,16 @@ func handleUART1() {
 // I2C on the SAMD21.
 type I2C struct {
 	Bus     *sam.SERCOM_I2CM_Type
-	SCL     uint8
-	SDA     uint8
-	PinMode GPIOMode
+	SCL     Pin
+	SDA     Pin
+	PinMode PinMode
 }
 
 // I2CConfig is used to store config info for I2C.
 type I2CConfig struct {
 	Frequency uint32
-	SCL       uint8
-	SDA       uint8
+	SCL       Pin
+	SDA       Pin
 }
 
 const (
@@ -496,8 +476,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 	}
 
 	// enable pins
-	GPIO{i2c.SDA}.Configure(GPIOConfig{Mode: i2c.PinMode})
-	GPIO{i2c.SCL}.Configure(GPIOConfig{Mode: i2c.PinMode})
+	i2c.SDA.Configure(PinConfig{Mode: i2c.PinMode})
+	i2c.SCL.Configure(PinConfig{Mode: i2c.PinMode})
 }
 
 // SetBaudRate sets the communication speed for the I2C.
@@ -770,11 +750,11 @@ func (i2s I2S) Configure(config I2SConfig) {
 	}
 
 	// configure pin for clock
-	GPIO{config.SCK}.Configure(GPIOConfig{Mode: GPIO_COM})
+	config.SCK.Configure(PinConfig{Mode: PinCom})
 
 	// configure pin for WS, if needed
-	if config.WS != 0xff {
-		GPIO{config.WS}.Configure(GPIOConfig{Mode: GPIO_COM})
+	if config.WS != NoPin {
+		config.WS.Configure(PinConfig{Mode: PinCom})
 	}
 
 	// now set serializer data size.
@@ -813,7 +793,7 @@ func (i2s I2S) Configure(config I2SConfig) {
 	}
 
 	// configure data pin
-	GPIO{config.SD}.Configure(GPIOConfig{Mode: GPIO_COM})
+	config.SD.Configure(PinConfig{Mode: PinCom})
 
 	// re-enable
 	i2s.Bus.CTRLA.SetBits(sam.I2S_CTRLA_ENABLE)
@@ -900,9 +880,9 @@ type SPI struct {
 // SPIConfig is used to store config info for SPI.
 type SPIConfig struct {
 	Frequency uint32
-	SCK       uint8
-	MOSI      uint8
-	MISO      uint8
+	SCK       Pin
+	MOSI      Pin
+	MISO      Pin
 	LSBFirst  bool
 	Mode      uint8
 }
@@ -927,9 +907,9 @@ func (spi SPI) Configure(config SPIConfig) {
 	}
 
 	// enable pins
-	GPIO{config.SCK}.Configure(GPIOConfig{Mode: GPIO_SERCOM_ALT})
-	GPIO{config.MOSI}.Configure(GPIOConfig{Mode: GPIO_SERCOM_ALT})
-	GPIO{config.MISO}.Configure(GPIOConfig{Mode: GPIO_SERCOM_ALT})
+	config.SCK.Configure(PinConfig{Mode: PinSERCOMAlt})
+	config.MOSI.Configure(PinConfig{Mode: PinSERCOMAlt})
+	config.MISO.Configure(PinConfig{Mode: PinSERCOMAlt})
 
 	// reset SERCOM
 	spi.Bus.CTRLA.SetBits(sam.SERCOM_SPI_CTRLA_SWRST)
@@ -1044,20 +1024,20 @@ func (pwm PWM) Configure() {
 	}
 
 	// Set pin as output
-	sam.PORT.DIRSET0.Set(1 << pwm.Pin)
+	sam.PORT.DIRSET0.Set(1 << uint8(pwm.Pin))
 	// Set pin to low
-	sam.PORT.OUTCLR0.Set(1 << pwm.Pin)
+	sam.PORT.OUTCLR0.Set(1 << uint8(pwm.Pin))
 
 	// Enable the port multiplexer for pin
 	pwm.setPinCfg(sam.PORT_PINCFG0_PMUXEN)
 
 	// Connect TCCX timer to pin.
 	// we normally use the F channel aka ALT
-	pwmConfig := GPIO_PWM_ALT
+	pwmConfig := PinPWMAlt
 
 	// in the case of PA6 or PA7 we have to use E channel
 	if pwm.Pin == 6 || pwm.Pin == 7 {
-		pwmConfig = GPIO_PWM
+		pwmConfig = PinPWM
 	}
 
 	if pwm.Pin&1 > 0 {
@@ -1102,22 +1082,22 @@ func (pwm PWM) Set(value uint16) {
 
 // getPMux returns the value for the correct PMUX register for this pin.
 func (pwm PWM) getPMux() uint8 {
-	return getPMux(pwm.Pin)
+	return pwm.Pin.getPMux()
 }
 
 // setPMux sets the value for the correct PMUX register for this pin.
 func (pwm PWM) setPMux(val uint8) {
-	setPMux(pwm.Pin, val)
+	pwm.Pin.setPMux(val)
 }
 
 // getPinCfg returns the value for the correct PINCFG register for this pin.
 func (pwm PWM) getPinCfg() uint8 {
-	return getPinCfg(pwm.Pin)
+	return pwm.Pin.getPinCfg()
 }
 
 // setPinCfg sets the value for the correct PINCFG register for this pin.
 func (pwm PWM) setPinCfg(val uint8) {
-	setPinCfg(pwm.Pin, val)
+	pwm.Pin.setPinCfg(val)
 }
 
 // getTimer returns the timer to be used for PWM on this pin
@@ -1260,8 +1240,8 @@ func (usbcdc USBCDC) Configure(config UARTConfig) {
 	sam.USB_DEVICE.DESCADD.Set(uint32(uintptr(unsafe.Pointer(&usbEndpointDescriptors))))
 
 	// configure pins
-	GPIO{USBCDC_DM_PIN}.Configure(GPIOConfig{Mode: GPIO_COM})
-	GPIO{USBCDC_DP_PIN}.Configure(GPIOConfig{Mode: GPIO_COM})
+	USBCDC_DM_PIN.Configure(PinConfig{Mode: PinCom})
+	USBCDC_DP_PIN.Configure(PinConfig{Mode: PinCom})
 
 	// performs pad calibration from store fuses
 	handlePadCalibration()

--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -13,100 +13,100 @@ import (
 
 // Return the register and mask to enable a given GPIO pin. This can be used to
 // implement bit-banged drivers.
-func (p GPIO) PortMaskSet() (*uint32, uint32) {
-	return &sam.PORT.OUTSET0.Reg, 1 << p.Pin
+func (p Pin) PortMaskSet() (*uint32, uint32) {
+	return &sam.PORT.OUTSET0.Reg, 1 << uint8(p)
 }
 
 // Return the register and mask to disable a given port. This can be used to
 // implement bit-banged drivers.
-func (p GPIO) PortMaskClear() (*uint32, uint32) {
-	return &sam.PORT.OUTCLR0.Reg, 1 << p.Pin
+func (p Pin) PortMaskClear() (*uint32, uint32) {
+	return &sam.PORT.OUTCLR0.Reg, 1 << uint8(p)
 }
 
 // Set the pin to high or low.
 // Warning: only use this on an output pin!
-func (p GPIO) Set(high bool) {
+func (p Pin) Set(high bool) {
 	if high {
-		sam.PORT.OUTSET0.Set(1 << p.Pin)
+		sam.PORT.OUTSET0.Set(1 << uint8(p))
 	} else {
-		sam.PORT.OUTCLR0.Set(1 << p.Pin)
+		sam.PORT.OUTCLR0.Set(1 << uint8(p))
 	}
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() bool {
-	return (sam.PORT.IN0.Get()>>p.Pin)&1 > 0
+func (p Pin) Get() bool {
+	return (sam.PORT.IN0.Get()>>uint8(p))&1 > 0
 }
 
 // Configure this pin with the given configuration.
-func (p GPIO) Configure(config GPIOConfig) {
+func (p Pin) Configure(config PinConfig) {
 	switch config.Mode {
-	case GPIO_OUTPUT:
-		sam.PORT.DIRSET0.Set(1 << p.Pin)
+	case PinOutput:
+		sam.PORT.DIRSET0.Set(1 << uint8(p))
 		// output is also set to input enable so pin can read back its own value
 		p.setPinCfg(sam.PORT_PINCFG0_INEN)
 
-	case GPIO_INPUT:
-		sam.PORT.DIRCLR0.Set(1 << p.Pin)
+	case PinInput:
+		sam.PORT.DIRCLR0.Set(1 << uint8(p))
 		p.setPinCfg(sam.PORT_PINCFG0_INEN)
 
-	case GPIO_INPUT_PULLDOWN:
-		sam.PORT.DIRCLR0.Set(1 << p.Pin)
-		sam.PORT.OUTCLR0.Set(1 << p.Pin)
+	case PinInputPulldown:
+		sam.PORT.DIRCLR0.Set(1 << uint8(p))
+		sam.PORT.OUTCLR0.Set(1 << uint8(p))
 		p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 
-	case GPIO_INPUT_PULLUP:
-		sam.PORT.DIRCLR0.Set(1 << p.Pin)
-		sam.PORT.OUTSET0.Set(1 << p.Pin)
+	case PinInputPullup:
+		sam.PORT.DIRCLR0.Set(1 << uint8(p))
+		sam.PORT.OUTSET0.Set(1 << uint8(p))
 		p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 
-	case GPIO_SERCOM:
-		if p.Pin&1 > 0 {
+	case PinSERCOM:
+		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR | sam.PORT_PINCFG0_INEN)
 
-	case GPIO_SERCOM_ALT:
-		if p.Pin&1 > 0 {
+	case PinSERCOMAlt:
+		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_SERCOM_ALT << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_SERCOM_ALT << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
 
-	case GPIO_COM:
-		if p.Pin&1 > 0 {
+	case PinCom:
+		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_COM << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_COM << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN)
-	case GPIO_ANALOG:
-		if p.Pin&1 > 0 {
+	case PinAnalog:
+		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_ANALOG << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_ANALOG << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
@@ -114,9 +114,8 @@ func (p GPIO) Configure(config GPIOConfig) {
 }
 
 // getPMux returns the value for the correct PMUX register for this pin.
-func getPMux(p uint8) uint8 {
-	pin := p >> 1
-	switch pin {
+func (p Pin) getPMux() uint8 {
+	switch p >> 1 {
 	case 0:
 		return sam.PORT.PMUX0_0.Get()
 	case 1:
@@ -155,9 +154,8 @@ func getPMux(p uint8) uint8 {
 }
 
 // setPMux sets the value for the correct PMUX register for this pin.
-func setPMux(p uint8, val uint8) {
-	pin := p >> 1
-	switch pin {
+func (p Pin) setPMux(val uint8) {
+	switch p >> 1 {
 	case 0:
 		sam.PORT.PMUX0_0.Set(val)
 	case 1:
@@ -194,7 +192,7 @@ func setPMux(p uint8, val uint8) {
 }
 
 // getPinCfg returns the value for the correct PINCFG register for this pin.
-func getPinCfg(p uint8) uint8 {
+func (p Pin) getPinCfg() uint8 {
 	switch p {
 	case 0:
 		return sam.PORT.PINCFG0_0.Get()
@@ -266,7 +264,7 @@ func getPinCfg(p uint8) uint8 {
 }
 
 // setPinCfg sets the value for the correct PINCFG register for this pin.
-func setPinCfg(p uint8, val uint8) {
+func (p Pin) setPinCfg(val uint8) {
 	switch p {
 	case 0:
 		sam.PORT.PINCFG0_0.Set(val)

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -13,143 +13,143 @@ import (
 
 // Return the register and mask to enable a given GPIO pin. This can be used to
 // implement bit-banged drivers.
-func (p GPIO) PortMaskSet() (*uint32, uint32) {
-	if p.Pin < 32 {
-		return &sam.PORT.OUTSET0.Reg, 1 << p.Pin
+func (p Pin) PortMaskSet() (*uint32, uint32) {
+	if p < 32 {
+		return &sam.PORT.OUTSET0.Reg, 1 << uint8(p)
 	} else {
-		return &sam.PORT.OUTSET1.Reg, 1 << (p.Pin - 32)
+		return &sam.PORT.OUTSET1.Reg, 1 << uint8(p-32)
 	}
 }
 
 // Return the register and mask to disable a given port. This can be used to
 // implement bit-banged drivers.
-func (p GPIO) PortMaskClear() (*uint32, uint32) {
-	if p.Pin < 32 {
-		return &sam.PORT.OUTCLR0.Reg, 1 << p.Pin
+func (p Pin) PortMaskClear() (*uint32, uint32) {
+	if p < 32 {
+		return &sam.PORT.OUTCLR0.Reg, 1 << uint8(p)
 	} else {
-		return &sam.PORT.OUTCLR1.Reg, 1 << (p.Pin - 32)
+		return &sam.PORT.OUTCLR1.Reg, 1 << uint8(p-32)
 	}
 }
 
 // Set the pin to high or low.
 // Warning: only use this on an output pin!
-func (p GPIO) Set(high bool) {
-	if p.Pin < 32 {
+func (p Pin) Set(high bool) {
+	if p < 32 {
 		if high {
-			sam.PORT.OUTSET0.Set(1 << p.Pin)
+			sam.PORT.OUTSET0.Set(1 << uint8(p))
 		} else {
-			sam.PORT.OUTCLR0.Set(1 << p.Pin)
+			sam.PORT.OUTCLR0.Set(1 << uint8(p))
 		}
 	} else {
 		if high {
-			sam.PORT.OUTSET1.Set(1 << (p.Pin - 32))
+			sam.PORT.OUTSET1.Set(1 << uint8(p-32))
 		} else {
-			sam.PORT.OUTCLR1.Set(1 << (p.Pin - 32))
+			sam.PORT.OUTCLR1.Set(1 << uint8(p-32))
 		}
 	}
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() bool {
-	if p.Pin < 32 {
-		return (sam.PORT.IN0.Get()>>p.Pin)&1 > 0
+func (p Pin) Get() bool {
+	if p < 32 {
+		return (sam.PORT.IN0.Get()>>uint8(p))&1 > 0
 	} else {
-		return (sam.PORT.IN1.Get()>>(p.Pin-32))&1 > 0
+		return (sam.PORT.IN1.Get()>>(uint8(p)-32))&1 > 0
 	}
 }
 
 // Configure this pin with the given configuration.
-func (p GPIO) Configure(config GPIOConfig) {
+func (p Pin) Configure(config PinConfig) {
 	switch config.Mode {
-	case GPIO_OUTPUT:
-		if p.Pin < 32 {
-			sam.PORT.DIRSET0.Set(1 << p.Pin)
+	case PinOutput:
+		if p < 32 {
+			sam.PORT.DIRSET0.Set(1 << uint8(p))
 			// output is also set to input enable so pin can read back its own value
 			p.setPinCfg(sam.PORT_PINCFG0_INEN)
 		} else {
-			sam.PORT.DIRSET1.Set(1 << (p.Pin - 32))
+			sam.PORT.DIRSET1.Set(1 << uint8(p-32))
 			// output is also set to input enable so pin can read back its own value
 			p.setPinCfg(sam.PORT_PINCFG0_INEN)
 		}
 
-	case GPIO_INPUT:
-		if p.Pin < 32 {
-			sam.PORT.DIRCLR0.Set(1 << p.Pin)
+	case PinInput:
+		if p < 32 {
+			sam.PORT.DIRCLR0.Set(1 << uint8(p))
 			p.setPinCfg(sam.PORT_PINCFG0_INEN)
 		} else {
-			sam.PORT.DIRCLR1.Set(1<<p.Pin - 32)
+			sam.PORT.DIRCLR1.Set(1<<uint8(p) - 32)
 			p.setPinCfg(sam.PORT_PINCFG0_INEN)
 		}
 
-	case GPIO_INPUT_PULLDOWN:
-		if p.Pin < 32 {
-			sam.PORT.DIRCLR0.Set(1 << p.Pin)
-			sam.PORT.OUTCLR0.Set(1 << p.Pin)
+	case PinInputPulldown:
+		if p < 32 {
+			sam.PORT.DIRCLR0.Set(1 << uint8(p))
+			sam.PORT.OUTCLR0.Set(1 << uint8(p))
 			p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 		} else {
-			sam.PORT.DIRCLR1.Set(1<<p.Pin - 32)
-			sam.PORT.OUTCLR1.Set(1<<p.Pin - 32)
+			sam.PORT.DIRCLR1.Set(1<<uint8(p) - 32)
+			sam.PORT.OUTCLR1.Set(1<<uint8(p) - 32)
 			p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 		}
 
-	case GPIO_INPUT_PULLUP:
-		if p.Pin < 32 {
-			sam.PORT.DIRCLR0.Set(1 << p.Pin)
-			sam.PORT.OUTSET0.Set(1 << p.Pin)
+	case PinInputPullup:
+		if p < 32 {
+			sam.PORT.DIRCLR0.Set(1 << uint8(p))
+			sam.PORT.OUTSET0.Set(1 << uint8(p))
 			p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 		} else {
-			sam.PORT.DIRCLR1.Set(1<<p.Pin - 32)
-			sam.PORT.OUTSET1.Set(1<<p.Pin - 32)
+			sam.PORT.DIRCLR1.Set(1<<uint8(p) - 32)
+			sam.PORT.OUTSET1.Set(1<<uint8(p) - 32)
 			p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 		}
 
-	case GPIO_SERCOM:
-		if p.Pin&1 > 0 {
+	case PinSERCOM:
+		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_SERCOM << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR | sam.PORT_PINCFG0_INEN)
 
-	case GPIO_SERCOM_ALT:
-		if p.Pin&1 > 0 {
+	case PinSERCOMAlt:
+		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_SERCOM_ALT << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_SERCOM_ALT << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
 
-	case GPIO_COM:
-		if p.Pin&1 > 0 {
+	case PinCom:
+		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_COM << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_COM << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN)
-	case GPIO_ANALOG:
-		if p.Pin&1 > 0 {
+	case PinAnalog:
+		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (GPIO_ANALOG << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (GPIO_ANALOG << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
@@ -157,9 +157,8 @@ func (p GPIO) Configure(config GPIOConfig) {
 }
 
 // getPMux returns the value for the correct PMUX register for this pin.
-func getPMux(p uint8) uint8 {
-	pin := p >> 1
-	switch pin {
+func (p Pin) getPMux() uint8 {
+	switch uint8(p) >> 1 {
 	case 0:
 		return sam.PORT.PMUX0_0.Get()
 	case 1:
@@ -230,9 +229,8 @@ func getPMux(p uint8) uint8 {
 }
 
 // setPMux sets the value for the correct PMUX register for this pin.
-func setPMux(p uint8, val uint8) {
-	pin := p >> 1
-	switch pin {
+func (p Pin) setPMux(val uint8) {
+	switch uint8(p) >> 1 {
 	case 0:
 		sam.PORT.PMUX0_0.Set(val)
 	case 1:
@@ -301,7 +299,7 @@ func setPMux(p uint8, val uint8) {
 }
 
 // getPinCfg returns the value for the correct PINCFG register for this pin.
-func getPinCfg(p uint8) uint8 {
+func (p Pin) getPinCfg() uint8 {
 	switch p {
 	case 0:
 		return sam.PORT.PINCFG0_0.Get()
@@ -437,7 +435,7 @@ func getPinCfg(p uint8) uint8 {
 }
 
 // setPinCfg sets the value for the correct PINCFG register for this pin.
-func setPinCfg(p uint8, val uint8) {
+func (p Pin) setPinCfg(val uint8) {
 	switch p {
 	case 0:
 		sam.PORT.PINCFG0_0.Set(val)

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -7,21 +7,21 @@ import (
 )
 
 // Configure sets the pin to input or output.
-func (p GPIO) Configure(config GPIOConfig) {
-	if config.Mode == GPIO_OUTPUT { // set output bit
-		avr.DDRB.SetBits(1 << p.Pin)
+func (p Pin) Configure(config PinConfig) {
+	if config.Mode == PinOutput { // set output bit
+		avr.DDRB.SetBits(1 << uint8(p))
 	} else { // configure input: clear output bit
-		avr.DDRB.ClearBits(1 << p.Pin)
+		avr.DDRB.ClearBits(1 << uint8(p))
 	}
 }
 
-func (p GPIO) getPortMask() (*avr.Register8, uint8) {
-	return avr.PORTB, 1 << p.Pin
+func (p Pin) getPortMask() (*avr.Register8, uint8) {
+	return avr.PORTB, 1 << uint8(p)
 }
 
 // Get returns the current value of a GPIO pin.
-func (p GPIO) Get() bool {
-	val := avr.PINB.Get() & (1 << p.Pin)
+func (p Pin) Get() bool {
+	val := avr.PINB.Get() & (1 << uint8(p))
 	return (val > 0)
 }
 

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -6,15 +6,15 @@ import (
 	"device/avr"
 )
 
-type GPIOMode uint8
+type PinMode uint8
 
 const (
-	GPIO_INPUT = iota
-	GPIO_OUTPUT
+	PinInput PinMode = iota
+	PinOutput
 )
 
 // Set changes the value of the GPIO pin. The pin must be configured as output.
-func (p GPIO) Set(value bool) {
+func (p Pin) Set(value bool) {
 	if value { // set bits
 		port, mask := p.PortMaskSet()
 		port.Set(mask)
@@ -30,7 +30,7 @@ func (p GPIO) Set(value bool) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p GPIO) PortMaskSet() (*avr.Register8, uint8) {
+func (p Pin) PortMaskSet() (*avr.Register8, uint8) {
 	port, mask := p.getPortMask()
 	return port, port.Get() | mask
 }
@@ -41,7 +41,7 @@ func (p GPIO) PortMaskSet() (*avr.Register8, uint8) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p GPIO) PortMaskClear() (*avr.Register8, uint8) {
+func (p Pin) PortMaskClear() (*avr.Register8, uint8) {
 	port, mask := p.getPortMask()
 	return port, port.Get() &^ mask
 }
@@ -68,7 +68,7 @@ func (a ADC) Get() uint16 {
 	// set the ADLAR bit (left-adjusted result) to get a value scaled to 16
 	// bits. This has the same effect as shifting the return value left by 6
 	// bits.
-	avr.ADMUX.Set(avr.ADMUX_REFS0 | avr.ADMUX_ADLAR | (a.Pin & 0x07))
+	avr.ADMUX.Set(avr.ADMUX_REFS0 | avr.ADMUX_ADLAR | (uint8(a.Pin) & 0x07))
 
 	// start the conversion
 	avr.ADCSRA.SetBits(avr.ADCSRA_ADSC)

--- a/src/machine/machine_dummy.go
+++ b/src/machine/machine_dummy.go
@@ -4,37 +4,37 @@ package machine
 
 // Dummy machine package, filled with no-ops.
 
-type GPIOMode uint8
+type PinMode uint8
 
 const (
-	GPIO_INPUT = iota
-	GPIO_OUTPUT
+	PinInput PinMode = iota
+	PinOutput
 )
 
 // Fake LED numbers, for testing.
 const (
-	LED  = LED1
-	LED1 = 0
-	LED2 = 0
-	LED3 = 0
-	LED4 = 0
+	LED  Pin = LED1
+	LED1 Pin = 0
+	LED2 Pin = 0
+	LED3 Pin = 0
+	LED4 Pin = 0
 )
 
 // Fake button numbers, for testing.
 const (
-	BUTTON  = BUTTON1
-	BUTTON1 = 0
-	BUTTON2 = 0
-	BUTTON3 = 0
-	BUTTON4 = 0
+	BUTTON  Pin = BUTTON1
+	BUTTON1 Pin = 0
+	BUTTON2 Pin = 0
+	BUTTON3 Pin = 0
+	BUTTON4 Pin = 0
 )
 
-func (p GPIO) Configure(config GPIOConfig) {
+func (p Pin) Configure(config PinConfig) {
 }
 
-func (p GPIO) Set(value bool) {
+func (p Pin) Set(value bool) {
 }
 
-func (p GPIO) Get() bool {
+func (p Pin) Get() bool {
 	return false
 }

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -9,13 +9,13 @@ import (
 const CPU_FREQUENCY = 16000000
 
 // Get peripheral and pin number for this GPIO pin.
-func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
-	return nrf.GPIO, p.Pin
+func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
+	return nrf.GPIO, uint32(p)
 }
 
-func (uart UART) setPins(tx, rx uint32) {
-	nrf.UART0.PSELTXD.Set(tx)
-	nrf.UART0.PSELRXD.Set(rx)
+func (uart UART) setPins(tx, rx Pin) {
+	nrf.UART0.PSELTXD.Set(uint32(tx))
+	nrf.UART0.PSELRXD.Set(uint32(rx))
 }
 
 //go:export UART0_IRQHandler
@@ -23,13 +23,13 @@ func handleUART0() {
 	UART0.handleInterrupt()
 }
 
-func (i2c I2C) setPins(scl, sda uint8) {
+func (i2c I2C) setPins(scl, sda Pin) {
 	i2c.Bus.PSELSCL.Set(uint32(scl))
 	i2c.Bus.PSELSDA.Set(uint32(sda))
 }
 
 // SPI
-func (spi SPI) setPins(sck, mosi, miso uint8) {
+func (spi SPI) setPins(sck, mosi, miso Pin) {
 	if sck == 0 {
 		sck = SPI0_SCK_PIN
 	}

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -10,13 +10,13 @@ import (
 const CPU_FREQUENCY = 64000000
 
 // Get peripheral and pin number for this GPIO pin.
-func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
-	return nrf.P0, p.Pin
+func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
+	return nrf.P0, uint32(p)
 }
 
-func (uart UART) setPins(tx, rx uint32) {
-	nrf.UART0.PSELTXD.Set(tx)
-	nrf.UART0.PSELRXD.Set(rx)
+func (uart UART) setPins(tx, rx Pin) {
+	nrf.UART0.PSELTXD.Set(uint32(tx))
+	nrf.UART0.PSELRXD.Set(uint32(rx))
 }
 
 //go:export UARTE0_UART0_IRQHandler
@@ -24,13 +24,13 @@ func handleUART0() {
 	UART0.handleInterrupt()
 }
 
-func (i2c I2C) setPins(scl, sda uint8) {
+func (i2c I2C) setPins(scl, sda Pin) {
 	i2c.Bus.PSELSCL.Set(uint32(scl))
 	i2c.Bus.PSELSDA.Set(uint32(sda))
 }
 
 // SPI
-func (spi SPI) setPins(sck, mosi, miso uint8) {
+func (spi SPI) setPins(sck, mosi, miso Pin) {
 	if sck == 0 {
 		sck = SPI0_SCK_PIN
 	}

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -10,17 +10,17 @@ import (
 const CPU_FREQUENCY = 64000000
 
 // Get peripheral and pin number for this GPIO pin.
-func (p GPIO) getPortPin() (*nrf.GPIO_Type, uint8) {
-	if p.Pin >= 32 {
-		return nrf.P1, p.Pin - 32
+func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
+	if p >= 32 {
+		return nrf.P1, uint32(p - 32)
 	} else {
-		return nrf.P0, p.Pin
+		return nrf.P0, uint32(p)
 	}
 }
 
-func (uart UART) setPins(tx, rx uint32) {
-	nrf.UART0.PSEL.TXD.Set(tx)
-	nrf.UART0.PSEL.RXD.Set(rx)
+func (uart UART) setPins(tx, rx Pin) {
+	nrf.UART0.PSEL.TXD.Set(uint32(tx))
+	nrf.UART0.PSEL.RXD.Set(uint32(rx))
 }
 
 //go:export UARTE0_UART0_IRQHandler
@@ -28,13 +28,13 @@ func handleUART0() {
 	UART0.handleInterrupt()
 }
 
-func (i2c I2C) setPins(scl, sda uint8) {
+func (i2c I2C) setPins(scl, sda Pin) {
 	i2c.Bus.PSEL.SCL.Set(uint32(scl))
 	i2c.Bus.PSEL.SDA.Set(uint32(sda))
 }
 
 // SPI
-func (spi SPI) setPins(sck, mosi, miso uint8) {
+func (spi SPI) setPins(sck, mosi, miso Pin) {
 	if sck == 0 {
 		sck = SPI0_SCK_PIN
 	}

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -4,10 +4,10 @@ package machine
 
 // Peripheral abstraction layer for the stm32.
 
-type GPIOMode uint8
+type PinMode uint8
 
 const (
-	portA = iota * 16
+	portA Pin = iota * 16
 	portB
 	portC
 	portD

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -6,8 +6,8 @@ import "errors"
 
 type UARTConfig struct {
 	BaudRate uint32
-	TX       uint8
-	RX       uint8
+	TX       Pin
+	RX       Pin
 }
 
 // To implement the UART interface for a board, you must declare a concrete type as follows:


### PR DESCRIPTION
Here is an API-breaking refactor I've long wanted to do. Basically, instead of having GPIO objects, all pins are represented by a Pin object (usually an `int8`, might be different on boards with _lots_ of pins). This has several advantages:

 * Pin numbers can have the type `Pin`, which immediately gives them the common `Configure`, `Set`, etc. methods. No need for `GPIO{rx}.Configure` etc.
 * I think Pin just looks nicer than GPIO. MicroPython has the same Pin type (as `machine.Pin`, actually).

Comments welcome. This PR is not nearly complete: the things that should work are some nrf-based boards and the blinky1/blinky2/echo examples.