### PR TITLE
Makefile: avoid libtinfo and libz dependency of LLVM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ commands:
           name: "Install apt dependencies"
           command: |
             sudo apt-get install \
-                libtinfo-dev \
                 python3 \
                 gcc-arm-linux-gnueabihf \
                 binutils-arm-none-eabi \
@@ -137,7 +136,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-8-v2
+            - llvm-build-8-linux-v4
       - run:
           name: "Build LLVM"
           command: |
@@ -155,7 +154,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-v2
+          key: llvm-build-8-linux-v4
           paths:
             llvm-build
       - run:
@@ -208,7 +207,7 @@ commands:
             - llvm
       - restore_cache:
           keys:
-            - llvm-build-8-macos-v2
+            - llvm-build-8-macos-v3
       - run:
           name: "Build LLVM"
           command: |
@@ -220,7 +219,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-macos-v2
+          key: llvm-build-8-macos-v3
           paths:
             llvm-build
       - run:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ llvm-source: llvm/README.txt llvm/tools/clang/README.txt llvm/tools/lld/README.m
 
 # Configure LLVM.
 llvm-build/build.ninja: llvm-source
-	mkdir -p llvm-build; cd llvm-build; cmake -G Ninja ../llvm "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;WebAssembly" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLIBCLANG_BUILD_STATIC=ON
+	mkdir -p llvm-build; cd llvm-build; cmake -G Ninja ../llvm "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;WebAssembly" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLIBCLANG_BUILD_STATIC=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF
 
 # Build LLVM.
 llvm-build: llvm-build/build.ninja


### PR DESCRIPTION
These two dependencies are optional but enabled by default when available. Disable them in the Makefile so that the `tinygo` binary is portable to systems that don't have them or have a different version (for example, Arch has a newer version of libcurses and thus libtinfo).