### PR TITLE
machine/stm32f103xx/nucleo-f103rb: add support for Nucleo F103RB STM32F1-based board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ smoketest:
 	tinygo build -size short -o test.elf -target=circuitplay-express examples/i2s
 	tinygo build -size short -o test.elf -target=gameboy-advance     examples/gba-display
 	tinygo build -size short -o test.elf -target=itsybitsy-m4        examples/blinky1
+	tinygo build -size short -o test.elf -target=nucleo-f103rb       examples/blinky1
 ifneq ($(AVR), 0)
 	tinygo build -size short -o test.elf -target=arduino             examples/blinky1
 	tinygo build -size short -o test.elf -target=digispark           examples/blinky1

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following 15 microcontroller boards are currently supported:
 * [Arduino Uno](https://store.arduino.cc/arduino-uno-rev3)
 * [BBC micro:bit](https://microbit.org/)
 * [ST Micro STM32F103XX "Bluepill"](http://wiki.stm32duino.com/index.php?title=Blue_Pill)
+* [ST Micro "Nucleo F103RB"](https://www.st.com/en/evaluation-tools/nucleo-f103rb.html)
 * [ST Micro STM32F407 "Discovery"](https://www.st.com/en/evaluation-tools/stm32f4discovery.html)
 * [Digispark](http://digistump.com/products/1)
 * [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF51-Dongle)

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -1,0 +1,124 @@
+// +build nucleof103rb
+
+package machine
+
+import "device/stm32"
+
+const (
+	PA0  = portA + 0
+	PA1  = portA + 1
+	PA2  = portA + 2
+	PA3  = portA + 3
+	PA4  = portA + 4
+	PA5  = portA + 5
+	PA6  = portA + 6
+	PA7  = portA + 7
+	PA8  = portA + 8
+	PA9  = portA + 9
+	PA10 = portA + 10
+	PA11 = portA + 11
+	PA12 = portA + 12
+	PA13 = portA + 13
+	PA14 = portA + 14
+	PA15 = portA + 15
+
+	PB0  = portB + 0
+	PB1  = portB + 1
+	PB2  = portB + 2
+	PB3  = portB + 3
+	PB4  = portB + 4
+	PB5  = portB + 5
+	PB6  = portB + 6
+	PB7  = portB + 7
+	PB8  = portB + 8
+	PB9  = portB + 9
+	PB10 = portB + 10
+	PB11 = portB + 11
+	PB12 = portB + 12
+	PB13 = portB + 13
+	PB14 = portB + 14
+	PB15 = portB + 15
+
+	PC0  = portC + 0
+	PC1  = portC + 1
+	PC2  = portC + 2
+	PC3  = portC + 3
+	PC4  = portC + 4
+	PC5  = portC + 5
+	PC6  = portC + 6
+	PC7  = portC + 7
+	PC8  = portC + 8
+	PC9  = portC + 9
+	PC10 = portC + 10
+	PC11 = portC + 11
+	PC12 = portC + 12
+	PC13 = portC + 13
+	PC14 = portC + 14
+	PC15 = portC + 15
+
+	PD0  = portD + 0
+	PD1  = portD + 1
+	PD2  = portD + 2
+	PD3  = portD + 3
+	PD4  = portD + 4
+	PD5  = portD + 5
+	PD6  = portD + 6
+	PD7  = portD + 7
+	PD8  = portD + 8
+	PD9  = portD + 9
+	PD10 = portD + 10
+	PD11 = portD + 11
+	PD12 = portD + 12
+	PD13 = portD + 13
+	PD14 = portD + 14
+	PD15 = portD + 15
+)
+
+const (
+	LED         = LED_BUILTIN
+	LED_BUILTIN = LED_GREEN
+	LED_GREEN   = PA5
+)
+
+const (
+	BUTTON      = BUTTON_USER
+	BUTTON_USER = PC13
+)
+
+// UART pins
+const (
+	UART_TX_PIN     = PA2
+	UART_RX_PIN     = PA3
+	UART_ALT_TX_PIN = PD5
+	UART_ALT_RX_PIN = PD6
+)
+
+var (
+	// USART2 is the hardware serial port connected to the onboard ST-LINK
+	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
+	// Both UART0 and UART1 refer to USART2.
+	UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    stm32.USART2,
+		IRQVal: stm32.IRQ_USART2,
+	}
+	UART2 = &UART0
+)
+
+//go:export USART2_IRQHandler
+func handleUART2() {
+	UART2.Receive(byte((UART2.Bus.DR.Get() & 0xFF)))
+}
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = PA5
+	SPI0_MISO_PIN = PA6
+	SPI0_MOSI_PIN = PA7
+)
+
+// I2C pins
+const (
+	SCL_PIN = PB6
+	SDA_PIN = PB7
+)

--- a/src/machine/board_stm32.go
+++ b/src/machine/board_stm32.go
@@ -1,4 +1,4 @@
-// +build bluepill stm32f4disco
+// +build bluepill nucleof103rb stm32f4disco
 
 package machine
 

--- a/targets/nucleo-f103rb.json
+++ b/targets/nucleo-f103rb.json
@@ -1,0 +1,18 @@
+{
+  "inherits": ["cortex-m"],
+  "llvm-target": "armv7m-none-eabi",
+  "build-tags": ["nucleof103rb", "stm32f103xx", "stm32"],
+  "cflags": [
+    "--target=armv7m-none-eabi",
+    "-Qunused-arguments"
+  ],
+  "ldflags": [
+    "-T", "targets/stm32f103rb.ld"
+  ],
+  "extra-files": [
+    "src/device/stm32/stm32f103xx.s"
+  ],
+  "flash": "openocd -f interface/stlink-v2-1.cfg -f target/stm32f1x.cfg -c 'program {hex} reset exit'",
+  "ocd-daemon": ["openocd", "-f", "interface/stlink-v2-1.cfg", "-f", "target/stm32f1x.cfg"],
+  "gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+}

--- a/targets/stm32f103rb.ld
+++ b/targets/stm32f103rb.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x08000000, LENGTH = 128K
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
Product: https://www.st.com/en/evaluation-tools/nucleo-f103rb.html

Compared to the already supported stm32f103xx "bluepill" board this:
- features 128 KiB flash memory size ("RB" suffix) instead of 64 KiB, see `targets/stm32f103rb.ld`
- has onboard ST-LINK/V2-1 programmer and debugger requiring different OpenOCD configuration file
- uses USART2 connected to ST-LINK/V2-1 debugger as virtual COM port over USB for `putchar()`
- has a user-accessible button besides the reset button

I own a NUCLEO-F103RB board and would love to see it supported by tinygo. I already ran a couple of tests on it:
- it can be flashed and initialized successfully with 72 MHz `HCLK`
- `blinky1`, `echo` and `button` examples work
- I2C works
- manually configured GPIO interrupts work

Do I need to supply anything else to get this contribution merged into tinygo? Maybe documentation somewhere? Do you like the target name `stm32f103rb-nucleo`?