### PR TITLE
Go 1.13 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,8 @@ commands:
       - run:
           name: "Install dependencies"
           command: |
-            curl https://dl.google.com/go/go1.12.5.darwin-amd64.tar.gz -o go1.12.5.darwin-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.12.5.darwin-amd64.tar.gz
+            curl https://dl.google.com/go/go1.13.darwin-amd64.tar.gz -o go1.13.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.13.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
             HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
       - restore_cache:
@@ -245,9 +245,14 @@ jobs:
       - image: circleci/golang:1.12-stretch
     steps:
       - test-linux
+  test-llvm8-go113:
+    docker:
+      - image: circleci/golang:1.13-stretch
+    steps:
+      - test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.13-stretch
     steps:
       - build-linux
   build-macos:
@@ -264,5 +269,6 @@ workflows:
     jobs:
       - test-llvm8-go111
       - test-llvm8-go112
+      - test-llvm8-go113
       - build-linux
       - build-macos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# TinyGo base stage installs Go 1.12, LLVM 8 and the TinyGo compiler itself.
-FROM golang:1.12 AS tinygo-base
+# TinyGo base stage installs Go 1.13, LLVM 8 and the TinyGo compiler itself.
+FROM golang:1.13 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" >> /etc/apt/sources.list && \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 clean:
 	@rm -rf build
 
