### PR TITLE
Generalize the scheduler beyond timers

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -38,6 +38,7 @@ const tinygoPath = "github.com/tinygo-org/tinygo"
 // during TinyGo optimization passes so they have to be marked as external
 // linkage until all TinyGo passes have finished.
 var functionsUsedInTransforms = []string{
+	"runtime.wrapMain",
 	"runtime.alloc",
 	"runtime.free",
 	"runtime.scheduler",

--- a/compiler/goroutine-lowering.go
+++ b/compiler/goroutine-lowering.go
@@ -126,6 +126,8 @@ type asyncFunc struct {
 // coroutine or the tasks implementation of goroutines, and whether goroutines
 // are necessary at all.
 func (c *Compiler) LowerGoroutines() error {
+	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
+	c.mod.NamedFunction("runtime.mainFunc").ReplaceAllUsesWith(realMain)
 	switch c.Scheduler() {
 	case "coroutines":
 		return c.lowerCoroutines()
@@ -146,10 +148,11 @@ func (c *Compiler) lowerTasks() error {
 	mainCall := uses[0]
 
 	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
+	wrapMain := c.mod.NamedFunction("runtime.wrapMain")
 	if len(getUses(c.mod.NamedFunction("runtime.startGoroutine"))) != 0 || len(getUses(c.mod.NamedFunction("runtime.yield"))) != 0 {
 		// Program needs a scheduler. Start main.main as a goroutine and start
 		// the scheduler.
-		realMainWrapper := c.createGoroutineStartWrapper(realMain)
+		realMainWrapper := c.createGoroutineStartWrapper(wrapMain)
 		c.builder.SetInsertPointBefore(mainCall)
 		zero := llvm.ConstInt(c.uintptrType, 0, false)
 		c.createRuntimeCall("startGoroutine", []llvm.Value{realMainWrapper, zero}, "")
@@ -192,13 +195,16 @@ func (c *Compiler) lowerCoroutines() error {
 	// optionally followed by a call to runtime.scheduler().
 	c.builder.SetInsertPointBefore(mainCall)
 	realMain := c.mod.NamedFunction(c.ir.MainPkg().Pkg.Path() + ".main")
-	var ph llvm.Value
+	wrapMain := c.mod.NamedFunction("runtime.wrapMain")
+	var ph, mainCallFn llvm.Value
 	if needsScheduler {
 		ph = c.createRuntimeCall("getFakeCoroutine", []llvm.Value{}, "")
+		mainCallFn = wrapMain
 	} else {
 		ph = llvm.Undef(c.i8ptrType)
+		mainCallFn = realMain
 	}
-	c.builder.CreateCall(realMain, []llvm.Value{llvm.Undef(c.i8ptrType), ph}, "")
+	c.builder.CreateCall(mainCallFn, []llvm.Value{llvm.Undef(c.i8ptrType), ph}, "")
 	if needsScheduler {
 		c.createRuntimeCall("scheduler", nil, "")
 	}

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -15,13 +15,26 @@ func initAll()
 //
 // Without scheduler:
 //
-//     main.main()
+//     mainFunc()
 //
 // With scheduler:
 //
-//     main.main()
+//     go wrapMain()
 //     scheduler()
 func callMain()
+
+// mainFunc is a temporary value that will be later replaced with the actual user-provided main function
+func mainFunc()
+
+// wrapMain is a wrapper which is used for invoking main.
+// When main completes, this allows the program to return.
+func wrapMain() {
+	// run main
+	mainFunc()
+
+	// when main is done, let the scheduler exit
+	schedulerDone = true
+}
 
 func GOMAXPROCS(n int) int {
 	// Note: setting GOMAXPROCS is ignored.

--- a/src/runtime/scheduler_old.go
+++ b/src/runtime/scheduler_old.go
@@ -1,0 +1,77 @@
+package runtime
+
+// This file implements a compatibility layer for the old scheduler layout as we migrate to an interrupt-driven scheduler.
+
+// queue of sleeping goroutines.
+var (
+	sleepQueue         *task
+	sleepQueueBaseTime timeUnit
+)
+
+// Add this task to the sleep queue, assuming its state is set to sleeping.
+func addSleepTask(t *task, duration int64) {
+	if schedulerDebug {
+		println("  set sleep:", t, uint(duration/tickMicros))
+		if t.state().next != nil {
+			panic("runtime: addSleepTask: expected next task to be nil")
+		}
+	}
+	t.state().data = uint(duration / tickMicros) // TODO: longer durations
+	now := ticks()
+	if sleepQueue == nil {
+		scheduleLog("  -> sleep new queue")
+
+		// set new base time
+		sleepQueueBaseTime = now
+	}
+
+	// Add to sleep queue.
+	q := &sleepQueue
+	for ; *q != nil; q = &((*q).state()).next {
+		if t.state().data < (*q).state().data {
+			// this will finish earlier than the next - insert here
+			break
+		} else {
+			// this will finish later - adjust delay
+			t.state().data -= (*q).state().data
+		}
+	}
+	if *q != nil {
+		// cut delay time between this sleep task and the next
+		(*q).state().data -= t.state().data
+	}
+	t.state().next = *q
+	*q = t
+}
+
+// pollTime is the last time value read by poll.
+var pollTime timeUnit
+
+// poll checks for goroutines that are ready to wake up.
+func poll() *task {
+	if sleepQueue == nil {
+		return nil
+	}
+
+	pollTime = ticks()
+	if pollTime-sleepQueueBaseTime >= timeUnit(sleepQueue.state().data) {
+		t := sleepQueue
+		scheduleLogTask("  awake:", t)
+		state := t.state()
+		sleepQueueBaseTime += timeUnit(state.data)
+		sleepQueue = state.next
+		state.next = nil
+		return t
+	}
+
+	return nil
+}
+
+// wait sleeps until a goroutine is ready to wake up.
+// This must only be called after poll returns nil.
+func wait() {
+	if sleepQueue == nil {
+		runtimePanic("deadlock")
+	}
+	sleepTicks(timeUnit(sleepQueue.state().data) - (pollTime - sleepQueueBaseTime))
+}

--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -47,10 +47,18 @@ func main() {
 		time.Sleep(2 * time.Millisecond)
 		x = 1
 	}()
-	time.Sleep(time.Second/2)
+	time.Sleep(time.Second / 2)
 	println("closure go call result:", x)
 
 	time.Sleep(2 * time.Millisecond)
+
+	// should not print anything, because we should exit as soon as we return
+	go delayedPrint()
+}
+
+func delayedPrint() {
+	time.Sleep(time.Second)
+	println("should have already exited")
 }
 
 func sub() {


### PR DESCRIPTION
This pull request begins the migration to the design discussed in #620 - moving the scheduler to a structure which allows anything to be used as a source of wakeups. For compatibility, the old scheduler timing components have been wrapped and put in a seperate file. As we implement fully correct functionality on various boards, we can exclude this temporary workaround with build tags.