### PR TITLE
macos: use llvm@8 instead of just llvm in paths

### DIFF
--- a/cgo/libclang_config.go
+++ b/cgo/libclang_config.go
@@ -4,8 +4,8 @@ package cgo
 
 /*
 #cgo linux  CFLAGS: -I/usr/lib/llvm-8/include
-#cgo darwin CFLAGS: -I/usr/local/opt/llvm/include
+#cgo darwin CFLAGS: -I/usr/local/opt/llvm@8/include
 #cgo linux  LDFLAGS: -L/usr/lib/llvm-8/lib -lclang
-#cgo darwin LDFLAGS: -L/usr/local/opt/llvm/lib -lclang -lffi
+#cgo darwin LDFLAGS: -L/usr/local/opt/llvm@8/lib -lclang -lffi
 */
 import "C"

--- a/commands.go
+++ b/commands.go
@@ -20,9 +20,9 @@ func init() {
 	// Add the path to a Homebrew-installed LLVM 8 for ease of use (no need to
 	// manually set $PATH).
 	if runtime.GOOS == "darwin" {
-		commands["clang"] = append(commands["clang"], "/usr/local/opt/llvm/bin/clang-8")
-		commands["ld.lld"] = append(commands["ld.lld"], "/usr/local/opt/llvm/bin/ld.lld")
-		commands["wasm-ld"] = append(commands["wasm-ld"], "/usr/local/opt/llvm/bin/wasm-ld")
+		commands["clang"] = append(commands["clang"], "/usr/local/opt/llvm@8/bin/clang-8")
+		commands["ld.lld"] = append(commands["ld.lld"], "/usr/local/opt/llvm@8/bin/ld.lld")
+		commands["wasm-ld"] = append(commands["wasm-ld"], "/usr/local/opt/llvm@8/bin/wasm-ld")
 	}
 	// Add the path for when LLVM was installed with the installer from
 	// llvm.org, which by default doesn't add LLVM to the $PATH environment

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	golang.org/x/tools v0.0.0-20190227180812-8dcc6e70cdef
-	tinygo.org/x/go-llvm v0.0.0-20190818154551-95bc4ffe1add
+	tinygo.org/x/go-llvm v0.0.0-20191103182207-90b6e4bdc0b9
 )

--- a/go.sum
+++ b/go.sum
@@ -20,3 +20,5 @@ tinygo.org/x/go-llvm v0.0.0-20190224120431-7707ae5d1261 h1:rJS2Hga39YAnm7DE4qrPm
 tinygo.org/x/go-llvm v0.0.0-20190224120431-7707ae5d1261/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
 tinygo.org/x/go-llvm v0.0.0-20190818154551-95bc4ffe1add h1:dFjMH1sLhYADg8UQm7DB56B7e+TfvAmWmEZLhyv3r/w=
 tinygo.org/x/go-llvm v0.0.0-20190818154551-95bc4ffe1add/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
+tinygo.org/x/go-llvm v0.0.0-20191103182207-90b6e4bdc0b9 h1:d6rAX39a3C0pKrY5HcojEGyN8w9ocU0v7X28lC/TRKU=
+tinygo.org/x/go-llvm v0.0.0-20191103182207-90b6e4bdc0b9/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=


### PR DESCRIPTION
Fixing compile errors when LLVM is only installed to `/usr/local/opt/llvm@8` and not `/usr/local/opt/llvm`.

Note: must be merged together with https://github.com/tinygo-org/go-llvm/pull/10