### PR TITLE
flash: allow flash operation on boards with UF2 and Daplink bootloaders

### DIFF
--- a/target.go
+++ b/target.go
@@ -26,27 +26,29 @@ var TINYGOROOT string
 // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/struct.TargetOptions.html
 // https://github.com/shepmaster/rust-arduino-blink-led-no-core-with-cargo/blob/master/blink/arduino.json
 type TargetSpec struct {
-	Inherits   []string `json:"inherits"`
-	Triple     string   `json:"llvm-target"`
-	CPU        string   `json:"cpu"`
-	Features   []string `json:"features"`
-	GOOS       string   `json:"goos"`
-	GOARCH     string   `json:"goarch"`
-	BuildTags  []string `json:"build-tags"`
-	GC         string   `json:"gc"`
-	Scheduler  string   `json:"scheduler"`
-	Compiler   string   `json:"compiler"`
-	Linker     string   `json:"linker"`
-	RTLib      string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
-	CFlags     []string `json:"cflags"`
-	LDFlags    []string `json:"ldflags"`
-	ExtraFiles []string `json:"extra-files"`
-	Emulator   []string `json:"emulator"`
-	Flasher    string   `json:"flash"`
-	OCDDaemon  []string `json:"ocd-daemon"`
-	GDB        string   `json:"gdb"`
-	GDBCmds    []string `json:"gdb-initial-cmds"`
-	PortReset  string   `json:"flash-1200-bps-reset"`
+	Inherits    []string `json:"inherits"`
+	Triple      string   `json:"llvm-target"`
+	CPU         string   `json:"cpu"`
+	Features    []string `json:"features"`
+	GOOS        string   `json:"goos"`
+	GOARCH      string   `json:"goarch"`
+	BuildTags   []string `json:"build-tags"`
+	GC          string   `json:"gc"`
+	Scheduler   string   `json:"scheduler"`
+	Compiler    string   `json:"compiler"`
+	Linker      string   `json:"linker"`
+	RTLib       string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
+	CFlags      []string `json:"cflags"`
+	LDFlags     []string `json:"ldflags"`
+	ExtraFiles  []string `json:"extra-files"`
+	Emulator    []string `json:"emulator"`
+	Flasher     string   `json:"flash"`
+	OCDDaemon   []string `json:"ocd-daemon"`
+	GDB         string   `json:"gdb"`
+	GDBCmds     []string `json:"gdb-initial-cmds"`
+	PortReset   string   `json:"flash-1200-bps-reset"`
+	FlashMethod string   `json:"flash-method"`
+	FlashVolume string   `json:"flash-msd-volume-name"`
 }
 
 // copyProperties copies all properties that are set in spec2 into itself.
@@ -103,6 +105,12 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	}
 	if spec2.PortReset != "" {
 		spec.PortReset = spec2.PortReset
+	}
+	if spec2.FlashMethod != "" {
+		spec.FlashMethod = spec2.FlashMethod
+	}
+	if spec2.FlashVolume != "" {
+		spec.FlashVolume = spec2.FlashVolume
 	}
 }
 
@@ -233,15 +241,16 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 	// No target spec available. Use the default one, useful on most systems
 	// with a regular OS.
 	spec := TargetSpec{
-		Triple:    triple,
-		GOOS:      goos,
-		GOARCH:    goarch,
-		BuildTags: []string{goos, goarch},
-		Compiler:  "clang",
-		Linker:    "cc",
-		GDB:       "gdb",
-		GDBCmds:   []string{"run"},
-		PortReset: "false",
+		Triple:      triple,
+		GOOS:        goos,
+		GOARCH:      goarch,
+		BuildTags:   []string{goos, goarch},
+		Compiler:    "clang",
+		Linker:      "cc",
+		GDB:         "gdb",
+		GDBCmds:     []string{"run"},
+		PortReset:   "false",
+		FlashMethod: "command",
 	}
 	if goos == "darwin" {
 		spec.LDFlags = append(spec.LDFlags, "-Wl,-dead_strip")

--- a/targets/circuitplay-express.json
+++ b/targets/circuitplay-express.json
@@ -1,5 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "circuitplay_express"],
-    "flash": "uf2conv.py {bin}"
+    "flash": "{uf2}",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "flash-msd-volume-name": "CPLAYBOOT"
 }

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -1,5 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "feather_m0"],
-    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
+    "flash": "{uf2}",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "flash-msd-volume-name": "FEATHERBOOT"
 }

--- a/targets/hifive1b.json
+++ b/targets/hifive1b.json
@@ -3,5 +3,8 @@
 	"build-tags": ["hifive1b"],
 	"ldflags": [
 		"-T", "targets/hifive1b.ld"
-	]
+	],
+	"flash": "{hex}",
+	"flash-method": "msd",
+    "flash-msd-volume-name": "HiFive"
 }

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -1,5 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "itsybitsy_m0"],
-    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
+    "flash": "{uf2}",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "flash-msd-volume-name": "ITSYBOOT"
 }

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -1,5 +1,8 @@
 {
     "inherits": ["atsamd51g19a"],
     "build-tags": ["sam", "atsamd51g19a", "itsybitsy_m4"],
-    "flash": "bossac -d -i -e -w -v -R --offset=0x4000 {bin}"
+    "flash": "{uf2}",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "flash-msd-volume-name": "ITSYM4BOOT"
 }

--- a/targets/microbit.json
+++ b/targets/microbit.json
@@ -3,5 +3,7 @@
 	"build-tags": ["microbit"],
 	"flash": "openocd -f interface/cmsis-dap.cfg -f target/nrf51.cfg -c 'program {hex} reset exit'",
 	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"],
+	"flash-method": "msd",
+	"flash-msd-volume-name": "MICROBIT"
 }

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -1,5 +1,8 @@
 {
     "inherits": ["atsamd21e18a"],
     "build-tags": ["sam", "atsamd21e18a", "trinket_m0"],
-    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {hex}"
+    "flash": "{uf2}",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "flash-msd-volume-name": "TRINKETBOOT"
 }


### PR DESCRIPTION
This PR adds the ability to use the `tinygo flash` command on boards with the UF2 bootloader such as all the boards used by Adafruit. It requires that PR #616 be merged first.

You then then just run a command like this to flash an Adafruit ItsyBitsy M4:

```
tinygo flash -target itsybitsy-m4 examples/blinky1
```