### PR TITLE
machine/samd21: use PinMode for SPI SERCOM peripherals

### DIFF
--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -37,7 +37,7 @@ const (
 	A0 Pin = PA02 // ADC/AIN[0]
 	A1 Pin = PB02 // ADC/AIN[10]
 	A2 Pin = PA11 // ADC/AIN[19]
-	A3 Pin = PA10 // ADC/AIN[18]
+	A3 Pin = PA10 // ADC/AIN[18],
 	A4 Pin = PB08 // ADC/AIN[2], SCL:  SERCOM2/PAD[1]
 	A5 Pin = PB09 // ADC/AIN[3], SDA:  SERCOM2/PAD[1]
 	A6 Pin = PA09 // ADC/AIN[17]
@@ -118,19 +118,20 @@ var (
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  Pin = PB11 // SCK: SERCOM4/PAD[3]
-	SPI0_MOSI_PIN Pin = PB10 // MOSI: SERCOM4/PAD[2]
-	SPI0_MISO_PIN Pin = PA12 // MISO: SERCOM4/PAD[0]
+	SPI0_SCK_PIN  Pin = A2 // SCK: SERCOM0/PAD[3]
+	SPI0_MOSI_PIN Pin = A3 // MOSI: SERCOM0/PAD[2]
+	SPI0_MISO_PIN Pin = A6 // MISO: SERCOM0/PAD[1]
 )
 
 // SPI on the Arduino Nano 33.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM1_SPI,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+	SPI0 = SPI{Bus: sam.SERCOM0_SPI,
+		SCK:     SPI0_SCK_PIN,
+		MOSI:    SPI0_MOSI_PIN,
+		MISO:    SPI0_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad0,
+		PinMode: PinSERCOM}
 )
 
 // I2S pins

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -115,11 +115,12 @@ const (
 // SPI on the Circuit Playground Express.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM3_SPI,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+		SCK:     SPI0_SCK_PIN,
+		MOSI:    SPI0_MOSI_PIN,
+		MISO:    SPI0_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad0,
+		PinMode: PinSERCOMAlt}
 )
 
 // I2S pins

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -89,11 +89,12 @@ const (
 // SPI on the Feather M0.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+		SCK:     SPI0_SCK_PIN,
+		MOSI:    SPI0_MOSI_PIN,
+		MISO:    SPI0_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad0,
+		PinMode: PinSERCOMAlt}
 )
 
 // I2S pins

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -91,11 +91,12 @@ const (
 // SPI on the ItsyBitsy M0.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+		SCK:     SPI0_SCK_PIN,
+		MOSI:    SPI0_MOSI_PIN,
+		MISO:    SPI0_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad0,
+		PinMode: PinSERCOMAlt}
 )
 
 // "Internal" SPI pins; SPI flash is attached to these on ItsyBitsy M0
@@ -109,11 +110,12 @@ const (
 // "Internal" SPI on Sercom 5
 var (
 	SPI1 = SPI{Bus: sam.SERCOM5_SPI,
-		SCK:   SPI1_SCK_PIN,
-		MOSI:  SPI1_MOSI_PIN,
-		MISO:  SPI1_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad1}
+		SCK:     SPI1_SCK_PIN,
+		MOSI:    SPI1_MOSI_PIN,
+		MISO:    SPI1_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad1,
+		PinMode: PinSERCOMAlt}
 )
 
 // I2S pins

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -66,11 +66,12 @@ const (
 // SPI on the Trinket M0.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM0_SPI,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+		SCK:     SPI0_SCK_PIN,
+		MOSI:    SPI0_MOSI_PIN,
+		MISO:    SPI0_MISO_PIN,
+		DOpad:   spiTXPad2SCK3,
+		DIpad:   sercomRXPad0,
+		PinMode: PinSERCOMAlt}
 )
 
 // I2C pins

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -876,12 +876,13 @@ func waitForSync() {
 
 // SPI
 type SPI struct {
-	Bus   *sam.SERCOM_SPI_Type
-	SCK   Pin
-	MOSI  Pin
-	MISO  Pin
-	DOpad int
-	DIpad int
+	Bus     *sam.SERCOM_SPI_Type
+	SCK     Pin
+	MOSI    Pin
+	MISO    Pin
+	DOpad   int
+	DIpad   int
+	PinMode PinMode
 }
 
 // SPIConfig is used to store config info for SPI.
@@ -896,13 +897,14 @@ type SPIConfig struct {
 
 // Configure is intended to setup the SPI interface.
 func (spi SPI) Configure(config SPIConfig) {
-
 	config.SCK = spi.SCK
 	config.MOSI = spi.MOSI
 	config.MISO = spi.MISO
 
 	doPad := spi.DOpad
 	diPad := spi.DIpad
+
+	pinMode := spi.PinMode
 
 	// set default frequency
 	if config.Frequency == 0 {
@@ -915,9 +917,9 @@ func (spi SPI) Configure(config SPIConfig) {
 	}
 
 	// enable pins
-	config.SCK.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MOSI.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MISO.Configure(PinConfig{Mode: PinSERCOMAlt})
+	config.SCK.Configure(PinConfig{Mode: pinMode})
+	config.MOSI.Configure(PinConfig{Mode: pinMode})
+	config.MISO.Configure(PinConfig{Mode: pinMode})
 
 	// reset SERCOM
 	spi.Bus.CTRLA.SetBits(sam.SERCOM_SPI_CTRLA_SWRST)


### PR DESCRIPTION
This PR allows use of `PinMode` for SPI SERCOM peripherals to allow for more configuration options on boards like Arduino Nano33-IoT that have many predefined pin mappings.
