### PR TITLE
runtime/samd51: correct initialization for RTC

### DIFF
--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -188,7 +188,7 @@ func initRTC() {
 	}
 
 	// set to use ulp 32k oscillator
-	sam.OSC32KCTRL.OSCULP32K.Set(sam.OSC32KCTRL_OSCULP32K_EN32K)
+	sam.OSC32KCTRL.OSCULP32K.SetBits(sam.OSC32KCTRL_OSCULP32K_EN32K)
 	sam.OSC32KCTRL.RTCCTRL.Set(sam.OSC32KCTRL_RTCCTRL_RTCSEL_ULP32K)
 
 	// set Mode0 to 32-bit counter (mode 0) with prescaler 1 and GCLK2 is 32KHz/1


### PR DESCRIPTION
This PR corrects the initialization for RTC by not overwriting all other other bits in the `OSCULP32K` register.