### PR TITLE
do type fixups for calls so that linkname can be used across types

### DIFF
--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -38,6 +38,17 @@ func (c *Compiler) createCall(fn llvm.Value, args []llvm.Value, name string) llv
 		fragments := c.expandFormalParam(arg)
 		expanded = append(expanded, fragments...)
 	}
+	fnParams := fn.Type().ElementType().ParamTypes()
+	for i, param := range expanded {
+		srcT, dstT := param.Type(), fnParams[i]
+		if srcT != dstT {
+			var err error
+			expanded[i], err = c.deepCast(param, dstT)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
 	return c.builder.CreateCall(fn, expanded, name)
 }
 

--- a/testdata/compiler-pragmas.go
+++ b/testdata/compiler-pragmas.go
@@ -1,0 +1,41 @@
+package main
+
+import "unsafe"
+
+var global = 3
+
+//go:linkname foo foo
+func foo(ptr unsafe.Pointer) {
+	if ptr == unsafe.Pointer(&global) {
+		println("pointer matches")
+	} else {
+		println("pointer mismatch!")
+	}
+}
+
+//go:linkname foobar foo
+func foobar(ptr *int)
+
+//go:linkname testMultiReturn multiret
+func testMultiReturn(x int) (*int, *int) {
+	for i := 2; i < x; i++ {
+		if x%i == 0 {
+			x /= i
+			return &x, &i
+		}
+	}
+	one := 1
+	return &x, &one
+}
+
+//go:linkname testMultiReturnCast multiret
+func testMultiReturnCast(int) (unsafe.Pointer, unsafe.Pointer)
+
+func main() {
+	foo(nil)
+	foobar(&global)
+	a, b := testMultiReturn(7)
+	println(*a, *b)
+	x, y := testMultiReturnCast(6)
+	println(*(*int)(x), *(*int)(y))
+}

--- a/testdata/compiler-pragmas.txt
+++ b/testdata/compiler-pragmas.txt
@@ -1,0 +1,4 @@
+pointer mismatch!
+pointer matches
+7 1
+3 2


### PR DESCRIPTION
This took longer than expected to implement, prerequisite to #606 