### PR TITLE
Refactor volatile operations

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -895,6 +895,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 	case *ssa.Store:
 		llvmAddr := c.getValue(frame, instr.Addr)
 		llvmVal := c.getValue(frame, instr.Val)
+		c.emitNilCheck(frame, llvmAddr, "store")
 		if c.targetData.TypeAllocSize(llvmVal.Type()) == 0 {
 			// nothing to store
 			return

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -197,7 +197,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 		},
 		ShouldOverlay: func(path string) bool {
 			switch path {
-			case "machine", "os", "reflect", "runtime", "sync":
+			case "machine", "os", "reflect", "runtime", "runtime/volatile", "sync":
 				return true
 			default:
 				if strings.HasPrefix(path, "device/") || strings.HasPrefix(path, "examples/") {
@@ -1106,17 +1106,22 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 
 	// Try to call the function directly for trivially static calls.
 	if fn := instr.StaticCallee(); fn != nil {
-		switch fn.RelString(nil) {
-		case "device/arm.ReadRegister":
+		name := fn.RelString(nil)
+		switch {
+		case name == "device/arm.ReadRegister":
 			return c.emitReadRegister(instr.Args)
-		case "device/arm.Asm", "device/avr.Asm":
+		case name == "device/arm.Asm" || name == "device/avr.Asm":
 			return c.emitAsm(instr.Args)
-		case "device/arm.AsmFull", "device/avr.AsmFull":
+		case name == "device/arm.AsmFull" || name == "device/avr.AsmFull":
 			return c.emitAsmFull(frame, instr)
-		case "device/arm.SVCall0", "device/arm.SVCall1", "device/arm.SVCall2", "device/arm.SVCall3", "device/arm.SVCall4":
+		case strings.HasPrefix(name, "device/arm.SVCall"):
 			return c.emitSVCall(frame, instr.Args)
-		case "syscall.Syscall", "syscall.Syscall6", "syscall.Syscall9":
+		case strings.HasPrefix(name, "syscall.Syscall"):
 			return c.emitSyscall(frame, instr)
+		case strings.HasPrefix(name, "runtime/volatile.Load"):
+			return c.emitVolatileLoad(frame, instr)
+		case strings.HasPrefix(name, "runtime/volatile.Store"):
+			return c.emitVolatileStore(frame, instr)
 		}
 
 		targetFunc := c.ir.GetFunction(fn)

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -1,0 +1,26 @@
+package compiler
+
+// This file implements volatile loads/stores in runtime/volatile.LoadT and
+// runtime/volatile.StoreT as compiler builtins.
+
+import (
+	"golang.org/x/tools/go/ssa"
+	"tinygo.org/x/go-llvm"
+)
+
+func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
+	addr := c.getValue(frame, instr.Args[0])
+	c.emitNilCheck(frame, addr, "deref")
+	val := c.builder.CreateLoad(addr, "")
+	val.SetVolatile(true)
+	return val, nil
+}
+
+func (c *Compiler) emitVolatileStore(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
+	addr := c.getValue(frame, instr.Args[0])
+	val := c.getValue(frame, instr.Args[1])
+	c.emitNilCheck(frame, addr, "deref")
+	store := c.builder.CreateStore(val, addr)
+	store.SetVolatile(true)
+	return llvm.Value{}, nil
+}

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -4,24 +4,25 @@ package machine
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 // Configure sets the pin to input or output.
 func (p GPIO) Configure(config GPIOConfig) {
 	if config.Mode == GPIO_OUTPUT { // set output bit
-		*avr.DDRB |= 1 << p.Pin
+		volatile.StoreUint8(avr.DDRB, *avr.DDRB|1<<p.Pin)
 	} else { // configure input: clear output bit
-		*avr.DDRB &^= 1 << p.Pin
+		volatile.StoreUint8(avr.DDRB, *avr.DDRB&^1<<p.Pin)
 	}
 }
 
-func (p GPIO) getPortMask() (*avr.RegValue, uint8) {
+func (p GPIO) getPortMask() (*uint8, uint8) {
 	return avr.PORTB, 1 << p.Pin
 }
 
 // Get returns the current value of a GPIO pin.
 func (p GPIO) Get() bool {
-	val := *avr.PINB & (1 << p.Pin)
+	val := volatile.LoadUint8(avr.PINB) & (1 << p.Pin)
 	return (val > 0)
 }
 

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -4,6 +4,7 @@ package machine
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 type GPIOMode uint8
@@ -17,10 +18,10 @@ const (
 func (p GPIO) Set(value bool) {
 	if value { // set bits
 		port, mask := p.PortMaskSet()
-		*port = mask
+		volatile.StoreUint8(port, mask)
 	} else { // clear bits
 		port, mask := p.PortMaskClear()
-		*port = mask
+		volatile.StoreUint8(port, mask)
 	}
 }
 
@@ -30,9 +31,9 @@ func (p GPIO) Set(value bool) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p GPIO) PortMaskSet() (*avr.RegValue, avr.RegValue) {
+func (p GPIO) PortMaskSet() (*uint8, uint8) {
 	port, mask := p.getPortMask()
-	return port, *port | avr.RegValue(mask)
+	return port, volatile.LoadUint8(port) | uint8(mask)
 }
 
 // Return the register and mask to disable a given port. This can be used to
@@ -41,18 +42,18 @@ func (p GPIO) PortMaskSet() (*avr.RegValue, avr.RegValue) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p GPIO) PortMaskClear() (*avr.RegValue, avr.RegValue) {
+func (p GPIO) PortMaskClear() (*uint8, uint8) {
 	port, mask := p.getPortMask()
-	return port, *port &^ avr.RegValue(mask)
+	return port, volatile.LoadUint8(port) &^ uint8(mask)
 }
 
 // InitADC initializes the registers needed for ADC.
 func InitADC() {
 	// set a2d prescaler so we are inside the desired 50-200 KHz range at 16MHz.
-	*avr.ADCSRA |= (avr.ADCSRA_ADPS2 | avr.ADCSRA_ADPS1 | avr.ADCSRA_ADPS0)
+	volatile.StoreUint8(avr.ADCSRA, volatile.LoadUint8(avr.ADCSRA)|(avr.ADCSRA_ADPS2|avr.ADCSRA_ADPS1|avr.ADCSRA_ADPS0))
 
 	// enable a2d conversions
-	*avr.ADCSRA |= avr.ADCSRA_ADEN
+	volatile.StoreUint8(avr.ADCSRA, volatile.LoadUint8(avr.ADCSRA)|avr.ADCSRA_ADEN)
 }
 
 // Configure configures a ADCPin to be able to be used to read data.
@@ -68,17 +69,17 @@ func (a ADC) Get() uint16 {
 	// set the ADLAR bit (left-adjusted result) to get a value scaled to 16
 	// bits. This has the same effect as shifting the return value left by 6
 	// bits.
-	*avr.ADMUX = avr.RegValue(avr.ADMUX_REFS0 | avr.ADMUX_ADLAR | (a.Pin & 0x07))
+	volatile.StoreUint8(avr.ADMUX, uint8(avr.ADMUX_REFS0|avr.ADMUX_ADLAR|(a.Pin&0x07)))
 
 	// start the conversion
-	*avr.ADCSRA |= avr.ADCSRA_ADSC
+	volatile.StoreUint8(avr.ADCSRA, volatile.LoadUint8(avr.ADCSRA)|avr.ADCSRA_ADSC)
 
 	// ADSC is cleared when the conversion finishes
-	for ok := true; ok; ok = (*avr.ADCSRA & avr.ADCSRA_ADSC) > 0 {
+	for ok := true; ok; ok = (volatile.LoadUint8(avr.ADCSRA) & avr.ADCSRA_ADSC) > 0 {
 	}
 
-	low := uint16(*avr.ADCL)
-	high := uint16(*avr.ADCH)
+	low := uint16(volatile.LoadUint8(avr.ADCL))
+	high := uint16(volatile.LoadUint8(avr.ADCH))
 	return uint16(low) | uint16(high<<8)
 }
 

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 // Sleep for a given period. The period is defined by the WDT peripheral, and is
@@ -17,19 +18,19 @@ func sleepWDT(period uint8) {
 	avr.Asm("cli")
 	avr.Asm("wdr")
 	// Start timed sequence.
-	*avr.WDTCSR |= avr.WDTCSR_WDCE | avr.WDTCSR_WDE
+	volatile.StoreUint8(avr.WDTCSR, volatile.LoadUint8(avr.WDTCSR)|avr.WDTCSR_WDCE|avr.WDTCSR_WDE)
 	// Enable WDT and set new timeout
-	*avr.WDTCSR = avr.WDTCSR_WDIE | avr.RegValue(period)
+	volatile.StoreUint8(avr.WDTCSR, avr.WDTCSR_WDIE|period)
 	avr.Asm("sei")
 
 	// Set sleep mode to idle and enable sleep mode.
 	// Note: when using something other than idle, the UART won't work
 	// correctly. This needs to be fixed, though, so we can truly sleep.
-	*avr.SMCR = (0 << 1) | avr.SMCR_SE
+	volatile.StoreUint8(avr.SMCR, (0<<1)|avr.SMCR_SE)
 
 	// go to sleep
 	avr.Asm("sleep")
 
 	// disable sleep
-	*avr.SMCR = 0
+	volatile.StoreUint8(avr.SMCR, 0)
 }

--- a/src/runtime/volatile/volatile.go
+++ b/src/runtime/volatile/volatile.go
@@ -1,0 +1,34 @@
+// Package volatile provides definitions for volatile loads and stores. These
+// are implemented as compiler builtins.
+//
+// The load operations load a volatile value. The store operations store to a
+// volatile value. The compiler will emit exactly one load or store operation
+// when possible and will not reorder volatile operations. However, the compiler
+// may move other operations across load/store operations, so make sure that all
+// relevant loads/stores are done in a volatile way if this is a problem.
+//
+// These loads and stores are commonly used to read/write values from memory
+// mapped peripheral devices. They do not provide atomicity, use the sync/atomic
+// package for that.
+//
+// For more details: https://llvm.org/docs/LangRef.html#volatile-memory-accesses
+// and https://blog.regehr.org/archives/28.
+package volatile
+
+// LoadUint8 loads the volatile value *addr.
+func LoadUint8(addr *uint8) (val uint8)
+
+// LoadUint16 loads the volatile value *addr.
+func LoadUint16(addr *uint16) (val uint16)
+
+// LoadUint32 loads the volatile value *addr.
+func LoadUint32(addr *uint32) (val uint32)
+
+// StoreUint8 stores val to the volatile value *addr.
+func StoreUint8(addr *uint8, val uint8)
+
+// StoreUint16 stores val to the volatile value *addr.
+func StoreUint16(addr *uint16, val uint16)
+
+// StoreUint32 stores val to the volatile value *addr.
+func StoreUint32(addr *uint32, val uint32)

--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -153,11 +153,6 @@ package {pkgName}
 
 import "unsafe"
 
-// Special type that causes loads/stores to be volatile (necessary for
-// memory-mapped registers).
-//go:volatile
-type RegValue uint8
-
 // Some information about this device.
 const (
 	DEVICE     = "{name}"
@@ -179,7 +174,7 @@ const (
         out.write('\n\t// {description}\n'.format(**peripheral))
         for register in peripheral['registers']:
             for variant in register['variants']:
-                out.write('\t{name} = (*RegValue)(unsafe.Pointer(uintptr(0x{address:x})))\n'.format(**variant))
+                out.write('\t{name} = (*uint8)(unsafe.Pointer(uintptr(0x{address:x})))\n'.format(**variant))
     out.write(')\n')
 
     for peripheral in device.peripherals:


### PR DESCRIPTION
At the moment we use the following to mark a value as volatile:

```go
//go:volatile
type RegValue uint8

// ... 

var SomeRegister = (*RegValue)(unsafe.Pointer(uintptr(0xdeadbeef)))
```

Eventually I'd like to move away from this. This is the first step, replacing all AVR operations with compiler builtins in runtime/volatile. (The package runtime/volatile may need to have a different location, suggestions are welcome).

I will post patches for other chips as well but would like to get this in as a start.

Also, while writing this patch, I noticed that nil pointers weren't checked on store operations. I have now added a check: the code size impact is below 1% for the testcases I looked at.