### PR TITLE
compiler: ensure that any passed in target is valid

### DIFF
--- a/target.go
+++ b/target.go
@@ -206,7 +206,7 @@ func LoadTarget(target string) (*TargetSpec, error) {
 		// Load target from given triple, ignore GOOS/GOARCH environment
 		// variables.
 		tripleSplit := strings.Split(target, "-")
-		if len(tripleSplit) == 1 {
+		if len(tripleSplit) < 3 {
 			return nil, errors.New("expected a full LLVM target or a custom target in -target flag")
 		}
 		goos := tripleSplit[2]

--- a/target_test.go
+++ b/target_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestLoadTarget(t *testing.T) {
+	_, err := LoadTarget("arduino")
+	if err != nil {
+		t.Error("LoadTarget test failed:", err)
+	}
+
+	_, err = LoadTarget("notexist")
+	if err == nil {
+		t.Error("LoadTarget should have failed with non existing target")
+	}
+
+	if err.Error() != "expected a full LLVM target or a custom target in -target flag" {
+		t.Error("LoadTarget failed for wrong reason:", err)
+	}
+}


### PR DESCRIPTION
This PR corrects #506 by ensuring that any passed in target, if it does not point to a .json file, is a full LLVM triple.
