### PR TITLE
cgo: improve diagnostics

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -131,6 +131,7 @@ var builtinAliases = map[string]struct{}{
 // somehow from C. This is done by adding some typedefs to get the size of each
 // type.
 const cgoTypes = `
+# 1 "<cgo>"
 typedef char                _Cgo_char;
 typedef signed char         _Cgo_schar;
 typedef unsigned char       _Cgo_uchar;
@@ -220,6 +221,8 @@ func Process(files []*ast.File, dir string, fset *token.FileSet, cflags []string
 			}
 			path, err := strconv.Unquote(spec.Path.Value)
 			if err != nil {
+				// This should not happen. An import path that is not properly
+				// quoted should not exist in a correct AST.
 				panic("could not parse import path: " + err.Error())
 			}
 			if path != "C" {


### PR DESCRIPTION
This commit improves diagnostics in a few ways:

  * All panics apart from panics with no (easy) recovery are converted to
    regular errors with source location.
  * Some errors were improved slightly to give more information. For
    example, show the libclang type kind as a string instead of a
    number.
  * Improve source location by respecting line directives in the C
    preprocessor.
  * Refactor to unify error handling between libclang diagnostics and
    failures to parse the libclang AST.

---

This commit comes from the softdevice branch. Making a new PR for ease of reviewing and to get this functionality merged while I continue work on SoftDevice support.