### PR TITLE
main: comment the TinyGo IR header line

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		return &multiError{errs}
 	}
 	if config.printIR {
-		fmt.Println("Generated LLVM IR:")
+		fmt.Println("; Generated LLVM IR:")
 		fmt.Println(c.IR())
 	}
 	if err := c.Verify(); err != nil {


### PR DESCRIPTION
Without this, clang tries to process the header line as valid input. eg:

```
$ tinygo build -printir -target wasm -o /dev/null src/examples/wasm/main/main.go > main.ll
$ clang --compile --target=wasm32-unknown-unknown-wasm -o main2.wasm main.ll
main.ll:1:1: error: expected top-level entity
Generated LLVM IR:
^
```