### PR TITLE
machine/stm32: refactor to use new volatile package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ gen-device-sam:
 	go fmt ./src/device/sam
 
 gen-device-stm32:
-	./tools/gen-device-svd.py lib/cmsis-svd/data/STMicro/ src/device/stm32/ --source=https://github.com/posborne/cmsis-svd/tree/master/data/STMicro
+	./tools/gen-device-svd-vol.py lib/cmsis-svd/data/STMicro/ src/device/stm32/ --source=https://github.com/posborne/cmsis-svd/tree/master/data/STMicro
 	go fmt ./src/device/stm32
 
 

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -74,23 +74,23 @@ func (p GPIO) getPort() *stm32.GPIO_Type {
 func (p GPIO) enableClock() {
 	switch p.Pin / 16 {
 	case 0:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOAEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOAEN)
 	case 1:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOBEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOBEN)
 	case 2:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOCEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOCEN)
 	case 3:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIODEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIODEN)
 	case 4:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOEEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOEEN)
 	case 5:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOFEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOFEN)
 	case 6:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOGEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOGEN)
 	case 7:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOHEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOHEN)
 	case 8:
-		stm32.RCC.AHB1ENR |= stm32.RCC_AHB1ENR_GPIOIEN
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOIEN)
 	default:
 		panic("machine: unknown port")
 	}
@@ -105,25 +105,25 @@ func (p GPIO) Configure(config GPIOConfig) {
 	pos := pin * 2
 
 	if config.Mode == GPIO_INPUT_FLOATING {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
-		port.PUPDR = stm32.RegValue((uint32(port.PUPDR)&^(0x3<<pos) | (uint32(GPIO_FLOATING) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
+		port.PUPDR.Set((uint32(port.PUPDR.Get())&^(0x3<<pos) | (uint32(GPIO_FLOATING) << pos)))
 	} else if config.Mode == GPIO_INPUT_PULLDOWN {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
-		port.PUPDR = stm32.RegValue((uint32(port.PUPDR)&^(0x3<<pos) | (uint32(GPIO_PULL_DOWN) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
+		port.PUPDR.Set((uint32(port.PUPDR.Get())&^(0x3<<pos) | (uint32(GPIO_PULL_DOWN) << pos)))
 	} else if config.Mode == GPIO_INPUT_PULLUP {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
-		port.PUPDR = stm32.RegValue((uint32(port.PUPDR)&^(0x3<<pos) | (uint32(GPIO_PULL_UP) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_INPUT) << pos)))
+		port.PUPDR.Set((uint32(port.PUPDR.Get())&^(0x3<<pos) | (uint32(GPIO_PULL_UP) << pos)))
 	} else if config.Mode == GPIO_OUTPUT {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_GENERAL_OUTPUT) << pos)))
-		port.OSPEEDR = stm32.RegValue((uint32(port.OSPEEDR)&^(0x3<<pos) | (uint32(GPIO_SPEED_HI) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_GENERAL_OUTPUT) << pos)))
+		port.OSPEEDR.Set((uint32(port.OSPEEDR.Get())&^(0x3<<pos) | (uint32(GPIO_SPEED_HI) << pos)))
 	} else if config.Mode == GPIO_UART_TX {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_ALTERNABTIVE) << pos)))
-		port.OSPEEDR = stm32.RegValue((uint32(port.OSPEEDR)&^(0x3<<pos) | (uint32(GPIO_SPEED_HI) << pos)))
-		port.PUPDR = stm32.RegValue((uint32(port.PUPDR)&^(0x3<<pos) | (uint32(GPIO_PULL_UP) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_ALTERNABTIVE) << pos)))
+		port.OSPEEDR.Set((uint32(port.OSPEEDR.Get())&^(0x3<<pos) | (uint32(GPIO_SPEED_HI) << pos)))
+		port.PUPDR.Set((uint32(port.PUPDR.Get())&^(0x3<<pos) | (uint32(GPIO_PULL_UP) << pos)))
 		p.setAltFunc(0x7)
 	} else if config.Mode == GPIO_UART_RX {
-		port.MODER = stm32.RegValue((uint32(port.MODER)&^(0x3<<pos) | (uint32(GPIO_MODE_ALTERNABTIVE) << pos)))
-		port.PUPDR = stm32.RegValue((uint32(port.PUPDR)&^(0x3<<pos) | (uint32(GPIO_FLOATING) << pos)))
+		port.MODER.Set((uint32(port.MODER.Get())&^(0x3<<pos) | (uint32(GPIO_MODE_ALTERNABTIVE) << pos)))
+		port.PUPDR.Set((uint32(port.PUPDR.Get())&^(0x3<<pos) | (uint32(GPIO_FLOATING) << pos)))
 		p.setAltFunc(0x7)
 	}
 }
