### PR TITLE
tools/generator: correctly handle padding when it is 3 bytes long

### DIFF
--- a/tools/gen-device-svd.py
+++ b/tools/gen-device-svd.py
@@ -396,6 +396,8 @@ const (
                     out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='volatile.Register8'))
                 elif bytesNeeded == 2:
                     out.write('\t_padding{padNumber} {regType}\n'.format(padNumber=padNumber, regType='volatile.Register16'))
+                elif bytesNeeded == 3:
+                    out.write('\t_padding{padNumber} [3]{regType}\n'.format(padNumber=padNumber, regType='volatile.Register8'))
                 else:
                     numSkip = (register['address'] - address) // eSize
                     if numSkip == 1:


### PR DESCRIPTION
This PR corrects generation of the Go device wrappers from the SVD files for SAM processors, when the padding is of length 3.