### PR TITLE
main: make $GOROOT more robust and configurable

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,7 +22,7 @@ type Program struct {
 	fset          *token.FileSet
 	TypeChecker   types.Config
 	Dir           string // current working directory (for error reporting)
-	TinyGoRoot    string // root of the TinyGo installation or root of the source code
+	TINYGOROOT    string // root of the TinyGo installation or root of the source code
 	CFlags        []string
 }
 
@@ -297,12 +297,12 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 	}
 	clangIncludes := ""
 	if len(p.CgoFiles) != 0 {
-		if _, err := os.Stat(filepath.Join(p.TinyGoRoot, "llvm", "tools", "clang", "lib", "Headers")); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(p.TINYGOROOT, "llvm", "tools", "clang", "lib", "Headers")); !os.IsNotExist(err) {
 			// Running from the source directory.
-			clangIncludes = filepath.Join(p.TinyGoRoot, "llvm", "tools", "clang", "lib", "Headers")
+			clangIncludes = filepath.Join(p.TINYGOROOT, "llvm", "tools", "clang", "lib", "Headers")
 		} else {
 			// Running from the installation directory.
-			clangIncludes = filepath.Join(p.TinyGoRoot, "lib", "clang", "include")
+			clangIncludes = filepath.Join(p.TINYGOROOT, "lib", "clang", "include")
 		}
 	}
 	for _, file := range p.CgoFiles {

--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		ldflags = append(ldflags, strings.Replace(flag, "{root}", root, -1))
 	}
 
+	goroot := getGoroot()
+	if goroot == "" {
+		return errors.New("cannot locate $GOROOT, please set it manually")
+	}
 	compilerConfig := compiler.Config{
 		Triple:        spec.Triple,
 		CPU:           spec.CPU,
@@ -87,7 +91,8 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		LDFlags:       ldflags,
 		Debug:         config.debug,
 		DumpSSA:       config.dumpSSA,
-		RootDir:       root,
+		TINYGOROOT:    root,
+		GOROOT:        goroot,
 		GOPATH:        getGopath(),
 		BuildTags:     spec.BuildTags,
 	}


### PR DESCRIPTION
Check various locations that $GOROOT may live, including the location of
the go binary. But make it possible to override this autodetection by
setting GOROOT manually as an environment variable.