@@ -133,9 +133,9 @@ func (p GPIO) setAltFunc(af uint32) {
 	pin := p.Pin % 16
 	pos := pin * 4
 	if pin >= 8 {
-		port.AFRH = stm32.RegValue(uint32(port.AFRH)&^(0xF<<pos) | ((af & 0xF) << pos))
+		port.AFRH.Set(uint32(port.AFRH.Get())&^(0xF<<pos) | ((af & 0xF) << pos))
 	} else {
-		port.AFRL = stm32.RegValue(uint32(port.AFRL)&^(0xF<<pos) | ((af & 0xF) << pos))
+		port.AFRL.Set(uint32(port.AFRL.Get())&^(0xF<<pos) | ((af & 0xF) << pos))
 	}
 }
 
@@ -145,9 +145,9 @@ func (p GPIO) Set(high bool) {
 	port := p.getPort()
 	pin := p.Pin % 16
 	if high {
-		port.BSRR = 1 << pin
+		port.BSRR.Set(1 << pin)
 	} else {
-		port.BSRR = 1 << (pin + 16)
+		port.BSRR.Set(1 << (pin + 16))
 	}
 }
 
@@ -178,7 +178,7 @@ func (uart UART) Configure(config UARTConfig) {
 	}
 
 	// Enable USART2 clock
-	stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_USART2EN
+	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_USART2EN)
 
 	/*
 	  Set baud rate(115200)
@@ -195,10 +195,10 @@ func (uart UART) Configure(config UARTConfig) {
 	  | 115200   | 0x16D  |
 	  +----------+--------+
 	*/
-	stm32.USART2.BRR = 0x16c
+	stm32.USART2.BRR.Set(0x16c)
 
 	// Enable USART2 port.
-	stm32.USART2.CR1 = stm32.USART_CR1_TE | stm32.USART_CR1_RE | stm32.USART_CR1_RXNEIE | stm32.USART_CR1_UE
+	stm32.USART2.CR1.Set(stm32.USART_CR1_TE | stm32.USART_CR1_RE | stm32.USART_CR1_RXNEIE | stm32.USART_CR1_UE)
 
 	// Enable RX IRQ.
 	arm.SetPriority(stm32.IRQ_USART2, 0xc0)
@@ -207,14 +207,14 @@ func (uart UART) Configure(config UARTConfig) {
 
 // WriteByte writes a byte of data to the UART.
 func (uart UART) WriteByte(c byte) error {
-	stm32.USART2.DR = stm32.RegValue(c)
+	stm32.USART2.DR.Set(uint32(c))
 
-	for (stm32.USART2.SR & stm32.USART_SR_TXE) == 0 {
+	for (stm32.USART2.SR.Get() & stm32.USART_SR_TXE) == 0 {
 	}
 	return nil
 }
 
 //go:export USART2_IRQHandler
 func handleUSART2() {
-	UART1.Receive(byte((stm32.USART2.DR & 0xFF)))
+	UART1.Receive(byte((stm32.USART2.DR.Get() & 0xFF)))
 }

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -21,33 +21,33 @@ func putchar(c byte) {
 
 // initCLK sets clock to 72MHz using HSE 8MHz crystal w/ PLL X 9 (8MHz x 9 = 72MHz).
 func initCLK() {
-	stm32.FLASH.ACR |= stm32.FLASH_ACR_LATENCY_2    // Two wait states, per datasheet
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE1_DIV_2    // prescale PCLK1 = HCLK/2
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PPRE2_DIV_NONE // prescale PCLK2 = HCLK/1
-	stm32.RCC.CR |= stm32.RCC_CR_HSEON              // enable HSE clock
+	stm32.FLASH.ACR.SetBits(stm32.FLASH_ACR_LATENCY_2)    // Two wait states, per datasheet
+	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_PPRE1_DIV_2)    // prescale PCLK1 = HCLK/2
+	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_PPRE2_DIV_NONE) // prescale PCLK2 = HCLK/1
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSEON)              // enable HSE clock
 
 	// wait for the HSEREADY flag
-	for (stm32.RCC.CR & stm32.RCC_CR_HSERDY) == 0 {
+	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSERDY) == 0 {
 	}
 
-	stm32.RCC.CR |= stm32.RCC_CR_HSION // enable HSI clock
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSION) // enable HSI clock
 
 	// wait for the HSIREADY flag
