### PR TITLE
Updated SPI pins so that they are configurable, enabling multiple SPI sercoms for ATSAMD21

### DIFF
--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -122,7 +122,12 @@ const (
 
 // SPI on the Arduino Nano 33.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM1_SPI}
+	SPI0 = SPI{Bus: sam.SERCOM1_SPI,
+		SCK:   SPI0_SCK_PIN,
+		MOSI:  SPI0_MOSI_PIN,
+		MISO:  SPI0_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad0}
 )
 
 // I2S pins

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -111,7 +111,12 @@ const (
 
 // SPI on the Circuit Playground Express.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM3_SPI}
+	SPI0 = SPI{Bus: sam.SERCOM3_SPI,
+		SCK:   SPI0_SCK_PIN,
+		MOSI:  SPI0_MOSI_PIN,
+		MISO:  SPI0_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad0}
 )
 
 // I2S pins

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -85,7 +85,12 @@ const (
 
 // SPI on the Feather M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM4_SPI}
+	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
+		SCK:   SPI0_SCK_PIN,
+		MOSI:  SPI0_MOSI_PIN,
+		MISO:  SPI0_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad0}
 )
 
 // I2S pins

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -2,7 +2,9 @@
 
 package machine
 
-import "device/sam"
+import (
+	"device/sam"
+)
 
 // GPIO Pins
 const (
@@ -85,7 +87,30 @@ const (
 
 // SPI on the ItsyBitsy M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM4_SPI}
+	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
+		SCK:   SPI0_SCK_PIN,
+		MOSI:  SPI0_MOSI_PIN,
+		MISO:  SPI0_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad0}
+)
+
+// "Internal" SPI pins; SPI flash is attached to these on ItsyBitsy M0
+const (
+	SPI1_CS_PIN   = PA27
+	SPI1_SCK_PIN  = PB23
+	SPI1_MOSI_PIN = PB22
+	SPI1_MISO_PIN = PB03
+)
+
+// "Internal" SPI on Sercom 5
+var (
+	SPI1 = SPI{Bus: sam.SERCOM5_SPI,
+		SCK:   SPI1_SCK_PIN,
+		MOSI:  SPI1_MOSI_PIN,
+		MISO:  SPI1_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad1}
 )
 
 // I2S pins

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -62,7 +62,12 @@ const (
 
 // SPI on the Trinket M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM0_SPI}
+	SPI0 = SPI{Bus: sam.SERCOM0_SPI,
+		SCK:   SPI0_SCK_PIN,
+		MOSI:  SPI0_MOSI_PIN,
+		MISO:  SPI0_MISO_PIN,
+		DOpad: spiTXPad2SCK3,
+		DIpad: sercomRXPad0}
 )
 
 // I2C pins

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -871,7 +871,12 @@ func waitForSync() {
 
 // SPI
 type SPI struct {
-	Bus *sam.SERCOM_SPI_Type
+	Bus   *sam.SERCOM_SPI_Type
+	SCK   Pin
+	MOSI  Pin
+	MISO  Pin
+	DOpad int
+	DIpad int
 }
 
 // SPIConfig is used to store config info for SPI.
@@ -886,12 +891,13 @@ type SPIConfig struct {
 
 // Configure is intended to setup the SPI interface.
 func (spi SPI) Configure(config SPIConfig) {
-	config.SCK = SPI0_SCK_PIN
-	config.MOSI = SPI0_MOSI_PIN
-	config.MISO = SPI0_MISO_PIN
 
-	doPad := spiTXPad2SCK3
-	diPad := sercomRXPad0
+	config.SCK = spi.SCK
+	config.MOSI = spi.MOSI
+	config.MISO = spi.MISO
+
+	doPad := spi.DOpad
+	diPad := spi.DIpad
 
 	// set default frequency
 	if config.Frequency == 0 {


### PR DESCRIPTION
Currently this code assumes that a atsamd21 board has a single SPI sercom:

https://github.com/tinygo-org/tinygo/blob/7d5542dda73e8dda066b604870eac279cd644a7e/src/machine/machine_atsamd21.go#L889

This is problematic for 2 reasons:

1) Some boards are designed with a second sercom configured for SPI such as Itsy Bitsy M0 (for SPI flash on sercom 5) and Arduino Nano 33 IOT (for SPI connection to ESP32 on sercom 2)
    itsy bitsy: https://cdn-learn.adafruit.com/assets/assets/000/054/505/original/adafruit_products_schem.png?1527457190
    nano IOT: https://content.arduino.cc/assets/NANO33IoTV2.0_sch.pdf
 2) Even if boards don't have on-board peripherals attached as above, if the pins for unused sercoms are broken out on the board, users may wish to configure them for SPI

I'm not sure what that should like from an API perspective, but I went ahead added the pins to the SPI struct (similar to what is being done for I2C).  This should in theory allow users to configure extra SPI interfaces if they choose.

FYI I updated all of the ATSAMD21 boards but I do not have hardware for all of them to test.

This issue is related to https://github.com/tinygo-org/drivers/issues/45 for boards with integrated SPI flash