### PR TITLE
machine/hifive1b: fix compiling in simulation (wasm)

### DIFF
--- a/src/machine/board_fe310.go
+++ b/src/machine/board_fe310.go
@@ -2,8 +2,6 @@
 
 package machine
 
-import "device/sifive"
-
 const (
 	P00 Pin = 0
 	P01 Pin = 1
@@ -37,11 +35,4 @@ const (
 	P29 Pin = 29
 	P30 Pin = 30
 	P31 Pin = 31
-)
-
-// SPI on the HiFive1.
-var (
-	SPI1 = SPI{
-		Bus: sifive.QSPI1,
-	}
 )

--- a/src/machine/board_hifive1b_baremetal.go
+++ b/src/machine/board_hifive1b_baremetal.go
@@ -1,0 +1,12 @@
+// +build fe310,hifive1b
+
+package machine
+
+import "device/sifive"
+
+// SPI on the HiFive1.
+var (
+	SPI1 = SPI{
+		Bus: sifive.QSPI1,
+	}
+)


### PR DESCRIPTION
CI started to fail because a file with just the hifive1b build tag also imported the device/sifive package. That doesn't work for wasm, necessary for play.tinygo.org.