-	for (stm32.RCC.CR & stm32.RCC_CR_HSIRDY) == 0 {
+	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSIRDY) == 0 {
 	}
 
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PLLSRC   // set PLL source to HSE
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_PLLMUL_9 // multiply by 9
-	stm32.RCC.CR |= stm32.RCC_CR_PLLON        // enable the PLL
+	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_PLLSRC)   // set PLL source to HSE
+	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_PLLMUL_9) // multiply by 9
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_PLLON)        // enable the PLL
 
 	// wait for the PLLRDY flag
-	for (stm32.RCC.CR & stm32.RCC_CR_PLLRDY) == 0 {
+	for (stm32.RCC.CR.Get() & stm32.RCC_CR_PLLRDY) == 0 {
 	}
 
-	stm32.RCC.CFGR |= stm32.RCC_CFGR_SW_PLL // set clock source to pll
+	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_SW_PLL) // set clock source to pll
 
 	// wait for PLL to be CLK
-	for (stm32.RCC.CFGR & stm32.RCC_CFGR_SWS_PLL) == 0 {
+	for (stm32.RCC.CFGR.Get() & stm32.RCC_CFGR_SWS_PLL) == 0 {
 	}
 }
 
@@ -65,43 +65,43 @@ var timerWakeup isrFlag
 
 func initRTC() {
 	// Enable the PWR and BKP.
-	stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_PWREN | stm32.RCC_APB1ENR_BKPEN
+	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_PWREN | stm32.RCC_APB1ENR_BKPEN)
 
 	// access to backup register
-	stm32.PWR.CR |= stm32.PWR_CR_DBP
+	stm32.PWR.CR.SetBits(stm32.PWR_CR_DBP)
 
 	// Enable LSE
-	stm32.RCC.BDCR |= stm32.RCC_BDCR_LSEON
+	stm32.RCC.BDCR.SetBits(stm32.RCC_BDCR_LSEON)
 
 	// wait until LSE is ready
