### PR TITLE
Make linker script an independent property

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -122,6 +122,9 @@ func (c *Config) LDFlags() []string {
 		heapSize := (c.Options.HeapSize + (65536 - 1)) &^ (65536 - 1)
 		ldflags = append(ldflags, "--initial-memory="+strconv.FormatInt(heapSize, 10))
 	}
+	if c.Target.LinkerScript != "" {
+		ldflags = append(ldflags, "-T", c.Target.LinkerScript)
+	}
 	return ldflags
 }
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -36,6 +36,7 @@ type TargetSpec struct {
 	RTLib            string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
 	CFlags           []string `json:"cflags"`
 	LDFlags          []string `json:"ldflags"`
+	LinkerScript     string   `json:"linkerscript"`
 	ExtraFiles       []string `json:"extra-files"`
 	Emulator         []string `json:"emulator"`
 	FlashCommand     string   `json:"flash-command"`
@@ -85,6 +86,9 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	}
 	spec.CFlags = append(spec.CFlags, spec2.CFlags...)
 	spec.LDFlags = append(spec.LDFlags, spec2.LDFlags...)
+	if spec2.LinkerScript != "" {
+		spec.LinkerScript = spec2.LinkerScript
+	}
 	spec.ExtraFiles = append(spec.ExtraFiles, spec2.ExtraFiles...)
 	if len(spec2.Emulator) != 0 {
 		spec.Emulator = spec2.Emulator

--- a/main.go
+++ b/main.go
@@ -187,24 +187,12 @@ func Compile(pkgName, outpath string, spec *compileopts.TargetSpec, options *com
 			}
 		}
 
-		// Merge and adjust LDFlags.
-		ldflags := append([]string{}, options.LDFlags...)
-		for _, flag := range spec.LDFlags {
-			ldflags = append(ldflags, strings.Replace(flag, "{root}", root, -1))
-		}
-
 		// Prepare link command.
 		executable := filepath.Join(dir, "main")
 		tmppath := executable // final file
-		ldflags = append(ldflags, "-o", executable, objfile, "-L", root)
+		ldflags := append(compilerConfig.LDFlags(), "-o", executable, objfile)
 		if spec.RTLib == "compiler-rt" {
 			ldflags = append(ldflags, librt)
-		}
-		if spec.GOARCH == "wasm" {
-			// Round heap size to next multiple of 65536 (the WebAssembly page
-			// size).
-			heapSize := (options.HeapSize + (65536 - 1)) &^ (65536 - 1)
-			ldflags = append(ldflags, "--initial-memory="+strconv.FormatInt(heapSize, 10))
 		}
 
 		// Compile extra files.

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -8,9 +8,9 @@
 	],
 	"ldflags": [
 		"-Wl,--defsym=_bootloader_size=512",
-		"-Wl,--defsym=_stack_size=512",
-		"-T", "src/device/avr/atmega328p.ld"
+		"-Wl,--defsym=_stack_size=512"
 	],
+	"linkerscript": "src/device/avr/atmega328p.ld",
 	"extra-files": [
 		"targets/avr.S",
 		"src/device/avr/atmega328p.s"

--- a/targets/atsamd21e18a.json
+++ b/targets/atsamd21e18a.json
@@ -6,9 +6,7 @@
 		"--target=armv6m-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/atsamd21.ld"
-	],
+	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21e18a.s"
 	]

--- a/targets/atsamd21g18a.json
+++ b/targets/atsamd21g18a.json
@@ -6,9 +6,7 @@
 		"--target=armv6m-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/atsamd21.ld"
-	],
+	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21g18a.s"
 	]

--- a/targets/atsamd51g19a.json
+++ b/targets/atsamd51g19a.json
@@ -6,9 +6,7 @@
 		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/atsamd51.ld"
-	],
+	"linkerscript": "targets/atsamd51.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51g19a.s"
 	]

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -6,9 +6,7 @@
 		"--target=armv7m-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/stm32.ld"
