### PR TITLE
machine/atsamd21: correct order of params for USB CDC descriptor

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1403,12 +1403,8 @@ func handleUSB() {
 					handleEndpoint(i)
 				}
 				setEPINTFLAG(i, epFlags)
-			case usb_CDC_ENDPOINT_IN, usb_CDC_ENDPOINT_ACM:
-				// set bank ready
-				setEPSTATUSCLR(i, sam.USB_DEVICE_EPSTATUSCLR_BK1RDY)
-
-				// ack transfer complete
-				setEPINTFLAG(i, sam.USB_DEVICE_EPINTFLAG_TRCPT1)
+			case usb_CDC_ENDPOINT_ACM:
+				setEPINTFLAG(i, epFlags)
 			}
 		}
 	}
@@ -1803,9 +1799,9 @@ func sendConfiguration(setup usbSetup) {
 
 		dif := NewInterfaceDescriptor(usb_CDC_DATA_INTERFACE, 2, usb_CDC_DATA_INTERFACE_CLASS, 0, 0)
 
-		in := NewEndpointDescriptor((usb_CDC_ENDPOINT_OUT | usbEndpointOut), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
+		out := NewEndpointDescriptor((usb_CDC_ENDPOINT_OUT | usbEndpointOut), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
 
-		out := NewEndpointDescriptor((usb_CDC_ENDPOINT_IN | usbEndpointIn), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
+		in := NewEndpointDescriptor((usb_CDC_ENDPOINT_IN | usbEndpointIn), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
 
 		cdc := NewCDCDescriptor(iad,
 			cif,
@@ -1815,8 +1811,8 @@ func sendConfiguration(setup usbSetup) {
 			callManagement,
 			cifin,
 			dif,
-			in,
-			out)
+			out,
+			in)
 
 		sz := uint16(configDescriptorSize + cdcSize)
 		config := NewConfigDescriptor(sz, 2)

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -316,8 +316,8 @@ func NewCDCDescriptor(i IADDescriptor, c InterfaceDescriptor,
 	callm CMFunctionalDescriptor,
 	ci EndpointDescriptor,
 	di InterfaceDescriptor,
-	inp EndpointDescriptor,
-	outp EndpointDescriptor) CDCDescriptor {
+	outp EndpointDescriptor,
+	inp EndpointDescriptor) CDCDescriptor {
 	return CDCDescriptor{iad: i,
 		cif:                  c,
 		header:               h,
@@ -352,8 +352,8 @@ func (d CDCDescriptor) Bytes() []byte {
 	buf.Write(d.callManagement.Bytes())
 	buf.Write(d.cifin.Bytes())
 	buf.Write(d.dif.Bytes())
-	buf.Write(d.in.Bytes())
 	buf.Write(d.out.Bytes())
+	buf.Write(d.in.Bytes())
 	return buf.Bytes()
 }
 


### PR DESCRIPTION
This PR corrects order of params for USB CDC descriptor. It still works the same way, this just make it consistent. It also removes the interrupt handler for `usb_CDC_ENDPOINT_IN` as there is was no code that actually enables it.