### PR TITLE
Makefile: add systick example to smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/serial
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/systick
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/test
 	@$(MD5SUM) test.hex
 	# test all targets/boards


### PR DESCRIPTION
This makes sure future changes will at least keep the example code compiling. See #654.