### PR TITLE
interp: add tests and implement runtime.sliceCopy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             - go-cache-v2-{{ checksum "go.mod" }}
       - llvm-source-linux
       - run: go install .
-      - run: go test -v ./transform .
+      - run: go test -v ./interp ./transform .
       - run: make gen-device -j4
       - run: make smoketest RISCV=0
       - save_cache:

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ build/tinygo:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -o build/tinygo -tags byollvm .
 
 test:
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -tags byollvm ./transform .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -tags byollvm ./interp ./transform .
 
 tinygo-test:
 	cd tests/tinygotest && tinygo test

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -187,11 +187,6 @@ func (c *Compiler) Module() llvm.Module {
 	return c.mod
 }
 
-// Return the LLVM target data object. Only valid after a successful compile.
-func (c *Compiler) TargetData() llvm.TargetData {
-	return c.targetData
-}
-
 // selectGC picks an appropriate GC strategy if none was provided.
 func (c *Compiler) selectGC() string {
 	if c.GC != "" {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -24,7 +24,7 @@ type Eval struct {
 
 // Run evaluates the function with the given name and then eliminates all
 // callers.
-func Run(mod llvm.Module, targetData llvm.TargetData, debug bool) error {
+func Run(mod llvm.Module, debug bool) error {
 	if debug {
 		println("\ncompile-time evaluation:")
 	}
@@ -32,7 +32,7 @@ func Run(mod llvm.Module, targetData llvm.TargetData, debug bool) error {
 	name := "runtime.initAll"
 	e := &Eval{
 		Mod:          mod,
-		TargetData:   targetData,
+		TargetData:   llvm.NewTargetData(mod.DataLayout()),
 		Debug:        debug,
 		dirtyGlobals: map[llvm.Value]struct{}{},
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1,0 +1,98 @@
+package interp
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"tinygo.org/x/go-llvm"
+)
+
+func TestInterp(t *testing.T) {
+	for _, name := range []string{
+		"basic",
+	} {
+		name := name // make tc local to this closure
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runTest(t, "testdata/"+name)
+		})
+	}
+}
+
+func runTest(t *testing.T, pathPrefix string) {
+	// Read the input IR.
+	ctx := llvm.NewContext()
+	buf, err := llvm.NewMemoryBufferFromFile(pathPrefix + ".ll")
+	os.Stat(pathPrefix + ".ll") // make sure this file is tracked by `go test` caching
+	if err != nil {
+		t.Fatalf("could not read file %s: %v", pathPrefix+".ll", err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatalf("could not load module:\n%v", err)
+	}
+
+	// Perform the transform.
+	err = Run(mod, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run some cleanup passes to get easy-to-read outputs.
+	pm := llvm.NewPassManager()
+	defer pm.Dispose()
+	pm.AddGlobalOptimizerPass()
+	pm.AddDeadStoreEliminationPass()
+	pm.Run(mod)
+
+	// Read the expected output IR.
+	out, err := ioutil.ReadFile(pathPrefix + ".out.ll")
+	if err != nil {
+		t.Fatalf("could not read output file %s: %v", pathPrefix+".out.ll", err)
+	}
+
+	// See whether the transform output matches with the expected output IR.
+	expected := string(out)
+	actual := mod.String()
+	if !fuzzyEqualIR(expected, actual) {
+		t.Logf("output does not match expected output:\n%s", actual)
+		t.Fail()
+	}
+}
+
+// fuzzyEqualIR returns true if the two LLVM IR strings passed in are roughly
+// equal. That means, only relevant lines are compared (excluding comments
+// etc.).
+func fuzzyEqualIR(s1, s2 string) bool {
+	lines1 := filterIrrelevantIRLines(strings.Split(s1, "\n"))
+	lines2 := filterIrrelevantIRLines(strings.Split(s2, "\n"))
+	if len(lines1) != len(lines2) {
+		return false
+	}
+	for i, line := range lines1 {
+		if line != lines2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// filterIrrelevantIRLines removes lines from the input slice of strings that
+// are not relevant in comparing IR. For example, empty lines and comments are
+// stripped out.
+func filterIrrelevantIRLines(lines []string) []string {
+	var out []string
+	for _, line := range lines {
+		if line == "" || line[0] == ';' {
+			continue
+		}
+		if strings.HasPrefix(line, "source_filename = ") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -12,6 +12,7 @@ import (
 func TestInterp(t *testing.T) {
 	for _, name := range []string{
 		"basic",
+		"slice-copy",
 	} {
 		name := name // make tc local to this closure
 		t.Run(name, func(t *testing.T) {

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -35,6 +35,8 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 		return &sideEffectResult{severity: sideEffectLimited}
 	case "runtime.interfaceImplements":
 		return &sideEffectResult{severity: sideEffectNone}
+	case "runtime.sliceCopy":
+		return &sideEffectResult{severity: sideEffectNone}
 	case "runtime.trackPointer":
 		return &sideEffectResult{severity: sideEffectNone}
 	case "llvm.dbg.value":

--- a/interp/testdata/basic.ll
+++ b/interp/testdata/basic.ll
@@ -1,0 +1,42 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@main.v1 = internal global i64 0
+
+declare void @runtime.printint64(i64) unnamed_addr
+
+declare void @runtime.printnl() unnamed_addr
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  call void @runtime.init()
+  call void @main.init()
+  ret void
+}
+
+define void @main() unnamed_addr {
+entry:
+  %0 = load i64, i64* @main.v1
+  call void @runtime.printint64(i64 %0)
+  call void @runtime.printnl()
+  ret void
+}
+
+define internal void @runtime.init() unnamed_addr {
+entry:
+  ret void
+}
+
+define internal void @main.init() unnamed_addr {
+entry:
+  store i64 3, i64* @main.v1
+  call void @"main.init#1"()
+  ret void
+}
+
+define internal void @"main.init#1"() unnamed_addr {
+entry:
+  call void @runtime.printint64(i64 5)
+  call void @runtime.printnl()
+  ret void
+}

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -1,0 +1,20 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+declare void @runtime.printint64(i64) unnamed_addr
+
+declare void @runtime.printnl() unnamed_addr
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  call void @runtime.printint64(i64 5)
+  call void @runtime.printnl()
+  ret void
+}
+
+define void @main() unnamed_addr {
+entry:
+  call void @runtime.printint64(i64 3)
+  call void @runtime.printnl()
+  ret void
+}

--- a/interp/testdata/slice-copy.ll
+++ b/interp/testdata/slice-copy.ll
@@ -1,0 +1,86 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@main.uint8SliceSrc.buf = internal global [2 x i8] c"\03d"
+@main.uint8SliceSrc = internal unnamed_addr global { i8*, i64, i64 } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* @main.uint8SliceSrc.buf, i32 0, i32 0), i64 2, i64 2 }
+@main.uint8SliceDst = internal unnamed_addr global { i8*, i64, i64 } zeroinitializer
+@main.int16SliceSrc.buf = internal global [3 x i16] [i16 5, i16 123, i16 1024]
+@main.int16SliceSrc = internal unnamed_addr global { i16*, i64, i64 } { i16* getelementptr inbounds ([3 x i16], [3 x i16]* @main.int16SliceSrc.buf, i32 0, i32 0), i64 3, i64 3 }
+@main.int16SliceDst = internal unnamed_addr global { i16*, i64, i64 } zeroinitializer
+
+declare i64 @runtime.sliceCopy(i8* %dst, i8* %src, i64 %dstLen, i64 %srcLen, i64 %elemSize) unnamed_addr
+
+declare i8* @runtime.alloc(i64) unnamed_addr
+
+declare void @runtime.printuint8(i8)
+
+declare void @runtime.printint16(i16)
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  call void @main.init()
+  ret void
+}
+
+define void @main() unnamed_addr {
+entry:
+  ; print(uintSliceSrc[0])
+  %uint8SliceSrc.buf = load i8*, i8** getelementptr inbounds ({ i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceSrc, i64 0, i32 0)
+  %uint8SliceSrc.val = load i8, i8* %uint8SliceSrc.buf
+  call void @runtime.printuint8(i8 %uint8SliceSrc.val)
+
+  ; print(uintSliceDst[0])
+  %uint8SliceDst.buf = load i8*, i8** getelementptr inbounds ({ i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceDst, i64 0, i32 0)
+  %uint8SliceDst.val = load i8, i8* %uint8SliceDst.buf
+  call void @runtime.printuint8(i8 %uint8SliceDst.val)
+
+  ; print(int16SliceSrc[0])
+  %int16SliceSrc.buf = load i16*, i16** getelementptr inbounds ({ i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceSrc, i64 0, i32 0)
+  %int16SliceSrc.val = load i16, i16* %int16SliceSrc.buf
+  call void @runtime.printint16(i16 %int16SliceSrc.val)
+
+  ; print(int16SliceDst[0])
+  %int16SliceDst.buf = load i16*, i16** getelementptr inbounds ({ i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceDst, i64 0, i32 0)
+  %int16SliceDst.val = load i16, i16* %int16SliceDst.buf
+  call void @runtime.printint16(i16 %int16SliceDst.val)
+  ret void
+}
+
+define internal void @main.init() unnamed_addr {
+entry:
+  ; equivalent of:
+  ;     uint8SliceDst = make([]uint8, len(uint8SliceSrc))
+  %uint8SliceSrc = load { i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceSrc
+  %uint8SliceSrc.len = extractvalue { i8*, i64, i64 } %uint8SliceSrc, 1
+  %uint8SliceDst.buf = call i8* @runtime.alloc(i64 %uint8SliceSrc.len)
+  %0 = insertvalue { i8*, i64, i64 } undef, i8* %uint8SliceDst.buf, 0
+  %1 = insertvalue { i8*, i64, i64 } %0, i64 %uint8SliceSrc.len, 1
+  %2 = insertvalue { i8*, i64, i64 } %1, i64 %uint8SliceSrc.len, 2
+  store { i8*, i64, i64 } %2, { i8*, i64, i64 }* @main.uint8SliceDst
+
+  ; equivalent of:
+  ;     copy(uint8SliceDst, uint8SliceSrc)
+  %uint8SliceSrc.buf = extractvalue { i8*, i64, i64 } %uint8SliceSrc, 0
+  %copy.n = call i64 @runtime.sliceCopy(i8* %uint8SliceDst.buf, i8* %uint8SliceSrc.buf, i64 %uint8SliceSrc.len, i64 %uint8SliceSrc.len, i64 1)
+
+  ; equivalent of:
+  ;     int16SliceDst = make([]int16, len(int16SliceSrc))
+  %int16SliceSrc = load { i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceSrc
+  %int16SliceSrc.len = extractvalue { i16*, i64, i64 } %int16SliceSrc, 1
+  %int16SliceSrc.len.bytes = mul i64 %int16SliceSrc.len, 2
+  %int16SliceDst.buf.raw = call i8* @runtime.alloc(i64 %int16SliceSrc.len.bytes)
+  %int16SliceDst.buf = bitcast i8* %int16SliceDst.buf.raw to i16*
+  %3 = insertvalue { i16*, i64, i64 } undef, i16* %int16SliceDst.buf, 0
+  %4 = insertvalue { i16*, i64, i64 } %3, i64 %int16SliceSrc.len, 1
+  %5 = insertvalue { i16*, i64, i64 } %4, i64 %int16SliceSrc.len, 2
+  store { i16*, i64, i64 } %5, { i16*, i64, i64 }* @main.int16SliceDst
+
+  ; equivalent of:
+  ;     copy(int16SliceDst, int16SliceSrc)
+  %int16SliceSrc.buf = extractvalue { i16*, i64, i64 } %int16SliceSrc, 0
+  %int16SliceSrc.buf.i8ptr = bitcast i16* %int16SliceSrc.buf to i8*
+  %int16SliceDst.buf.i8ptr = bitcast i16* %int16SliceDst.buf to i8*
+  %copy.n2 = call i64 @runtime.sliceCopy(i8* %int16SliceDst.buf.i8ptr, i8* %int16SliceSrc.buf.i8ptr, i64 %int16SliceSrc.len, i64 %int16SliceSrc.len, i64 2)
+
+  ret void
+}

--- a/interp/testdata/slice-copy.out.ll
+++ b/interp/testdata/slice-copy.out.ll
@@ -1,0 +1,20 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+declare void @runtime.printuint8(i8) local_unnamed_addr
+
+declare void @runtime.printint16(i16) local_unnamed_addr
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  ret void
+}
+
+define void @main() unnamed_addr {
+entry:
+  call void @runtime.printuint8(i8 3)
+  call void @runtime.printuint8(i8 3)
+  call void @runtime.printint16(i16 5)
+  call void @runtime.printint16(i16 5)
+  ret void
+}

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 		return errors.New("verification error after IR construction")
 	}
 
-	err = interp.Run(c.Module(), c.TargetData(), config.dumpSSA)
+	err = interp.Run(c.Module(), config.dumpSSA)
 	if err != nil {
 		return err
 	}

--- a/testdata/init.go
+++ b/testdata/init.go
@@ -13,6 +13,11 @@ func main() {
 	println("v5:", len(v5), v5 == nil)
 	println("v6:", v6)
 	println("v7:", cap(v7), string(v7))
+
+	println(uint8SliceSrc[0])
+	println(uint8SliceDst[0])
+	println(intSliceSrc[0])
+	println(intSliceDst[0])
 }
 
 type (
@@ -30,4 +35,17 @@ var (
 	v5 = map[string]int{}
 	v6 = float64(v1) < 2.6
 	v7 = []byte("foo")
+
+	uint8SliceSrc = []uint8{3, 100}
+	uint8SliceDst []uint8
+	intSliceSrc = []int16{5, 123, 1024}
+	intSliceDst []int16
 )
+
+func init() {
+	uint8SliceDst = make([]uint8, len(uint8SliceSrc))
+	copy(uint8SliceDst, uint8SliceSrc)
+
+	intSliceDst = make([]int16, len(intSliceSrc))
+	copy(intSliceDst, intSliceSrc)
+}

--- a/testdata/init.txt
+++ b/testdata/init.txt
@@ -7,3 +7,7 @@ v4: 0 true
 v5: 0 false
 v6: false
 v7: 3 foo
+3
+3
+5
+5


### PR DESCRIPTION
Two changes that depend on each other. I can split out the PR if that makes it easier to review.

* Add tests. Start out with a basic test to see whether interp roughly works.
* implement `runtime.sliceCopy` in the interp package. That function uses lots of pointer casting so it's hard to interpret it directly, therefore I implemented it directly in interp.

This change gets 3 packages to compile: encoding/base32, encoding/base64, and encoding/pem. With that, compiling encoding/json is one step closer.

Fixes #437.