### PR TITLE
cgo: do not allow capturing of external/exported functions

### DIFF
--- a/compiler/optimizer.go
+++ b/compiler/optimizer.go
@@ -307,18 +307,6 @@ func (c *Compiler) doesEscape(value llvm.Value) bool {
 				return true
 			}
 		} else if use.IsACallInst() != nilValue {
-			// Call only escapes when the (pointer) parameter is not marked
-			// "nocapture". This flag means that the parameter does not escape
-			// the give function.
-			if use.CalledValue().IsAFunction() != nilValue {
-				if use.CalledValue().IsDeclaration() {
-					// Kind of dirty: assume external functions don't let
-					// pointers escape.
-					// TODO: introduce //go:noescape that sets the 'nocapture'
-					// flag on each input parameter.
-					continue
-				}
-			}
 			if !c.hasFlag(use, value, "nocapture") {
 				return true
 			}


### PR DESCRIPTION
Instead of assuming all declared (but not defined) functions are CGo
functions, mark all pointer params of externally visible symbols
'nocapture'. This means you may not store pointers between function
calls.

This is already the case when calling CGo functions upstream:
https://golang.org/cmd/cgo/#hdr-Passing_pointers

---

This is part of #285, because escape analysis would otherwise do incorrect things when compiling packages independently.