### PR TITLE
wasm: fix wasm-ld hang

### DIFF
--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -13,6 +13,7 @@
 	],
 	"ldflags": [
 		"--allow-undefined",
+		"--no-threads",
 		"--export-all"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"]


### PR DESCRIPTION
See the following bugs for more information:
https://bugs.llvm.org/show_bug.cgi?id=41508
https://bugs.llvm.org/show_bug.cgi?id=37064

This should be removed again when we switch to LLVM 9, it may have a very small (basically negligible) compile time cost.