### PR TITLE
docker: use Go 1.12 base Docker image for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# TinyGo base stage just installs LLVM 8 and the TinyGo compiler itself.
-FROM golang:latest AS tinygo-base
+# TinyGo base stage installs Go 1.12, LLVM 8 and the TinyGo compiler itself.
+FROM golang:1.12 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" >> /etc/apt/sources.list && \


### PR DESCRIPTION
This PR modifies the Dockerfile used for the `tinygo-dev` image to use the Go 1.12 base Docker image for compatibility.