### PR TITLE
compiler: fix comp. of func calls for func values of a defined type

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1146,7 +1146,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 		value := c.getValue(frame, instr.Value)
 		// This is a func value, which cannot be called directly. We have to
 		// extract the function pointer and context first from the func value.
-		funcPtr, context, err := c.decodeFuncValue(value, instr.Value.Type().(*types.Signature))
+		funcPtr, context, err := c.decodeFuncValue(value, instr.Value.Type().Underlying().(*types.Signature))
 		if err != nil {
 			return llvm.Value{}, err
 		}


### PR DESCRIPTION
When compiling a piece of code where a function value is called,
the compiler panics if the function value's type is a defined type,
and not just a type literal (function signature): The type assertion
(*types.Signature) fails, because the type of the func value is a
*types.Named.

This patch fixes this by using the type's underlying type, so that a
types.Named is properly turned into its underlying types.Signature,
before the type assertion takes place.
It takes advantage of the property that all types have an underlying type
(both are the same, if a type is not named).

Fixes #320