### PR TITLE
arduino: fix avr hex not working when flashed

### DIFF
--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -31,10 +31,10 @@ const (
 )
 
 //go:extern _sbss
-var _sbss unsafe.Pointer
+var _sbss [0]byte
 
 //go:extern _ebss
-var _ebss unsafe.Pointer
+var _ebss [0]byte
 
 //go:export main
 func main() {
@@ -49,8 +49,8 @@ func preinit() {
 	// Initialize .bss: zero-initialized global variables.
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
-		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		*(*uint8)(ptr) = 0
+		ptr = unsafe.Pointer(uintptr(ptr) + 1)
 	}
 }
 


### PR DESCRIPTION
An optimization introduced in

https://github.com/tinygo-org/tinygo/commit/a04db67ea9d882eed9164321bcb503f76a65d2f1

seems to have broken arduino uno compiled hex. Setting optimzation
flags to 1, 2, or s builds proper hex binaries though.

These patches have been the result of troubleshooting over slack:

> @aykevl 
> that preinit also doesn't look right. Can you try this variant, with 8-bit stores instead of 32-bit stores?
> There might be some alignment issue: the _ebss might not be aligned resulting in ptr != unsafe.Pointer(&_ebss) never being true.

Co-authored-by: Ayke van Laethem <aykevanlaethem@gmail.com>
Co-authored-by: Jaden Weiss <jadr2ddude@gmail.com>