### PR TITLE
Make testdata/coroutines.go AVR compatible

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1045,9 +1045,9 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 		// interprocedural optimizations. For example, heap-to-stack
 		// transformations are not sound as goroutines can outlive their parent.
 		calleeType := calleeFn.LLVMFn.Type()
-		calleeValue := c.builder.CreateBitCast(calleeFn.LLVMFn, c.i8ptrType, "")
+		calleeValue := c.builder.CreatePtrToInt(calleeFn.LLVMFn, c.uintptrType, "")
 		calleeValue = c.createRuntimeCall("makeGoroutine", []llvm.Value{calleeValue}, "")
-		calleeValue = c.builder.CreateBitCast(calleeValue, calleeType, "")
+		calleeValue = c.builder.CreateIntToPtr(calleeValue, calleeType, "")
 
 		// Get all function parameters to pass to the goroutine.
 		var params []llvm.Value

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -47,7 +47,7 @@ func (t *coroutine) promise() *taskState {
 	return (*taskState)(t._promise(int32(unsafe.Alignof(taskState{})), false))
 }
 
-func makeGoroutine(*uint8) *uint8
+func makeGoroutine(uintptr) uintptr
 
 // Compiler stub to get the current goroutine. Calls to this function are
 // removed in the goroutine lowering pass.


### PR DESCRIPTION
The first commit allows testdata/coroutines.go to be compiled for AVR. It fails during optimizing due what appears to be a LLVM error (see commit message for details).

While looking into this, I found some errors that have been fixed in the second commit.