### PR TITLE
Small test improvements

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/tinygo-org/tinygo/loader"
@@ -66,15 +67,15 @@ func TestCompiler(t *testing.T) {
 func runTest(path string, target string, t *testing.T) {
 	t.Parallel()
 
-	if target == "arm--linux-gnueabihf" && path == "testdata/cgo/" {
+	if target == "arm--linux-gnueabihf" && strings.HasPrefix(path, "testdata/cgo/") {
 		t.Skip("TODO: improve CGo")
 	}
 
-	if target == "aarch64--linux-gnu" && path == "testdata/cgo/" {
+	if target == "aarch64--linux-gnu" && strings.HasPrefix(path, "testdata/cgo/") {
 		t.Skip("TODO: improve CGo")
 	}
 
-	if target == "wasm" && path == "testdata/gc.go" {
+	if target == "wasm" && strings.HasPrefix(path, "testdata/gc.go") {
 		t.Skip("known to fail")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -94,7 +94,7 @@ func runTest(path string, target string, t *testing.T) {
 
 	tmpFile, err := ioutil.TempFile("", "tinygo-test-build")
 	if err != nil {
-		t.Fatal("could not create temporary directory:", err)
+		t.Fatal("could not create temporary file:", err)
 	}
 	defer os.Remove(tmpFile.Name())
 


### PR DESCRIPTION
Hi!  This PR has a collection of things I think improve the tests. As I haven't talked to any of y'all about them, I recognize that you may disagree. I will not be offended of you don't like some of this, or want me to separate them, or whatnot. 

* Add an ENV the makefile will parse to add `-short` to the `go test` options
* Add llvm bin directory to the PATH in the Makefile
* Enable parallel tests. This required moving tmpfile creation into `runTest`, instead of being shared.
* Change the targeting and dispatch. 

Caveat — I’m on a osx laptop. I can run the short tests successfully, but I get clang errors no matter what I do. So this _probably_ doesn’t make things worse, but I can’t test all the permutations