### PR TITLE
add reflectlite minimal implementation

### DIFF
--- a/src/reflectlite/reflectlite.go
+++ b/src/reflectlite/reflectlite.go
@@ -1,0 +1,11 @@
+package reflectlite
+
+import "reflect"
+
+func Swapper(slice interface{}) func(i, j int) {
+	return reflect.Swapper(slice)
+}
+
+type Value = reflect.Value
+type Kind = reflect.Kind
+type ValueError = reflect.ValueError


### PR DESCRIPTION
This basically aliases functions in `internal/reflectlite` to `reflect`. This fixes the Go 1.13 import cycle issue with the `errors` package (#519).