### PR TITLE
Add implementation for os.Exit and syscall.Exit

### DIFF
--- a/src/os/proc.go
+++ b/src/os/proc.go
@@ -1,0 +1,17 @@
+// Package os implements a subset of the Go "os" package. See
+// https://godoc.org/os for details.
+//
+// Note that the current implementation is blocking. This limitation should be
+// removed in a future version.
+package os
+
+import (
+	"syscall"
+)
+
+// Exit causes the current program to exit with the given status code.
+// Conventionally, code zero indicates success, non-zero an error.
+// The program terminates immediately; deferred functions are not run.
+func Exit(code int) {
+	syscall.Exit(code)
+}

--- a/src/syscall/syscall.go
+++ b/src/syscall/syscall.go
@@ -1,0 +1,3 @@
+package syscall
+
+func Exit(code int)


### PR DESCRIPTION
For `syscall.Exit`, it looks like that's supposed to be provided by the runtime so I wasn't sure if I needed to give it a specific body.

On `os.Exit`, golang has some extra [guards](https://golang.org/src/os/proc.go?s=1559:1578#L49) for race protection but I wasn't sure if that was needed here.