### PR TITLE
Skip calling ticks when the sleep queue is empty

### DIFF
--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -226,10 +226,13 @@ func addSleepTask(t *task, duration int64) {
 // Run the scheduler until all tasks have finished.
 func scheduler() {
 	// Main scheduler loop.
+	var now timeUnit
 	for {
 		scheduleLog("")
 		scheduleLog("  schedule")
-		now := ticks()
+		if sleepQueue != nil {
+			now = ticks()
+		}
 
 		// Add tasks that are done sleeping to the end of the runqueue so they
 		// will be executed soon.


### PR DESCRIPTION
This was a micro-optimization I worked on when messing around with #513. I later put it in #606.

Basically:
1. When running scheduler-heavy code (in the original case a goroutine/channel benchmark), the scheduler gets bottlenecked by expensive calls to check the time on the system. This patch allows us to skip the check and get a [massive improvement in performance](https://twitter.com/CompuJad/status/1168357191230853120?s=20).
2. When a piece of code does not care about timing, `sleepQueue != nil` gets constant-folded to false and all of the timing code gets optimized away.