### PR TITLE
test: replace ExitStatus() with go1.11 compatible syntax

### DIFF
--- a/main.go
+++ b/main.go
@@ -367,7 +367,10 @@ func Test(pkgName, target string, config *BuildConfig) error {
 		if err != nil {
 			// Propagate the exit code
 			if err, ok := err.(*exec.ExitError); ok {
-				os.Exit(err.ExitCode())
+				if status, ok := err.Sys().(syscall.WaitStatus); ok {
+					os.Exit(status.ExitStatus())
+				}
+				os.Exit(1)
 			}
 			return &commandError{"failed to run compiled binary", tmppath, err}
 		}


### PR DESCRIPTION
This PR should replace the use of `ExitStatus()` in the `tinygo test` command with an uglier syntax for handling test exit that apparently worked in go.11.