### PR TITLE
fix miscompile of function nil panics

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -38,6 +38,7 @@ var functionsUsedInTransforms = []string{
 	"runtime.alloc",
 	"runtime.free",
 	"runtime.scheduler",
+	"runtime.nilPanic",
 }
 
 var taskFunctionsUsedInTransforms = []string{


### PR DESCRIPTION
Under some extreme circumstances, invoking a nil function resulted in a crash with an illegal instruction signal (SIGILL), rather than the intended nil panic.

This was a result of a sequence of events:
1. IR generated
2. tinygo runs IR through optimization passes, which changes the calling convention of `runtime.nilPanic` to `fastcc`
3. function lowering creates a call to `runtime.nilPanic` with the default calling convention
4. tinygo runs IR through optimization passes again, and LLVM notices the calling convention mismatch, replacing it with an `llvm.trap`
5. `llvm.trap` is invoked when running the code, which manifests itself as an illegal instruction

This PR marks `runtime.nilPanic` as used in transformations, which prevents removal or calling convention changes.

This fixes #623.