### PR TITLE
compiler: refactor globals and named types

### DIFF
--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -12,7 +12,7 @@ import (
 
 // emitMakeChan returns a new channel value for the given channel type.
 func (c *Compiler) emitMakeChan(expr *ssa.MakeChan) (llvm.Value, error) {
-	chanType := c.mod.GetTypeByName("runtime.channel")
+	chanType := c.getLLVMType(c.getRuntimeType("channel"))
 	size := c.targetData.TypeAllocSize(chanType)
 	sizeValue := llvm.ConstInt(c.uintptrType, size, false)
 	ptr := c.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "chan.alloc")

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"errors"
 	"fmt"
+	"go/ast"
 	"go/build"
 	"go/constant"
 	"go/token"
@@ -66,6 +67,7 @@ type Compiler struct {
 	interfaceInvokeWrappers []interfaceInvokeWrapper
 	ir                      *ir.Program
 	diagnostics             []error
+	astComments             map[string]*ast.CommentGroup
 }
 
 type Frame struct {
@@ -275,20 +277,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 
 	var frames []*Frame
 
-	// Declare all globals.
-	for _, g := range c.ir.Globals {
-		typ := g.Type().(*types.Pointer).Elem()
-		llvmType := c.getLLVMType(typ)
-		global := c.mod.NamedGlobal(g.LinkName())
-		if global.IsNil() {
-			global = llvm.AddGlobal(c.mod, llvmType, g.LinkName())
-		}
-		g.LLVMGlobal = global
-		if !g.IsExtern() {
-			global.SetLinkage(llvm.InternalLinkage)
-			global.SetInitializer(c.getZeroValue(llvmType))
-		}
-	}
+	c.loadASTComments(lprogram)
 
 	// Declare all functions.
 	for _, f := range c.ir.Functions {
@@ -1360,9 +1349,9 @@ func (c *Compiler) getValue(frame *Frame, expr ssa.Value) llvm.Value {
 		}
 		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature)
 	case *ssa.Global:
-		value := c.ir.GetGlobal(expr).LLVMGlobal
+		value := c.getGlobal(expr)
 		if value.IsNil() {
-			c.addError(expr.Pos(), "global not found: "+c.ir.GetGlobal(expr).LinkName())
+			c.addError(expr.Pos(), "global not found: "+expr.RelString(nil))
 			return llvm.Undef(c.getLLVMType(expr.Type()))
 		}
 		return value
@@ -2514,8 +2503,8 @@ func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
 			//     var C.add unsafe.Pointer
 			// Instead of a load from the global, create a bitcast of the
 			// function pointer itself.
-			global := c.ir.GetGlobal(unop.X.(*ssa.Global))
-			name := global.LinkName()[:len(global.LinkName())-len("$funcaddr")]
+			globalName := c.getGlobalInfo(unop.X.(*ssa.Global)).linkName
+			name := globalName[:len(globalName)-len("$funcaddr")]
 			fn := c.mod.NamedFunction(name)
 			if fn.IsNil() {
 				return llvm.Value{}, c.makeError(unop.Pos(), "cgo function not found: "+name)

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -29,7 +29,7 @@ func (c *Compiler) deferInitFunc(frame *Frame) {
 	frame.deferClosureFuncs = make(map[*ir.Function]int)
 
 	// Create defer list pointer.
-	deferType := llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)
+	deferType := llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)
 	frame.deferPtr = c.builder.CreateAlloca(deferType, "deferPtr")
 	c.builder.CreateStore(llvm.ConstPointerNull(deferType), frame.deferPtr)
 }
@@ -200,7 +200,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 			}
 
 			// Get the real defer struct type and cast to it.
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0), c.i8ptrType}
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0), c.i8ptrType}
 			for _, arg := range callback.Args {
 				valueTypes = append(valueTypes, c.getLLVMType(arg.Type()))
 			}
@@ -231,7 +231,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 			// Direct call.
 
 			// Get the real defer struct type and cast to it.
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)}
 			for _, param := range callback.Params {
 				valueTypes = append(valueTypes, c.getLLVMType(param.Type()))
 			}
