### PR TITLE
Remove `//go:volatile` pragma

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1075,12 +1075,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			// nothing to store
 			return
 		}
-		store := c.builder.CreateStore(llvmVal, llvmAddr)
-		valType := instr.Addr.Type().Underlying().(*types.Pointer).Elem()
-		if c.ir.IsVolatile(valType) {
-			// Volatile store, for memory-mapped registers.
-			store.SetVolatile(true)
-		}
+		c.builder.CreateStore(llvmVal, llvmAddr)
 	default:
 		c.addError(instr.Pos(), "unknown instruction: "+instr.String())
 	}
@@ -2494,7 +2489,7 @@ func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
 			return llvm.Value{}, c.makeError(unop.Pos(), "todo: unknown type for negate: "+unop.X.Type().Underlying().String())
 		}
 	case token.MUL: // *x, dereference pointer
-		valType := unop.X.Type().Underlying().(*types.Pointer).Elem()
+		unop.X.Type().Underlying().(*types.Pointer).Elem()
 		if c.targetData.TypeAllocSize(x.Type().ElementType()) == 0 {
 			// zero-length data
 			return c.getZeroValue(x.Type().ElementType()), nil
@@ -2514,10 +2509,6 @@ func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
 		} else {
 			c.emitNilCheck(frame, x, "deref")
 			load := c.builder.CreateLoad(x, "")
-			if c.ir.IsVolatile(valType) {
-				// Volatile load, for memory-mapped registers.
-				load.SetVolatile(true)
-			}
 			return load, nil
 		}
 	case token.XOR: // ^x, toggle all bits in integer

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -100,9 +100,6 @@ func NewProgram(lprogram *loader.Program, mainPath string) *Program {
 						}
 						for _, spec := range decl.Specs {
 							switch spec := spec.(type) {
-							case *ast.TypeSpec: // decl.Tok == token.TYPE
-								id := pkgInfo.Pkg.Path() + "." + spec.Name.Name
-								comments[id] = decl.Doc
 							case *ast.ValueSpec: // decl.Tok == token.VAR
 								for _, name := range spec.Names {
 									id := pkgInfo.Pkg.Path() + "." + name.Name
@@ -430,29 +427,6 @@ func (g *Global) CName() string {
 		return name[2:]
 	}
 	return ""
-}
-
-// Return true if this named type is annotated with the //go:volatile pragma,
-// for volatile loads and stores.
-func (p *Program) IsVolatile(t types.Type) bool {
-	if t, ok := t.(*types.Named); !ok {
-		return false
-	} else {
-		if t.Obj().Pkg() == nil {
-			return false
-		}
-		id := t.Obj().Pkg().Path() + "." + t.Obj().Name()
-		doc := p.comments[id]
-		if doc == nil {
-			return false
-		}
-		for _, line := range doc.List {
-			if strings.TrimSpace(line.Text) == "//go:volatile" {
-				return true
-			}
-		}
-		return false
-	}
 }
 
 // Get all methods of a type.

--- a/src/machine/buffer.go
+++ b/src/machine/buffer.go
@@ -1,9 +1,10 @@
 package machine
 
-const bufferSize = 128
+import (
+	"runtime/volatile"
+)
 
-//go:volatile
-type volatileByte byte
+const bufferSize = 128
 
 // RingBuffer is ring buffer implementation inspired by post at
 // https://www.embeddedrelated.com/showthread/comp.arch.embedded/77084-1.php
@@ -12,9 +13,9 @@ type volatileByte byte
 // members of a struct are not compiled correctly by TinyGo.
 // See https://github.com/tinygo-org/tinygo/issues/151 for details.
 type RingBuffer struct {
-	rxbuffer [bufferSize]volatileByte
-	head     volatileByte
-	tail     volatileByte
+	rxbuffer [bufferSize]volatile.Register8
+	head     volatile.Register8
+	tail     volatile.Register8
 }
 
 // NewRingBuffer returns a new ring buffer.
@@ -24,15 +25,15 @@ func NewRingBuffer() *RingBuffer {
 
 // Used returns how many bytes in buffer have been used.
 func (rb *RingBuffer) Used() uint8 {
-	return uint8(rb.head - rb.tail)
+	return uint8(rb.head.Get() - rb.tail.Get())
 }
 
 // Put stores a byte in the buffer. If the buffer is already
 // full, the method will return false.
 func (rb *RingBuffer) Put(val byte) bool {
 	if rb.Used() != bufferSize {
-		rb.head++
-		rb.rxbuffer[rb.head%bufferSize] = volatileByte(val)
+		rb.head.Set(rb.head.Get() + 1)
+		rb.rxbuffer[rb.head.Get()%bufferSize].Set(val)
 		return true
 	}
 	return false
@@ -42,8 +43,8 @@ func (rb *RingBuffer) Put(val byte) bool {
 // the method will return a false as the second value.
 func (rb *RingBuffer) Get() (byte, bool) {
 	if rb.Used() != 0 {
-		rb.tail++
-		return byte(rb.rxbuffer[rb.tail%bufferSize]), true
+		rb.tail.Set(rb.tail.Get() + 1)
+		return rb.rxbuffer[rb.tail.Get()%bufferSize].Get(), true
 	}
 	return 0, false
 }

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -4,6 +4,7 @@ package machine
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 // Configure sets the pin to input or output.
@@ -34,7 +35,7 @@ func (p Pin) Get() bool {
 	}
 }
 
-func (p Pin) getPortMask() (*avr.Register8, uint8) {
+func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 	if p < 8 {
 		return avr.PORTD, 1 << uint8(p)
 	} else {

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -4,6 +4,7 @@ package machine
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 // Configure sets the pin to input or output.
@@ -15,7 +16,7 @@ func (p Pin) Configure(config PinConfig) {
 	}
 }
 
-func (p Pin) getPortMask() (*avr.Register8, uint8) {
+func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 	return avr.PORTB, 1 << uint8(p)
 }
 

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -4,6 +4,7 @@ package machine
 
 import (
 	"device/avr"
+	"runtime/volatile"
 )
 
 type PinMode uint8
@@ -30,7 +31,7 @@ func (p Pin) Set(value bool) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p Pin) PortMaskSet() (*avr.Register8, uint8) {
+func (p Pin) PortMaskSet() (*volatile.Register8, uint8) {
 	port, mask := p.getPortMask()
 	return port, port.Get() | mask
 }
@@ -41,7 +42,7 @@ func (p Pin) PortMaskSet() (*avr.Register8, uint8) {
 // Warning: there are no separate pin set/clear registers on the AVR. The
 // returned mask is only valid as long as no other pin in the same port has been
 // changed.
-func (p Pin) PortMaskClear() (*avr.Register8, uint8) {
+func (p Pin) PortMaskClear() (*volatile.Register8, uint8) {
 	port, mask := p.getPortMask()
 	return port, port.Get() &^ mask
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -4,9 +4,9 @@ package machine
 
 import (
 	"bytes"
-	"device/sam"
 	"encoding/binary"
 	"errors"
+	"runtime/volatile"
 )
 
 const deviceDescriptorSize = 18
@@ -484,11 +484,11 @@ const (
 // 		 RoReg8                    Reserved1[0x5];
 //   } UsbDeviceDescBank;
 type usbDeviceDescBank struct {
-	ADDR      sam.Register32
-	PCKSIZE   sam.Register32
-	EXTREG    sam.Register16
-	STATUS_BK sam.Register8
-	_reserved [5]sam.Register8
+	ADDR      volatile.Register32
+	PCKSIZE   volatile.Register32
+	EXTREG    volatile.Register16
+	STATUS_BK volatile.Register8
+	_reserved [5]volatile.Register8
 }
 
 type usbDeviceDescriptor struct {

--- a/src/runtime/runtime_qemu.go
+++ b/src/runtime/runtime_qemu.go
@@ -7,6 +7,7 @@ package runtime
 
 import (
 	"device/arm"
+	"runtime/volatile"
 	"unsafe"
 )
 
@@ -36,12 +37,9 @@ func ticks() timeUnit {
 	return timestamp
 }
 
-//go:volatile
-type regValue uint32
-
 // UART0 output register.
-var stdoutWrite *regValue = (*regValue)(unsafe.Pointer(uintptr(0x4000c000)))
+var stdoutWrite = (*volatile.Register8)(unsafe.Pointer(uintptr(0x4000c000)))
 
 func putchar(c byte) {
-	*stdoutWrite = regValue(c)
+	stdoutWrite.Set(uint8(c))
 }

--- a/src/runtime/volatile/register.go
+++ b/src/runtime/volatile/register.go
@@ -1,0 +1,162 @@
+package volatile
+
+// This file defines Register{8,16,32} types, which are convenience types for
+// volatile register accesses.
+
+// Special types that causes loads/stores to be volatile (necessary for
+// memory-mapped registers).
+type Register8 struct {
+	Reg uint8
+}
+
+// Get returns the value in the register. It is the volatile equivalent of:
+//
+//     *r.Reg
+//
+//go:inline
+func (r *Register8) Get() uint8 {
+	return LoadUint8(&r.Reg)
+}
+
+// Set updates the register value. It is the volatile equivalent of:
+//
+//     *r.Reg = value
+//
+//go:inline
+func (r *Register8) Set(value uint8) {
+	StoreUint8(&r.Reg, value)
+}
+
+// SetBits reads the register, sets the given bits, and writes it back. It is
+// the volatile equivalent of:
+//
+//     r.Reg |= value
+//
+//go:inline
+func (r *Register8) SetBits(value uint8) {
+	StoreUint8(&r.Reg, LoadUint8(&r.Reg)|value)
+}
+
+// ClearBits reads the register, clears the given bits, and writes it back. It
+// is the volatile equivalent of:
+//
+//     r.Reg &^= value
+//
+//go:inline
+func (r *Register8) ClearBits(value uint8) {
+	StoreUint8(&r.Reg, LoadUint8(&r.Reg)&^value)
+}
+
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register8) HasBits(value uint8) bool {
+	return (r.Get() & value) > 0
+}
+
+type Register16 struct {
+	Reg uint16
+}
+
+// Get returns the value in the register. It is the volatile equivalent of:
+//
+//     *r.Reg
+//
+//go:inline
+func (r *Register16) Get() uint16 {
+	return LoadUint16(&r.Reg)
+}
+
+// Set updates the register value. It is the volatile equivalent of:
+//
+//     *r.Reg = value
+//
+//go:inline
+func (r *Register16) Set(value uint16) {
+	StoreUint16(&r.Reg, value)
+}
+
+// SetBits reads the register, sets the given bits, and writes it back. It is
+// the volatile equivalent of:
+//
+//     r.Reg |= value
+//
+//go:inline
+func (r *Register16) SetBits(value uint16) {
+	StoreUint16(&r.Reg, LoadUint16(&r.Reg)|value)
+}
+
+// ClearBits reads the register, clears the given bits, and writes it back. It
+// is the volatile equivalent of:
+//
+//     r.Reg &^= value
+//
+//go:inline
+func (r *Register16) ClearBits(value uint16) {
+	StoreUint16(&r.Reg, LoadUint16(&r.Reg)&^value)
+}
+
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register16) HasBits(value uint16) bool {
+	return (r.Get() & value) > 0
+}
+
+type Register32 struct {
+	Reg uint32
+}
+
+// Get returns the value in the register. It is the volatile equivalent of:
+//
+//     *r.Reg
+//
+//go:inline
+func (r *Register32) Get() uint32 {
+	return LoadUint32(&r.Reg)
+}
+
+// Set updates the register value. It is the volatile equivalent of:
+//
+//     *r.Reg = value
+//
+//go:inline
+func (r *Register32) Set(value uint32) {
+	StoreUint32(&r.Reg, value)
+}
+
+// SetBits reads the register, sets the given bits, and writes it back. It is
+// the volatile equivalent of:
+//
+//     r.Reg |= value
+//
+//go:inline
+func (r *Register32) SetBits(value uint32) {
+	StoreUint32(&r.Reg, LoadUint32(&r.Reg)|value)
+}
+
+// ClearBits reads the register, clears the given bits, and writes it back. It
+// is the volatile equivalent of:
+//
+//     r.Reg &^= value
+//
+//go:inline
+func (r *Register32) ClearBits(value uint32) {
+	StoreUint32(&r.Reg, LoadUint32(&r.Reg)&^value)
+}
+
+// HasBits reads the register and then checks to see if the passed bits are set. It
+// is the volatile equivalent of:
+//
+//     (*r.Reg & value) > 0
+//
+//go:inline
+func (r *Register32) HasBits(value uint32) bool {
+	return (r.Get() & value) > 0
+}

--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -156,60 +156,6 @@ import (
 	"unsafe"
 )
 
-// Special type that causes loads/stores to be volatile (necessary for
-// memory-mapped registers).
-type Register8 struct {{
-	Reg uint8
-}}
-
-// Get returns the value in the register. It is the volatile equivalent of:
-//
-//     *r.Reg
-//
-//go:inline
-func (r *Register8) Get() uint8 {{
-	return volatile.LoadUint8(&r.Reg)
-}}
-
-// Set updates the register value. It is the volatile equivalent of:
-//
-//     *r.Reg = value
-//
-//go:inline
-func (r *Register8) Set(value uint8) {{
-	volatile.StoreUint8(&r.Reg, value)
-}}
-
-// SetBits reads the register, sets the given bits, and writes it back. It is
-// the volatile equivalent of:
-//
-//     r.Reg |= value
-//
-//go:inline
-func (r *Register8) SetBits(value uint8) {{
-	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) | value)
-}}
-
-// ClearBits reads the register, clears the given bits, and writes it back. It
-// is the volatile equivalent of:
-//
-//     r.Reg &^= value
-//
-//go:inline
-func (r *Register8) ClearBits(value uint8) {{
-	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) &^ value)
-}}
-
-// HasBits reads the register and then checks to see if the passed bits are set. It
-// is the volatile equivalent of:
-//
-//     (*r.Reg & value) > 0
-//
-//go:inline
-func (r *Register8) HasBits(value uint8) bool {{
-	return (r.Get() & value) > 0
-}}
-
 // Some information about this device.
 const (
 	DEVICE     = "{name}"
@@ -231,7 +177,7 @@ const (
         out.write('\n\t// {description}\n'.format(**peripheral))
         for register in peripheral['registers']:
             for variant in register['variants']:
-                out.write('\t{name} = (*Register8)(unsafe.Pointer(uintptr(0x{address:x})))\n'.format(**variant))
+                out.write('\t{name} = (*volatile.Register8)(unsafe.Pointer(uintptr(0x{address:x})))\n'.format(**variant))
     out.write(')\n')
 
     for peripheral in device.peripherals:

--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -305,164 +305,6 @@ import (
 	"unsafe"
 )
 
-// Special types that causes loads/stores to be volatile (necessary for
-// memory-mapped registers).
-type Register8 struct {{
-	Reg uint8
-}}
-
-// Get returns the value in the register. It is the volatile equivalent of:
-//
-//     *r.Reg
-//
-//go:inline
-func (r *Register8) Get() uint8 {{
-	return volatile.LoadUint8(&r.Reg)
-}}
-
-// Set updates the register value. It is the volatile equivalent of:
-//
-//     *r.Reg = value
-//
-//go:inline
-func (r *Register8) Set(value uint8) {{
-	volatile.StoreUint8(&r.Reg, value)
-}}
-
-// SetBits reads the register, sets the given bits, and writes it back. It is
-// the volatile equivalent of:
-//
-//     r.Reg |= value
-//
-//go:inline
-func (r *Register8) SetBits(value uint8) {{
-	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) | value)
-}}
-
-// ClearBits reads the register, clears the given bits, and writes it back. It
-// is the volatile equivalent of:
-//
-//     r.Reg &^= value
-//
-//go:inline
-func (r *Register8) ClearBits(value uint8) {{
-	volatile.StoreUint8(&r.Reg, volatile.LoadUint8(&r.Reg) &^ value)
-}}
-
-// HasBits reads the register and then checks to see if the passed bits are set. It
-// is the volatile equivalent of:
-//
-//     (*r.Reg & value) > 0
-//
-//go:inline
-func (r *Register8) HasBits(value uint8) bool {{
-	return (r.Get() & value) > 0
-}}
-
-type Register16 struct {{
-	Reg uint16
-}}
-
-// Get returns the value in the register. It is the volatile equivalent of:
-//
-//     *r.Reg
-//
-//go:inline
-func (r *Register16) Get() uint16 {{
-	return volatile.LoadUint16(&r.Reg)
-}}
-
-// Set updates the register value. It is the volatile equivalent of:
-//
-//     *r.Reg = value
-//
-//go:inline
-func (r *Register16) Set(value uint16) {{
-	volatile.StoreUint16(&r.Reg, value)
-}}
-
-// SetBits reads the register, sets the given bits, and writes it back. It is
-// the volatile equivalent of:
-//
-//     r.Reg |= value
-//
-//go:inline
-func (r *Register16) SetBits(value uint16) {{
-	volatile.StoreUint16(&r.Reg, volatile.LoadUint16(&r.Reg) | value)
-}}
-
-// ClearBits reads the register, clears the given bits, and writes it back. It
-// is the volatile equivalent of:
-//
-//     r.Reg &^= value
-//
-//go:inline
-func (r *Register16) ClearBits(value uint16) {{
-	volatile.StoreUint16(&r.Reg, volatile.LoadUint16(&r.Reg) &^ value)
-}}
-
-// HasBits reads the register and then checks to see if the passed bits are set. It
-// is the volatile equivalent of:
-//
-//     (*r.Reg & value) > 0
-//
-//go:inline
-func (r *Register16) HasBits(value uint16) bool {{
-	return (r.Get() & value) > 0
-}}
-
-type Register32 struct {{
-	Reg uint32
-}}
-
-// Get returns the value in the register. It is the volatile equivalent of:
-//
-//     *r.Reg
-//
-//go:inline
-func (r *Register32) Get() uint32 {{
-	return volatile.LoadUint32(&r.Reg)
-}}
-
-// Set updates the register value. It is the volatile equivalent of:
-//
-//     *r.Reg = value
-//
-//go:inline
-func (r *Register32) Set(value uint32) {{
-	volatile.StoreUint32(&r.Reg, value)
-}}
-
-// SetBits reads the register, sets the given bits, and writes it back. It is
-// the volatile equivalent of:
-//
-//     r.Reg |= value
-//
-//go:inline
-func (r *Register32) SetBits(value uint32) {{
-	volatile.StoreUint32(&r.Reg, volatile.LoadUint32(&r.Reg) | value)
-}}
-
-// ClearBits reads the register, clears the given bits, and writes it back. It
-// is the volatile equivalent of:
-//
-//     r.Reg &^= value
-//
-//go:inline
-func (r *Register32) ClearBits(value uint32) {{
-	volatile.StoreUint32(&r.Reg, volatile.LoadUint32(&r.Reg) &^ value)
-}}
-
-// HasBits reads the register and then checks to see if the passed bits are set. It
-// is the volatile equivalent of:
-//
-//     (*r.Reg & value) > 0
-//
-//go:inline
-func (r *Register32) HasBits(value uint32) bool {{
-	return (r.Get() & value) > 0
-}}
-
 // Some information about this device.
 const (
 	DEVICE     = "{name}"
@@ -499,22 +341,22 @@ const (
                 continue
             eSize = register['elementsize']
             if eSize == 4:
-                regType = 'Register32'
+                regType = 'volatile.Register32'
             elif eSize == 2:
-                regType = 'Register16'
+                regType = 'volatile.Register16'
             elif eSize == 1:
-                regType = 'Register8'        
+                regType = 'volatile.Register8'
             else:
                 eSize = 4
-                regType = 'Register32'
+                regType = 'volatile.Register32'
 
             # insert padding, if needed
             if address < register['address']:
                 bytesNeeded = register['address'] - address
                 if bytesNeeded == 1:
-                    out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='Register8'))
+                    out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='volatile.Register8'))
                 elif bytesNeeded == 2:
-                    out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='Register16'))
+                    out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='volatile.Register16'))
                 else:
                     numSkip = (register['address'] - address) // eSize
                     if numSkip == 1:
