### PR TITLE
gitignore: ignore llvm-project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ src/device/sifive/*.s
 src/device/stm32/*.go
 src/device/stm32/*.s
 vendor
-llvm
 llvm-build
+llvm-project


### PR DESCRIPTION
It was ignored before when the directory was still just called llvm, but
now it isn't anymore. Fix that.