### PR TITLE
ci: avoid rebuilding LLVM on Azure (Windows)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,9 @@
+# Avoid lengthy LLVM rebuilds on each newly pushed branch. Pull requests will
+# be built anyway.
+trigger:
+- master
+- dev
+
 jobs:
 - job: Build
   timeoutInMinutes: 180


### PR DESCRIPTION
Note: waiting for CI to check that the PR is still being built...