@@ -531,28 +373,28 @@ const (
                 subaddress = register['address']
                 for subregister in register['registers']:
                     if subregister['elementsize'] == 4:
-                        subregType = 'Register32'
+                        subregType = 'volatile.Register32'
                     elif subregister['elementsize'] == 2:
-                        subregType = 'Register16'
+                        subregType = 'volatile.Register16'
                     else:
-                        subregType = 'Register8'
+                        subregType = 'volatile.Register8'
 
                     if subregister['array']:
                         subregType = '[{}]{}'.format(subregister['array'], subregType)
                     if subaddress != subregister['address']:
                         bytesNeeded = subregister['address'] - subaddress
                         if bytesNeeded == 1:
-                            regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='Register8')
+                            regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='volatile.Register8')
                         elif bytesNeeded == 2:
-                            regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='Register16')
+                            regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='volatile.Register16')
                         else:
                             numSkip = (subregister['address'] - subaddress)
                             if numSkip < 1:
                                 continue
                             elif numSkip == 1:
-                                regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='Register8')
+                                regType += '\t\t_padding{padNumber} {subregType}\n'.format(padNumber=padNumber, subregType='volatile.Register8')
                             else:
-                                regType += '\t\t_padding{padNumber} [{num}]{subregType}\n'.format(padNumber=padNumber, num=numSkip, subregType='Register8')
+                                regType += '\t\t_padding{padNumber} [{num}]{subregType}\n'.format(padNumber=padNumber, num=numSkip, subregType='volatile.Register8')
                         padNumber += 1
                         subaddress += bytesNeeded
                     if subregister['array'] is not None:


### PR DESCRIPTION
Split up in multiple commits to make it easier to review and find regressions, if any.
One bigger change is that I moved the `Register`* types to runtime/volatile. This makes it easier to share them. However, a 'register' type is now also used for ISR flags and regular volatile values (for example, in a ring buffer) so maybe it should be renamed?