### PR TITLE
WASM: Support for setting an imported function's module name

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -791,6 +791,11 @@ func (c *Compiler) parseFuncDecl(f *ir.Function) *Frame {
 	// External/exported functions may not retain pointer values.
 	// https://golang.org/cmd/cgo/#hdr-Passing_pointers
 	if f.IsExported() {
+		// Set the wasm-import-module attribute if the function's module is set.
+		if f.Module() != "" {
+			wasmImportModuleAttr := c.ctx.CreateStringAttribute("wasm-import-module", f.Module())
+			frame.fn.LLVMFn.AddFunctionAttr(wasmImportModuleAttr)
+		}
 		nocaptureKind := llvm.AttributeKindID("nocapture")
 		nocapture := c.ctx.CreateEnumAttribute(nocaptureKind, 0)
 		for i, typ := range paramTypes {

--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -2,8 +2,9 @@
 
 The examples here show two different ways of using WebAssembly with TinyGo:
 
-1. Defining and exporting functions via the `//go:export <name>` directive. See
-[the export folder](./export) for an example of this.
+1. Defining and exporting functions via the `//go:export [module] <name>` directive. See
+[the export folder](./export) for an example of this.  `module` is optional and overrides
+the default module name of "env".
 1. Defining and executing a `func main()`. This is similar to how the Go
 standard library implementation works. See [the main folder](./main) for an
 example of this.


### PR DESCRIPTION
I need to compile a WebAssembly program that imports functions from a host that uses a module namespace other than the standard `env`.  I enhanced `go:export` to support this.  For example, in addition to the default export (`env` module)

```go
//go:export multiply
func multiply(x, y int) int {
    return x * y;
}
```

You can set the module using `//go:export [module] <name>`

```go
//go:export math multiply
func multiply(x, y int) int {
    return x * y;
}
```

Alternatively, you can use a separate comment `//go:module <name>` in conjunction with `go:export` or `go:linkname`.  I'm happy to make any tweaks to the argument format.

I tried to run `make test` but got clang linker errors.  I tested using `go install` and `wasm2wat` to print the imports of the compiled wasm.

I believe this fixes #423.