### PR TITLE
governance: add CONTRIBUTORS file to repo

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,14 @@
+# This is the official list of TinyGo authors for copyright purposes.
+#
+# This file is not actively maintained.
+# To be included, send a change adding the individual or
+# company who owns a contribution's copyright.
+#
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+#
+# Please keep the list sorted.
+
+Ron Evans <ron@hybridgroup.com>


### PR DESCRIPTION
This PR adds a CONTRIBUTORS file to repo to clarify who are the famous "The TinyGo Authors".