### PR TITLE
targets: refactor flash/gdb target configuration

### DIFF
--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "arduino_nano33"],
-    "flash": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
+    "flash-command": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -15,5 +15,5 @@
 		"targets/avr.S",
 		"src/device/avr/atmega328p.s"
 	],
-	"flash": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}"
+	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}"
 }

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -12,7 +12,7 @@
 	"extra-files": [
 		"src/device/stm32/stm32f103xx.s"
 	],
-	"flash": "openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c 'program {hex} reset exit'",
-	"ocd-daemon": ["openocd", "-f", "interface/stlink-v2.cfg", "-f", "target/stm32f1x.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-method": "openocd",
+	"openocd-interface": "stlink-v2",
+	"openocd-target": "stm32f1x"
 }

--- a/targets/circuitplay-express.json
+++ b/targets/circuitplay-express.json
@@ -1,8 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "circuitplay_express"],
-    "flash": "{uf2}",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "flash-msd-volume-name": "CPLAYBOOT"
+    "msd-volume-name": "CPLAYBOOT",
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -15,5 +15,5 @@
 		"targets/avr.S",
 		"src/device/avr/attiny85.s"
 	],
-	"flash": "micronucleus --run {hex}"
+	"flash-command": "micronucleus --run {hex}"
 }

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -1,8 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "feather_m0"],
-    "flash": "{uf2}",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "flash-msd-volume-name": "FEATHERBOOT"
+    "msd-volume-name": "FEATHERBOOT",
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/hifive1b.json
+++ b/targets/hifive1b.json
@@ -4,7 +4,7 @@
 	"ldflags": [
 		"-T", "targets/hifive1b.ld"
 	],
-	"flash": "{hex}",
 	"flash-method": "msd",
-    "flash-msd-volume-name": "HiFive"
+	"msd-volume-name": "HiFive",
+	"msd-firmware-name": "firmware.hex"
 }

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -1,8 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "itsybitsy_m0"],
-    "flash": "{uf2}",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "flash-msd-volume-name": "ITSYBOOT"
+    "msd-volume-name": "ITSYBOOT",
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -1,8 +1,8 @@
 {
     "inherits": ["atsamd51g19a"],
     "build-tags": ["sam", "atsamd51g19a", "itsybitsy_m4"],
-    "flash": "{uf2}",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "flash-msd-volume-name": "ITSYM4BOOT"
+    "msd-volume-name": "ITSYM4BOOT",
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/microbit.json
+++ b/targets/microbit.json
@@ -1,9 +1,8 @@
 {
 	"inherits": ["nrf51"],
 	"build-tags": ["microbit"],
-	"flash": "openocd -f interface/cmsis-dap.cfg -f target/nrf51.cfg -c 'program {hex} reset exit'",
-	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"],
 	"flash-method": "msd",
-	"flash-msd-volume-name": "MICROBIT"
+	"openocd-interface": "cmsis-dap",
+	"msd-volume-name": "MICROBIT",
+	"msd-firmware-name": "firmware.hex"
 }

--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -14,5 +14,6 @@
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf51.c",
 		"src/device/nrf/nrf51.s"
-	]
+	],
+	"openocd-target": "nrf51"
 }

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -15,5 +15,6 @@
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf52.c",
 		"src/device/nrf/nrf52.s"
-	]
+	],
+	"openocd-target": "nrf51"
 }

--- a/targets/nrf52840-mdk.json
+++ b/targets/nrf52840-mdk.json
@@ -1,7 +1,6 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["nrf52840_mdk"],
-	"flash": "openocd -f interface/cmsis-dap.cfg -f target/nrf51.cfg -c 'program {hex} reset exit'",
-	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-method": "openocd",
+	"openocd-interface": "cmsis-dap"
 }

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -15,5 +15,6 @@
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf52840.c",
 		"src/device/nrf/nrf52840.s"
-	]
+	],
+	"openocd-target": "nrf51"
 }

--- a/targets/nucleo-f103rb.json
+++ b/targets/nucleo-f103rb.json
@@ -12,7 +12,7 @@
   "extra-files": [
     "src/device/stm32/stm32f103xx.s"
   ],
