### PR TITLE
cgo: add support for bitfields using generated getters and setters

### DIFF
--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -64,3 +64,7 @@ long long tinygo_clang_getEnumConstantDeclValue(CXCursor c) {
 CXType tinygo_clang_getEnumDeclIntegerType(CXCursor c) {
 	return clang_getEnumDeclIntegerType(c);
 }
+
+unsigned tinygo_clang_Cursor_isBitField(CXCursor c) {
+	return clang_Cursor_isBitField(c);
+}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -18,6 +18,7 @@ short globalArray[3] = {5, 6, 7};
 joined_t globalUnion;
 int globalUnionSize = sizeof(globalUnion);
 option_t globalOption = optionG;
+bitfield_t globalBitfield = {244, 15, 1, 2, 47, 5};
 
 int fortytwo() {
 	return 42;

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -64,6 +64,11 @@ func main() {
 	println("union global data:", C.globalUnion.data[0], C.globalUnion.data[1], C.globalUnion.data[2])
 	println("union field:", printUnion(C.globalUnion).f)
 	var _ C.union_joined = C.globalUnion
+	printBitfield(&C.globalBitfield)
+	C.globalBitfield.set_bitfield_a(7)
+	C.globalBitfield.set_bitfield_b(0)
+	C.globalBitfield.set_bitfield_c(0xff)
+	printBitfield(&C.globalBitfield)
 
 	// elaborated type
 	p := C.struct_point{x: 3, y: 5}
@@ -107,4 +112,12 @@ func printUnion(union C.joined_t) C.joined_t {
 //export mul
 func mul(a, b C.int) C.int {
 	return a * b
+}
+
+func printBitfield(bitfield *C.bitfield_t) {
+	println("bitfield a:", bitfield.bitfield_a())
+	println("bitfield b:", bitfield.bitfield_b())
+	println("bitfield c:", bitfield.bitfield_c())
+	println("bitfield d:", bitfield.d)
+	println("bitfield e:", bitfield.e)
 }

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -65,6 +65,17 @@ typedef enum {
 	option3A = 21,
 } option3_t;
 
+typedef struct {
+	unsigned char start;
+	unsigned char a : 5;
+	unsigned char b : 1;
+	unsigned char c : 2;
+	unsigned char :0; // new field
+	unsigned char d : 6;
+	unsigned char e : 3;
+	// Note that C++ allows bitfields bigger than the underlying type.
+} bitfield_t;
+
 // test globals and datatypes
 extern int global;
 extern int unusedGlobal;
@@ -85,6 +96,7 @@ extern short globalArray[3];
 extern joined_t globalUnion;
 extern int globalUnionSize;
 extern option_t globalOption;
+extern bitfield_t globalBitfield;
 
 // test duplicate definitions
 int add(int a, int b);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -31,6 +31,16 @@ union local data:  5 8 1
 union s: true
 union f: +6.280000e+000
 union field: +6.280000e+000
+bitfield a: 15
+bitfield b: 1
+bitfield c: 2
+bitfield d: 47
+bitfield e: 5
+bitfield a: 7
+bitfield b: 0
+bitfield c: 3
+bitfield d: 47
+bitfield e: 5
 struct: 3 5
 n in chain: 3
 n in chain: 6


### PR DESCRIPTION
Bitfields are not supported by regular CGo, but because they are often used on embedded systems we really need them.
Unfortunately, there is no simple way to support them as Go (quite reasonably!) does not support them. Therefore, CGo will create getters and setters for bitfields avoiding complexity in the rest of the compiler.