### PR TITLE
main: fix multiple errors being reported as one

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,10 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 
 	// Compile Go code to IR.
 	errs := c.Compile(pkgName)
-	if errs != nil {
+	if len(errs) != 0 {
+		if len(errs) == 1 {
+			return errs[0]
+		}
 		return &multiError{errs}
 	}
 	if config.printIR {


### PR DESCRIPTION
A quick fix for an issue I accidentally introduced in #294. Only one error encountered during parse/typecheck would be shown. With this fix, all of them are.