### PR TITLE
main: set the current working directory when calling an external linker

### DIFF
--- a/linker-builtin.go
+++ b/linker-builtin.go
@@ -63,6 +63,7 @@ func Link(linker string, flags ...string) error {
 		cmd := exec.Command(linker, flags...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Dir = sourceDir()
 		return cmd.Run()
 	}
 }

--- a/linker-external.go
+++ b/linker-external.go
@@ -20,5 +20,6 @@ func Link(linker string, flags ...string) error {
 	cmd := exec.Command(linker, flags...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Dir = sourceDir()
 	return cmd.Run()
 }


### PR DESCRIPTION
In particular, while LLVM lld supports -L for linker scripts imported with the `INCLUDE` command, GNU ld does not seem to support this.

This is a prerequisite for supporting the HiFive1 board in the TinyGo Playground.