### PR TITLE
ci: fix Go image on the Debian Stretch images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,17 +225,17 @@ commands:
 jobs:
   test-llvm8-go111:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.11-stretch
     steps:
       - test-linux
   test-llvm8-go112:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-stretch
     steps:
       - test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-stretch
     steps:
       - build-linux
   build-macos:


### PR DESCRIPTION
The build broke because the images got upgraded from stretch to buster.
Specify the stretch images (for now) so that it works again.
We can upgrade to buster for go1.12 at a later time.