### PR TITLE
machine/nrf: do not compare slices against nil

### DIFF
--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	ErrTxSlicesRequired   = errors.New("SPI Tx requires a write or read slice, or both")
 	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
 )
 
@@ -348,10 +347,6 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // 		spi.Tx(nil, rx)
 //
 func (spi SPI) Tx(w, r []byte) error {
-	if w == nil && r == nil {
-		return ErrTxSlicesRequired
-	}
-
 	var err error
 
 	switch {


### PR DESCRIPTION
Comparing slices against nil currently causes the slice to escape, due to a limitation in LLVM 8. This leads to lots of unnecessary heap allocations. With LLVM 9 and some modifications to TinyGo, this should be fixed. However, this commit is an easy win right now.

Returning an error when both slices are nil is not necessary, when the check is left out it should just do nothing.

For updating an SPI screen using the st7735 driver, this results in a ~7% performance win.