### PR TITLE
machine/stm32f103xx: allow board specific UART usage

### DIFF
--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -2,6 +2,8 @@
 
 package machine
 
+import "device/stm32"
+
 // https://wiki.stm32duino.com/index.php?title=File:Bluepillpinout.gif
 const (
 	PA0  = portA + 0
@@ -47,9 +49,27 @@ const (
 
 // UART pins
 const (
-	UART_TX_PIN = PA9
-	UART_RX_PIN = PA10
+	UART_TX_PIN     = PA9
+	UART_RX_PIN     = PA10
+	UART_ALT_TX_PIN = PB6
+	UART_ALT_RX_PIN = PB7
 )
+
+var (
+	// USART1 is the first hardware serial port on the STM32.
+	// Both UART0 and UART1 refer to USART1.
+	UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    stm32.USART1,
+		IRQVal: stm32.IRQ_USART1,
+	}
+	UART1 = &UART0
+)
+
+//go:export USART1_IRQHandler
+func handleUART1() {
+	UART1.Receive(byte((UART1.Bus.DR.Get() & 0xFF)))
+}
 
 // SPI pins
 const (


### PR DESCRIPTION
Motivation: The bluepill uses USART1 as UART0 but other boards like the STM32 Nucleo boards (and disco as well) use USART2 for USB virtual COM port.

In the future I would like to contribue support for a STM32 Nucleo board which is why I want this refactoring.

To avoid duplication of code the same pattern as in `machine_atsamd21.go` and e.g. `board_arduino_nano33.go` is applied where only UART-specific variables and interrupt handling code (due to the export) is moved to `board_*.go`.

Please let me know what you think, maybe @aykevl or @deadprogram, as I don't own a bluepill so I cannot test for regressions - in theory everything should continue to work transparently.