### PR TITLE
machine/stm32f103xx: Add machine.Pin.Get method

### DIFF
--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -99,6 +99,14 @@ func (p Pin) Set(high bool) {
 	}
 }
 
+// Get returns the current value of a GPIO pin.
+func (p Pin) Get() bool {
+	port := p.getPort()
+	pin := uint8(p) % 16
+	val := port.IDR.Get() & (1 << pin)
+	return (val > 0)
+}
+
 // UART
 type UART struct {
 	Buffer *RingBuffer


### PR DESCRIPTION
I wanted to use a button and noticed that `Pin.Set()` is implemented for stm32f103xx but `Pin.Get()` not - maybe I'm missing something obvious but other `machine_*.go` include both so I figured it's the right way to add it.

I tested with a simple `for { led.Set(button.Get()); time.Sleep(time.Millisecond * 10) }` on my stm32f103xx board and it worked.