### PR TITLE
testing: Add Benchmark B struct stub

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -1,0 +1,10 @@
+package testing
+
+// B is a type passed to Benchmark functions to manage benchmark timing and to
+// specify the number of iterations to run.
+//
+// TODO: Implement benchmarks. This struct allows test files containing
+// benchmarks to compile and run, but will not run the benchmarks themselves.
+type B struct {
+	N int
+}

--- a/tests/tinygotest/main_test.go
+++ b/tests/tinygotest/main_test.go
@@ -14,3 +14,6 @@ func TestFail2(t *testing.T) {
 
 func TestPass(t *testing.T) {
 }
+
+func BenchmarkNotImplemented(b *testing.B) {
+}


### PR DESCRIPTION
This struct allows test files containing basic benchmarks to compile
and run, but will not run the benchmarks themselves.

For #491