### PR TITLE
Give readable names to subtests and run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,12 +44,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-8-v5
+            - llvm-source-8-v6
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-8-v5
+          key: llvm-source-8-v6
           paths:
             - llvm-project
   test-linux:
@@ -101,7 +101,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-8-linux-v7-assert
+            - llvm-build-8-linux-v9-assert
       - run:
           name: "Build LLVM"
           command: |
@@ -109,9 +109,9 @@ commands:
             then
               # install dependencies
               sudo apt-get install cmake clang ninja-build
-              # make build faster
-              export CC=clang
-              export CXX=clang++
+              # make build faster - disabled for now due to a bug
+              # export CC=clang
+              # export CXX=clang++
               # hack ninja to use less jobs
               echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
               chmod +x /go/bin/ninja
@@ -119,7 +119,7 @@ commands:
               make ASSERT=1 llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-linux-v7-assert
+          key: llvm-build-8-linux-v9-assert
           paths:
             llvm-build
       - run:
@@ -166,7 +166,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-8-linux-v7
+            - llvm-build-8-linux-v9
       - run:
           name: "Build LLVM"
           command: |
@@ -174,9 +174,9 @@ commands:
             then
               # install dependencies
               sudo apt-get install cmake clang ninja-build
-              # make build faster
-              export CC=clang
-              export CXX=clang++
+              # make build faster - disabled for now due to a bug
+              # export CC=clang
+              # export CXX=clang++
               # hack ninja to use less jobs
               echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
               chmod +x /go/bin/ninja
@@ -184,7 +184,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-linux-v7
+          key: llvm-build-8-linux-v9
           paths:
             llvm-build
       - run:
@@ -239,17 +239,17 @@ commands:
             - go-cache-macos-v2-{{ checksum "go.mod" }}
       - restore_cache:
           keys:
-            - llvm-source-8-macos-v5
+            - llvm-source-8-macos-v6
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-8-macos-v5
+          key: llvm-source-8-macos-v6
           paths:
             - llvm-project
       - restore_cache:
           keys:
-            - llvm-build-8-macos-v6
+            - llvm-build-8-macos-v7
       - run:
           name: "Build LLVM"
           command: |
@@ -261,7 +261,7 @@ commands:
               make llvm-build
             fi
       - save_cache:
-          key: llvm-build-8-macos-v6
+          key: llvm-build-8-macos-v7
           paths:
             llvm-build
       - run:

