### PR TITLE
Change scheduler termination condition to return of main

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -38,6 +38,7 @@ const tinygoPath = "github.com/tinygo-org/tinygo"
 // during TinyGo optimization passes so they have to be marked as external
 // linkage until all TinyGo passes have finished.
 var functionsUsedInTransforms = []string{
+	"runtime.wrapMain",
 	"runtime.alloc",
 	"runtime.free",
 	"runtime.scheduler",

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -126,6 +126,8 @@ type asyncFunc struct {
 // coroutine or the tasks implementation of goroutines, and whether goroutines
 // are necessary at all.
 func (c *Compiler) LowerGoroutines() error {
+	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
+	c.mod.NamedFunction("runtime.mainFunc").ReplaceAllUsesWith(realMain)
 	switch c.Scheduler() {
 	case "coroutines":
 		return c.lowerCoroutines()
@@ -146,10 +148,11 @@ func (c *Compiler) lowerTasks() error {
 	mainCall := uses[0]
 
 	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
+	wrapMain := c.mod.NamedFunction("runtime.wrapMain")
 	if len(getUses(c.mod.NamedFunction("runtime.startGoroutine"))) != 0 || len(getUses(c.mod.NamedFunction("runtime.yield"))) != 0 {
 		// Program needs a scheduler. Start main.main as a goroutine and start
 		// the scheduler.
-		realMainWrapper := c.createGoroutineStartWrapper(realMain)
+		realMainWrapper := c.createGoroutineStartWrapper(wrapMain)
 		c.builder.SetInsertPointBefore(mainCall)
 		zero := llvm.ConstInt(c.uintptrType, 0, false)
 		c.createRuntimeCall("startGoroutine", []llvm.Value{realMainWrapper, zero}, "")
@@ -192,13 +195,16 @@ func (c *Compiler) lowerCoroutines() error {
 	// optionally followed by a call to runtime.scheduler().
 	c.builder.SetInsertPointBefore(mainCall)
 	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
-	var ph llvm.Value
+	wrapMain := c.mod.NamedFunction("runtime.wrapMain")
+	var ph, mainCallFn llvm.Value
 	if needsScheduler {
 		ph = c.createRuntimeCall("getFakeCoroutine", []llvm.Value{}, "")
+		mainCallFn = wrapMain
 	} else {
 		ph = llvm.Undef(c.i8ptrType)
+		mainCallFn = realMain
 	}
-	c.builder.CreateCall(realMain, []llvm.Value{llvm.Undef(c.i8ptrType), ph}, "")
+	c.builder.CreateCall(mainCallFn, []llvm.Value{llvm.Undef(c.i8ptrType), ph}, "")
 	if needsScheduler {
 		c.createRuntimeCall("scheduler", nil, "")
 	}

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -15,13 +15,26 @@ func initAll()
 //
 // Without scheduler:
 //
-//     main.main()
+//     mainFunc()
 //
 // With scheduler:
 //
-//     main.main()
+//     go wrapMain()
 //     scheduler()
 func callMain()
+
+// mainFunc is a temporary value that will be later replaced with the actual user-provided main function
+func mainFunc()
+
+// wrapMain is a wrapper which is used for invoking main.
+// When main completes, this allows the program to return.
+func wrapMain() {
+	// run main
+	mainFunc()
+
+	// when main is done, let the scheduler exit
+	schedulerDone = true
+}
 
 func GOMAXPROCS(n int) int {
 	// Note: setting GOMAXPROCS is ignored.

--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -47,10 +47,18 @@ func main() {
 		time.Sleep(2 * time.Millisecond)
 		x = 1
 	}()
-	time.Sleep(time.Second/2)
+	time.Sleep(time.Second / 2)
 	println("closure go call result:", x)
 
 	time.Sleep(2 * time.Millisecond)
+
+	// should not print anything, because we should exit as soon as we return
+	go delayedPrint()
+}
+
+func delayedPrint() {
+	time.Sleep(time.Second)
+	println("should have already exited")
 }
 
 func sub() {


### PR DESCRIPTION
Previously, the tinygo scheduler kept running until the run queue and sleep queue are both empty. This behavior has always been incorrect, but edge cases have not been frequently hit. **Once interrupts are added, we will no longer have such an easy method to determine whether there are goroutines that might resume.** Thus, we need to replace this termination condition.

The [Go spec](https://golang.org/ref/spec) section on _[Program execution](https://golang.org/ref/spec#Program_execution)_ states:
>Program execution begins by initializing the main package and then invoking the function main. When that function invocation returns, the program exits. It does not wait for other (non-main) goroutines to complete.

Thus, the correct termination condition would be the return of main. This PR creates a wrapper around main that signals the scheduler when main returns, and modifies the scheduler to return when it sees this signal.