### PR TITLE
machine/atsamd21: refactor SPI pin handling to only look at pin numbers

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -22,7 +22,7 @@ func (c *Compiler) emitLookupBoundsCheck(frame *Frame, arrayLen, index llvm.Valu
 	if index.Type().IntTypeWidth() < arrayLen.Type().IntTypeWidth() {
 		// Sometimes, the index can be e.g. an uint8 or int8, and we have to
 		// correctly extend that type.
-		if indexType.(*types.Basic).Info()&types.IsUnsigned == 0 {
+		if indexType.Underlying().(*types.Basic).Info()&types.IsUnsigned == 0 {
 			index = c.builder.CreateZExt(index, arrayLen.Type(), "")
 		} else {
 			index = c.builder.CreateSExt(index, arrayLen.Type(), "")

--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -125,13 +125,10 @@ const (
 
 // SPI on the Arduino Nano 33.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM0_SPI,
-		SCK:     SPI0_SCK_PIN,
-		MOSI:    SPI0_MOSI_PIN,
-		MISO:    SPI0_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad0,
-		PinMode: PinSERCOM}
+	SPI0 = SPI{
+		Bus:    sam.SERCOM0_SPI,
+		SERCOM: 0,
+	}
 )
 
 // I2S pins

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -114,13 +114,10 @@ const (
 
 // SPI on the Circuit Playground Express.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM3_SPI,
-		SCK:     SPI0_SCK_PIN,
-		MOSI:    SPI0_MOSI_PIN,
-		MISO:    SPI0_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad0,
-		PinMode: PinSERCOMAlt}
+	SPI0 = SPI{
+		Bus:    sam.SERCOM3_SPI,
+		SERCOM: 3,
+	}
 )
 
 // I2S pins

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -88,13 +88,10 @@ const (
 
 // SPI on the Feather M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
-		SCK:     SPI0_SCK_PIN,
-		MOSI:    SPI0_MOSI_PIN,
-		MISO:    SPI0_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad0,
-		PinMode: PinSERCOMAlt}
+	SPI0 = SPI{
+		Bus:    sam.SERCOM4_SPI,
+		SERCOM: 4,
+	}
 )
 
 // I2S pins

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -90,13 +90,10 @@ const (
 
 // SPI on the ItsyBitsy M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM4_SPI,
-		SCK:     SPI0_SCK_PIN,
-		MOSI:    SPI0_MOSI_PIN,
-		MISO:    SPI0_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad0,
-		PinMode: PinSERCOMAlt}
+	SPI0 = SPI{
+		Bus:    sam.SERCOM4_SPI,
+		SERCOM: 4,
+	}
 )
 
 // "Internal" SPI pins; SPI flash is attached to these on ItsyBitsy M0
@@ -109,13 +106,10 @@ const (
 
 // "Internal" SPI on Sercom 5
 var (
-	SPI1 = SPI{Bus: sam.SERCOM5_SPI,
-		SCK:     SPI1_SCK_PIN,
-		MOSI:    SPI1_MOSI_PIN,
-		MISO:    SPI1_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad1,
-		PinMode: PinSERCOMAlt}
+	SPI1 = SPI{
+		Bus:    sam.SERCOM5_SPI,
+		SERCOM: 5,
+	}
 )
 
 // I2S pins

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -65,13 +65,10 @@ const (
 
 // SPI on the Trinket M0.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM0_SPI,
-		SCK:     SPI0_SCK_PIN,
-		MOSI:    SPI0_MOSI_PIN,
-		MISO:    SPI0_MISO_PIN,
-		DOpad:   spiTXPad2SCK3,
-		DIpad:   sercomRXPad0,
-		PinMode: PinSERCOMAlt}
+	SPI0 = SPI{
+		Bus:    sam.SERCOM0_SPI,
+		SERCOM: 0,
+	}
 )
 
 // I2C pins

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -1,5 +1,12 @@
 package machine
 
+import "errors"
+
+var (
+	ErrInvalidInputPin  = errors.New("machine: invalid input pin")
+	ErrInvalidOutputPin = errors.New("machine: invalid output pin")
+)
+
 type PinConfig struct {
 	Mode PinMode
 }

--- a/testdata/slice.go
+++ b/testdata/slice.go
@@ -2,6 +2,13 @@ package main
 
 type MySlice [32]byte
 
+type myUint8 uint8
+
+// Indexing into slice with named type (regression test).
+var array = [4]int{
+	myUint8(2): 3,
+}
+
 func main() {
 	l := 5
 	foo := []int{1, 2, 4, 5}


### PR DESCRIPTION
Pin mode and pad numbers are automatically calculated from the pin numbers, returning an error if no pinout could be found.

Not yet properly tested. However, while doing some initial testing, I found that there was an inconsistency in the Nano 33 IoT pinout for SPI0: the MISO pin is `A6` or `PA09` which has SERCOM0/PAD1 while the `DIpad` was set to `sercomRXPad0` - thus SERCOM0/PAD0 (pin PA08). I don't know which of the two it is supposed to be and whether I didn't miss anything but I'm surprised this worked. @deadprogram can you take a look?

Also, are there espat examples for the Nano 33 IoT (or other SPI tests) that should work with little or no modification?

This is just the first step, my goal is to convert UART and I2C in the same way. And also see whether this is possible on the SAMD51.