### PR TITLE
nrf: improve SPI write-only speed, by making use of double buffering

### DIFF
--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build nrf sam stm32,!stm32f407
+// +build sam stm32,!stm32f407
 
 package machine
 


### PR DESCRIPTION
The SPI peripheral in the nrf chips support double buffering, which makes it possible to keep sending continuously. This change introduces double buffering on the nrf chips, which should improve SPI performance.

Tested on the pca10040 (nrf52832).

I'm not very happy with the code duplication but I didn't see a clean way to do it otherwise (suggestions welcome).

@conejoninja you may be interested in this: it should improve the performance of the hub75 driver.