### PR TITLE
wasm: use println instead of fmt

### DIFF
--- a/src/examples/wasm/main/main.go
+++ b/src/examples/wasm/main/main.go
@@ -1,9 +1,5 @@
 package main
 
-import (
-	"fmt"
-)
-
 func main() {
-	fmt.Println("Hello world!")
+	println("Hello world!")
 }


### PR DESCRIPTION
The generated wasm is 575 bytes when compiled with -no-debug (and works), which is a much better first experience for new users than the 20KB+ added (atm) by including `fmt`. :smile: