### PR TITLE
main: version 0.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,17 +225,17 @@ commands:
 jobs:
   test-llvm8-go111:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11-stretch
     steps:
       - test-linux
   test-llvm8-go112:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-stretch
     steps:
       - test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-stretch
     steps:
       - build-linux
   build-macos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.1
+---
+* **targets**
+  - `atsamd21`: add support for the `-port` flag in the flash subcommand
+
 0.7.0
 ---
 * **command line**

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package main
 
 // version of this package.
 // Update this value before release of new version of software.
-const version = "0.7.0"
+const version = "0.7.1"


### PR DESCRIPTION
This release contains a small fix for some atsamd21-based boards to make them usable on macOS: it now allows to specify the serial port using the `-port` flag.