### PR TITLE
main: add the absolute path to clang-8 etc. on macOS

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -13,6 +14,16 @@ var commands = map[string][]string{
 	"clang":   {"clang-8"},
 	"ld.lld":  {"ld.lld-8", "ld.lld"},
 	"wasm-ld": {"wasm-ld-8", "wasm-ld"},
+}
+
+func init() {
+	// Add the path to a Homebrew-installed LLVM 8 for ease of use (no need to
+	// manually set $PATH).
+	if runtime.GOOS == "darwin" {
+		commands["clang"] = append(commands["clang"], "/usr/local/opt/llvm/bin/clang-8")
+		commands["ld.lld"] = append(commands["ld.lld"], "/usr/local/opt/llvm/bin/ld.lld")
+		commands["wasm-ld"] = append(commands["wasm-ld"], "/usr/local/opt/llvm/bin/wasm-ld")
+	}
 }
 
 func execCommand(cmdNames []string, args ...string) error {


### PR DESCRIPTION
This avoids the need to correctly set $PATH if LLVM 8 has been installed using Homebrew.