### PR TITLE
Stub out reflect.New and reflect.Zero

### DIFF
--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -502,6 +502,14 @@ func MakeSlice(typ Type, len, cap int) Value {
 	panic("unimplemented: reflect.MakeSlice()")
 }
 
+func Zero(typ Type) Value {
+	panic("unimplemented: reflect.Zero()")
+}
+
+func New(typ Type) Value {
+	panic("unimplemented: reflect.New()")
+}
+
 type funcHeader struct {
 	Context unsafe.Pointer
 	Code    unsafe.Pointer


### PR DESCRIPTION
This stubs out `reflect.Zero` and `reflect.New`. I believe this worked since the errors relating to these two functions went away when I tried to compile my project. Unfortunately I can't get `make test` running on my laptop so I can't run the full test suite. I'm going to try to get tiny-go setup on my other computer and see if I have better luck there.

Opening for now in case folks have any feedback on the PR or advice!