### PR TITLE
Fix miscompile of static calls to closures

### DIFF
--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -41,6 +41,16 @@ func main() {
 	})
 
 	time.Sleep(2 * time.Millisecond)
+
+	var x int
+	go func() {
+		time.Sleep(2 * time.Millisecond)
+		x = 1
+	}()
+	time.Sleep(time.Second/2)
+	println("closure go call result:", x)
+
+	time.Sleep(2 * time.Millisecond)
 }
 
 func sub() {

--- a/testdata/coroutines.txt
+++ b/testdata/coroutines.txt
@@ -13,3 +13,4 @@ done with non-blocking goroutine
 async interface method call
 slept inside func pointer 8
 slept inside closure, with value: 20 8
+closure go call result: 1


### PR DESCRIPTION
This PR fixes #508

Previously, spawning a goroutine with a closure whose function is statically known would result in a call that did not pass in the closure context. This resulted in undefined behavior. After copying in the appropriate context extraction code, the function-lowering pass attempted to transform the `makeGoroutine` operation, which caused the code to compile but have an LLVM assertion failure. The relevant code in the function-lowering pass has been modified to ignore `makeGoroutine` calls.