### PR TITLE
machine: add support for the X9 Pro smartwatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pinetime-devkit0    examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=x9pro               examples/blinky1
+	@$(MD5SUM) test.hex
 ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=arduino             examples/blinky1
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 19 microcontroller boards are currently supported:
+The following 20 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
 * [Adafruit Feather M0](https://www.adafruit.com/product/2772)
@@ -64,6 +64,7 @@ The following 19 microcontroller boards are currently supported:
 * [ST Micro "Nucleo F103RB"](https://www.st.com/en/evaluation-tools/nucleo-f103rb.html)
 * [ST Micro STM32F103XX "Bluepill"](http://wiki.stm32duino.com/index.php?title=Blue_Pill)
 * [ST Micro STM32F407 "Discovery"](https://www.st.com/en/evaluation-tools/stm32f4discovery.html)
+* [X9 Pro smartwatch](https://github.com/curtpw/nRF5x-device-reverse-engineering/tree/master/X9-nrf52832-activity-tracker/)
 
 For more information, see [this list of boards](https://tinygo.org/microcontrollers/). Pull requests for additional support are welcome!
 

--- a/src/machine/board_x9pro.go
+++ b/src/machine/board_x9pro.go
@@ -1,0 +1,28 @@
+// +build x9pro
+
+package machine
+
+// https://hackaday.io/project/144350-hacking-wearables-for-mental-health-and-more/details
+const (
+	LED           Pin = 4 // HR LED pin
+	UART_TX_PIN   Pin = NoPin
+	UART_RX_PIN   Pin = NoPin
+	SCL_PIN       Pin = NoPin
+	SDA_PIN       Pin = NoPin
+	SPI0_SCK_PIN  Pin = 18
+	SPI0_MISO_PIN Pin = 19
+	SPI0_MOSI_PIN Pin = 20
+)
+
+// LCD pins.
+const (
+	OLED_CS      Pin = 15 // chip select
+	OLED_RES     Pin = 14 // reset pin
+	OLED_DC      Pin = 13 // data/command
+	OLED_SCK     Pin = 12 // SPI clock
+	OLED_MOSI    Pin = 11 // SPI MOSI (master-out, slave-in)
+	OLED_LED_POW Pin = 16
+	OLED_IC_POW  Pin = 17
+)
+
+const HasLowFrequencyCrystal = true

--- a/targets/x9pro.json
+++ b/targets/x9pro.json
@@ -1,0 +1,8 @@
+{
+	"inherits": ["nrf52"],
+	"build-tags": ["x9pro"],
+	"flash-method": "openocd",
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
+	"openocd-interface": "jlink",
+	"openocd-transport": "swd"
+}


### PR DESCRIPTION
This is a Chinese smart watch sold on AliExpress etc. It is based on a nrf52832. More information:
https://github.com/curtpw/nRF5x-device-reverse-engineering/tree/master/X9-nrf52832-activity-tracker

The HR LED and the display work.

---

I'm wondering, what's the threshold for adding boards? This is just a generic smartwatch that may disappear in a few years. It's basically all reverse engineerd. I happen to have one lying around from the time before the PineTime (that would definitely be my preference now!).