### PR TITLE
main: halt GDB on start

### DIFF
--- a/main.go
+++ b/main.go
@@ -530,9 +530,8 @@ func FlashGDB(pkgName, target, port string, ocdOutput bool, config *BuildConfig)
 		switch gdbInterface {
 		case "native":
 			// Run GDB directly.
-			gdbCommands = append(gdbCommands, "run")
 		case "openocd":
-			gdbCommands = append(gdbCommands, "target remote :3333", "monitor halt", "load", "monitor reset", "c")
+			gdbCommands = append(gdbCommands, "target remote :3333", "monitor halt", "load", "monitor reset halt")
 
 			// We need a separate debugging daemon for on-chip debugging.
 			args, err := spec.OpenOCDConfiguration()


### PR DESCRIPTION
Most programmers support the "reset halt" command, which resets the
target but keeps it halted at the first instruction. This is a much more
natural way of working with GDB, and allows setting breakpoints before
the program is started.

This commit switches to `reset halt` by default and also stops running
the program directly when debugging natively on the host.

You will now have to run `run` or `continue` manually after dropping in the GDB shell.