### PR TITLE
runtime: implement memcpy

### DIFF
--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -132,3 +132,9 @@ func libc_memset(ptr unsafe.Pointer, c byte, size uintptr) {
 func libc_memmove(dst, src unsafe.Pointer, size uintptr) {
 	memmove(dst, src, size)
 }
+
+// Implement memcpy for LLVM and compiler-rt.
+//go:export memcpy
+func libc_memcpy(dst, src unsafe.Pointer, size uintptr) {
+	memcpy(dst, src, size)
+}


### PR DESCRIPTION
A call to memcpy is sometimes created by the compiler, for example when compiling with `-opt=s` or `opt=2`.