### PR TITLE
Fix bug in IR regarding type aliases

### DIFF
--- a/ir/ir.go
+++ b/ir/ir.go
@@ -178,6 +178,9 @@ func (p *Program) AddPackage(pkg *ssa.Package) {
 }
 
 func (p *Program) addFunction(ssaFn *ssa.Function) {
+	if _, ok := p.functionMap[ssaFn]; ok {
+		return
+	}
 	f := &Function{Function: ssaFn}
 	f.parsePragmas()
 	p.Functions = append(p.Functions, f)

--- a/testdata/alias.go
+++ b/testdata/alias.go
@@ -1,0 +1,38 @@
+package main
+
+type x struct{}
+
+func (x x) name() string {
+	return "x"
+}
+
+type y = x
+
+type a struct {
+	n int
+}
+
+func (a a) fruit() string {
+	return "apple"
+}
+
+type b = a
+
+type fruit interface {
+	fruit() string
+}
+
+type f = fruit
+
+func main() {
+	// test a basic alias
+	println(y{}.name())
+
+	// test using a type alias value as an interface
+	var v f = b{}
+	println(v.fruit())
+
+	// test comparing an alias interface with the referred-to type
+	println(a{} == b{})
+	println(a{2} == b{3})
+}

--- a/testdata/alias.txt
+++ b/testdata/alias.txt
@@ -1,0 +1,4 @@
+x
+apple
+true
+false


### PR DESCRIPTION
During SSA construction, we used to run into issues where we would unintentionally create two IR function wrappers for the same function, which then resulted in one getting discarded during SimpleDCE and one not getting discarded. However, in the process of discarding one, we removed the other from the lookup table and therefore got null when attempting to look up the function.

This PR also adds a regression test, which also tests other aspects of type aliases.