### PR TITLE
machine/samd51: allow setting pinmode for each of the SPI pins

### DIFF
--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -75,9 +75,11 @@ const (
 // SPI on the ItsyBitsy M4.
 var (
 	SPI0 = SPI{Bus: sam.SERCOM1_SPIM,
-		SCK:   SPI0_SCK_PIN,
-		MOSI:  SPI0_MOSI_PIN,
-		MISO:  SPI0_MISO_PIN,
-		DOpad: spiTXPad2SCK3,
-		DIpad: sercomRXPad0}
+		SCK:         SPI0_SCK_PIN,
+		MOSI:        SPI0_MOSI_PIN,
+		MISO:        SPI0_MISO_PIN,
+		DOpad:       spiTXPad2SCK3,
+		DIpad:       sercomRXPad3,
+		MISOPinMode: PinSERCOM,
+	}
 )

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -884,12 +884,15 @@ func (i2c I2C) readByte() byte {
 
 // SPI
 type SPI struct {
-	Bus   *sam.SERCOM_SPIM_Type
-	SCK   Pin
-	MOSI  Pin
-	MISO  Pin
-	DOpad int
-	DIpad int
+	Bus         *sam.SERCOM_SPIM_Type
+	SCK         Pin
+	MOSI        Pin
+	MISO        Pin
+	DOpad       int
+	DIpad       int
+	SCKPinMode  PinMode
+	MOSIPinMode PinMode
+	MISOPinMode PinMode
 }
 
 // SPIConfig is used to store config info for SPI.
@@ -904,10 +907,6 @@ type SPIConfig struct {
 
 // Configure is intended to setup the SPI interface.
 func (spi SPI) Configure(config SPIConfig) {
-	config.SCK = spi.SCK
-	config.MOSI = spi.MOSI
-	config.MISO = spi.MISO
-
 	doPad := spi.DOpad
 	diPad := spi.DIpad
 
@@ -922,9 +921,19 @@ func (spi SPI) Configure(config SPIConfig) {
 	}
 
 	// enable pins
-	config.SCK.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MOSI.Configure(PinConfig{Mode: PinSERCOMAlt})
-	config.MISO.Configure(PinConfig{Mode: PinSERCOMAlt})
+	if spi.SCKPinMode == 0 {
+		spi.SCKPinMode = PinSERCOMAlt
+	}
+	if spi.MOSIPinMode == 0 {
+		spi.MOSIPinMode = PinSERCOMAlt
+	}
+	if spi.MISOPinMode == 0 {
+		spi.MISOPinMode = PinSERCOMAlt
+	}
+
+	spi.SCK.Configure(PinConfig{Mode: spi.SCKPinMode})
+	spi.MOSI.Configure(PinConfig{Mode: spi.MOSIPinMode})
+	spi.MISO.Configure(PinConfig{Mode: spi.MISOPinMode})
 
 	// reset SERCOM
 	spi.Bus.CTRLA.SetBits(sam.SERCOM_SPIM_CTRLA_SWRST)


### PR DESCRIPTION
This PR allows setting pinmode for each of the SPI pins individually on the SAMD51 processor, since some SERCOM settings require both the Sercom and SercomAlt muxes be set at the same time. This allows the default SPI0 to be used on the ItsyBitsy-M4 for bi-directional SPI devices that both read and write data. The previous code only worked for write-only devices like the APA102 LEDs.

I looked at the mux functions that were used for the SAMD21, but the SAMD51 has more SERCOMs and more possible pad settings, so the code would require some adaptation to be used. That will have to be for a future PR.