### PR TITLE
compiler: ensure the dwarf cu language is set to Go

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -278,7 +278,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 	// Initialize debug information.
 	if c.Debug {
 		c.cu = c.dibuilder.CreateCompileUnit(llvm.DICompileUnit{
-			Language:  0xb, // DW_LANG_C99 (0xc, off-by-one?)
+			Language:  0x15, // DW_LANG_OpenCL (0x16, off-by-one?)
 			File:      mainPath,
 			Dir:       "",
 			Producer:  "TinyGo",


### PR DESCRIPTION
Might as well have the Dwarf Compile Unit language set to Go:

```
xorshift-gc-dumb-dwarf.wasm:    file format WASM

.debug_info contents:
0x00000000: Compile Unit: length = 0x00000163 version = 0x0004 abbr_offset = 0x0000 addr_size = 0x04 (next unit at 0x00000167)

0x0000000b: DW_TAG_compile_unit
              DW_AT_producer    ("TinyGo")
              DW_AT_language    (DW_LANG_Go)
...
```

This PR takes into account the (hopefully temporary) off-by-one problem with the LLVM language attribute.