### PR TITLE
Add x86 baremetal target

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1308,7 +1308,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 	if fn := instr.StaticCallee(); fn != nil {
 		name := fn.RelString(nil)
 		switch {
-		case name == "device/arm.ReadRegister" || name == "device/riscv.ReadRegister":
+		case name == "device/arm.ReadRegister" || name == "device/riscv.ReadRegister" || name == "device/x86.ReadRegister":
 			return c.emitReadRegister(name, instr.Args)
 		case name == "device/arm.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
 			return c.emitAsm(instr.Args)

--- a/compiler/inlineasm.go
+++ b/compiler/inlineasm.go
@@ -27,6 +27,8 @@ func (c *Compiler) emitReadRegister(name string, args []ssa.Value) (llvm.Value, 
 		asm = "mov $0, " + regname
 	case "device/riscv.ReadRegister":
 		asm = "mv $0, " + regname
+	case "device/x86.ReadRegister":
+		asm = "mov $0, " + regname
 	default:
 		panic("unknown architecture")
 	}

--- a/src/device/x86/x86.go
+++ b/src/device/x86/x86.go
@@ -1,0 +1,5 @@
+package x86
+
+// ReadRegister returns the contents of the specified register. The register
+// must be a processor register, reachable with the "mov" instruction.
+func ReadRegister(name string) uintptr

--- a/src/machine/machine_i386-baremetal.go
+++ b/src/machine/machine_i386-baremetal.go
@@ -1,0 +1,159 @@
+// +build 386,baremetal
+
+package machine
+
+import (
+	"unsafe"
+)
+
+// PinSet is only provided for compatibility.
+type PinMode uint8
+
+// Set does nothing. The x86 platform usually doesn't expose any GPIO pins.
+func (p Pin) Set(value bool) {
+	// do nothing
+}
+
+//export outb
+func outb(port uint16, val uint8)
+
+var COM1 = UART{port: 0x3f8}
+
+type UART struct {
+	port uint16
+}
+
+// Configure allows the given COM port to be used for serial output.
+func (uart UART) Configure() {
+	// https://wiki.osdev.org/Serial_Ports#Initialization
+	outb(uart.port+1, 0x00) // Disable all interrupts
+	outb(uart.port+3, 0x80) // Enable DLAB (set baud rate divisor)
+	outb(uart.port+0, 0x03) // Set divisor to 3 (lo byte) 38400 baud
+	outb(uart.port+1, 0x00) //                  (hi byte)
+	outb(uart.port+3, 0x03) // 8 bits, no parity, one stop bit
+	outb(uart.port+2, 0xC7) // Enable FIFO, clear them, with 14-byte threshold
+	outb(uart.port+4, 0x0B) // IRQs enabled, RTS/DSR set
+}
+
+// WriteByte sends a single byte to this COM port.
+func (uart UART) WriteByte(c byte) error {
+	// TODO: wait until the previous char has been sent.
+	// This does not seem to be necessary in QEMU.
+	outb(uart.port, c)
+	return nil
+}
+
+const (
+	ConsoleWidth  = 80
+	ConsoleHeight = 25
+)
+
+// VGA colors, as used by the console interface.
+const (
+	VGAColorBlack = iota
+	VGAColorBlue
+	VGAColorGreen
+	VGAColorCyan
+	VGAColorRed
+	VGAColorMagenta
+	VGAColorBrown
+	VGAColorLightGrey
+	VGAColorDarkGrey
+	VGAColorLightBlue
+	VGAColorLightGreen
+	VGAColorLightCyan
+	VGAColorLightRed
+	VGAColorLightMagenta
+	VGAColorLightBrown
+	VGAColorWhite
+)
+
+var consoleRawBuffer = (*[25][80]uint16)(unsafe.Pointer(uintptr(0xB8000)))
+
+// Console0 is the standard console for this system.
+var Console0 = Console{}
+
+// Console represents the VGA console on this system.
+type Console struct {
+	x     int
+	y     int
+	color uint8
+}
+
+// Configure resets the console to the default state.
+func (c *Console) Configure() {
+	c.x = 0
+	c.y = 0
+	c.SetColor(VGAColorWhite, VGAColorBlack)
+	c.Clear()
+}
+
+// Clear erases everything from the console and puts the cursor in the top left.
+func (c *Console) Clear() {
+	for x := 0; x < ConsoleWidth; x++ {
+		for y := 0; y < ConsoleHeight; y++ {
+			c.SetEntry(x, y, ' ', makeVGAColor(VGAColorWhite, VGAColorBlack))
+		}
+	}
+}
+
+// Scroll moves the screen up by the given number of lines.
+func (c *Console) Scroll(lines int) {
+	// Move the screen up by this amount.
+	for y := lines; y < ConsoleHeight; y++ {
+		for x := 0; x < ConsoleWidth; x++ {
+			consoleRawBuffer[y-lines][x] = consoleRawBuffer[y][x]
+		}
+	}
+
+	// Clear the last lines.
+	for y := ConsoleHeight - lines; y < ConsoleHeight; y++ {
+		for x := 0; x < ConsoleWidth; x++ {
+			c.SetEntry(x, y, ' ', c.color)
+		}
+	}
+}
+
+// SetByte sets a byte at the given location, without affecting the cursor
+// position.
+func (c *Console) SetEntry(x, y int, ch byte, color uint8) {
+	consoleRawBuffer[y][x] = uint16(ch) | uint16(c.color)<<8
+}
+
+// SetColor updates the current cursor color.
+func (c *Console) SetColor(foreground, background uint8) {
+	c.color = makeVGAColor(foreground, background)
+}
+
+// WriteByte writes one char to the console, wrapping around if necessary.
+func (c *Console) WriteByte(ch byte) error {
+	if ch == '\r' {
+		return nil
+	}
+	if ch == '\n' {
+		c.x = 0
+		c.y++
+		return nil
+	}
+	if c.x == ConsoleWidth {
+		c.x = 0
+		c.y++
+	}
+	if c.y >= ConsoleHeight {
+		c.Scroll(c.y - ConsoleHeight + 1)
+		c.y = ConsoleHeight - 1
+	}
+	c.SetEntry(c.x, c.y, ch, c.color)
+	c.x++
+	return nil
+}
+
+// makeVGAColor converts a background/foreground color into a single VGA color
+// to be used directly in the VGA framebuffer.
+func makeVGAColor(foreground, background uint8) uint8 {
+	return foreground | background<<4
+}
+
+// Halt shuts down the system immediately.
+//export halt
+func Halt()

--- a/src/runtime/runtime_i386-baremetal.go
+++ b/src/runtime/runtime_i386-baremetal.go
@@ -1,0 +1,52 @@
+// +build 386,baremetal
+
+package runtime
+
+import (
+	"device/x86"
+	"machine"
+)
+
+type timeUnit int64
+
+const tickMicros = 1
+
+//export main
+func main() {
+	initConsole()
+
+	// Run all init functions.
+	initAll()
+
+	// Run main.main().
+	callMain()
+
+	machine.Halt()
+}
+
+func initConsole() {
+	machine.COM1.Configure()
+}
+
+func putchar(c byte) {
+	machine.COM1.WriteByte(c)
+}
+
+func ticks() timeUnit {
+	return 0
+}
+
+const asyncScheduler = false
+
+func sleepTicks(d timeUnit) {
+	// TODO
+}
+
+func abort() {
+	// Try to shutdown.
+	machine.Halt()
+}
+
+func getCurrentStackPointer() uintptr {
+	return x86.ReadRegister("%esp")
+}

--- a/targets/i386-baremetal.json
+++ b/targets/i386-baremetal.json
@@ -1,0 +1,24 @@
+{
+    "llvm-target": "i686-pc-none-elf",
+    "build-tags": ["baremetal", "linux", "386"],
+    "goos": "linux",
+    "goarch": "386",
+    "compiler": "clang",
+    "linker": "ld.lld",
+    "cflags": [
+        "--target=i686-pc-none-elf",
+        "-Oz",
+        "-Werror",
+        "-Qunused-arguments",
+        "-fno-exceptions", "-fno-unwind-tables",
+        "-ffunction-sections", "-fdata-sections"
+    ],
+    "ldflags": [
+        "--gc-sections",
+        "-Ttargets/i386-baremetal.ld"
+    ],
+    "extra-files": [
+        "targets/i386-baremetal.s"
+    ],
+    "emulator": ["qemu-system-i386", "-nographic", "-serial", "stdio", "-monitor", "none", "-kernel"]
+}

--- a/targets/i386-baremetal.ld
+++ b/targets/i386-baremetal.ld
@@ -1,0 +1,58 @@
+ENTRY(_start)
+
+SECTIONS
+{
+    /* Begin putting sections at 1 MiB, a conventional place for kernels to be
+       loaded at by the bootloader. */
+    . = 1M;
+
+    /* First put the multiboot header, as it is required to be put very early
+       early in the image or the bootloader won't recognize the file format.
+       Next we'll put the .text section. */
+    .text : ALIGN(4K)
+    {
+        *(.multiboot)
+        *(.text .text.*)
+    }
+
+    /* Read-only data. */
+    .rodata : ALIGN(4K)
+    {
+        *(.rodata .rodata.*)
+    }
+
+    /* Read-write data (initialized). */
+    .data : ALIGN(4K)
+    {
+        _sdata = .;
+        *(.data .data.*)
+        _edata = .;
+    }
+
+    /* Read-write data (uninitialized) and stack. */
+    .bss : ALIGN(4K)
+    {
+        _sbss = .;
+        *(COMMON)
+        *(.bss .bss.*)
+        _ebss = .;
+    }
+
+    .stack : ALIGN(4K)
+    {
+        /* Define the stack here in the .bss section. */
+        . = . + 16K;
+        _stack_top = .;
+    }
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+    }
+}
+
+/* For the memory allocator. */
+_heap_start = _ebss;
+_heap_end = _ebss + 1M;
+_globals_start = _sdata;
+_globals_end = _ebss;

--- a/targets/i386-baremetal.s
+++ b/targets/i386-baremetal.s
@@ -1,0 +1,53 @@
+// Based on https://wiki.osdev.org/Bare_Bones
+
+// Declare constants for the multiboot header.
+.set ALIGN,    1<<0             // align loaded modules on page boundaries
+.set MEMINFO,  1<<1             // provide memory map
+.set FLAGS,    ALIGN | MEMINFO  // this is the Multiboot 'flag' field
+.set MAGIC,    0x1BADB002       // 'magic number' lets bootloader find the header
+.set CHECKSUM, -(MAGIC + FLAGS) // checksum of above, to prove we are multiboot
+
+// Declare the multiboot section, which the bootloader will search for in the
+// first 8kB of the kernel image.
+.section .multiboot
+.align 4
+.long MAGIC
+.long FLAGS
+.long CHECKSUM
+
+// Entry point, jumped to from the bootloader.
+.section .text
+.global _start
+.type _start, @function
+_start:
+    // Set up a stack: this is not done by the bootloader.
+    mov $_stack_top, %esp
+
+    // Jump to the main function.
+    call main
+
+    // Lock up the system, as a safety guard. We should never reach this point.
+    cli
+1:  hlt
+    jmp 1b
+
+
+.section .text.outb
+.global outb
+.type outb, @function
+outb:
+    movl    8(%esp), %eax
+    movl    4(%esp), %edx
+    outb %al, %dx
+    ret
+
+.section .text.halt
+.global halt
+.type halt, @function
+halt:
+    movw    $0x2000, %ax
+    movl    $0x604, %edx
+    outw    %ax, %dx
+    // Lock up in case shutdown wasn't enough (we're not running in QEMU).
+1:  hlt
+    jmp 1b


### PR DESCRIPTION
This could be useful for unikernels. At the moment, it isn't working well: most programs don't actually work.

Basically just playing around to see how far we can go. A unikernel in Go compiled with TinyGo should certainly be achievable.