### PR TITLE
cgo: add support for anonymous structs

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -36,6 +36,7 @@ type cgoPackage struct {
 	typedefs        map[string]*typedefInfo
 	elaboratedTypes map[string]*elaboratedTypeInfo
 	enums           map[string]enumInfo
+	anonStructNum   int
 }
 
 // constantInfo stores some information about a CGo constant found by libclang
@@ -68,7 +69,7 @@ type typedefInfo struct {
 // elaboratedTypeInfo contains some information about an elaborated type
 // (struct, union) found in the C AST.
 type elaboratedTypeInfo struct {
-	typeExpr  ast.Expr
+	typeExpr  *ast.StructType
 	pos       token.Pos
 	bitfields []bitfieldInfo
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -71,8 +71,12 @@ func main() {
 	printBitfield(&C.globalBitfield)
 
 	// elaborated type
-	p := C.struct_point{x: 3, y: 5}
+	p := C.struct_point2d{x: 3, y: 5}
 	println("struct:", p.x, p.y)
+
+	// multiple anonymous structs (inside a typedef)
+	var _ C.point2d_t = C.point2d_t{x: 3, y: 5}
+	var _ C.point3d_t = C.point3d_t{x: 3, y: 5, z: 7}
 
 	// recursive types, test using a linked list
 	list := &C.list_t{n: 3, next: &C.struct_list_t{n: 6, next: &C.list_t{n: 7, next: nil}}}

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -27,10 +27,21 @@ typedef struct collection {
 	unsigned char c;
 } collection_t;
 
-struct point {
+struct point2d {
 	int x;
 	int y;
 };
+
+typedef struct {
+	int x;
+	int y;
+} point2d_t;
+
+typedef struct {
+	int x;
+	int y;
+	int z;
+} point3d_t;
 
 // linked list
 typedef struct list_t {


### PR DESCRIPTION
This is necessary for most non-trivial CGo code (example: the nRF SoftDevice).