### PR TITLE
machine, runtime/all: Add HasBits() method to all registers

### DIFF
--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -165,7 +165,7 @@ func (i2c I2C) start(address uint8, write bool) {
 	avr.TWCR.Set((avr.TWCR_TWINT | avr.TWCR_TWSTA | avr.TWCR_TWEN))
 
 	// Wait till start condition is transmitted.
-	for (avr.TWCR.Get() & avr.TWCR_TWINT) == 0 {
+	for !avr.TWCR.HasBits(avr.TWCR_TWINT) {
 	}
 
 	// Write 7-bit shifted peripheral address.
@@ -182,7 +182,7 @@ func (i2c I2C) stop() {
 	avr.TWCR.Set(avr.TWCR_TWEN | avr.TWCR_TWINT | avr.TWCR_TWSTO)
 
 	// Wait for stop condition to be executed on bus.
-	for (avr.TWCR.Get() & avr.TWCR_TWSTO) == 0 {
+	for !avr.TWCR.HasBits(avr.TWCR_TWSTO) {
 	}
 }
 
@@ -195,7 +195,7 @@ func (i2c I2C) writeByte(data byte) {
 	avr.TWCR.Set(avr.TWCR_TWEN | avr.TWCR_TWINT)
 
 	// Wait till data is transmitted.
-	for (avr.TWCR.Get() & avr.TWCR_TWINT) == 0 {
+	for !avr.TWCR.HasBits(avr.TWCR_TWINT) {
 	}
 }
 
@@ -205,7 +205,7 @@ func (i2c I2C) readByte() byte {
 	avr.TWCR.Set(avr.TWCR_TWEN | avr.TWCR_TWINT | avr.TWCR_TWEA)
 
 	// Wait till read request is transmitted.
-	for (avr.TWCR.Get() & avr.TWCR_TWINT) == 0 {
+	for !avr.TWCR.HasBits(avr.TWCR_TWINT) {
 	}
 
 	return byte(avr.TWDR.Get())
@@ -239,7 +239,7 @@ func (uart UART) Configure(config UARTConfig) {
 // WriteByte writes a byte of data to the UART.
 func (uart UART) WriteByte(c byte) error {
 	// Wait until UART buffer is not busy.
-	for (avr.UCSR0A.Get() & avr.UCSR0A_UDRE0) == 0 {
+	for !avr.UCSR0A.HasBits(avr.UCSR0A_UDRE0) {
 	}
 	avr.UDR0.Set(c) // send char
 	return nil
@@ -251,7 +251,7 @@ func handleUSART_RX() {
 	data := avr.UDR0.Get()
 
 	// Ensure no error.
-	if (avr.UCSR0A.Get() & (avr.UCSR0A_FE0 | avr.UCSR0A_DOR0 | avr.UCSR0A_UPE0)) == 0 {
+	if !avr.UCSR0A.HasBits(avr.UCSR0A_FE0 | avr.UCSR0A_DOR0 | avr.UCSR0A_UPE0) {
 		// Put data from UDR register into buffer.
 		UART0.Receive(byte(data))
 	}

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -74,7 +74,7 @@ func (a ADC) Get() uint16 {
 	avr.ADCSRA.SetBits(avr.ADCSRA_ADSC)
 
 	// ADSC is cleared when the conversion finishes
-	for ok := true; ok; ok = (avr.ADCSRA.Get() & avr.ADCSRA_ADSC) > 0 {
+	for ok := true; ok; ok = avr.ADCSRA.HasBits(avr.ADCSRA_ADSC) {
 	}
 
 	return uint16(avr.ADCL.Get()) | uint16(avr.ADCH.Get())<<8

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -439,7 +439,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear timeout here
 			timeout := i2cTimeout
-			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -478,7 +478,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -524,7 +524,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -579,7 +579,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -721,7 +721,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		}
 
 		timeout = i2cTimeout
-		for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY|stm32.I2C_SR2_TRA) {
+		for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY | stm32.I2C_SR2_TRA) {
 			timeout--
 			if timeout == 0 {
 				return errors.New("I2C timeout on send write address")

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -157,7 +157,7 @@ func (uart UART) SetBaudRate(br uint32) {
 func (uart UART) WriteByte(c byte) error {
 	stm32.USART1.DR.Set(uint32(c))
 
-	for (stm32.USART1.SR.Get() & stm32.USART_SR_TXE) == 0 {
+	for !stm32.USART1.SR.HasBits(stm32.USART_SR_TXE) {
 	}
 	return nil
 }
@@ -265,15 +265,15 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.DR.Set(uint32(w))
 
 	// Wait until transmit complete
-	for (spi.Bus.SR.Get() & stm32.SPI_SR_TXE) == 0 {
+	for !spi.Bus.SR.HasBits(stm32.SPI_SR_TXE) {
 	}
 
 	// Wait until receive complete
-	for (spi.Bus.SR.Get() & stm32.SPI_SR_RXNE) == 0 {
+	for !spi.Bus.SR.HasBits(stm32.SPI_SR_RXNE) {
 	}
 
 	// Wait until SPI is not busy
-	for (spi.Bus.SR.Get() & stm32.SPI_SR_BSY) > 0 {
+	for spi.Bus.SR.HasBits(stm32.SPI_SR_BSY) {
 	}
 
 	// Return received data from SPI data register
@@ -439,7 +439,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear timeout here
 			timeout := i2cTimeout
-			for i2c.Bus.SR2.Get()&(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) == 0 {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -450,7 +450,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
 
 			timeout = i2cTimeout
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_RxNE) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read 1 byte")
@@ -478,7 +478,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for i2c.Bus.SR2.Get()&(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) == 0 {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -490,7 +490,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// wait for btf. we need a longer timeout here than normal.
 			timeout = 1000
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_BTF) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read 2 bytes")
@@ -524,7 +524,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for i2c.Bus.SR2.Get()&(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) == 0 {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -536,7 +536,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// wait for btf. we need a longer timeout here than normal.
 			timeout = 1000
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_BTF) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
 					println("I2C timeout on read 3 bytes")
@@ -551,7 +551,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			r[0] = byte(i2c.Bus.DR.Get())
 
 			timeout = 1000
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_BTF) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read 3 bytes")
@@ -579,7 +579,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// clear address here
 			timeout := i2cTimeout
-			for i2c.Bus.SR2.Get()&(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) == 0 {
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read clear address")
@@ -592,7 +592,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 				// wait for btf. we need a longer timeout here than normal.
 				timeout = 1000
-				for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_BTF) == 0 {
+				for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 					timeout--
 					if timeout == 0 {
 						println("I2C timeout on read 3 bytes")
@@ -606,7 +606,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 			// wait for btf. we need a longer timeout here than normal.
 			timeout = 1000
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_BTF) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read more than 3 bytes")
@@ -626,7 +626,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			r[len(r)-2] = byte(i2c.Bus.DR.Get())
 
 			timeout = i2cTimeout
-			for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_RxNE) == 0 {
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
 				timeout--
 				if timeout == 0 {
 					return errors.New("I2C timeout on read last byte of more than 3")
@@ -650,7 +650,7 @@ const i2cTimeout = 500
 func (i2c I2C) signalStart() error {
 	// Wait until I2C is not busy
 	timeout := i2cTimeout
-	for (i2c.Bus.SR2.Get() & stm32.I2C_SR2_BUSY) > 0 {
+	for i2c.Bus.SR2.HasBits(stm32.I2C_SR2_BUSY) {
 		timeout--
 		if timeout == 0 {
 			return errors.New("I2C busy on start")
@@ -665,7 +665,7 @@ func (i2c I2C) signalStart() error {
 
 	// Wait for I2C EV5 aka SB flag.
 	timeout = i2cTimeout
-	for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_SB) == 0 {
+	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_SB) {
 		timeout--
 		if timeout == 0 {
 			return errors.New("I2C timeout on start")
@@ -688,7 +688,7 @@ func (i2c I2C) signalStop() error {
 func (i2c I2C) waitForStop() error {
 	// Wait until I2C is stopped
 	timeout := i2cTimeout
-	for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_STOPF) > 0 {
+	for i2c.Bus.SR1.HasBits(stm32.I2C_SR1_STOPF) {
 		timeout--
 		if timeout == 0 {
 			println("I2C timeout on wait for stop signal")
@@ -713,7 +713,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 	timeout := i2cTimeout
 	if write {
 		// EV6 which is ADDR flag.
-		for i2c.Bus.SR1.Get()&stm32.I2C_SR1_ADDR == 0 {
+		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
 			timeout--
 			if timeout == 0 {
 				return errors.New("I2C timeout on send write address")
@@ -721,7 +721,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		}
 
 		timeout = i2cTimeout
-		for i2c.Bus.SR2.Get()&(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY|stm32.I2C_SR2_TRA) == 0 {
+		for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL|stm32.I2C_SR2_BUSY|stm32.I2C_SR2_TRA) {
 			timeout--
 			if timeout == 0 {
 				return errors.New("I2C timeout on send write address")
@@ -729,7 +729,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		}
 	} else {
 		// I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED which is ADDR flag.
-		for (i2c.Bus.SR1.Get() & stm32.I2C_SR1_ADDR) == 0 {
+		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
 			timeout--
 			if timeout == 0 {
 				return errors.New("I2C timeout on send read address")
@@ -749,7 +749,7 @@ func (i2c I2C) WriteByte(data byte) error {
 	// output on the bus.
 	// I2C_EVENT_MASTER_BYTE_TRANSMITTED is TXE flag.
 	timeout := i2cTimeout
-	for i2c.Bus.SR1.Get()&stm32.I2C_SR1_TxE == 0 {
+	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_TxE) {
 		timeout--
 		if timeout == 0 {
 			return errors.New("I2C timeout on write")

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -209,7 +209,7 @@ func (uart UART) Configure(config UARTConfig) {
 func (uart UART) WriteByte(c byte) error {
 	stm32.USART2.DR.Set(uint32(c))
 
-	for (stm32.USART2.SR.Get() & stm32.USART_SR_TXE) == 0 {
+	for !stm32.USART2.SR.HasBits(stm32.USART_SR_TXE) {
 	}
 	return nil
 }

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -67,13 +67,13 @@ func initClocks() {
 		sam.SYSCTRL_OSC32K_EN1K |
 		sam.SYSCTRL_OSC32K_ENABLE)
 	// Wait for oscillator stabilization
-	for (sam.SYSCTRL.PCLKSR.Get() & sam.SYSCTRL_PCLKSR_OSC32KRDY) == 0 {
+	for !sam.SYSCTRL.PCLKSR.HasBits(sam.SYSCTRL_PCLKSR_OSC32KRDY) {
 	}
 
 	// Software reset the module to ensure it is re-initialized correctly
 	sam.GCLK.CTRL.Set(sam.GCLK_CTRL_SWRST)
 	// Wait for reset to complete
-	for (sam.GCLK.CTRL.Get()&sam.GCLK_CTRL_SWRST) > 0 && (sam.GCLK.STATUS.Get()&sam.GCLK_STATUS_SYNCBUSY) > 0 {
+	for sam.GCLK.CTRL.HasBits(sam.GCLK_CTRL_SWRST) && sam.GCLK.STATUS.HasBits(sam.GCLK_STATUS_SYNCBUSY) {
 	}
 
 	// Put OSC32K as source of Generic Clock Generator 1
@@ -96,7 +96,7 @@ func initClocks() {
 	// Remove the OnDemand mode, Bug http://avr32.icgroup.norway.atmel.com/bugzilla/show_bug.cgi?id=9905
 	sam.SYSCTRL.DFLLCTRL.Set(sam.SYSCTRL_DFLLCTRL_ENABLE)
 	// Wait for ready
-	for (sam.SYSCTRL.PCLKSR.Get() & sam.SYSCTRL_PCLKSR_DFLLRDY) == 0 {
+	for !sam.SYSCTRL.PCLKSR.HasBits(sam.SYSCTRL_PCLKSR_DFLLRDY) {
 	}
 
 	// Handle DFLL calibration based on info learned from Arduino SAMD implementation,
@@ -130,13 +130,13 @@ func initClocks() {
 		sam.SYSCTRL_DFLLCTRL_USBCRM |
 		sam.SYSCTRL_DFLLCTRL_BPLCKC)
 	// Wait for ready
-	for (sam.SYSCTRL.PCLKSR.Get() & sam.SYSCTRL_PCLKSR_DFLLRDY) == 0 {
+	for !sam.SYSCTRL.PCLKSR.HasBits(sam.SYSCTRL_PCLKSR_DFLLRDY) {
 	}
 
 	// Re-enable the DFLL
 	sam.SYSCTRL.DFLLCTRL.SetBits(sam.SYSCTRL_DFLLCTRL_ENABLE)
 	// Wait for ready
-	for (sam.SYSCTRL.PCLKSR.Get() & sam.SYSCTRL_PCLKSR_DFLLRDY) == 0 {
+	for !sam.SYSCTRL.PCLKSR.HasBits(sam.SYSCTRL_PCLKSR_DFLLRDY) {
 	}
 
 	// Switch Generic Clock Generator 0 to DFLL48M. CPU will run at 48MHz.
@@ -154,7 +154,7 @@ func initClocks() {
 	sam.SYSCTRL.OSC8M.SetBits(sam.SYSCTRL_OSC8M_PRESC_0 << sam.SYSCTRL_OSC8M_PRESC_Pos)
 	sam.SYSCTRL.OSC8M.ClearBits(1 << sam.SYSCTRL_OSC8M_ONDEMAND_Pos)
 	// Wait for oscillator stabilization
-	for (sam.SYSCTRL.PCLKSR.Get() & sam.SYSCTRL_PCLKSR_OSC8MRDY) == 0 {
+	for !sam.SYSCTRL.PCLKSR.HasBits(sam.SYSCTRL_PCLKSR_OSC8MRDY) {
 	}
 
 	// Use OSC8M as source for Generic Clock Generator 3
@@ -218,7 +218,7 @@ func initRTC() {
 }
 
 func waitForSync() {
-	for (sam.GCLK.STATUS.Get() & sam.GCLK_STATUS_SYNCBUSY) > 0 {
+	for sam.GCLK.STATUS.HasBits(sam.GCLK_STATUS_SYNCBUSY) {
 	}
 }
 

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -27,13 +27,13 @@ func initCLK() {
 	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSEON)              // enable HSE clock
 
 	// wait for the HSEREADY flag
-	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSERDY) == 0 {
+	for !stm32.RCC.CR.HasBits(stm32.RCC_CR_HSERDY) {
 	}
 
 	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSION) // enable HSI clock
 
 	// wait for the HSIREADY flag
-	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSIRDY) == 0 {
+	for !stm32.RCC.CR.HasBits(stm32.RCC_CR_HSIRDY) {
 	}
 
 	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_PLLSRC)   // set PLL source to HSE
@@ -41,13 +41,13 @@ func initCLK() {
 	stm32.RCC.CR.SetBits(stm32.RCC_CR_PLLON)        // enable the PLL
 
 	// wait for the PLLRDY flag
-	for (stm32.RCC.CR.Get() & stm32.RCC_CR_PLLRDY) == 0 {
+	for !stm32.RCC.CR.HasBits(stm32.RCC_CR_PLLRDY) {
 	}
 
 	stm32.RCC.CFGR.SetBits(stm32.RCC_CFGR_SW_PLL) // set clock source to pll
 
 	// wait for PLL to be CLK
-	for (stm32.RCC.CFGR.Get() & stm32.RCC_CFGR_SWS_PLL) == 0 {
+	for !stm32.RCC.CFGR.HasBits(stm32.RCC_CFGR_SWS_PLL) {
 	}
 }
 
@@ -74,7 +74,7 @@ func initRTC() {
 	stm32.RCC.BDCR.SetBits(stm32.RCC_BDCR_LSEON)
 
 	// wait until LSE is ready
-	for stm32.RCC.BDCR.Get()&stm32.RCC_BDCR_LSERDY == 0 {
+	for !stm32.RCC.BDCR.HasBits(stm32.RCC_BDCR_LSERDY) {
 	}
 
 	// Select LSE
@@ -95,7 +95,7 @@ func initRTC() {
 	stm32.RTC.CRL.ClearBits(stm32.RTC_CRL_RSF)
 
 	// Wait till flag is set
-	for stm32.RTC.CRL.Get()&stm32.RTC_CRL_RSF == 0 {
+	for !stm32.RTC.CRL.HasBits(stm32.RTC_CRL_RSF) {
 	}
 }
 
@@ -184,7 +184,7 @@ func timerSleep(ticks uint32) {
 
 //go:export TIM3_IRQHandler
 func handleTIM3() {
-	if (stm32.TIM3.SR.Get() & stm32.TIM_SR_UIF) > 0 {
+	if stm32.TIM3.SR.HasBits(stm32.TIM_SR_UIF) {
 		// Disable the timer.
 		stm32.TIM3.CR1.ClearBits(stm32.TIM_CR1_CEN)
 

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -43,7 +43,7 @@ func initCLK() {
 	// Reset clock registers
 	// Set HSION
 	stm32.RCC.CR.SetBits(stm32.RCC_CR_HSION)
-	for (stm32.RCC.CR.Get() & stm32.RCC_CR_HSIRDY) == 0 {
+	for !stm32.RCC.CR.HasBits(stm32.RCC_CR_HSIRDY) {
 	}
 
 	// Reset CFGR
@@ -66,11 +66,11 @@ func initCLK() {
 	// Wait till HSE is ready and if timeout is reached exit
 	for {
 		startupCounter++
-		if (stm32.RCC.CR.Get()&stm32.RCC_CR_HSERDY != 0) || (startupCounter == HSE_STARTUP_TIMEOUT) {
+		if stm32.RCC.CR.HasBits(stm32.RCC_CR_HSERDY) || (startupCounter == HSE_STARTUP_TIMEOUT) {
 			break
 		}
 	}
-	if (stm32.RCC.CR.Get() & stm32.RCC_CR_HSERDY) != 0 {
+	if stm32.RCC.CR.HasBits(stm32.RCC_CR_HSERDY) {
 		// Enable high performance mode, System frequency up to 168MHz
 		stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_PWREN)
 		stm32.PWR.CR.SetBits(0x4000) // PWR_CR_VOS
@@ -187,7 +187,7 @@ func timerSleep(ticks uint32) {
 
 //go:export TIM3_IRQHandler
 func handleTIM3() {
-	if (stm32.TIM3.SR.Get() & stm32.TIM_SR_UIF) > 0 {
+	if stm32.TIM3.SR.HasBits(stm32.TIM_SR_UIF) {
 		// Disable the timer.
 		stm32.TIM3.CR1.ClearBits(stm32.TIM_CR1_CEN)
 
@@ -201,7 +201,7 @@ func handleTIM3() {
 
 //go:export TIM7_IRQHandler
 func handleTIM7() {
-	if (stm32.TIM7.SR.Get() & stm32.TIM_SR_UIF) > 0 {
+	if stm32.TIM7.SR.HasBits(stm32.TIM_SR_UIF) {
 		// clear the update flag
 		stm32.TIM7.SR.ClearBits(stm32.TIM_SR_UIF)
 		tickCount++

--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -200,6 +200,16 @@ func (r *Register8) ClearBits(value uint8) {{
 	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) &^ value)
 }}
 
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register8) HasBits(value uint8) bool {{
+	return (r.Get() & value) > 0
+}}
+
 // Some information about this device.
 const (
 	DEVICE     = "{name}"

--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -349,6 +349,16 @@ func (r *Register8) ClearBits(value uint8) {{
 	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) &^ value)
 }}
 
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register8) HasBits(value uint8) bool {{
+	return (r.Get() & value) > 0
+}}
+
 type Register16 struct {{
 	Reg uint16
 }}
@@ -391,6 +401,16 @@ func (r *Register16) ClearBits(value uint16) {{
 	volatile.StoreUint16(&r.Reg, volatile.LoadUint16(&r.Reg) &^ value)
 }}
 
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register16) HasBits(value uint16) bool {{
+	return (r.Get() & value) > 0
+}}
+
 type Register32 struct {{
 	Reg uint32
 }}
@@ -431,6 +451,16 @@ func (r *Register32) SetBits(value uint32) {{
 //go:inline
 func (r *Register32) ClearBits(value uint32) {{
 	volatile.StoreUint32(&r.Reg, volatile.LoadUint32(&r.Reg) &^ value)
+}}
+
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register32) HasBits(value uint32) bool {{
+	return (r.Get() & value) > 0
 }}
 
 // Some information about this device.


### PR DESCRIPTION
This PR adds a `HasBits()` method to all of the volatile registers, to allow for a simpler syntax for the very common bit comparison operations especially those performed in loops.

This was discussed in https://github.com/tinygo-org/tinygo/pull/358#discussion_r285389690