### PR TITLE
machine/samd21: Implement reset processor 

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -73,7 +73,31 @@ func SVCall4(num uintptr, a1, a2, a3, a4 interface{}) uintptr
 const (
 	SCS_BASE  = 0xE000E000
 	NVIC_BASE = SCS_BASE + 0x0100
+	SCB_BASE  = SCS_BASE + 0x0D00
 )
+
+const (
+	SCB_AIRCR_VECTKEY_Pos     = 16
+	SCB_AIRCR_SYSRESETREQ_Pos = 2
+	SCB_AIRCR_SYSRESETREQ_Msk = 1 << SCB_AIRCR_SYSRESETREQ_Pos
+)
+
+// System Control Block (SCB)
+//
+// SCB_Type provides the definitions for the System Control Block Registers.
+type SCB_Type struct {
+	CPUID volatile.Register32    // CPUID Base Register
+	ICSR  volatile.Register32    // Interrupt Control and State Register
+	VTOR  volatile.Register32    // Vector Table Offset Register
+	AIRCR volatile.Register32    // Application Interrupt and Reset Control Register
+	SCR   volatile.Register32    // System Control Register
+	CCR   volatile.Register32    // Configuration Control Register
+	_     volatile.Register32    // RESERVED1;
+	SHP   [2]volatile.Register32 // System Handlers Priority Registers. [0] is RESERVED
+	SHCSR volatile.Register32    // System Handler Control and State Register
+}
+
+var SCB = (*SCB_Type)(unsafe.Pointer(uintptr(SCB_BASE)))
 
 // Nested Vectored Interrupt Controller (NVIC).
 //
@@ -133,4 +157,11 @@ func DisableInterrupts() uintptr {
 // nested.
 func EnableInterrupts(mask uintptr) {
 	Asm("cpsie if")
+}
+
+// SystemReset performs a hard system reset.
+func SystemReset() {
+	// SCB->AIRCR  = ((0x5FA << SCB_AIRCR_VECTKEY_Pos)      |
+	//              SCB_AIRCR_SYSRESETREQ_Msk);
+	SCB.AIRCR.Set((0x5FA << SCB_AIRCR_VECTKEY_Pos) | SCB_AIRCR_SYSRESETREQ_Msk)
 }

--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -164,4 +164,8 @@ func SystemReset() {
 	// SCB->AIRCR  = ((0x5FA << SCB_AIRCR_VECTKEY_Pos)      |
 	//              SCB_AIRCR_SYSRESETREQ_Msk);
 	SCB.AIRCR.Set((0x5FA << SCB_AIRCR_VECTKEY_Pos) | SCB_AIRCR_SYSRESETREQ_Msk)
+
+	for {
+		Asm("wfi")
+	}
 }

--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -8,6 +8,9 @@ package machine
 
 import "device/sam"
 
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0x07738135
+
 // GPIO Pins
 const (
 	RX0 Pin = PB23 // UART2 RX

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -4,6 +4,9 @@ package machine
 
 import "device/sam"
 
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0xf01669ef
+
 // GPIO Pins
 const (
 	D0  = PB09

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -4,6 +4,9 @@ package machine
 
 import "device/sam"
 
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0xf01669ef
+
 // GPIO Pins
 const (
 	D0  = PA11  // UART0 RX

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -6,6 +6,9 @@ import (
 	"device/sam"
 )
 
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0xf01669ef
+
 // GPIO Pins
 const (
 	D0  = PA11 // UART0 RX

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -4,6 +4,9 @@ package machine
 
 import "device/sam"
 
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0xf01669ef
+
 // GPIO Pins
 const (
 	D0  = PA08 // PWM available

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2081,7 +2081,7 @@ func ResetProcessor() {
 
 	// Perform magic reset into bootloader, as mentioned in
 	// https://github.com/arduino/ArduinoCore-samd/issues/197
-	*(*uint32)(unsafe.Pointer(uintptr(0x20007FFC))) = 0x07738135
+	*(*uint32)(unsafe.Pointer(uintptr(0x20007FFC))) = RESET_MAGIC_VALUE
 
 	arm.SystemReset()
 }


### PR DESCRIPTION
This PR is a draft for adding a software-based system reset to be able to flash new software on SAMD21 boards without pushing the reset button to start the bootloader.