-	for stm32.RCC.BDCR&stm32.RCC_BDCR_LSERDY == 0 {
+	for stm32.RCC.BDCR.Get()&stm32.RCC_BDCR_LSERDY == 0 {
 	}
 
 	// Select LSE
-	stm32.RCC.BDCR |= stm32.RCC_RTCCLKSource_LSE
+	stm32.RCC.BDCR.SetBits(stm32.RCC_RTCCLKSource_LSE)
 
 	// set prescaler to "max" per datasheet
-	stm32.RTC.PRLH = stm32.RTC_PRLH_PRLH_Msk
-	stm32.RTC.PRLL = stm32.RTC_PRLL_PRLL_Msk
+	stm32.RTC.PRLH.Set(stm32.RTC_PRLH_PRLH_Msk)
+	stm32.RTC.PRLL.Set(stm32.RTC_PRLL_PRLL_Msk)
 
 	// set count to zero
-	stm32.RTC.CNTH = 0x0
-	stm32.RTC.CNTL = 0x0
+	stm32.RTC.CNTH.Set(0x0)
+	stm32.RTC.CNTL.Set(0x0)
 
 	// Enable RTC
-	stm32.RCC.BDCR |= stm32.RCC_BDCR_RTCEN
+	stm32.RCC.BDCR.SetBits(stm32.RCC_BDCR_RTCEN)
 
 	// Clear RSF
-	stm32.RTC.CRL &^= stm32.RTC_CRL_RSF
+	stm32.RTC.CRL.ClearBits(stm32.RTC_CRL_RSF)
 
 	// Wait till flag is set
-	for stm32.RTC.CRL&stm32.RTC_CRL_RSF == 0 {
+	for stm32.RTC.CRL.Get()&stm32.RTC_CRL_RSF == 0 {
 	}
 }
 
 // Enable the TIM3 clock.
 func initTIM() {
-	stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_TIM3EN
+	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_TIM3EN)
 
 	arm.SetPriority(stm32.IRQ_TIM3, 0xc3)
 	arm.EnableIRQ(stm32.IRQ_TIM3)
@@ -122,10 +122,10 @@ func sleepTicks(d timeUnit) {
 // number of ticks (microseconds) since start.
 func ticks() timeUnit {
 	// convert RTC counter from seconds to microseconds
-	timerCounter := uint64(stm32.RTC.CNTH<<16|stm32.RTC.CNTL) * 1000 * 1000
+	timerCounter := uint64(stm32.RTC.CNTH.Get()<<16|stm32.RTC.CNTL.Get()) * 1000 * 1000
 
 	// add the fractional part of current time using DIV register
-	timerCounter += uint64(0x8000-stm32.RTC.DIVL) * 31
+	timerCounter += uint64(0x8000-stm32.RTC.DIVL.Get()) * 31
 
 	// change since last measurement
 	offset := (timerCounter - timerLastCounter)
@@ -165,16 +165,16 @@ func timerSleep(ticks uint32) {
 	// The current scaling only supports a range of 100 usec to 6553 msec.
 
 	// prescale counter down from 72mhz to 10khz aka 0.1 ms frequency.
-	stm32.TIM3.PSC = machine.CPU_FREQUENCY/10000 - 1 // 7199
+	stm32.TIM3.PSC.Set(machine.CPU_FREQUENCY/10000 - 1) // 7199
 
 	// set duty aka duration
-	stm32.TIM3.ARR = stm32.RegValue(ticks/100) - 1 // convert from microseconds to 0.1 ms
+	stm32.TIM3.ARR.Set(ticks/100 - 1) // convert from microseconds to 0.1 ms
 
 	// Enable the hardware interrupt.
-	stm32.TIM3.DIER |= stm32.TIM_DIER_UIE
+	stm32.TIM3.DIER.SetBits(stm32.TIM_DIER_UIE)
 
 	// Enable the timer.
-	stm32.TIM3.CR1 |= stm32.TIM_CR1_CEN
+	stm32.TIM3.CR1.SetBits(stm32.TIM_CR1_CEN)
 
 	// wait till timer wakes up
 	for !timerWakeup {
@@ -184,12 +184,12 @@ func timerSleep(ticks uint32) {
 
 //go:export TIM3_IRQHandler
 func handleTIM3() {
-	if (stm32.TIM3.SR & stm32.TIM_SR_UIF) > 0 {
+	if (stm32.TIM3.SR.Get() & stm32.TIM_SR_UIF) > 0 {
 		// Disable the timer.
-		stm32.TIM3.CR1 &^= stm32.TIM_CR1_CEN
+		stm32.TIM3.CR1.ClearBits(stm32.TIM_CR1_CEN)
 
 		// clear the update flag
-		stm32.TIM3.SR &^= stm32.TIM_SR_UIF
+		stm32.TIM3.SR.ClearBits(stm32.TIM_SR_UIF)
 
 		// timer was triggered
 		timerWakeup = true

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -42,58 +42,59 @@ func initCLK() {
 
 	// Reset clock registers
 	// Set HSION
-	stm32.RCC.CR |= stm32.RCC_CR_HSION
-	for (stm32.RCC.CR & stm32.RCC_CR_HSIRDY) == 0 {
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSION)
+	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSIRDY) == 0 {
 	}
 
 	// Reset CFGR
-	stm32.RCC.CFGR = 0x00000000
+	stm32.RCC.CFGR.Set(0x00000000)
 	// Reset HSEON, CSSON and PLLON
-	stm32.RCC.CR &= 0xFEF6FFFF
+	stm32.RCC.CR.ClearBits(stm32.RCC_CR_HSEON | stm32.RCC_CR_CSSON | stm32.RCC_CR_PLLON)
 	// Reset PLLCFGR
-	stm32.RCC.PLLCFGR = 0x24003010
+	stm32.RCC.PLLCFGR.Set(0x24003010)
 	// Reset HSEBYP
-	stm32.RCC.CR &= 0xFFFBFFFF
+	stm32.RCC.CR.ClearBits(stm32.RCC_CR_HSEBYP)
 	// Disable all interrupts
-	stm32.RCC.CIR = 0x00000000
+	stm32.RCC.CIR.Set(0x00000000)
 
 	// Set up the clock
 	var startupCounter uint32 = 0
 
 	// Enable HSE
-	stm32.RCC.CR = stm32.RCC_CR_HSEON
+	stm32.RCC.CR.Set(stm32.RCC_CR_HSEON)
+
 	// Wait till HSE is ready and if timeout is reached exit
 	for {
 		startupCounter++
-		if (stm32.RCC.CR&stm32.RCC_CR_HSERDY != 0) || (startupCounter == HSE_STARTUP_TIMEOUT) {
+		if (stm32.RCC.CR.Get()&stm32.RCC_CR_HSERDY != 0) || (startupCounter == HSE_STARTUP_TIMEOUT) {
 			break
 		}
 	}
-	if (stm32.RCC.CR & stm32.RCC_CR_HSERDY) != 0 {
+	if (stm32.RCC.CR.Get() & stm32.RCC_CR_HSERDY) != 0 {
 		// Enable high performance mode, System frequency up to 168MHz
-		stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_PWREN
-		stm32.PWR.CR |= 0x4000 // PWR_CR_VOS
+		stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_PWREN)
+		stm32.PWR.CR.SetBits(0x4000) // PWR_CR_VOS
 		// HCLK = SYSCLK / 1
-		stm32.RCC.CFGR |= (0x0 << stm32.RCC_CFGR_HPRE_Pos)
+		stm32.RCC.CFGR.SetBits(0x0 << stm32.RCC_CFGR_HPRE_Pos)
 		// PCLK2 = HCLK / 2
-		stm32.RCC.CFGR |= (0x4 << stm32.RCC_CFGR_PPRE2_Pos)
+		stm32.RCC.CFGR.SetBits(0x4 << stm32.RCC_CFGR_PPRE2_Pos)
 		// PCLK1 = HCLK / 4
-		stm32.RCC.CFGR |= (0x5 << stm32.RCC_CFGR_PPRE1_Pos)
+		stm32.RCC.CFGR.SetBits(0x5 << stm32.RCC_CFGR_PPRE1_Pos)
 		// Configure the main PLL
 		// PLL Options - See RM0090 Reference Manual pg. 95
-		stm32.RCC.PLLCFGR = PLL_M | (PLL_N << 6) | (((PLL_P >> 1) - 1) << 16) |
-			(1 << stm32.RCC_PLLCFGR_PLLSRC_Pos) | (PLL_Q << 24)
+		stm32.RCC.PLLCFGR.Set(PLL_M | (PLL_N << 6) | (((PLL_P >> 1) - 1) << 16) |
+			(1 << stm32.RCC_PLLCFGR_PLLSRC_Pos) | (PLL_Q << 24))
 		// Enable main PLL
-		stm32.RCC.CR |= stm32.RCC_CR_PLLON
+		stm32.RCC.CR.SetBits(stm32.RCC_CR_PLLON)
 		// Wait till the main PLL is ready
-		for (stm32.RCC.CR & stm32.RCC_CR_PLLRDY) == 0 {
+		for (stm32.RCC.CR.Get() & stm32.RCC_CR_PLLRDY) == 0 {
 		}
 		// Configure Flash prefetch, Instruction cache, Data cache and wait state
-		stm32.FLASH.ACR = stm32.FLASH_ACR_ICEN | stm32.FLASH_ACR_DCEN | (5 << stm32.FLASH_ACR_LATENCY_Pos)
+		stm32.FLASH.ACR.Set(stm32.FLASH_ACR_ICEN | stm32.FLASH_ACR_DCEN | (5 << stm32.FLASH_ACR_LATENCY_Pos))
 		// Select the main PLL as system clock source
-		stm32.RCC.CFGR &^= stm32.RCC_CFGR_SW0 | stm32.RCC_CFGR_SW1
-		stm32.RCC.CFGR |= (0x2 << stm32.RCC_CFGR_SW0_Pos)
-		for (stm32.RCC.CFGR & (0x3 << stm32.RCC_CFGR_SWS0_Pos)) != (0x2 << stm32.RCC_CFGR_SWS0_Pos) {
+		stm32.RCC.CFGR.ClearBits(stm32.RCC_CFGR_SW0 | stm32.RCC_CFGR_SW1)
+		stm32.RCC.CFGR.SetBits(0x2 << stm32.RCC_CFGR_SW0_Pos)
+		for (stm32.RCC.CFGR.Get() & (0x3 << stm32.RCC_CFGR_SWS0_Pos)) != (0x2 << stm32.RCC_CFGR_SWS0_Pos) {
 		}
 
 	} else {
@@ -102,7 +103,7 @@ func initCLK() {
 		}
 	}
 	// Enable the CCM RAM clock
-	stm32.RCC.AHB1ENR |= (1 << 20)
+	stm32.RCC.AHB1ENR.SetBits(1 << 20)
 
 }
 
@@ -120,7 +121,7 @@ var timerWakeup isrFlag
 
 // Enable the TIM3 clock.(sleep count)
 func initTIM3() {
-	stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_TIM3EN
+	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_TIM3EN)
 
 	arm.SetPriority(stm32.IRQ_TIM3, 0xc3)
 	arm.EnableIRQ(stm32.IRQ_TIM3)
@@ -128,17 +129,17 @@ func initTIM3() {
 
 // Enable the TIM7 clock.(tick count)
 func initTIM7() {
-	stm32.RCC.APB1ENR |= stm32.RCC_APB1ENR_TIM7EN
+	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_TIM7EN)
 
 	// CK_INT = APB1 x2 = 84mhz
-	stm32.TIM7.PSC = 84000000/10000 - 1     // 84mhz to 10khz(0.1ms)
-	stm32.TIM7.ARR = stm32.RegValue(10) - 1 // interrupt per 1ms
+	stm32.TIM7.PSC.Set(84000000/10000 - 1) // 84mhz to 10khz(0.1ms)
+	stm32.TIM7.ARR.Set(10 - 1)             // interrupt per 1ms
 
 	// Enable the hardware interrupt.
-	stm32.TIM7.DIER |= stm32.TIM_DIER_UIE
+	stm32.TIM7.DIER.SetBits(stm32.TIM_DIER_UIE)
 
 	// Enable the timer.
-	stm32.TIM7.CR1 |= stm32.TIM_CR1_CEN
+	stm32.TIM7.CR1.SetBits(stm32.TIM_CR1_CEN)
 
 	arm.SetPriority(stm32.IRQ_TIM7, 0xc1)
 	arm.EnableIRQ(stm32.IRQ_TIM7)
@@ -163,20 +164,20 @@ func timerSleep(ticks uint32) {
 
 	// CK_INT = APB1 x2 = 84mhz
 	// prescale counter down from 84mhz to 10khz aka 0.1 ms frequency.
-	stm32.TIM3.PSC = 84000000/10000 - 1 // 8399
+	stm32.TIM3.PSC.Set(84000000/10000 - 1) // 8399
 
 	// set duty aka duration
 	arr := (ticks / 100) - 1 // convert from microseconds to 0.1 ms
 	if arr == 0 {
 		arr = 1 // avoid blocking
 	}
-	stm32.TIM3.ARR = stm32.RegValue(arr)
+	stm32.TIM3.ARR.Set(arr)
 
 	// Enable the hardware interrupt.
-	stm32.TIM3.DIER |= stm32.TIM_DIER_UIE
+	stm32.TIM3.DIER.SetBits(stm32.TIM_DIER_UIE)
 
 	// Enable the timer.
-	stm32.TIM3.CR1 |= stm32.TIM_CR1_CEN
+	stm32.TIM3.CR1.SetBits(stm32.TIM_CR1_CEN)
 
 	// wait till timer wakes up
 	for !timerWakeup {
@@ -186,12 +187,12 @@ func timerSleep(ticks uint32) {
 
 //go:export TIM3_IRQHandler
 func handleTIM3() {
-	if (stm32.TIM3.SR & stm32.TIM_SR_UIF) > 0 {
+	if (stm32.TIM3.SR.Get() & stm32.TIM_SR_UIF) > 0 {
 		// Disable the timer.
-		stm32.TIM3.CR1 &^= stm32.TIM_CR1_CEN
+		stm32.TIM3.CR1.ClearBits(stm32.TIM_CR1_CEN)
 
 		// clear the update flag
-		stm32.TIM3.SR &^= stm32.TIM_SR_UIF
+		stm32.TIM3.SR.ClearBits(stm32.TIM_SR_UIF)
 
 		// timer was triggered
 		timerWakeup = true
@@ -200,9 +201,9 @@ func handleTIM3() {
 
 //go:export TIM7_IRQHandler
 func handleTIM7() {
-	if (stm32.TIM7.SR & stm32.TIM_SR_UIF) > 0 {
+	if (stm32.TIM7.SR.Get() & stm32.TIM_SR_UIF) > 0 {
 		// clear the update flag
-		stm32.TIM7.SR &^= stm32.TIM_SR_UIF
+		stm32.TIM7.SR.ClearBits(stm32.TIM_SR_UIF)
 		tickCount++
 	}
 }


### PR DESCRIPTION
This PR refactors all current STM32-based board implementations to use the new volatile package for register access.

Tested on my Bluepill board.