### PR TITLE
Remove the troublesome interfaceHeader from reflect

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -318,7 +318,7 @@ func (t Type) Size() uintptr {
 	case Slice:
 		return unsafe.Sizeof(SliceHeader{})
 	case Interface:
-		return unsafe.Sizeof(interfaceHeader{})
+		return unsafe.Sizeof(interface{}(nil))
 	case Array:
 		return t.Elem().Size() * uintptr(t.Len())
 	case Struct:
@@ -364,7 +364,7 @@ func (t Type) Align() int {
 	case Slice:
 		return int(unsafe.Alignof(SliceHeader{}))
 	case Interface:
-		return int(unsafe.Alignof(interfaceHeader{}))
+		return int(unsafe.Alignof(interface{}(nil)))
 	case Struct:
 		numField := t.NumField()
 		alignment := 1

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -12,6 +12,16 @@ type _interface struct {
 	value    unsafe.Pointer
 }
 
+//go:inline
+func composeInterface(typecode uintptr, value unsafe.Pointer) _interface {
+	return _interface{typecode, value}
+}
+
+//go:inline
+func decomposeInterface(i _interface) (uintptr, unsafe.Pointer) {
+	return i.typecode, i.value
+}
+
 // Return true iff both interfaces are equal.
 func interfaceEqual(x, y _interface) bool {
 	if x.typecode != y.typecode {


### PR DESCRIPTION
So before we were running into issues related to GEP operations through bitcasts. This should hopefully resolve this. I completely removed interfaceHeader, replacing it with a pair of functions inside `runtime` called `compose` and `decompose`. The `compose` and `decompose` functions are set to be always inlined in order to minimize overhead.

More testing may be necessary to ensure that this really works in a decent manner.