### PR TITLE
properly handle nil New func in sync.Pool

### DIFF
--- a/src/sync/pool.go
+++ b/src/sync/pool.go
@@ -8,6 +8,9 @@ type Pool struct {
 
 // Get returns the value of calling Pool.New().
 func (p *Pool) Get() interface{} {
+	if p.New == nil {
+		return nil
+	}
 	return p.New()
 }
 


### PR DESCRIPTION
With `sync.Pool`, `New` is allowed to be nil so that applications can implement their own behavior. This patch makes tinygo's `sync.Pool` work properly when a `New` func is not specified.