### PR TITLE
Makefile: use official LLVM GitHub monorepo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,12 +44,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-8-v3
+            - llvm-source-8-v4
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-8-v3
+          key: llvm-source-8-v4
           paths:
             - llvm
   smoketest:
@@ -106,7 +106,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-8-linux-v5
+            - llvm-build-8-linux-v6
       - run:
           name: "Build LLVM"
           command: |
@@ -124,7 +124,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-linux-v5
+          key: llvm-build-8-linux-v6
           paths:
             llvm-build
       - run:
@@ -169,17 +169,17 @@ commands:
             HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
       - restore_cache:
           keys:
-            - llvm-source-8-macos-v3
+            - llvm-source-8-macos-v4
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-8-macos-v3
+          key: llvm-source-8-macos-v4
           paths:
             - llvm
       - restore_cache:
           keys:
-            - llvm-build-8-macos-v4
+            - llvm-build-8-macos-v5
       - run:
           name: "Build LLVM"
           command: |
@@ -191,7 +191,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-macos-v4
+          key: llvm-build-8-macos-v5
           paths:
             llvm-build
       - run:


### PR DESCRIPTION
Now using a more simplified change than the original PR, to use the system compiler for both LLVM and the TinyGo binary. :smile: