### PR TITLE
machine/atmega: add PORT C GPIO support

### DIFF
--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -12,14 +12,18 @@ func (p Pin) Configure(config PinConfig) {
 	if config.Mode == PinOutput { // set output bit
 		if p < 8 {
 			avr.DDRD.SetBits(1 << uint8(p))
-		} else {
+		} else if p < 14 {
 			avr.DDRB.SetBits(1 << uint8(p-8))
+		} else {
+			avr.DDRC.SetBits(1 << uint8(p-14))
 		}
 	} else { // configure input: clear output bit
 		if p < 8 {
 			avr.DDRD.ClearBits(1 << uint8(p))
-		} else {
+		} else if p < 14 {
 			avr.DDRB.ClearBits(1 << uint8(p-8))
+		} else {
+			avr.DDRC.ClearBits(1 << uint8(p-14))
 		}
 	}
 }
@@ -29,8 +33,11 @@ func (p Pin) Get() bool {
 	if p < 8 {
 		val := avr.PIND.Get() & (1 << uint8(p))
 		return (val > 0)
-	} else {
+	} else if p < 14 {
 		val := avr.PINB.Get() & (1 << uint8(p-8))
+		return (val > 0)
+	} else {
+		val := avr.PINC.Get() & (1 << uint8(p-14))
 		return (val > 0)
 	}
 }
@@ -38,8 +45,10 @@ func (p Pin) Get() bool {
 func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 	if p < 8 {
 		return avr.PORTD, 1 << uint8(p)
-	} else {
+	} else if p < 14 {
 		return avr.PORTB, 1 << uint8(p-8)
+	} else {
+		return avr.PORTC, 1 << uint8(p-14)
 	}
 }
 


### PR DESCRIPTION
This pull request is for Arduino Uno. This patch enables the A0-A5 pins to be used as GPIO 14-19.