### PR TITLE
machine/gameboy-advance: allow TinyGo to directly output GBA files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ smoketest:
 	tinygo build -size short -o test.elf -target=stm32f4disco        examples/blinky1
 	tinygo build -size short -o test.elf -target=stm32f4disco        examples/blinky2
 	tinygo build -size short -o test.elf -target=circuitplay-express examples/i2s
-	tinygo build -size short -o test.elf -target=gameboy-advance     examples/gba-display
+	tinygo build -size short -o test.gba -target=gameboy-advance     examples/gba-display
 	tinygo build -size short -o test.elf -target=itsybitsy-m4        examples/blinky1
 	tinygo build -size short -o test.elf -target=nucleo-f103rb       examples/blinky1
 ifneq ($(AVR), 0)

--- a/main.go
+++ b/main.go
@@ -312,7 +312,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		}
 
 		// Get an Intel .hex file or .bin file from the .elf file.
-		if outext == ".hex" || outext == ".bin" {
+		if outext == ".hex" || outext == ".bin" || outext == ".gba" {
 			tmppath = filepath.Join(dir, "main"+outext)
 			err := Objcopy(executable, tmppath)
 			if err != nil {

--- a/objcopy.go
+++ b/objcopy.go
@@ -108,6 +108,10 @@ func Objcopy(infile, outfile string) error {
 
 	// Write to the file, in the correct format.
 	switch filepath.Ext(outfile) {
+	case ".gba":
+		// The address is not stored in a .gba file.
+		_, err := f.Write(data)
+		return err
 	case ".bin":
 		// The address is not stored in a .bin file (therefore you
 		// should use .hex files in most cases).


### PR DESCRIPTION
This PR allow TinyGo to directly output GBA files that are ready for flashing by performing internal objcopy.

For example:

```
tinygo build -o ~/main.gba -target gameboy-advance examples/gba-display
```