### PR TITLE
Device path at flash time for several boards

### DIFF
--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,5 +1,5 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "arduino_nano33"],
-    "flash": "bossac -d -i -e -w -v -R --offset=0x2000 {bin}"
+    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}"
 }

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -1,5 +1,5 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "feather_m0"],
-    "flash": "bossac -d -i -e -w -v -R --offset=0x2000 {hex}"
+    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
 }

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -1,5 +1,5 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "itsybitsy_m0"],
-    "flash": "bossac -d -i -e -w -v -R --offset=0x2000 {hex}"
+    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
 }

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -1,5 +1,5 @@
 {
     "inherits": ["atsamd21e18a"],
     "build-tags": ["sam", "atsamd21e18a", "trinket_m0"],
-    "flash": "bossac -d -i -e -w -v -R --offset=0x2000 {hex}"
+    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
 }


### PR DESCRIPTION
## What
Allow flash-time setting of device paths for several common boards.

## Why
bossac CLI tool doesn't properly resolve device paths for these (and probably others) on macOS

## Usage
`tinygo flash -target arduino-nano33 -port=/dev/tty.usbmodem145101 ./main.go`