### PR TITLE
compiler: make goroutine lowering panic message more helpful

### DIFF
--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -403,7 +403,7 @@ func (c *Compiler) markAsyncFunctions() (needsScheduler bool, err error) {
 				parentHandle = f.LastParam()
 				if parentHandle.IsNil() || parentHandle.Name() != "parentHandle" {
 					// sanity check
-					panic("trying to make exported function async")
+					panic("trying to make exported function async: " + f.Name())
 				}
 			}
 


### PR DESCRIPTION
This is a workaround for an existing issue, to see which function is to blame.

It should be fixed in a better way, but this provides at least a hint where to look to debug this issue.