### PR TITLE
compiler,runtime: fix new task-based scheduler

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -37,6 +37,7 @@ var functionsUsedInTransforms = []string{
 	"runtime.alloc",
 	"runtime.free",
 	"runtime.sleepTask",
+	"runtime.sleepCurrentTask",
 	"runtime.setTaskStatePtr",
 	"runtime.getTaskStatePtr",
 	"runtime.activateTask",

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -150,6 +150,10 @@ func (c *Compiler) lowerTasks() error {
 		zero := llvm.ConstInt(c.uintptrType, 0, false)
 		c.createRuntimeCall("startGoroutine", []llvm.Value{realMainWrapper, zero}, "")
 		c.createRuntimeCall("scheduler", nil, "")
+		sleep := c.mod.NamedFunction("time.Sleep")
+		if !sleep.IsNil() {
+			sleep.ReplaceAllUsesWith(c.mod.NamedFunction("runtime.sleepCurrentTask"))
+		}
 	} else {
 		// Program doesn't need a scheduler. Call main.main directly.
 		c.builder.SetInsertPointBefore(mainCall)

--- a/src/runtime/scheduler_tasks.go
+++ b/src/runtime/scheduler_tasks.go
@@ -98,6 +98,12 @@ func startGoroutine(fn, args uintptr) {
 
 //go:linkname sleep time.Sleep
 func sleep(d int64) {
+	sleepTicks(timeUnit(d / tickMicros))
+}
+
+// sleepCurrentTask suspends the current goroutine. This is a compiler
+// intrinsic. It replaces calls to time.Sleep when a scheduler is in use.
+func sleepCurrentTask(d int64) {
 	sleepTask(currentTask, d)
 	swapTask(currentTask, &schedulerState)
 }


### PR DESCRIPTION
A bug was introduced in the previous commit that led to miscompilations
in the time.Sleep function when the scheduler was disabled, because
time.Sleep (implemented in the runtime) tried to switch to the scheduler
stack.

This commit restores the binary size of most examples to what it was
before, but still reduces static RAM consumption (.bss) slightly. This
gives me some confidence that it does indeed fix the introduced bug.