### PR TITLE
Optimize stack pointer tracking

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -865,6 +865,10 @@ func (c *Compiler) parseFunc(frame *Frame) {
 		// Add LLVM inline hint to functions with //go:inline pragma.
 		inline := c.ctx.CreateEnumAttribute(llvm.AttributeKindID("inlinehint"), 0)
 		frame.fn.LLVMFn.AddFunctionAttr(inline)
+	case ir.InlineNone:
+		// Add LLVM attribute to always avoid inlining this function.
+		noinline := c.ctx.CreateEnumAttribute(llvm.AttributeKindID("noinline"), 0)
+		frame.fn.LLVMFn.AddFunctionAttr(noinline)
 	}
 
 	// Add debug info, if needed.

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -56,6 +56,10 @@ const (
 	// //go:inline). The compiler will be more likely to inline this function,
 	// but it is not a guarantee.
 	InlineHint
+
+	// Don't inline, just like the GCC noinline attribute. Signalled using
+	// //go:noinline.
+	InlineNone
 )
 
 // Create and initialize a new *Program from a *ssa.Program.
@@ -227,6 +231,8 @@ func (f *Function) parsePragmas() {
 				f.exported = true
 			case "//go:inline":
 				f.inline = InlineHint
+			case "//go:noinline":
+				f.inline = InlineNone
 			case "//go:interrupt":
 				if len(parts) != 2 {
 					continue

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -203,6 +203,7 @@ func init() {
 
 // alloc tries to find some free space on the heap, possibly doing a garbage
 // collection cycle if needed. If no space is free, it panics.
+//go:noinline
 func alloc(size uintptr) unsafe.Pointer {
 	if size == 0 {
 		return unsafe.Pointer(&zeroSizedAlloc)


### PR DESCRIPTION
This implements a few optimizations that together reduce the repulsion demo WebAssembly from 100.2kB to 96.7kB. It also allows the repulsion demo to run much longer when a bigger heap has been configured (that's not yet an option but the code can be manually modified).

@johanbrandhorst 