### PR TITLE
tools: make tools python2 compatible

### DIFF
--- a/tools/gen-device-avr.py
+++ b/tools/gen-device-avr.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+
+from __future__ import print_function
 
 import sys
 import os

--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+
+from __future__ import print_function
 
 import sys
 import os


### PR DESCRIPTION
This allows the tools to be used for Python 2 and Python 3, and makes it easier to support Windows.

I have quickly verified that there should be no observable difference when using Python 2: all files generated for nrf and for avr are identical.