### PR TITLE
Uses `go version' and zversion.go to detect version, fixes #433

### DIFF
--- a/target.go
+++ b/target.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -384,14 +385,24 @@ func isGoroot(goroot string) bool {
 // getGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.
 func getGorootVersion(goroot string) (major, minor int, err error) {
-	data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION"))
-	if err != nil {
-		return 0, 0, err
+	var s string
+
+	if out, err := exec.Command("go", "version"); err == nil {
+		s = strings.Fields(out)[2]
+	} else {
+		data, err := ioutil.ReadFile(filepath.Join(goroot, "src", "runtime", "internal", "sys", "zversion.go"))
+		if err != nil {
+			return 0, 0, err
+		}
+
+		r := regexp.MustCompile("const TheVersion = `(.*)`")
+		s = string(r.FindSubmatch(data)[1])
 	}
-	s := string(data)
-	if s[:2] != "go" {
+
+	if s == "" || s[:2] != "go" {
 		return 0, 0, errors.New("could not parse Go version: version does not start with 'go' prefix")
 	}
+
 	parts := strings.Split(s[2:], ".")
 	if len(parts) < 2 {
 		return 0, 0, errors.New("could not parse Go version: version has less than two parts")

--- a/target.go
+++ b/target.go
@@ -387,16 +387,13 @@ func isGoroot(goroot string) bool {
 func getGorootVersion(goroot string) (major, minor int, err error) {
 	var s string
 
-	if out, err := exec.Command("go", "version"); err == nil {
-		s = strings.Fields(out)[2]
-
-	} else if data, err := ioutil.ReadFile(filepath.Join(
+	if data, err := ioutil.ReadFile(filepath.Join(
 		goroot, "src", "runtime", "internal", "sys", "zversion.go")); err == nil {
 
 		r := regexp.MustCompile("const TheVersion = `(.*)`")
 		matches := r.FindSubmatch(data)
 		if len(matches) != 2 {
-			return 0, 0, errors.New("Invalid go version output: " + data)
+			return 0, 0, errors.New("Invalid go version output:\n" + string(data))
 		}
 
 		s = string(matches[1])

--- a/target.go
+++ b/target.go
@@ -391,7 +391,7 @@ func getGorootVersion(goroot string) (major, minor int, err error) {
 		s = strings.Fields(out)[2]
 
 	} else if data, err := ioutil.ReadFile(filepath.Join(
-		goroot, "src", "runtime", "internal", "sys", "zversion.go")); err != nil {
+		goroot, "src", "runtime", "internal", "sys", "zversion.go")); err == nil {
 
 		r := regexp.MustCompile("const TheVersion = `(.*)`")
 		matches := r.FindSubmatch(data)
@@ -401,7 +401,7 @@ func getGorootVersion(goroot string) (major, minor int, err error) {
 
 		s = string(matches[1])
 
-	} else if data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION")); err != nil {
+	} else if data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION")); err == nil {
 		s = string(data)
 	}
 

--- a/target.go
+++ b/target.go
@@ -403,10 +403,9 @@ func getGorootVersion(goroot string) (major, minor int, err error) {
 
 	} else if data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION")); err == nil {
 		s = string(data)
-	}
 
-	if err != nil {
-		return
+	} else {
+		return 0, 0, err
 	}
 
 	if s == "" || s[:2] != "go" {


### PR DESCRIPTION
This first executes `go version` then parses it. If it fails, it reads `zversion.go`. If all else fails, it dies like usual.
