### PR TITLE
machine/samd51: correct channel init and pin map for ADC

### DIFF
--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -28,7 +28,7 @@ const (
 // Analog pins
 const (
 	A0 = PA02 // ADC/AIN[0]
-	A1 = PB05 // ADC/AIN[2]
+	A1 = PA05 // ADC/AIN[2]
 	A2 = PB08 // ADC/AIN[3]
 	A3 = PB09 // ADC/AIN[4]
 	A4 = PA04 // ADC/AIN[5]

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -386,11 +386,8 @@ func (a ADC) Get() uint16 {
 	for bus.SYNCBUSY.HasBits(sam.ADC_SYNCBUSY_INPUTCTRL) {
 	}
 
-	// Selection for the positive ADC input
-	bus.INPUTCTRL.ClearBits(sam.ADC_INPUTCTRL_MUXPOS_Msk)
-	for bus.SYNCBUSY.HasBits(sam.ADC_SYNCBUSY_ENABLE) {
-	}
-	bus.INPUTCTRL.SetBits(uint16(ch << sam.ADC_INPUTCTRL_MUXPOS_Pos))
+	// Selection for the positive ADC input channel
+	bus.INPUTCTRL.SetBits((uint16(ch) & sam.ADC_INPUTCTRL_MUXPOS_Msk) << sam.ADC_INPUTCTRL_MUXPOS_Pos)
 	for bus.SYNCBUSY.HasBits(sam.ADC_SYNCBUSY_ENABLE) {
 	}
 


### PR DESCRIPTION
This PR corrects the channel init for ADC on the SAMD51 processor. It also corrects the pin map for pin A1 on the ItsyBitsy-M4.