@@ -260,7 +260,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 		case *ssa.MakeClosure:
 			// Get the real defer struct type and cast to it.
 			fn := c.ir.GetFunction(callback.Fn.(*ssa.Function))
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.mod.GetTypeByName("runtime._defer"), 0)}
+			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)}
 			params := fn.Signature.Params()
 			for i := 0; i < params.Len(); i++ {
 				valueTypes = append(valueTypes, c.getLLVMType(params.At(i).Type()))

--- a/compiler/func-lowering.go
+++ b/compiler/func-lowering.go
@@ -51,7 +51,7 @@ func (c *Compiler) LowerFuncValues() {
 	}
 
 	// Find all func values used in the program with their signatures.
-	funcValueWithSignaturePtr := llvm.PointerType(c.mod.GetTypeByName("runtime.funcValueWithSignature"), 0)
+	funcValueWithSignaturePtr := llvm.PointerType(c.getLLVMRuntimeType("funcValueWithSignature"), 0)
 	signatures := map[string]*funcSignatureInfo{}
 	for global := c.mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
 		if global.Type() != funcValueWithSignaturePtr {

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -52,7 +52,7 @@ func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signa
 		funcValueWithSignatureGlobalName := funcPtr.Name() + "$withSignature"
 		funcValueWithSignatureGlobal := c.mod.NamedGlobal(funcValueWithSignatureGlobalName)
 		if funcValueWithSignatureGlobal.IsNil() {
-			funcValueWithSignatureType := c.mod.GetTypeByName("runtime.funcValueWithSignature")
+			funcValueWithSignatureType := c.getLLVMRuntimeType("funcValueWithSignature")
 			funcValueWithSignature := llvm.ConstNamedStruct(funcValueWithSignatureType, []llvm.Value{
 				llvm.ConstPtrToInt(funcPtr, c.uintptrType),
 				sigGlobal,
@@ -126,7 +126,7 @@ func (c *Compiler) getFuncType(typ *types.Signature) llvm.Type {
 		rawPtr := c.getRawFuncType(typ)
 		return c.ctx.StructType([]llvm.Type{c.i8ptrType, rawPtr}, false)
 	case funcValueSwitch:
-		return c.mod.GetTypeByName("runtime.funcValue")
+		return c.getLLVMRuntimeType("funcValue")
 	default:
 		panic("unimplemented func value variant")
 	}

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -321,7 +321,7 @@ func (c *Compiler) markAsyncFunctions() (needsScheduler bool, err error) {
 
 		// Coroutine setup.
 		c.builder.SetInsertPointBefore(f.EntryBasicBlock().FirstInstruction())
-		taskState := c.builder.CreateAlloca(c.mod.GetTypeByName("runtime.taskState"), "task.state")
+		taskState := c.builder.CreateAlloca(c.getLLVMRuntimeType("taskState"), "task.state")
 		stateI8 := c.builder.CreateBitCast(taskState, c.i8ptrType, "task.state.i8")
 		id := c.builder.CreateCall(coroIdFunc, []llvm.Value{
 			llvm.ConstInt(c.ctx.Int32Type(), 0, false),

--- a/compiler/interface-lowering.go
+++ b/compiler/interface-lowering.go
@@ -163,8 +163,8 @@ func (c *Compiler) LowerInterfaces() {
 // run runs the pass itself.
 func (p *lowerInterfacesPass) run() {
 	// Collect all type codes.
-	typecodeIDPtr := llvm.PointerType(p.mod.GetTypeByName("runtime.typecodeID"), 0)
-	typeInInterfacePtr := llvm.PointerType(p.mod.GetTypeByName("runtime.typeInInterface"), 0)
+	typecodeIDPtr := llvm.PointerType(p.getLLVMRuntimeType("typecodeID"), 0)
+	typeInInterfacePtr := llvm.PointerType(p.getLLVMRuntimeType("typeInInterface"), 0)
 	var typesInInterfaces []llvm.Value
 	for global := p.mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
 		switch global.Type() {

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -28,14 +28,14 @@ func (c *Compiler) parseMakeInterface(val llvm.Value, typ types.Type, pos token.
 	itfMethodSetGlobal := c.getTypeMethodSet(typ)
 	itfConcreteTypeGlobal := c.mod.NamedGlobal("typeInInterface:" + itfTypeCodeGlobal.Name())
 	if itfConcreteTypeGlobal.IsNil() {
-		typeInInterface := c.mod.GetTypeByName("runtime.typeInInterface")
+		typeInInterface := c.getLLVMRuntimeType("typeInInterface")
 		itfConcreteTypeGlobal = llvm.AddGlobal(c.mod, typeInInterface, "typeInInterface:"+itfTypeCodeGlobal.Name())
 		itfConcreteTypeGlobal.SetInitializer(llvm.ConstNamedStruct(typeInInterface, []llvm.Value{itfTypeCodeGlobal, itfMethodSetGlobal}))
 		itfConcreteTypeGlobal.SetGlobalConstant(true)
 		itfConcreteTypeGlobal.SetLinkage(llvm.PrivateLinkage)
 	}
 	itfTypeCode := c.builder.CreatePtrToInt(itfConcreteTypeGlobal, c.uintptrType, "")
-	itf := llvm.Undef(c.mod.GetTypeByName("runtime._interface"))
+	itf := llvm.Undef(c.getLLVMRuntimeType("_interface"))
 	itf = c.builder.CreateInsertValue(itf, itfTypeCode, 0, "")
 	itf = c.builder.CreateInsertValue(itf, itfValue, 1, "")
 	return itf
@@ -48,7 +48,7 @@ func (c *Compiler) getTypeCode(typ types.Type) llvm.Value {
 	globalName := "type:" + getTypeCodeName(typ)
 	global := c.mod.NamedGlobal(globalName)
 	if global.IsNil() {
-		global = llvm.AddGlobal(c.mod, c.mod.GetTypeByName("runtime.typecodeID"), globalName)
+		global = llvm.AddGlobal(c.mod, c.getLLVMRuntimeType("typecodeID"), globalName)
 		global.SetGlobalConstant(true)
 	}
 	return global
@@ -163,11 +163,11 @@ func (c *Compiler) getTypeMethodSet(typ types.Type) llvm.Value {
 	ms := c.ir.Program.MethodSets.MethodSet(typ)
 	if ms.Len() == 0 {
 		// no methods, so can leave that one out
-		return llvm.ConstPointerNull(llvm.PointerType(c.mod.GetTypeByName("runtime.interfaceMethodInfo"), 0))
+		return llvm.ConstPointerNull(llvm.PointerType(c.getLLVMRuntimeType("interfaceMethodInfo"), 0))
 	}
 
 	methods := make([]llvm.Value, ms.Len())
-	interfaceMethodInfoType := c.mod.GetTypeByName("runtime.interfaceMethodInfo")
+	interfaceMethodInfoType := c.getLLVMRuntimeType("interfaceMethodInfo")
 	for i := 0; i < ms.Len(); i++ {
 		method := ms.At(i)
 		signatureGlobal := c.getMethodSignature(method.Obj().(*types.Func))

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -1,0 +1,107 @@
+package compiler
+
+// This file manages symbols, that is, functions and globals. It reads their
+// pragmas, determines the link name, etc.
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"github.com/tinygo-org/tinygo/loader"
+	"golang.org/x/tools/go/ssa"
+	"tinygo.org/x/go-llvm"
+)
+
+// globalInfo contains some information about a specific global. By default,
+// linkName is equal to .RelString(nil) on a global and extern is false, but for
+// some symbols this is different (due to //go:extern for example).
+type globalInfo struct {
+	linkName string // go:extern
+	extern   bool   // go:extern
+}
+
+// loadASTComments loads comments on globals from the AST, for use later in the
+// program. In particular, they are required for //go:extern pragmas on globals.
+func (c *Compiler) loadASTComments(lprogram *loader.Program) {
+	c.astComments = map[string]*ast.CommentGroup{}
+	for _, pkgInfo := range lprogram.Sorted() {
+		for _, file := range pkgInfo.Files {
+			for _, decl := range file.Decls {
+				switch decl := decl.(type) {
+				case *ast.GenDecl:
+					switch decl.Tok {
+					case token.VAR:
+						if len(decl.Specs) != 1 {
+							continue
+						}
+						for _, spec := range decl.Specs {
+							switch spec := spec.(type) {
+							case *ast.ValueSpec: // decl.Tok == token.VAR
+								for _, name := range spec.Names {
+									id := pkgInfo.Pkg.Path() + "." + name.Name
+									c.astComments[id] = decl.Doc
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// getGlobal returns a LLVM IR global value for a Go SSA global. It is added to
+// the LLVM IR if it has not been added already.
+func (c *Compiler) getGlobal(g *ssa.Global) llvm.Value {
+	info := c.getGlobalInfo(g)
+	llvmGlobal := c.mod.NamedGlobal(info.linkName)
+	if llvmGlobal.IsNil() {
+		llvmType := c.getLLVMType(g.Type().(*types.Pointer).Elem())
+		llvmGlobal = llvm.AddGlobal(c.mod, llvmType, info.linkName)
+		if !info.extern {
+			llvmGlobal.SetInitializer(c.getZeroValue(llvmType))
+			llvmGlobal.SetLinkage(llvm.InternalLinkage)
+		}
+	}
+	return llvmGlobal
+}
+
+// getGlobalInfo returns some information about a specific global.
+func (c *Compiler) getGlobalInfo(g *ssa.Global) globalInfo {
+	info := globalInfo{}
+	if strings.HasPrefix(g.Name(), "C.") {
+		// Created by CGo: such a name cannot be created by regular C code.
+		info.linkName = g.Name()[2:]
+		info.extern = true
+	} else {
+		// Pick the default linkName.
+		info.linkName = g.RelString(nil)
+		// Check for //go: pragmas, which may change the link name (among
+		// others).
+		doc := c.astComments[info.linkName]
+		if doc != nil {
+			info.parsePragmas(doc)
+		}
+	}
+	return info
+}
+
+// Parse //go: pragma comments from the source. In particular, it parses the
+// //go:extern pragma on globals.
+func (info *globalInfo) parsePragmas(doc *ast.CommentGroup) {
+	for _, comment := range doc.List {
+		if !strings.HasPrefix(comment.Text, "//go:") {
+			continue
+		}
+		parts := strings.Fields(comment.Text)
+		switch parts[0] {
+		case "//go:extern":
+			info.extern = true
+			if len(parts) == 2 {
+				info.linkName = parts[1]
+			}
+		}
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -26,7 +26,6 @@ type Program struct {
 	Globals       []*Global
 	globalMap     map[*ssa.Global]*Global
 	comments      map[string]*ast.CommentGroup
-	NamedTypes    []*NamedType
 }
 
 // Function or method.
@@ -48,19 +47,6 @@ type Global struct {
 	LLVMGlobal llvm.Value
 	linkName   string // go:extern
 	extern     bool   // go:extern
-}
-
-// Type with a name and possibly methods.
-type NamedType struct {
-	*ssa.Type
-	LLVMType llvm.Type
-}
-
-// Type that is at some point put in an interface.
-type TypeWithMethods struct {
-	t       types.Type
-	Num     int
-	Methods map[string]*types.Selection
 }
 
 // Interface type that is at some point used in a type assert (to check whether
@@ -210,8 +196,6 @@ func (p *Program) AddPackage(pkg *ssa.Package) {
 		case *ssa.Function:
 			p.addFunction(member)
 		case *ssa.Type:
-			t := &NamedType{Type: member}
-			p.NamedTypes = append(p.NamedTypes, t)
 			methods := getAllMethods(pkg.Prog, member.Type())
 			if !types.IsInterface(member.Type()) {
 				// named type


### PR DESCRIPTION
Trying to get rid of the `ir` package, that is not necessary anymore and has been holding back other refactors (in particular, #285).

There is more to come, but refactoring functions in the same way has far more side effects so needs some more fixes (like #399).