### PR TITLE
Improve debug info to show function arguments in stack traces

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1944,10 +1944,12 @@ func (c *Compiler) parseBinOp(op token.Token, typ types.Type, x, y llvm.Value, p
 		default:
 			return llvm.Value{}, c.makeError(pos, "binop on interface: "+op.String())
 		}
-	case *types.Map, *types.Pointer:
+	case *types.Chan, *types.Map, *types.Pointer:
 		// Maps are in general not comparable, but can be compared against nil
 		// (which is a nil pointer). This means they can be trivially compared
 		// by treating them as a pointer.
+		// Channels behave as pointers in that they are equal as long as they
+		// are created with the same call to make or if both are nil.
 		switch op {
 		case token.EQL: // ==
 			return c.builder.CreateICmp(llvm.IntEQ, x, y, ""), nil

--- a/interp/frame.go
+++ b/interp/frame.go
@@ -347,6 +347,8 @@ func (fr *frame) evalBasicBlock(bb, incoming llvm.BasicBlock, indent string) (re
 				fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstInt(fr.Mod.Context().Int1Type(), implements, false)}
 			case callee.Name() == "runtime.nanotime":
 				fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstInt(fr.Mod.Context().Int64Type(), 0, false)}
+			case callee.Name() == "llvm.dbg.value":
+				// do nothing
 			case strings.HasPrefix(callee.Name(), "runtime.print") || callee.Name() == "runtime._panic":
 				// This are all print instructions, which necessarily have side
 				// effects but no results.

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -18,7 +18,6 @@ type Eval struct {
 	TargetData      llvm.TargetData
 	Debug           bool
 	builder         llvm.Builder
-	dibuilder       *llvm.DIBuilder
 	dirtyGlobals    map[llvm.Value]struct{}
 	sideEffectFuncs map[llvm.Value]*sideEffectResult // cache of side effect scan results
 }
@@ -38,7 +37,6 @@ func Run(mod llvm.Module, targetData llvm.TargetData, debug bool) error {
 		dirtyGlobals: map[llvm.Value]struct{}{},
 	}
 	e.builder = mod.Context().NewBuilder()
-	e.dibuilder = llvm.NewDIBuilder(mod)
 
 	initAll := mod.NamedFunction(name)
 	bb := initAll.EntryBasicBlock()
@@ -49,7 +47,6 @@ func Run(mod llvm.Module, targetData llvm.TargetData, debug bool) error {
 	e.builder.SetInsertPointBefore(bb.FirstInstruction())
 	dummy := e.builder.CreateAlloca(e.Mod.Context().Int8Type(), "dummy")
 	e.builder.SetInsertPointBefore(dummy)
-	e.builder.SetInstDebugLocation(bb.FirstInstruction())
 	var initCalls []llvm.Value
 	for inst := bb.FirstInstruction(); !inst.IsNil(); inst = llvm.NextInstruction(inst) {
 		if inst == dummy {

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -35,6 +35,8 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 		return &sideEffectResult{severity: sideEffectLimited}
 	case "runtime.interfaceImplements":
 		return &sideEffectResult{severity: sideEffectNone}
+	case "llvm.dbg.value":
+		return &sideEffectResult{severity: sideEffectNone}
 	}
 	if e.sideEffectFuncs == nil {
 		e.sideEffectFuncs = make(map[llvm.Value]*sideEffectResult)

--- a/testdata/channel.go
+++ b/testdata/channel.go
@@ -4,7 +4,7 @@ import "time"
 
 func main() {
 	ch := make(chan int)
-	println("len, cap of channel:", len(ch), cap(ch))
+	println("len, cap of channel:", len(ch), cap(ch), ch == nil)
 	go sender(ch)
 
 	n, ok := <-ch

--- a/testdata/channel.txt
+++ b/testdata/channel.txt
@@ -1,4 +1,4 @@
-len, cap of channel: 0 0
+len, cap of channel: 0 0 false
 recv from open channel: 1 true
 received num: 2
 received num: 3


### PR DESCRIPTION
Improve debug information (see commit). Also, implement comparing channel values (found while working on this).

```
This commit adds debug info to function arguments, so that in many cases
you can see them when compiling with less optimizations enabled.
Unfortunately, due to the way Go SSA works, it is hard to preserve them
in many cases.
Local variables are not yet saved.

Also, change the language type to C, to make sure lldb shows function
arguments. The previous language was Modula 3, apparently due to a
off-by-one error somewhere.
```