### PR TITLE
machine/spi: do not compare slices against nil, same as #612

### DIFF
--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -5,7 +5,6 @@ package machine
 import "errors"
 
 var (
-	ErrTxSlicesRequired   = errors.New("SPI Tx requires a write or read slice, or both")
 	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
 )
 
@@ -28,10 +27,6 @@ var (
 // 		spi.Tx(nil, rx)
 //
 func (spi SPI) Tx(w, r []byte) error {
-	if w == nil && r == nil {
-		return ErrTxSlicesRequired
-	}
-
 	var err error
 
 	switch {


### PR DESCRIPTION
This PR changes to not compare slices against nil, same as #612 but for all platforms that use shared SPI implementation for `Tx()`
