### PR TITLE
docker: perform a hard submodule reset after having moved the git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN wget -O- https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 COPY . /go/src/github.com/tinygo-org/tinygo
 
+# remove submodules directories and re-init them to fix any hard-coded paths
+# after copying the tinygo directory in the previous step.
 RUN cd /go/src/github.com/tinygo-org/tinygo/ && \
-    git submodule update --init
+    rm -rf ./lib/* && \
+    git submodule update --init --recursive --force
 
 RUN cd /go/src/github.com/tinygo-org/tinygo/ && \
     dep ensure --vendor-only && \


### PR DESCRIPTION
This PR performs a hard submodule reset after having moved the git repo before continuing the docker build process.

EDIT: original technique did not work as expected, but a more brute force one did.