### PR TITLE
machine/stm32f103xx: fix i2c 2 byte read

### DIFF
--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -505,7 +505,12 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			r[1] = byte(i2c.Bus.DR.Get())
 
 			// wait for stop
-			return i2c.waitForStop()
+			err = i2c.waitForStop()
+
+			//disable pos
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_POS)
+
+			return err
 
 		case 3:
 			// Enable ACK of received data


### PR DESCRIPTION
Fixes #371