### PR TITLE
compiler: add support for 'go' on func values

### DIFF
--- a/compiler/func.go
+++ b/compiler/func.go
@@ -32,10 +32,15 @@ const (
 // funcImplementation picks an appropriate func value implementation for the
 // target.
 func (c *Compiler) funcImplementation() funcValueImplementation {
-	if c.GOARCH == "wasm" {
+	// Always pick the switch implementation, as it allows the use of blocking
+	// inside a function that is used as a func value.
+	switch c.selectScheduler() {
+	case "coroutines":
 		return funcValueSwitch
-	} else {
+	case "tasks":
 		return funcValueDoubleword
+	default:
+		panic("unknown scheduler type")
 	}
 }
 

--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -28,6 +28,19 @@ func main() {
 	var printer Printer
 	printer = &myPrinter{}
 	printer.Print()
+
+	sleepFuncValue(func(x int) {
+		time.Sleep(1 * time.Millisecond)
+		println("slept inside func pointer", x)
+	})
+	time.Sleep(1 * time.Millisecond)
+	n := 20
+	sleepFuncValue(func(x int) {
+		time.Sleep(1 * time.Millisecond)
+		println("slept inside closure, with value:", n, x)
+	})
+
+	time.Sleep(2 * time.Millisecond)
 }
 
 func sub() {
@@ -47,6 +60,10 @@ func delayedValue() int {
 	return 42
 }
 
+func sleepFuncValue(fn func(int)) {
+	go fn(8)
+}
+
 func nowait() {
 	println("non-blocking goroutine")
 }
@@ -55,7 +72,7 @@ type Printer interface {
 	Print()
 }
 
-type myPrinter struct{
+type myPrinter struct {
 }
 
 func (i *myPrinter) Print() {

--- a/testdata/coroutines.txt
+++ b/testdata/coroutines.txt
@@ -11,3 +11,5 @@ value produced after some time: 42
 non-blocking goroutine
 done with non-blocking goroutine
 async interface method call
+slept inside func pointer 8
+slept inside closure, with value: 20 8


### PR DESCRIPTION
This commit allows starting a new goroutine directly from a func value,
not just when the static callee is known.

This is necessary to support the whole time package, not just the
commonly used subset that was compiled with the SimpleDCE pass enabled.

---

This is the first commit of #466, splitting it off because it is useful in general and makes the PR somewhat smaller.