### PR TITLE
machine/hifive1: complete support for GPIO Get() interface

### DIFF
--- a/src/machine/board_hifive1b.go
+++ b/src/machine/board_hifive1b.go
@@ -3,6 +3,29 @@
 package machine
 
 const (
+	D0  = P16
+	D1  = P17
+	D2  = P18
+	D3  = P19 // Green LED/PWM
+	D4  = P20 // PWM
+	D5  = P21 // Blue LED/PWM
+	D6  = P22 // Red LED/PWM
+	D7  = P16
+	D8  = NoPin // PWM?
+	D9  = P01
+	D10 = P02
+	D11 = P03
+	D12 = P04
+	D13 = P05
+	D14 = NoPin // not connected
+	D15 = P09   // does not seem to work?
+	D16 = P10   // PWM
+	D17 = P11   // PWM
+	D18 = P12   // SDA/PWM
+	D19 = P13   // SDL/PWM
+)
+
+const (
 	LED       = LED1
 	LED1      = LED_RED
 	LED2      = LED_GREEN

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -30,6 +30,13 @@ func (p Pin) Set(high bool) {
 	}
 }
 
+// Get returns the current value of a GPIO pin.
+func (p Pin) Get() bool {
+	val := sifive.GPIO0.VALUE.Get() & (1 << uint8(p))
+	println(sifive.GPIO0.VALUE.Get())
+	return (val > 0)
+}
+
 type UART struct {
 	Bus    *sifive.UART_Type
 	Buffer *RingBuffer

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -47,17 +47,17 @@ func init() {
 
 func pric_init() {
 	// Make sure the HFROSC is on
-	sifive.PRIC.HFROSCCFG.SetBits(sifive.PRIC_HFROSCCFG_ENABLE)
+	sifive.PRCI.HFROSCCFG.SetBits(sifive.PRCI_HFROSCCFG_ENABLE)
 
 	// Run off 16 MHz Crystal for accuracy.
-	sifive.PRIC.PLLCFG.SetBits(sifive.PRIC_PLLCFG_REFSEL | sifive.PRIC_PLLCFG_BYPASS)
-	sifive.PRIC.PLLCFG.SetBits(sifive.PRIC_PLLCFG_SEL)
+	sifive.PRCI.PLLCFG.SetBits(sifive.PRCI_PLLCFG_REFSEL | sifive.PRCI_PLLCFG_BYPASS)
+	sifive.PRCI.PLLCFG.SetBits(sifive.PRCI_PLLCFG_SEL)
 
 	// Turn off HFROSC to save power
-	sifive.PRIC.HFROSCCFG.ClearBits(sifive.PRIC_HFROSCCFG_ENABLE)
+	sifive.PRCI.HFROSCCFG.ClearBits(sifive.PRCI_HFROSCCFG_ENABLE)
 
 	// Enable the RTC.
-	sifive.RTC.CONFIG.Set(sifive.RTC_CONFIG_ENALWAYS)
+	sifive.RTC.RTCCFG.Set(sifive.RTC_RTCCFG_ENALWAYS)
 }
 
 func preinit() {
@@ -85,10 +85,10 @@ func putchar(c byte) {
 func ticks() timeUnit {
 	// Combining the low bits and the high bits yields a time span of over 270
 	// years without counter rollover.
-	highBits := sifive.RTC.HI.Get()
+	highBits := sifive.RTC.RTCHI.Get()
 	for {
-		lowBits := sifive.RTC.LO.Get()
-		newHighBits := sifive.RTC.HI.Get()
+		lowBits := sifive.RTC.RTCLO.Get()
+		newHighBits := sifive.RTC.RTCHI.Get()
 		if newHighBits == highBits {
 			// High bits stayed the same.
 			return timeUnit(lowBits) | (timeUnit(highBits) << 32)


### PR DESCRIPTION
This PR adds support for the HiFive1 GPIO Get() as well as preparing for several other upcoming additions.

It requires a newer version of the cmsis-svd with the e510x SVD file.

This PR needs #601 be merged fist, and then I will update the PR to remove that commit.