### PR TITLE
cgo: add support for enum types

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -613,9 +613,15 @@ func (p *cgoPackage) makeASTType(typ C.CXType, pos token.Pos) ast.Expr {
 		}
 	}
 	if typeName == "" {
+		// Report this as an error.
+		spelling := getString(C.clang_getTypeSpelling(typ))
+		p.errors = append(p.errors, scanner.Error{
+			Pos: p.fset.PositionFor(pos, true),
+			Msg: fmt.Sprintf("unknown C type: %v (libclang type kind %d)", spelling, typ.kind),
+		})
 		// Fallback, probably incorrect but at least the error points to an odd
 		// type name.
-		typeName = "C." + getString(C.clang_getTypeSpelling(typ))
+		typeName = "C." + spelling
 	}
 	return &ast.Ident{
 		NamePos: pos,

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -56,3 +56,11 @@ CXSourceRange tinygo_clang_getCursorExtent(CXCursor c) {
 CXTranslationUnit tinygo_clang_Cursor_getTranslationUnit(CXCursor c) {
 	return clang_Cursor_getTranslationUnit(c);
 }
+
+long long tinygo_clang_getEnumConstantDeclValue(CXCursor c) {
+	return clang_getEnumConstantDeclValue(c);
+}
+
+CXType tinygo_clang_getEnumDeclIntegerType(CXCursor c) {
+	return clang_getEnumDeclIntegerType(c);
+}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -17,6 +17,7 @@ int globalStructSize = sizeof(globalStruct);
 short globalArray[3] = {5, 6, 7};
 joined_t globalUnion;
 int globalUnionSize = sizeof(globalUnion);
+option_t globalOption = optionG;
 
 int fortytwo() {
 	return 42;

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -75,6 +75,24 @@ func main() {
 		println("n in chain:", list.n)
 		list = (*C.list_t)(list.next)
 	}
+
+	// named enum
+	var _ C.enum_option = C.optionA
+	var _ C.option_t = C.optionA
+	println("option:", C.globalOption)
+	println("option A:", C.optionA)
+	println("option B:", C.optionB)
+	println("option C:", C.optionC)
+	println("option D:", C.optionD)
+	println("option E:", C.optionE)
+	println("option F:", C.optionF)
+	println("option G:", C.optionG)
+
+	// anonymous enum
+	var _ C.option2_t = C.option2A
+	var _ C.option3_t = C.option3A
+	println("option 2A:", C.option2A)
+	println("option 3A:", C.option3A)
 }
 
 func printUnion(union C.joined_t) C.joined_t {

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -47,6 +47,24 @@ void unionSetShort(short s);
 void unionSetFloat(float f);
 void unionSetData(short f0, short f1, short f2);
 
+typedef enum option {
+	optionA,
+	optionB,
+	optionC = -5,
+	optionD,
+	optionE = 10,
+	optionF,
+	optionG,
+} option_t;
+
+typedef enum {
+	option2A = 20,
+} option2_t;
+
+typedef enum {
+	option3A = 21,
+} option3_t;
+
 // test globals and datatypes
 extern int global;
 extern int unusedGlobal;
@@ -66,6 +84,7 @@ extern int globalStructSize;
 extern short globalArray[3];
 extern joined_t globalUnion;
 extern int globalUnionSize;
+extern option_t globalOption;
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -35,3 +35,13 @@ struct: 3 5
 n in chain: 3
 n in chain: 6
 n in chain: 7
+option: 12
+option A: 0
+option B: 1
+option C: -5
+option D: -4
+option E: 10
+option F: 11
+option G: 12
+option 2A: 20
+option 3A: 21


### PR DESCRIPTION
This commit adds support for C enums (treated as Go constants) and improves cgo error reporting when cgo encounters a type it does not understand.