-	],
+	"linkerscript": "targets/stm32.ld",
 	"extra-files": [
 		"src/device/stm32/stm32f103xx.s"
 	],

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -8,9 +8,9 @@
 	],
 	"ldflags": [
 		"-Wl,--defsym=_bootloader_size=2180",
-		"-Wl,--defsym=_stack_size=128",
-		"-T", "src/device/avr/attiny85.ld"
+		"-Wl,--defsym=_stack_size=128"
 	],
+	"linkerscript": "src/device/avr/attiny85.ld",
 	"extra-files": [
 		"targets/avr.S",
 		"src/device/avr/attiny85.s"

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -19,9 +19,9 @@
 		"-ffunction-sections", "-fdata-sections"
 	],
 	"ldflags": [
-		"--gc-sections",
-		"-Ttargets/gameboy-advance.ld"
+		"--gc-sections"
 	],
+	"linkerscript": "targets/gameboy-advance.ld",
 	"extra-files": [
 		"targets/gameboy-advance.s"
 	],

--- a/targets/hifive1b.json
+++ b/targets/hifive1b.json
@@ -1,9 +1,7 @@
 {
 	"inherits": ["fe310"],
 	"build-tags": ["hifive1b"],
-	"ldflags": [
-		"-T", "targets/hifive1b.ld"
-	],
+	"linkerscript": "targets/hifive1b.ld",
 	"flash-method": "msd",
 	"msd-volume-name": "HiFive",
 	"msd-firmware-name": "firmware.hex"

--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -8,9 +8,7 @@
 		"-DNRF51",
 		"-I{root}/lib/CMSIS/CMSIS/Include"
 	],
-	"ldflags": [
-		"-T", "targets/nrf51.ld"
-	],
+	"linkerscript": "targets/nrf51.ld",
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf51.c",
 		"src/device/nrf/nrf51.s"

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -9,9 +9,7 @@
 		"-DNRF52832_XXAA",
 		"-I{root}/lib/CMSIS/CMSIS/Include"
 	],
-	"ldflags": [
-		"-T", "targets/nrf52.ld"
-	],
+	"linkerscript": "targets/nrf52.ld",
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf52.c",
 		"src/device/nrf/nrf52.s"

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -9,9 +9,7 @@
 		"-DNRF52840_XXAA",
 		"-I{root}/lib/CMSIS/CMSIS/Include"
 	],
-	"ldflags": [
-		"-T", "targets/nrf52840.ld"
-	],
+	"linkerscript": "targets/nrf52840.ld",
 	"extra-files": [
 		"lib/nrfx/mdk/system_nrf52840.c",
 		"src/device/nrf/nrf52840.s"

--- a/targets/nucleo-f103rb.json
+++ b/targets/nucleo-f103rb.json
@@ -6,9 +6,7 @@
     "--target=armv7m-none-eabi",
     "-Qunused-arguments"
   ],
-  "ldflags": [
-    "-T", "targets/stm32f103rb.ld"
-  ],
+  "linkerscript": "targets/stm32f103rb.ld",
   "extra-files": [
     "src/device/stm32/stm32f103xx.s"
   ],

--- a/targets/qemu.json
+++ b/targets/qemu.json
@@ -6,9 +6,7 @@
 		"--target=armv7m-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/lm3s6965.ld"
-	],
+	"linkerscript": "targets/lm3s6965.ld",
 	"extra-files": [
 		"targets/qemu.s"
 	],

--- a/targets/stm32f4disco.json
+++ b/targets/stm32f4disco.json
@@ -6,9 +6,7 @@
     "--target=armv7em-none-eabi",
     "-Qunused-arguments"
   ],
-  "ldflags": [
-    "-T", "targets/stm32f407.ld"
-  ],
+  "linkerscript": "targets/stm32f407.ld",
   "extra-files": [
     "src/device/stm32/stm32f407.s"
   ],


### PR DESCRIPTION
Setting the linker script as one property (instead of as part of the generic ldflags property) allows it to be overriden.

This is important for the SoftDevice on Nordic chips, because the SoftDevice takes up a fixed part of the flash/RAM and the application must be flashed at a different position. With this linkerscript option, it is possible to create (for example) a pca10040-s132v6 that overrides the default linker script.

Depends on #677.