--- a/compiler/check.go
+++ b/compiler/check.go
@@ -21,7 +21,7 @@ func (c *Compiler) checkType(t llvm.Type, checked map[llvm.Type]struct{}, specia
 	switch {
 	case t.Context() == c.ctx:
 		// this is correct
-	case t.Context() == llvm.GlobalContext():
+	case t.Context() == globalCtx:
 		// somewhere we accidentally used the global context instead of a real context
 		return fmt.Errorf("type %q uses global context", t.String())
 	default:
@@ -148,7 +148,7 @@ func (c *Compiler) checkModule() error {
 	switch {
 	case c.mod.Context() == c.ctx:
 		// this is correct
-	case c.mod.Context() == llvm.GlobalContext():
+	case c.mod.Context() == globalCtx:
 		// somewhere we accidentally used the global context instead of a real context
 		return errors.New("module uses global context")
 	default:

--- a/compiler/check.go
+++ b/compiler/check.go
@@ -10,6 +10,8 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
+var globalCtx = llvm.GlobalContext()
+
 func (c *Compiler) checkType(t llvm.Type, checked map[llvm.Type]struct{}, specials map[llvm.TypeKind]llvm.Type) error {
 	// prevent infinite recursion for self-referential types
 	if _, ok := checked[t]; ok {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -182,6 +182,11 @@ func NewCompiler(pkgName string, config Config) (*Compiler, error) {
 	return c, nil
 }
 
+func (c *Compiler) Dispose() {
+	c.mod.Dispose()
+	c.ctx.Dispose()
+}
+
 func (c *Compiler) Packages() []*loader.Package {
 	return c.ir.LoaderProgram.Sorted()
 }
@@ -439,14 +444,14 @@ func (c *Compiler) Compile(mainPath string) []error {
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
 				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(), // Error on mismatch
-				llvm.GlobalContext().MDString("Debug Info Version"),
+				c.ctx.MDString("Debug Info Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 3, false).ConstantAsMetadata(), // DWARF version
 			}),
 		)
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
 				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(),
-				llvm.GlobalContext().MDString("Dwarf Version"),
+				c.ctx.MDString("Dwarf Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 4, false).ConstantAsMetadata(),
 			}),
 		)

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -104,8 +104,8 @@ func (c *Compiler) makeStructTypeFields(typ *types.Struct) llvm.Value {
 		fieldName.SetLinkage(llvm.PrivateLinkage)
 		fieldName.SetUnnamedAddr(true)
 		fieldName = llvm.ConstGEP(fieldName, []llvm.Value{
-			llvm.ConstInt(llvm.Int32Type(), 0, false),
-			llvm.ConstInt(llvm.Int32Type(), 0, false),
+			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 		})
 		fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, fieldName, []uint32{1})
 		if typ.Tag(i) != "" {
@@ -113,8 +113,8 @@ func (c *Compiler) makeStructTypeFields(typ *types.Struct) llvm.Value {
 			fieldTag.SetLinkage(llvm.PrivateLinkage)
 			fieldTag.SetUnnamedAddr(true)
 			fieldTag = llvm.ConstGEP(fieldTag, []llvm.Value{
-				llvm.ConstInt(llvm.Int32Type(), 0, false),
-				llvm.ConstInt(llvm.Int32Type(), 0, false),
+				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 			})
 			fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, fieldTag, []uint32{2})
 		}

--- a/linker-builtin.go
+++ b/linker-builtin.go
@@ -5,11 +5,11 @@ package main
 // This file provides a Link() function that uses the bundled lld if possible.
 
 import (
-	"errors"
+	//"errors"
 	"os"
 	"os/exec"
 	"sync"
-	"unsafe"
+	//"unsafe"
 
 	"github.com/tinygo-org/tinygo/goenv"
 )
@@ -29,7 +29,7 @@ var linkerLock sync.Mutex
 //
 // This version uses the built-in linker when trying to use lld.
 func Link(linker string, flags ...string) error {
-	linkerLock.Lock()
+	/*linkerLock.Lock()
 	defer linkerLock.Unlock()
 	switch linker {
 	case "ld.lld":
@@ -63,15 +63,15 @@ func Link(linker string, flags ...string) error {
 			return errors.New("failed to link using built-in wasm-ld")
 		}
 		return nil
-	default:
-		// Fall back to external command.
-		if cmdNames, ok := commands[linker]; ok {
-			return execCommand(cmdNames, flags...)
-		}
-		cmd := exec.Command(linker, flags...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Dir = goenv.Get("TINYGOROOT")
-		return cmd.Run()
+	default:*/
+	// Fall back to external command.
+	if cmdNames, ok := commands[linker]; ok {
+		return execCommand(cmdNames, flags...)
 	}
+	cmd := exec.Command(linker, flags...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = goenv.Get("TINYGOROOT")
+	return cmd.Run()
+	//}
 }

--- a/linker-builtin.go
+++ b/linker-builtin.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"sync"
 	"unsafe"
 
 	"github.com/tinygo-org/tinygo/goenv"
@@ -21,10 +22,15 @@ bool tinygo_link_wasm(int argc, char **argv);
 */
 import "C"
 
+// I don't think that LLD is thread-safe.
+var linkerLock sync.Mutex
+
 // Link invokes a linker with the given name and flags.
 //
 // This version uses the built-in linker when trying to use lld.
 func Link(linker string, flags ...string) error {
+	linkerLock.Lock()
+	defer linkerLock.Unlock()
 	switch linker {
 	case "ld.lld":
 		flags = append([]string{"tinygo:" + linker}, flags...)

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func Compile(pkgName, outpath string, spec *TargetSpec, config *BuildConfig, act
 	if err != nil {
 		return err
 	}
+	defer c.Dispose()
 
 	// Compile Go code to IR.
 	errs := c.Compile(pkgName)


### PR DESCRIPTION
This patch restructures the tests a bit so that the names of the subtests indicate the platform that they were run on. Additionally, the tests are now run in parallel. On my machine, this reduced the time needed to run the tests from 81 seconds to 28 seconds.