### PR TITLE
compiler,runtime: fix multiple definitions of a single function

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -820,6 +820,9 @@ func (c *Compiler) parseFunc(frame *Frame) {
 	if c.DumpSSA {
 		fmt.Printf("\nfunc %s:\n", frame.fn.Function)
 	}
+	if !frame.fn.LLVMFn.IsDeclaration() {
+		panic("function is already defined: " + frame.fn.LLVMFn.Name())
+	}
 	if !frame.fn.IsExported() {
 		frame.fn.LLVMFn.SetLinkage(llvm.InternalLinkage)
 		frame.fn.LLVMFn.SetUnnamedAddr(true)

--- a/main.go
+++ b/main.go
@@ -80,6 +80,17 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	if goroot == "" {
 		return errors.New("cannot locate $GOROOT, please set it manually")
 	}
+	tags := spec.BuildTags
+	major, minor := getGorootVersion(goroot)
+	if major != 1 {
+		if major == 0 {
+			return errors.New("could not read version from GOROOT: " + goroot)
+		}
+		return fmt.Errorf("expected major version 1, got go%d.%d", major, minor)
+	}
+	for i := 1; i <= minor; i++ {
+		tags = append(tags, fmt.Sprintf("go1.%d", i))
+	}
 	compilerConfig := compiler.Config{
 		Triple:        spec.Triple,
 		CPU:           spec.CPU,
@@ -94,7 +105,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		TINYGOROOT:    root,
 		GOROOT:        goroot,
 		GOPATH:        getGopath(),
-		BuildTags:     spec.BuildTags,
+		BuildTags:     tags,
 	}
 	c, err := compiler.NewCompiler(pkgName, compilerConfig)
 	if err != nil {

--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -166,9 +166,10 @@ func decodeUTF8(s string, index uintptr) (rune, uintptr) {
 	}
 }
 
-// indexByte returns the index of the first instance of c in s, or -1 if c is not present in s.
-//go:linkname indexByte strings.IndexByte
-func indexByte(s string, c byte) int {
+// indexByteString returns the index of the first instance of c in s, or -1 if c
+// is not present in s.
+//go:linkname indexByteString internal/bytealg.IndexByteString
+func indexByteString(s string, c byte) int {
 	for i := 0; i < len(s); i++ {
 		if s[i] == c {
 			return i

--- a/src/runtime/strings_go111.go
+++ b/src/runtime/strings_go111.go
@@ -1,0 +1,12 @@
+// +build !go1.12
+
+package runtime
+
+// indexByte provides compatibility with Go 1.11.
+// See the following:
+// https://github.com/tinygo-org/tinygo/issues/351
+// https://github.com/golang/go/commit/ad4a58e31501bce5de2aad90a620eaecdc1eecb8
+//go:linkname indexByte strings.IndexByte
+func indexByte(s string, c byte) int {
+	return indexByteString(s, c)
+}

--- a/target.go
+++ b/target.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -367,4 +369,27 @@ func getGoroot() string {
 func isGoroot(goroot string) bool {
 	_, err := os.Stat(filepath.Join(goroot, "src", "runtime", "internal", "sys", "zversion.go"))
 	return err == nil
+}
+
+// getGorootVersion returns the major and minor version for a given GOROOT path.
+// If the goroot cannot be determined, (0, 0) is returned.
+func getGorootVersion(goroot string) (major, minor int) {
+	data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION"))
+	if err != nil {
+		return
+	}
+	s := string(data)
+	if s[:2] != "go" {
+		return
+	}
+	parts := strings.Split(s[2:], ".")
+	if len(parts) < 2 {
+		return
+	}
+
+	// Ignore the errors, strconv.Atoi will return 0 on most errors and we
+	// don't really handle errors here anyway.
+	major, _ = strconv.Atoi(parts[0])
+	minor, _ = strconv.Atoi(parts[1])
+	return
 }

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 )
 
 func main() {
+	// package os, fmt
 	fmt.Println("stdin: ", os.Stdin.Fd())
 	fmt.Println("stdout:", os.Stdout.Fd())
 	fmt.Println("stderr:", os.Stderr.Fd())
 
+	// package math/rand
 	fmt.Println("pseudorandom number:", rand.Int31())
+
+	// package strings
+	fmt.Println("strings.IndexByte:", strings.IndexByte("asdf", 'd'))
 }

--- a/testdata/stdlib.txt
+++ b/testdata/stdlib.txt
@@ -2,3 +2,4 @@ stdin:  0
 stdout: 1
 stderr: 2
 pseudorandom number: 1298498081
+strings.IndexByte: 2


### PR DESCRIPTION
`strings.IndexByte` used to be implemented in the runtime. Now it is implemented using a direct call to `internal/bytealg.IndexByte`. Fixes #351.

The real problem is of course https://github.com/golang/go/issues/31330.