### PR TITLE
Fix linked lists in reflection

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -92,7 +92,7 @@ func (c *Compiler) makeStructTypeFields(typ *types.Struct) llvm.Value {
 	for i := 0; i < typ.NumFields(); i++ {
 		fieldGlobalValue := c.getZeroValue(runtimeStructField)
 		fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, c.getTypeCode(typ.Field(i).Type()), []uint32{0})
-		fieldName := c.makeGlobalBytes([]byte(typ.Field(i).Name()), "reflect/types.structFieldName")
+		fieldName := c.makeGlobalArray([]byte(typ.Field(i).Name()), "reflect/types.structFieldName", c.ctx.Int8Type())
 		fieldName.SetLinkage(llvm.PrivateLinkage)
 		fieldName.SetUnnamedAddr(true)
 		fieldName = llvm.ConstGEP(fieldName, []llvm.Value{
@@ -101,7 +101,7 @@ func (c *Compiler) makeStructTypeFields(typ *types.Struct) llvm.Value {
 		})
 		fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, fieldName, []uint32{1})
 		if typ.Tag(i) != "" {
-			fieldTag := c.makeGlobalBytes([]byte(typ.Tag(i)), "reflect/types.structFieldTag")
+			fieldTag := c.makeGlobalArray([]byte(typ.Tag(i)), "reflect/types.structFieldTag", c.ctx.Int8Type())
 			fieldTag = llvm.ConstGEP(fieldTag, []llvm.Value{
 				llvm.ConstInt(llvm.Int32Type(), 0, false),
 				llvm.ConstInt(llvm.Int32Type(), 0, false),

--- a/src/reflect/sidetables.go
+++ b/src/reflect/sidetables.go
@@ -5,10 +5,10 @@ import (
 )
 
 // This stores a varint for each named type. Named types are identified by their
-// name instead of by their type. The named types stored in this struct are the
-// simpler non-basic types: pointer, struct, and channel.
+// name instead of by their type. The named types stored in this struct are
+// non-basic types: pointer, struct, and channel.
 //go:extern reflect.namedNonBasicTypesSidetable
-var namedNonBasicTypesSidetable byte
+var namedNonBasicTypesSidetable uintptr
 
 //go:extern reflect.structTypesSidetable
 var structTypesSidetable byte

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -163,7 +163,7 @@ func (t Type) stripPrefix() Type {
 	if (t>>4)%2 != 0 {
 		// This is a named type. The data is stored in a sidetable.
 		namedTypeNum := t >> 5
-		n, _ := readVarint(unsafe.Pointer(uintptr(unsafe.Pointer(&namedNonBasicTypesSidetable)) + uintptr(namedTypeNum)))
+		n := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&namedNonBasicTypesSidetable)) + uintptr(namedTypeNum)*unsafe.Sizeof(uintptr(0))))
 		return Type(n)
 	}
 	// Not a named type, so the value is stored directly in the type code.

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -69,9 +69,14 @@ func (v Value) Kind() Kind {
 	return v.Type().Kind()
 }
 
+// IsNil returns whether the value is the nil value. It panics if the value Kind
+// is not a channel, map, pointer, function, slice, or interface.
 func (v Value) IsNil() bool {
 	switch v.Kind() {
 	case Chan, Map, Ptr:
+		if v.isIndirect() {
+			return *(*uintptr)(v.value) == 0
+		}
 		return v.value == nil
 	case Func:
 		if v.value == nil {
@@ -96,9 +101,14 @@ func (v Value) IsNil() bool {
 	}
 }
 
+// Pointer returns the underlying pointer of the given value for the following
+// types: chan, map, pointer, unsafe.Pointer, slice, func.
 func (v Value) Pointer() uintptr {
 	switch v.Kind() {
 	case Chan, Map, Ptr, UnsafePointer:
+		if v.isIndirect() {
+			return *(*uintptr)(v.value)
+		}
 		return uintptr(v.value)
 	case Slice:
 		slice := (*SliceHeader)(v.value)

--- a/testdata/reflect.go
+++ b/testdata/reflect.go
@@ -22,6 +22,10 @@ type (
 		buf  []byte
 		Buf  []byte
 	}
+	linkedList struct {
+		next *linkedList `description:"chain"`
+		foo  int
+	}
 )
 
 func main() {
@@ -103,6 +107,9 @@ func main() {
 			c int8
 		}{42, 321, 123},
 		mystruct{5, point{-5, 3}, struct{}{}, []byte{'G', 'o'}, []byte{'X'}},
+		&linkedList{
+			foo: 42,
+		},
 	} {
 		showValue(reflect.ValueOf(v), "")
 	}

--- a/testdata/reflect.txt
+++ b/testdata/reflect.txt
@@ -293,6 +293,22 @@ reflect type: struct
     indexing: 0
     reflect type: uint8 settable=true
       uint: 88
+reflect type: ptr
+  pointer: true struct
+  nil: false
+  reflect type: struct settable=true
+    struct: 2
+    field: 0 next
+    tag: description:"chain"
+    embedded: false
+    reflect type: ptr
+      pointer: false struct
+      nil: true
+    field: 1 foo
+    tag: 
+    embedded: false
+    reflect type: int
+      int: 42
 
 sizes:
 int8 1 8


### PR DESCRIPTION
Linked lists are usually implemented as follows:

    type linkedList struct {
        next *linkedList
        data int // whatever
    }

This caused a stack overflow while writing out the reflect run-time type
information. This has now been fixed by splitting the allocation of a
named type number from setting the underlying type in the sidetable.

---

Oh man, this bug took so long to fix! I somehow just couldn't grasp the problem well enough, causing me to work on it for a whole day...
This should fix the remaining issue in #466 that causes the build to fail there. (That doesn't mean that PR is mergeable, but should get CI green at least).