### PR TITLE
WIP machine: explicitly pass pin numbers to serial peripherals

### DIFF
--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -115,6 +115,7 @@ const (
 // SPI on the Circuit Playground Express.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM3_SPI,
+		SERCOM: 3,
 		SCK:     SPI0_SCK_PIN,
 		MOSI:    SPI0_MOSI_PIN,
 		MISO:    SPI0_MISO_PIN,

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -1,5 +1,17 @@
 package machine
 
+import (
+	"errors"
+)
+
+// These errors may be returned by SPI.Configure, I2C.Configure, or
+// UART.Configure. They indicate that one of the pins (input/output) are
+// incorrect.
+var (
+	ErrInvalidOutputPin = errors.New("machine: invalid output pin")
+	ErrInvalidInputPin  = errors.New("machine: invalid input pin")
+)
+
 type PinConfig struct {
 	Mode PinMode
 }

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -737,32 +737,18 @@ func (i2c I2C) readByte() byte {
 
 // SPI
 type SPI struct {
-	Bus   *sam.SERCOM_SPI_Type
-	SCK   Pin
-	MOSI  Pin
-	MISO  Pin
-	DOpad int
-	DIpad int
+	Bus *sam.SERCOM_SPI_Type
 }
 
 // SPIConfig is used to store config info for SPI.
 type SPIConfig struct {
 	Frequency uint32
-	SCK       Pin
-	MOSI      Pin
-	MISO      Pin
 	LSBFirst  bool
 	Mode      uint8
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) {
-	config.SCK = spi.SCK
-	config.MOSI = spi.MOSI
-	config.MISO = spi.MISO
-
-	doPad := spi.DOpad
-	diPad := spi.DIpad
+func (spi SPI) Configure(sck, mosi, miso Pin, config SPIConfig) error {
 
 	// set default frequency
 	if config.Frequency == 0 {
@@ -775,9 +761,9 @@ func (spi SPI) Configure(config SPIConfig) {
 	}
 
 	// enable pins
-	config.SCK.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MOSI.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MISO.Configure(PinConfig{Mode: PinSERCOMAlt})
+	sck.Configure(PinConfig{Mode: PinSERCOMAlt})
+	mosi.Configure(PinConfig{Mode: PinSERCOMAlt})
+	miso.Configure(PinConfig{Mode: PinSERCOMAlt})
 
 	// reset SERCOM
 	spi.Bus.CTRLA.SetBits(sam.SERCOM_SPI_CTRLA_SWRST)
@@ -830,6 +816,8 @@ func (spi SPI) Configure(config SPIConfig) {
 	spi.Bus.CTRLA.SetBits(sam.SERCOM_SPI_CTRLA_ENABLE)
 	for spi.Bus.SYNCBUSY.HasBits(sam.SERCOM_SPI_SYNCBUSY_ENABLE) {
 	}
+
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -30,15 +30,6 @@ func (i2c I2C) setPins(scl, sda Pin) {
 
 // SPI
 func (spi SPI) setPins(sck, mosi, miso Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if mosi == 0 {
-		mosi = SPI0_MOSI_PIN
-	}
-	if miso == 0 {
-		miso = SPI0_MISO_PIN
-	}
 	spi.Bus.PSELSCK.Set(uint32(sck))
 	spi.Bus.PSELMOSI.Set(uint32(mosi))
 	spi.Bus.PSELMISO.Set(uint32(miso))

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -31,15 +31,6 @@ func (i2c I2C) setPins(scl, sda Pin) {
 
 // SPI
 func (spi SPI) setPins(sck, mosi, miso Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if mosi == 0 {
-		mosi = SPI0_MOSI_PIN
-	}
-	if miso == 0 {
-		miso = SPI0_MISO_PIN
-	}
 	spi.Bus.PSEL.SCK.Set(uint32(sck))
 	spi.Bus.PSEL.MOSI.Set(uint32(mosi))
 	spi.Bus.PSEL.MISO.Set(uint32(miso))

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -35,15 +35,6 @@ func (i2c I2C) setPins(scl, sda Pin) {
 
 // SPI
 func (spi SPI) setPins(sck, mosi, miso Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if mosi == 0 {
-		mosi = SPI0_MOSI_PIN
-	}
-	if miso == 0 {
-		miso = SPI0_MISO_PIN
-	}
 	spi.Bus.PSEL.SCK.Set(uint32(sck))
 	spi.Bus.PSEL.MOSI.Set(uint32(mosi))
 	spi.Bus.PSEL.MISO.Set(uint32(miso))

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -196,9 +196,6 @@ var (
 // SPIConfig is used to store config info for SPI.
 type SPIConfig struct {
 	Frequency uint32
-	SCK       Pin
-	MOSI      Pin
-	MISO      Pin
 	LSBFirst  bool
 	Mode      uint8
 }
@@ -209,7 +206,7 @@ type SPIConfig struct {
 // - allow setting data size to 16 bits?
 // - allow setting direction in HW for additional optimization?
 // - hardware SS pin?
-func (spi SPI) Configure(config SPIConfig) {
+func (spi SPI) Configure(sck, mosi, miso Pin, config SPIConfig) {
 	// enable clock for SPI
 	stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_SPI1EN)
 
@@ -267,7 +264,7 @@ func (spi SPI) Configure(config SPIConfig) {
 	spi.Bus.CR1.Set(conf)
 
 	// init pins
-	spi.setPins(config.SCK, config.MOSI, config.MISO)
+	spi.setPins(sck, mosi, miso)
 
 	// enable SPI interface
 	spi.Bus.CR1.SetBits(stm32.SPI_CR1_SPE)
@@ -295,16 +292,6 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 }
 
 func (spi SPI) setPins(sck, mosi, miso Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if mosi == 0 {
-		mosi = SPI0_MOSI_PIN
-	}
-	if miso == 0 {
-		miso = SPI0_MISO_PIN
-	}
-
 	sck.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
 	mosi.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
 	miso.Configure(PinConfig{Mode: PinInputModeFloating})

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -6,8 +6,6 @@ import "errors"
 
 type UARTConfig struct {
 	BaudRate uint32
-	TX       Pin
-	RX       Pin
 }
 
 // To implement the UART interface for a board, you must declare a concrete type as follows:

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -26,7 +26,7 @@ func main() {
 }
 
 func init() {
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.UART0.Configure(machine.UART_TX_PIN, machine.UART_RX_PIN, machine.UARTConfig{})
 	initLFCLK()
 	initRTC()
 }


### PR DESCRIPTION
This is an attempt to change the API so that you would only need to pass pin numbers to serial peripherals (UART, SPI, I2C).

```go
func (UART) Configure(tx, rx Pin, config UARTConfig) error
func (SPI) Configure(sck, mosi, miso Pin, config SPIConfig) error
func (I2C) Configure(scl, sda Pin, config I2CConfig) error
```

This change has several benefits:

  1. It is far more flexible. All available pins per device can be used, instead of a few that are fixed in the machine package.
  2. It is much simpler to use: just pass the pin numbers. Especially on devices like SAMD, you don't need to worry about pin modes (sercom/sercom-alt), pad numbers, or whatever. The documentation can state what kind of pins are supported per SERCOM and you can just pick those.
  3. Pin number 0 can be used. Previously, if you actually wanted to use pin 0, it might be considered an unset pin and the default pin number might be used instead.
  4. Simulation is much easier. Instead of having to simulate the whole pin multiplexer, just use the given pin numbers.
  5. It is possible to get an error message back when you passed an invalid pin number.
  6. It's impossible to forget to set the correct pin by leaving it out of the config struct.

Of course, this is a breaking change so will have to be discussed more widely before applying.