### PR TITLE
Changing main.go to server.go in documentation

### DIFF
--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -34,7 +34,7 @@ $ make main
 Start the local web server:
 
 ```bash
-$ go run main.go
+$ go run server.go
 Serving ./html on http://localhost:8080
 ```
 


### PR DESCRIPTION
The documentation refereed to a `main.go` file that is actually called `server.go`