### PR TITLE
Fix issue with new-style volatile operations

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -114,6 +114,11 @@ func (c *Compiler) emitSliceBoundsCheck(frame *Frame, capacity, low, high llvm.V
 // has no effect in well-behaved programs, but makes sure no uncaught nil
 // pointer dereferences exist in valid Go code.
 func (c *Compiler) emitNilCheck(frame *Frame, ptr llvm.Value, blockPrefix string) {
+	// Check whether we need to emit this check at all.
+	if !ptr.IsAGlobalValue().IsNil() {
+		return
+	}
+
 	// Check whether this is a nil pointer.
 	faultBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".nil")
 	nextBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".next")

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -109,7 +109,16 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 				default:
 					panic("unreachable")
 				}
-			case llvm.Load, llvm.Store:
+			case llvm.Load:
+				if inst.IsVolatile() {
+					result.updateSeverity(sideEffectLimited)
+				}
+				if _, ok := e.dirtyGlobals[inst.Operand(0)]; ok {
+					if e.hasLocalSideEffects(dirtyLocals, inst) {
+						result.updateSeverity(sideEffectLimited)
+					}
+				}
+			case llvm.Store:
 				if inst.IsVolatile() {
 					result.updateSeverity(sideEffectLimited)
 				}


### PR DESCRIPTION
This fixes a bug in interp so that new-style register accesses work correctly. Previously, this hit the error `interp: branch on a non-constant`.

Also added a small optimization that I found while working on this.