### PR TITLE
device/arm: add system timer registers

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -168,7 +168,6 @@ const (
 	SYST_CALIB_NOREF     = 0x80000000 // Bit NOREF.
 )
 
-
 // Enable the given interrupt number.
 func EnableIRQ(irq uint32) {
 	NVIC.ISER[irq>>5].Set(1 << (irq & 0x1F))
@@ -220,7 +219,6 @@ func SystemReset() {
 	}
 }
 
-
 func SetupSystemTimer(cycle_count uint32) error {
 	// turn it off
 	SYST.SYST_CSR.ClearBits(SYST_CSR_TICKINT | SYST_CSR_ENABLE)
@@ -228,7 +226,7 @@ func SetupSystemTimer(cycle_count uint32) error {
 		// leave the system timer turned off.
 		return nil
 	}
-	if cycle_count & SYST_RVR_RELOAD_Msk != cycle_count {
+	if cycle_count&SYST_RVR_RELOAD_Msk != cycle_count {
 		// The cycle refresh register is only 24 bits wide.  The user-specified value will overflow.
 		return errors.New("requested cycle count is too large, overflows 24 bit counter")
 	}

--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -219,22 +219,26 @@ func SystemReset() {
 	}
 }
 
-func SetupSystemTimer(cycle_count uint32) error {
+// Set up the system timer to generate periodic tick events.
+// This will cause SysTick_Handler to fire once per tick.
+// The cyclecount parameter is a counter value which can range from 0 to
+// 0xffffff.  A value of 0 disables the timer.
+func SetupSystemTimer(cyclecount uint32) error {
 	// turn it off
 	SYST.SYST_CSR.ClearBits(SYST_CSR_TICKINT | SYST_CSR_ENABLE)
-	if cycle_count == 0 {
+	if cyclecount == 0 {
 		// leave the system timer turned off.
 		return nil
 	}
-	if cycle_count&SYST_RVR_RELOAD_Msk != cycle_count {
+	if cyclecount&SYST_RVR_RELOAD_Msk != cyclecount {
 		// The cycle refresh register is only 24 bits wide.  The user-specified value will overflow.
 		return errors.New("requested cycle count is too large, overflows 24 bit counter")
 	}
 
 	// set refresh count
-	SYST.SYST_RVR.Set(cycle_count)
+	SYST.SYST_RVR.Set(cyclecount)
 	// set current counter value
-	SYST.SYST_CVR.Set(cycle_count)
+	SYST.SYST_CVR.Set(cyclecount)
 	// enable clock, enable SysTick interrupt when clock reaches 0, run it off of the processor clock
 	SYST.SYST_CSR.SetBits(SYST_CSR_TICKINT | SYST_CSR_ENABLE | SYST_CSR_CLKSOURCE)
 	return nil

--- a/src/examples/systick/README.md
+++ b/src/examples/systick/README.md
@@ -1,0 +1,12 @@
+# TinyGo ARM SysTick example
+
+This example uses the ARM System Timer to blink an LED.  The timer fires
+an interrupt 10 times per second.  The interrupt handler toggles the LED on
+and off.
+
+Many ARM-based chips have this timer feature.  If you run the example and the
+LED blinks, then you have one.
+
+The System Timer runs from a cycle counter.  The more cycles, the slower the
+LED will blink.  This counter is 24 bits wide, which places an upper bound on
+the number of cycles, and the slowness of the blinking.

--- a/src/examples/systick/systick.go
+++ b/src/examples/systick/systick.go
@@ -11,8 +11,8 @@ func main() {
 	// timer fires 10 times per second
 	arm.SetupSystemTimer(machine.CPU_FREQUENCY / 10)
 
-   for {
-   }
+	for {
+	}
 }
 
 var led_state bool

--- a/src/examples/systick/systick.go
+++ b/src/examples/systick/systick.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"device/arm"
+	"machine"
+)
+
+func main() {
+	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	// timer fires 10 times per second
+	arm.SetupSystemTimer(machine.CPU_FREQUENCY / 10)
+
+   for {
+   }
+}
+
+var led_state bool
+
+//go:export SysTick_Handler
+func timer_isr() {
+	if led_state {
+		machine.LED.Low()
+	} else {
+		machine.LED.High()
+	}
+	led_state = !led_state
+}


### PR DESCRIPTION
Add SYST registers and bit definitions to device/arm.
Add a setup function.
Add an example that uses it to blink an LED.

See also issue #651.