### PR TITLE
Fix memory corruption in the portable garbage collector

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1403,7 +1403,6 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 				// Size would be truncated if truncated to uintptr.
 				return llvm.Value{}, c.makeError(expr.Pos(), fmt.Sprintf("value is too big (%v bytes)", size))
 			}
-			// TODO: escape analysis
 			sizeValue := llvm.ConstInt(c.uintptrType, size, false)
 			buf := c.createRuntimeCall("alloc", []llvm.Value{sizeValue}, expr.Comment)
 			buf = c.builder.CreateBitCast(buf, llvm.PointerType(typ, 0), "")
@@ -1650,7 +1649,6 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		c.emitSliceBoundsCheck(frame, maxSize, sliceLen, sliceCap, expr.Len.Type().(*types.Basic), expr.Cap.Type().(*types.Basic))
 
 		// Allocate the backing array.
-		// TODO: escape analysis
 		sliceCapCast, err := c.parseConvert(expr.Cap.Type(), types.Typ[types.Uintptr], sliceCap, expr.Pos())
 		if err != nil {
 			return llvm.Value{}, err

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -336,6 +336,9 @@ func (c *Compiler) markAsyncFunctions() (needsScheduler bool, err error) {
 			size = c.builder.CreateZExt(size, c.uintptrType, "task.size.uintptr")
 		}
 		data := c.createRuntimeCall("alloc", []llvm.Value{size}, "task.data")
+		if c.needsStackObjects() {
+			c.trackPointer(data)
+		}
 		frame.taskHandle = c.builder.CreateCall(coroBeginFunc, []llvm.Value{id, data}, "task.handle")
 
 		// Modify async calls so this function suspends right after the child

--- a/compiler/wordpack.go
+++ b/compiler/wordpack.go
@@ -39,6 +39,9 @@ func (c *Compiler) emitPointerPack(values []llvm.Value) llvm.Value {
 		// Packed data is bigger than a pointer, so allocate it on the heap.
 		sizeValue := llvm.ConstInt(c.uintptrType, size, false)
 		packedHeapAlloc = c.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "")
+		if c.needsStackObjects() {
+			c.trackPointer(packedHeapAlloc)
+		}
 		packedAlloc = c.builder.CreateBitCast(packedHeapAlloc, llvm.PointerType(packedType, 0), "")
 	}
 	// Store all values in the alloca or heap pointer.


### PR DESCRIPTION
Track some more allocations (in particular, during goroutine lowering) because not tracking them causes use-after-free errors.