### PR TITLE
WASM: Support for setting an imported function's module name

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -821,6 +821,11 @@ func (c *Compiler) parseFuncDecl(f *ir.Function) *Frame {
 	// External/exported functions may not retain pointer values.
 	// https://golang.org/cmd/cgo/#hdr-Passing_pointers
 	if f.IsExported() {
+		// Set the wasm-import-module attribute if the function's module is set.
+		if f.Module() != "" {
+			wasmImportModuleAttr := c.ctx.CreateStringAttribute("wasm-import-module", f.Module())
+			frame.fn.LLVMFn.AddFunctionAttr(wasmImportModuleAttr)
+		}
 		nocaptureKind := llvm.AttributeKindID("nocapture")
 		nocapture := c.ctx.CreateEnumAttribute(nocaptureKind, 0)
 		for i, typ := range paramTypes {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -28,7 +28,7 @@ type Program struct {
 type Function struct {
 	*ssa.Function
 	LLVMFn    llvm.Value
-	module    string     // go:module, go:export
+	module    string     // go:wasm-module
 	linkName  string     // go:linkname, go:export, go:interrupt
 	exported  bool       // go:export
 	nobounds  bool       // go:nobounds
@@ -224,26 +224,18 @@ func (f *Function) parsePragmas() {
 			}
 			parts := strings.Fields(text)
 			switch parts[0] {
-			case "//go:module":
+			case "//go:export":
+				if len(parts) != 2 {
+					continue
+				}
+				f.linkName = parts[1]
+				f.exported = true
+			case "//go:wasm-module":
 				// Alternative comment for setting the import module.
 				if len(parts) != 2 {
 					continue
 				}
 				f.module = parts[1]
-			case "//go:export":
-				// Accept:
-				// [module] linkName
-				// where module is an optional WASM import module name.
-				switch len(parts) {
-				case 2:
-					f.linkName = parts[1]
-				case 3:
-					f.module = parts[1]
-					f.linkName = parts[2]
-				default:
-					continue
-				}
-				f.exported = true
 			case "//go:inline":
 				f.inline = InlineHint
 			case "//go:noinline":

--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -2,9 +2,10 @@
 
 The examples here show two different ways of using WebAssembly with TinyGo:
 
-1. Defining and exporting functions via the `//go:export [module] <name>` directive. See
-[the export folder](./export) for an example of this.  `module` is optional and overrides
-the default module name of "env".
+1. Defining and exporting functions via the `//go:export <name>` directive. See
+[the export folder](./export) for an example of this.  Additionally, the Wasm
+module (which has a default value of `env`) can be specified using
+`//go:wasm-module <module>`.
 1. Defining and executing a `func main()`. This is similar to how the Go
 standard library implementation works. See [the main folder](./main) for an
 example of this.

--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -2,8 +2,9 @@
 
 The examples here show two different ways of using WebAssembly with TinyGo:
 
-1. Defining and exporting functions via the `//go:export <name>` directive. See
-[the export folder](./export) for an example of this.
+1. Defining and exporting functions via the `//go:export [module] <name>` directive. See
+[the export folder](./export) for an example of this.  `module` is optional and overrides
+the default module name of "env".
 1. Defining and executing a `func main()`. This is similar to how the Go
 standard library implementation works. See [the main folder](./main) for an
 example of this.


### PR DESCRIPTION
I need to compile a WebAssembly program that imports functions from a host that uses a module namespace other than the standard `env`.  I enhanced `go:export` to support this.  For example, in addition to the default export (`env` module)

```go
//go:export multiply
func multiply(x, y int) int {
    return x * y;
}
```

You can set the module using `//go:export [module] <name>`

```go
//go:export math multiply
func multiply(x, y int) int {
    return x * y;
}
```

Alternatively, you can use a separate comment `//go:module <name>` in conjunction with `go:export` or `go:linkname`.  I'm happy to make any tweaks to the argument format.

I tried to run `make test` but got clang linker errors.  I tested using `go install` and `wasm2wat` to print the imports of the compiled wasm.

This is a first step for issue #423.