-  "flash": "openocd -f interface/stlink-v2-1.cfg -f target/stm32f1x.cfg -c 'program {hex} reset exit'",
-  "ocd-daemon": ["openocd", "-f", "interface/stlink-v2-1.cfg", "-f", "target/stm32f1x.cfg"],
-  "gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+  "flash-method": "openocd",
+  "openocd-interface": "stlink-v2-1",
+  "openocd-target": "stm32f1x"
 }

--- a/targets/pca10031.json
+++ b/targets/pca10031.json
@@ -1,7 +1,6 @@
 {
 	"inherits": ["nrf51"],
 	"build-tags": ["pca10031"],
-	"flash": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
-	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-command": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
+	"openocd-interface": "cmsis-dap"
 }

--- a/targets/pca10040.json
+++ b/targets/pca10040.json
@@ -1,7 +1,8 @@
 {
 	"inherits": ["nrf52"],
 	"build-tags": ["pca10040"],
-	"flash": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
-	"ocd-daemon": ["openocd", "-f", "interface/jlink.cfg", "-c", "transport select swd", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-method": "openocd",
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
+	"openocd-interface": "jlink",
+	"openocd-transport": "swd"
 }

--- a/targets/pca10056.json
+++ b/targets/pca10056.json
@@ -1,7 +1,8 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["pca10056"],
-	"flash": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
-	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-method": "command",
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
+	"msd-volume-name": "JLINK",
+	"msd-firmware-name": "firmware.hex"
 }

--- a/targets/reelboard.json
+++ b/targets/reelboard.json
@@ -1,7 +1,8 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["reelboard"],
-	"flash": "openocd -f interface/cmsis-dap.cfg -f target/nrf51.cfg -c 'program {hex} reset exit'",
-	"ocd-daemon": ["openocd", "-f", "interface/cmsis-dap.cfg", "-f", "target/nrf51.cfg"],
-	"gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+	"flash-method": "msd",
+	"msd-volume-name": "reel-board",
+	"msd-firmware-name": "firmware.hex",
+	"openocd-interface": "cmsis-dap"
 }

--- a/targets/stm32f4disco.json
+++ b/targets/stm32f4disco.json
@@ -12,7 +12,7 @@
   "extra-files": [
     "src/device/stm32/stm32f407.s"
   ],
-  "flash": "openocd -f interface/stlink-v2.cfg -f target/stm32f4x.cfg -c 'program {hex} reset exit'",
-  "ocd-daemon": ["openocd", "-f", "interface/stlink.cfg", "-f", "target/stm32f4x.cfg"],
-  "gdb-initial-cmds": ["target remote :3333", "monitor halt", "load", "monitor reset", "c"]
+  "flash-method": "openocd",
+  "openocd-interface": "stlink-v2",
+  "openocd-target": "stm32f4x"
 }

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -1,8 +1,8 @@
 {
     "inherits": ["atsamd21e18a"],
     "build-tags": ["sam", "atsamd21e18a", "trinket_m0"],
-    "flash": "{uf2}",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "flash-msd-volume-name": "TRINKETBOOT"
+    "msd-volume-name": "TRINKETBOOT",
+    "msd-firmware-name": "firmware.uf2"
 }


### PR DESCRIPTION
Instead of specifying explicit commands, most of these commands have been replaced by more specific properties.

This is work that will be necessary for an eventual `-programmer` flag to the compiler, with which it is possible to select which programmer to use to flash or debug a chip. That's not very useful for boards that already include a programmer or bootloader for that purpose, but is very useful for novel boards or single-purpose boards that are not already included in TinyGo. It also avoids a lot of boilerplate and may allow custom .json descriptors in programs with only known-safe properties.

---

I have tested all the boards I could get my hands on:

* Arduino Uno
* Digispark
* pca10040
* pca10056: couldn't get the debugger to work and I suspect that configuration was wrong anyway, but flashing works fine.
* reelboard
* microbit
* bluepill
* circuitplay-express
* itsybitsy-m4
* hifive1b

@deadprogram can you test these boards, to be sure?
* pca10031
* feather-m0
* itsybitsy-m0
* trinket-m0

@Chillance can you test this board?
* nrf52840-mdk

@cmur2 can you test this board?
* nucleo-f103rb

@mickey-happygolucky can you test this board?
* stm32f4disco