### PR TITLE
all: make the heap size configurable

### DIFF
--- a/src/runtime/arch_wasm.go
+++ b/src/runtime/arch_wasm.go
@@ -14,9 +14,12 @@ const TargetBits = 32
 //go:extern __heap_base
 var heapStartSymbol unsafe.Pointer
 
+//go:export llvm.wasm.memory.size.i32
+func wasm_memory_size(index int32) int32
+
 var (
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd   = (heapStart + wasmPageSize - 1) &^ (wasmPageSize - 1) // conservative guess: one page of heap memory
+	heapEnd   = uintptr(wasm_memory_size(0) * wasmPageSize)
 )
 
 const wasmPageSize = 64 * 1024

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -14,6 +14,7 @@
 	"ldflags": [
 		"--allow-undefined",
 		"--no-threads",
+		"--stack-first",
 		"--export-all"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"]


### PR DESCRIPTION
When the target supports it, allow the (initial) heap size to be
configured. This is useful for WebAssembly, for example.

This also changes the default heap size of WebAssembly from 64kB to 1MB.