-FMT_PATHS = ./*.go cgo compiler interp ir loader src/device/arm src/examples src/machine src/os src/reflect src/runtime src/sync src/syscall transform
+FMT_PATHS = ./*.go cgo compiler interp ir loader src/device/arm src/examples src/machine src/os src/reflect src/runtime src/sync src/syscall src/internal/reflectlite transform
 fmt:
 	@gofmt -l -w $(FMT_PATHS)
 fmt-check:
@@ -55,23 +55,23 @@ gen-device: gen-device-avr gen-device-nrf gen-device-sam gen-device-sifive gen-d
 gen-device-avr:
 	./tools/gen-device-avr.py lib/avr/packs/atmega src/device/avr/
 	./tools/gen-device-avr.py lib/avr/packs/tiny src/device/avr/
-	$(GO) fmt ./src/device/avr
+	GO111MODULE=off $(GO) fmt ./src/device/avr
 
 gen-device-nrf:
 	./tools/gen-device-svd.py lib/nrfx/mdk/ src/device/nrf/ --source=https://github.com/NordicSemiconductor/nrfx/tree/master/mdk
-	$(GO) fmt ./src/device/nrf
+	GO111MODULE=off $(GO) fmt ./src/device/nrf
 
 gen-device-sam:
 	./tools/gen-device-svd.py lib/cmsis-svd/data/Atmel/ src/device/sam/ --source=https://github.com/posborne/cmsis-svd/tree/master/data/Atmel
-	$(GO) fmt ./src/device/sam
+	GO111MODULE=off $(GO) fmt ./src/device/sam
 
 gen-device-sifive:
 	./tools/gen-device-svd.py lib/cmsis-svd/data/SiFive-Community/ src/device/sifive/ --source=https://github.com/AdaCore/svd2ada/tree/master/CMSIS-SVD/SiFive-Community
-	$(GO) fmt ./src/device/sifive
+	GO111MODULE=off $(GO) fmt ./src/device/sifive
 
 gen-device-stm32:
 	./tools/gen-device-svd.py lib/cmsis-svd/data/STMicro/ src/device/stm32/ --source=https://github.com/posborne/cmsis-svd/tree/master/data/STMicro
-	$(GO) fmt ./src/device/stm32
+	GO111MODULE=off $(GO) fmt ./src/device/stm32
 
 
 # Get LLVM sources.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -272,7 +272,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 				path = path[len(tinygoPath+"/src/"):]
 			}
 			switch path {
-			case "machine", "os", "reflect", "runtime", "runtime/volatile", "sync", "testing":
+			case "machine", "os", "reflect", "runtime", "runtime/volatile", "sync", "testing", "internal/reflectlite":
 				return path
 			default:
 				if strings.HasPrefix(path, "device/") || strings.HasPrefix(path, "examples/") {

--- a/compiler/reflect.go
+++ b/compiler/reflect.go
@@ -126,15 +126,8 @@ type typeCodeAssignmentState struct {
 // that is ever stored in an interface. It tries to use the smallest possible
 // numbers to make the code that works with interfaces as small as possible.
 func (c *Compiler) assignTypeCodes(typeSlice typeInfoSlice) {
-	fn := c.mod.NamedFunction("reflect.ValueOf")
-	if fn.IsNil() {
-		// reflect.ValueOf is never used, so we can use the most efficient
-		// encoding possible.
-		for i, t := range typeSlice {
-			t.num = uint64(i + 1)
-		}
-		return
-	}
+	// if reflect were not used, we could skip generating the sidetable
+	// this does not help in practice, and is difficult to do correctly
 
 	// Assign typecodes the way the reflect package expects.
 	state := typeCodeAssignmentState{

--- a/interp/values.go
+++ b/interp/values.go
@@ -99,7 +99,7 @@ func (v *LocalValue) GetElementPtr(indices []uint32) Value {
 		return &LocalValue{v.Eval, gep}
 	}
 	switch v.Underlying.Opcode() {
-	case llvm.GetElementPtr, llvm.IntToPtr:
+	case llvm.GetElementPtr, llvm.IntToPtr, llvm.BitCast:
 		int32Type := v.Underlying.Type().Context().Int32Type()
 		llvmIndices := getLLVMIndices(int32Type, indices)
 		return &LocalValue{v.Eval, llvm.ConstGEP(v.Underlying, llvmIndices)}

--- a/main.go
+++ b/main.go
@@ -90,8 +90,8 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	if err != nil {
 		return fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || (minor != 11 && minor != 12) {
-		return fmt.Errorf("requires go version 1.11 or 1.12, got go%d.%d", major, minor)
+	if major != 1 || (minor != 11 && minor != 12 && minor != 13) {
+		return fmt.Errorf("requires go version 1.11, 1.12, or 1.13, got go%d.%d", major, minor)
 	}
 	for i := 1; i <= minor; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))

--- a/src/internal/reflectlite/reflect.go
+++ b/src/internal/reflectlite/reflect.go
@@ -1,0 +1,51 @@
+package reflectlite
+
+import "reflect"
+
+func Swapper(slice interface{}) func(i, j int) {
+	return reflect.Swapper(slice)
+}
+
+type Kind = reflect.Kind
+type Type = reflect.Type
+type Value = reflect.Value
+
+const (
+	Invalid       Kind = reflect.Invalid
+	Bool          Kind = reflect.Bool
+	Int           Kind = reflect.Int
+	Int8          Kind = reflect.Int8
+	Int16         Kind = reflect.Int16
+	Int32         Kind = reflect.Int32
+	Int64         Kind = reflect.Int64
+	Uint          Kind = reflect.Uint
+	Uint8         Kind = reflect.Uint8
+	Uint16        Kind = reflect.Uint16
+	Uint32        Kind = reflect.Uint32
+	Uint64        Kind = reflect.Uint64
+	Uintptr       Kind = reflect.Uintptr
+	Float32       Kind = reflect.Float32
+	Float64       Kind = reflect.Float64
+	Complex64     Kind = reflect.Complex64
+	Complex128    Kind = reflect.Complex128
+	Array         Kind = reflect.Array
+	Chan          Kind = reflect.Chan
+	Func          Kind = reflect.Func
+	Interface     Kind = reflect.Interface
+	Map           Kind = reflect.Map
+	Ptr           Kind = reflect.Ptr
+	Slice         Kind = reflect.Slice
+	String        Kind = reflect.String
+	Struct        Kind = reflect.Struct
+	UnsafePointer Kind = reflect.UnsafePointer
+)
+
+func ValueOf(i interface{}) reflect.Value {
+	return reflect.ValueOf(i)
+}
+
+func TypeOf(i interface{}) reflect.Type {
+	return reflect.TypeOf(i)
+}
+
+type ValueError = reflect.ValueError

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -398,6 +398,13 @@ func (t Type) AssignableTo(u Type) bool {
 	return false
 }
 
+func (t Type) Implements(u Type) bool {
+	if t.Kind() != Interface {
+		panic("reflect: non-interface type passed to Type.Implements")
+	}
+	return u.AssignableTo(t)
+}
+
 // Comparable returns whether values of this type can be compared to each other.
 func (t Type) Comparable() bool {
 	switch t.Kind() {


### PR DESCRIPTION
This is a work-in-progress branch for implementing support for Go 1.13. Currently, the core problem with this request is the following line:

https://github.com/golang/go/blob/37f1dd97f7bbbc6a78bccc06cb49a4ae612d2657/src/errors/wrap.go#L92
```
var errorType = reflectlite.TypeOf((*error)(nil)).Elem()
```

At the moment, it appears that we incorrectly optimize `reflect.TypeOf((*error)(nil)).Kind()` to `uint16`. A `uint16` has no element type, therefore this triggers a panic during initialization of the `errors` package.