### PR TITLE
cgo: add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             - go-cache-v2-{{ checksum "go.mod" }}
       - llvm-source-linux
       - run: go install .
-      - run: go test -v ./interp ./transform .
+      - run: go test -v ./cgo ./interp ./transform .
       - run: make gen-device -j4
       - run: make smoketest RISCV=0
       - save_cache:

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ tinygo:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -o build/tinygo$(EXE) -tags byollvm .
 
 test:
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -tags byollvm ./interp ./transform .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -tags byollvm ./cgo ./interp ./transform .
 
 tinygo-test:
 	cd tests/tinygotest && tinygo test

--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -343,18 +343,18 @@ func (p *cgoPackage) addFuncPtrDecls() {
 	if len(p.functions) == 0 {
 		return
 	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.VAR,
-		Lparen: token.NoPos,
-		Rparen: token.NoPos,
-	}
 	names := make([]string, 0, len(p.functions))
 	for name := range p.functions {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.VAR,
+			Lparen: token.NoPos,
+			Rparen: token.NoPos,
+		}
 		fn := p.functions[name]
 		obj := &ast.Object{
 			Kind: ast.Typ,
@@ -379,27 +379,19 @@ func (p *cgoPackage) addFuncPtrDecls() {
 		}
 		obj.Decl = valueSpec
 		gen.Specs = append(gen.Specs, valueSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // addConstDecls declares external C constants in the Go source.
 // It adds code like the following to the AST:
 //
-//     const (
-//         C.CONST_INT = 5
-//         C.CONST_FLOAT = 5.8
-//         // ...
-//     )
+//     const C.CONST_INT = 5
+//     const C.CONST_FLOAT = 5.8
+//     // ...
 func (p *cgoPackage) addConstDecls() {
 	if len(p.constants) == 0 {
 		return
-	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.CONST,
-		Lparen: token.NoPos,
-		Rparen: token.NoPos,
 	}
 	names := make([]string, 0, len(p.constants))
 	for name := range p.constants {
@@ -407,6 +399,12 @@ func (p *cgoPackage) addConstDecls() {
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.CONST,
+			Lparen: token.NoPos,
+			Rparen: token.NoPos,
+		}
 		constVal := p.constants[name]
 		obj := &ast.Object{
 			Kind: ast.Con,
@@ -422,27 +420,19 @@ func (p *cgoPackage) addConstDecls() {
 		}
 		obj.Decl = valueSpec
 		gen.Specs = append(gen.Specs, valueSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // addVarDecls declares external C globals in the Go source.
 // It adds code like the following to the AST:
 //
-//     var (
-//         C.globalInt  int
-//         C.globalBool bool
-//         // ...
-//     )
+//     var C.globalInt  int
+//     var C.globalBool bool
+//     // ...
 func (p *cgoPackage) addVarDecls() {
 	if len(p.globals) == 0 {
 		return
-	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.VAR,
-		Lparen: token.NoPos,
-		Rparen: token.NoPos,
 	}
 	names := make([]string, 0, len(p.globals))
 	for name := range p.globals {
@@ -450,6 +440,12 @@ func (p *cgoPackage) addVarDecls() {
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.VAR,
+			Lparen: token.NoPos,
+			Rparen: token.NoPos,
+		}
 		global := p.globals[name]
 		obj := &ast.Object{
 			Kind: ast.Var,
@@ -465,31 +461,29 @@ func (p *cgoPackage) addVarDecls() {
 		}
 		obj.Decl = valueSpec
 		gen.Specs = append(gen.Specs, valueSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // addTypeAliases aliases some built-in Go types with their equivalent C types.
 // It adds code like the following to the AST:
 //
-//     type (
-//         C.int8_t  = int8
-//         C.int16_t = int16
-//         // ...
-//     )
+//     type C.int8_t  = int8
+//     type C.int16_t = int16
+//     // ...
 func (p *cgoPackage) addTypeAliases() {
 	aliasKeys := make([]string, 0, len(cgoAliases))
 	for key := range cgoAliases {
 		aliasKeys = append(aliasKeys, key)
 	}
 	sort.Strings(aliasKeys)
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.TYPE,
-		Lparen: token.NoPos,
-		Rparen: token.NoPos,
-	}
 	for _, typeName := range aliasKeys {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.TYPE,
+			Lparen: token.NoPos,
+			Rparen: token.NoPos,
+		}
 		goTypeName := cgoAliases[typeName]
 		obj := &ast.Object{
 			Kind: ast.Typ,
@@ -509,17 +503,13 @@ func (p *cgoPackage) addTypeAliases() {
 		}
 		obj.Decl = typeSpec
 		gen.Specs = append(gen.Specs, typeSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 func (p *cgoPackage) addTypedefs() {
 	if len(p.typedefs) == 0 {
 		return
-	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.TYPE,
 	}
 	names := make([]string, 0, len(p.typedefs))
 	for name := range p.typedefs {
@@ -527,6 +517,10 @@ func (p *cgoPackage) addTypedefs() {
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.TYPE,
+		}
 		typedef := p.typedefs[name]
 		typeName := "C." + name
 		isAlias := true
@@ -555,8 +549,8 @@ func (p *cgoPackage) addTypedefs() {
 		}
 		obj.Decl = typeSpec
 		gen.Specs = append(gen.Specs, typeSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // addElaboratedTypes adds C elaborated types as aliases. These are the "struct
@@ -568,16 +562,16 @@ func (p *cgoPackage) addElaboratedTypes() {
 	if len(p.elaboratedTypes) == 0 {
 		return
 	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.TYPE,
-	}
 	names := make([]string, 0, len(p.elaboratedTypes))
 	for name := range p.elaboratedTypes {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.TYPE,
+		}
 		typ := p.elaboratedTypes[name]
 		typeName := "C." + name
 		obj := &ast.Object{
@@ -599,8 +593,8 @@ func (p *cgoPackage) addElaboratedTypes() {
 			p.createBitfieldGetter(bitfield, typeName)
 			p.createBitfieldSetter(bitfield, typeName)
 		}
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // createBitfieldGetter creates a bitfield getter function like the following:
@@ -905,16 +899,16 @@ func (p *cgoPackage) addEnumTypes() {
 	if len(p.enums) == 0 {
 		return
 	}
-	gen := &ast.GenDecl{
-		TokPos: token.NoPos,
-		Tok:    token.TYPE,
-	}
 	names := make([]string, 0, len(p.enums))
 	for name := range p.enums {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		gen := &ast.GenDecl{
+			TokPos: token.NoPos,
+			Tok:    token.TYPE,
+		}
 		typ := p.enums[name]
 		typeName := "C.enum_" + name
 		obj := &ast.Object{
@@ -931,8 +925,8 @@ func (p *cgoPackage) addEnumTypes() {
 		}
 		obj.Decl = typeSpec
 		gen.Specs = append(gen.Specs, typeSpec)
+		p.generated.Decls = append(p.generated.Decls, gen)
 	}
-	p.generated.Decls = append(p.generated.Decls, gen)
 }
 
 // findMissingCGoNames traverses the AST and finds all C.something names. Only

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -15,7 +15,7 @@ import (
 func TestCGo(t *testing.T) {
 	var cflags = []string{"--target=armv6m-none-eabi"}
 
-	for _, name := range []string{"basic"} {
+	for _, name := range []string{"basic", "types"} {
 		name := name // avoid a race condition
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -1,0 +1,62 @@
+package cgo
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCGo(t *testing.T) {
+	var cflags = []string{"--target=armv6m-none-eabi"}
+
+	for _, name := range []string{"basic"} {
+		name := name // avoid a race condition
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Read the AST in memory.
+			path := filepath.Join("testdata", name+".go")
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatal("could not parse Go source file:", err)
+			}
+
+			// Process the AST with CGo.
+			cgoAST, errs := Process([]*ast.File{f}, "testdata", fset, cflags)
+			for _, err := range errs {
+				t.Errorf("error during CGo processing: %v", err)
+			}
+
+			// Store the (formatted) output in a buffer. Format it, so it
+			// becomes easier to read (and will hopefully change less with CGo
+			// changes).
+			buf := &bytes.Buffer{}
+			err = format.Node(buf, fset, cgoAST)
+			if err != nil {
+				t.Errorf("could not write out CGo AST: %v", err)
+			}
+			actual := strings.Replace(string(buf.Bytes()), "\r\n", "\n", -1)
+
+			// Read the file with the expected output, to compare against.
+			outfile := filepath.Join("testdata", name+".out.go")
+			expectedBytes, err := ioutil.ReadFile(outfile)
+			if err != nil {
+				t.Fatalf("could not read expected output: %v", err)
+			}
+			expected := strings.Replace(string(expectedBytes), "\r\n", "\n", -1)
+
+			// Check whether the output is as expected.
+			if expected != actual {
+				// It is not. Test failed.
+				t.Errorf("output did not match:\n%s", string(actual))
+			}
+		})
+	}
+}

--- a/cgo/testdata/basic.go
+++ b/cgo/testdata/basic.go
@@ -1,0 +1,3 @@
+package main
+
+import "C"

--- a/cgo/testdata/basic.out.go
+++ b/cgo/testdata/basic.out.go
@@ -1,0 +1,24 @@
+package main
+
+import "unsafe"
+
+type C.int16_t = int16
+type C.int32_t = int32
+type C.int64_t = int64
+type C.int8_t = int8
+type C.uint16_t = uint16
+type C.uint32_t = uint32
+type C.uint64_t = uint64
+type C.uint8_t = uint8
+type C.uintptr_t = uintptr
+type C.char uint8
+type C.int int32
+type C.long int32
+type C.longlong int64
+type C.schar int8
+type C.short int16
+type C.uchar uint8
+type C.uint uint32
+type C.ulong uint32
+type C.ulonglong uint64
+type C.ushort uint16

--- a/cgo/testdata/types.go
+++ b/cgo/testdata/types.go
@@ -1,0 +1,91 @@
+package main
+
+/*
+// Simple typedef.
+typedef int myint;
+
+// Structs, with or without name.
+typedef struct {
+	int x;
+	int y;
+} point2d_t;
+typedef struct point3d {
+	int x;
+	int y;
+	int z;
+} point3d_t;
+
+// Enums. These define constant numbers. All these constants must be given the
+// correct number.
+typedef enum option {
+	optionA,
+	optionB,
+	optionC = -5,
+	optionD,
+	optionE = 10,
+	optionF,
+	optionG,
+} option_t;
+
+// Anonymous enum.
+typedef enum {
+	option2A = 20,
+} option2_t;
+
+// Various types that are usually translated directly to Go types, but storing
+// them in a struct reveals them.
+typedef struct {
+	float  f;
+	double d;
+	int    *ptr;
+} types_t;
+
+// Arrays.
+typedef int myIntArray[10];
+
+// Bitfields.
+typedef struct {
+	unsigned char start;
+	unsigned char a : 5;
+	unsigned char b : 1;
+	unsigned char c : 2;
+	unsigned char :0; // new field
+	unsigned char d : 6;
+	unsigned char e : 3;
+	// Note that C++ allows bitfields bigger than the underlying type.
+} bitfield_t;
+*/
+import "C"
+
+var (
+	// Simple typedefs.
+	_ C.myint
+
+	// Structs.
+	_ C.point2d_t
+	_ C.point3d_t
+	_ C.struct_point3d
+
+	// Enums (anonymous and named).
+	_ C.option_t
+	_ C.enum_option
+	_ C.option2_t
+
+	// Various types.
+	_ C.types_t
+
+	// Arrays.
+	_ C.myIntArray
+	_ C.myIntArrayPtr
+)
+
+// Test bitfield accesses.
+func foo() {
+	var x C.bitfield_t
+	x.start = 3
+	x.a = 4
+	x.b = 1
+	x.c = 2
+	x.d = 10
+	x.e = 5
+}

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -1,0 +1,75 @@
+package main
+
+import "unsafe"
+
+const C.option2A = 20
+const C.optionA = 0
+const C.optionB = 1
+const C.optionC = -5
+const C.optionD = -4
+const C.optionE = 10
+const C.optionF = 11
+const C.optionG = 12
+
+type C.int16_t = int16
+type C.int32_t = int32
+type C.int64_t = int64
+type C.int8_t = int8
+type C.uint16_t = uint16
+type C.uint32_t = uint32
+type C.uint64_t = uint64
+type C.uint8_t = uint8
+type C.uintptr_t = uintptr
+type C.char uint8
+type C.int int32
+type C.long int32
+type C.longlong int64
+type C.schar int8
+type C.short int16
+type C.uchar uint8
+type C.uint uint32
+type C.ulong uint32
+type C.ulonglong uint64
+type C.ushort uint16
+type C.bitfield_t = C.struct_1
+type C.myIntArray = [10]C.int
+type C.myint = C.int
+type C.option2_t = C.uint
+type C.option_t = C.enum_option
+type C.point2d_t = struct {
+	x C.int
+	y C.int
+}
+type C.point3d_t = C.struct_point3d
+type C.types_t = struct {
+	f   float32
+	d   float64
+	ptr *C.int
+}
+
+func (s *C.struct_1) bitfield_a() C.uchar          { return s.__bitfield_1 & 0x1f }
+func (s *C.struct_1) set_bitfield_a(value C.uchar) { s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0 }
+func (s *C.struct_1) bitfield_b() C.uchar {
+	return s.__bitfield_1 >> 5 & 0x1
+}
+func (s *C.struct_1) set_bitfield_b(value C.uchar) { s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5 }
+func (s *C.struct_1) bitfield_c() C.uchar {
+	return s.__bitfield_1 >> 6
+}
+func (s *C.struct_1) set_bitfield_c(value C.uchar,
+
+) { s.__bitfield_1 = s.__bitfield_1&0x3f | value<<6 }
+
+type C.struct_1 struct {
+	start        C.uchar
+	__bitfield_1 C.uchar
+
+	d C.uchar
+	e C.uchar
+}
+type C.struct_point3d struct {
+	x C.int
+	y C.int
+	z C.int
+}
+type C.enum_option C.int


### PR DESCRIPTION
Add tests to CGo processing. They should not only be useful for testing, but also for documentation: you can easily see what CGo generates.

The formatting is somewhat messy but that is (I think) because CGo doesn't output very precise location information. This might be improved in the future but is not very important (it's more of an implementation detail).