### PR TITLE
runtime: work around a bug in LLVM for .bss zeroing

### DIFF
--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -47,10 +47,10 @@ func main() {
 
 func preinit() {
 	// Initialize .bss: zero-initialized global variables.
-	ptr := uintptr(unsafe.Pointer(&_sbss))
-	for ptr != uintptr(unsafe.Pointer(&_ebss)) {
-		*(*uint8)(unsafe.Pointer(ptr)) = 0
-		ptr += 1
+	ptr := unsafe.Pointer(&_sbss)
+	for ptr != unsafe.Pointer(&_ebss) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	}
 }
 

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -24,19 +24,19 @@ var _edata unsafe.Pointer
 
 func preinit() {
 	// Initialize .bss: zero-initialized global variables.
-	ptr := uintptr(unsafe.Pointer(&_sbss))
-	for ptr != uintptr(unsafe.Pointer(&_ebss)) {
-		*(*uint32)(unsafe.Pointer(ptr)) = 0
-		ptr += 4
+	ptr := unsafe.Pointer(&_sbss)
+	for ptr != unsafe.Pointer(&_ebss) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	}
 
 	// Initialize .data: global variables initialized from flash.
-	src := uintptr(unsafe.Pointer(&_sidata))
-	dst := uintptr(unsafe.Pointer(&_sdata))
-	for dst != uintptr(unsafe.Pointer(&_edata)) {
-		*(*uint32)(unsafe.Pointer(dst)) = *(*uint32)(unsafe.Pointer(src))
-		dst += 4
-		src += 4
+	src := unsafe.Pointer(&_sidata)
+	dst := unsafe.Pointer(&_sdata)
+	for dst != unsafe.Pointer(&_edata) {
+		*(*uint32)(dst) = *(*uint32)(src)
+		dst = unsafe.Pointer(uintptr(dst) + 4)
+		src = unsafe.Pointer(uintptr(src) + 4)
 	}
 }
 

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -62,19 +62,19 @@ func pric_init() {
 
 func preinit() {
 	// Initialize .bss: zero-initialized global variables.
-	ptr := uintptr(unsafe.Pointer(&_sbss))
-	for ptr != uintptr(unsafe.Pointer(&_ebss)) {
-		*(*uint32)(unsafe.Pointer(ptr)) = 0
-		ptr += 4
+	ptr := unsafe.Pointer(&_sbss)
+	for ptr != unsafe.Pointer(&_ebss) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Pointer(uintptr(ptr) + 4)
 	}
 
 	// Initialize .data: global variables initialized from flash.
-	src := uintptr(unsafe.Pointer(&_sidata))
-	dst := uintptr(unsafe.Pointer(&_sdata))
-	for dst != uintptr(unsafe.Pointer(&_edata)) {
-		*(*uint32)(unsafe.Pointer(dst)) = *(*uint32)(unsafe.Pointer(src))
-		dst += 4
-		src += 4
+	src := unsafe.Pointer(&_sidata)
+	dst := unsafe.Pointer(&_sdata)
+	for dst != unsafe.Pointer(&_edata) {
+		*(*uint32)(dst) = *(*uint32)(src)
+		dst = unsafe.Pointer(uintptr(dst) + 4)
+		src = unsafe.Pointer(uintptr(src) + 4)
 	}
 }
 


### PR DESCRIPTION
See the following bug: https://bugs.llvm.org/show_bug.cgi?id=42881

I think this is a bug in LLVM, but the code in question wasn't the best
code anyway. By fixing this, about 16 bytes of code are saved on ARM
chips (and much more on AVR).