### PR TITLE
all: try more locations to find Clang built-in headers

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -41,6 +41,7 @@ type Config struct {
 	PanicStrategy string   // panic strategy ("abort" or "trap")
 	CFlags        []string // cflags to pass to cgo
 	LDFlags       []string // ldflags to pass to cgo
+	ClangHeaders  string   // Clang built-in header include path
 	DumpSSA       bool     // dump Go SSA, for compiler debugging
 	Debug         bool     // add debug symbols for gdb
 	GOROOT        string   // GOROOT
@@ -235,9 +236,10 @@ func (c *Compiler) Compile(mainPath string) []error {
 				MaxAlign: int64(c.targetData.PrefTypeAlignment(c.i8ptrType)),
 			},
 		},
-		Dir:        wd,
-		TINYGOROOT: c.TINYGOROOT,
-		CFlags:     c.CFlags,
+		Dir:          wd,
+		TINYGOROOT:   c.TINYGOROOT,
+		CFlags:       c.CFlags,
+		ClangHeaders: c.ClangHeaders,
 	}
 	if strings.HasSuffix(mainPath, ".go") {
 		_, err = lprogram.ImportFile(mainPath)

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		PanicStrategy: config.panicStrategy,
 		CFlags:        cflags,
 		LDFlags:       ldflags,
+		ClangHeaders:  getClangHeaderPath(root),
 		Debug:         config.debug,
 		DumpSSA:       config.dumpSSA,
 		TINYGOROOT:    root,

--- a/target.go
+++ b/target.go
@@ -401,3 +401,51 @@ func getGorootVersion(goroot string) (major, minor int, err error) {
 	}
 	return
 }
+
+// getClangHeaderPath returns the path to the built-in Clang headers. It tries
+// multiple locations, which should make it find the directory when installed in
+// various ways.
+func getClangHeaderPath(TINYGOROOT string) string {
+	// Check whether we're running from the source directory.
+	path := filepath.Join(TINYGOROOT, "llvm", "tools", "clang", "lib", "Headers")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return path
+	}
+
+	// Check whether we're running from the installation directory.
+	path = filepath.Join(TINYGOROOT, "lib", "clang", "include")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return path
+	}
+
+	// It looks like we are built with a system-installed LLVM. Do a last
+	// attempt: try to use Clang headers relative to the clang binary.
+	for _, cmdName := range commands["clang"] {
+		binpath, err := exec.LookPath(cmdName)
+		if err == nil {
+			// This should be the command that will also be used by
+			// execCommand. To avoid inconsistencies, make sure we use the
+			// headers relative to this command.
+			binpath, err = filepath.EvalSymlinks(binpath)
+			if err != nil {
+				// Unexpected.
+				return ""
+			}
+			// Example executable:
+			//     /usr/lib/llvm-8/bin/clang
+			// Example include path:
+			//     /usr/lib/llvm-8/lib/clang/8.0.1/include/
+			llvmRoot := filepath.Dir(filepath.Dir(binpath))
+			clangVersionRoot := filepath.Join(llvmRoot, "lib", "clang")
+			dirnames, err := ioutil.ReadDir(clangVersionRoot)
+			if err != nil || len(dirnames) != 1 {
+				// Unexpected.
+				return ""
+			}
+			return filepath.Join(clangVersionRoot, dirnames[0].Name(), "include")
+		}
+	}
+
+	// Could not find it.
+	return ""
+}


### PR DESCRIPTION
This commit fixes the case where TinyGo was built with `go build` and
LLVM sources were never downloaded into the TinyGo source directory.