### PR TITLE
Adding Board: Feather M4 Express

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,8 @@ smoketest:
 	@$(MD5SUM) test.gba
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m4        examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-m4          examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-f103rb       examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pinetime-devkit0    examples/blinky1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following 20 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
 * [Adafruit Feather M0](https://www.adafruit.com/product/2772)
+* [Adafruit Feather M4](https://www.adafruit.com/product/3857)
 * [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727)
 * [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800)
 * [Adafruit Trinket M0](https://www.adafruit.com/product/3500)

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -83,5 +83,7 @@ var (
 		DOpad:       spiTXPad3SCK1,
 		DIpad:       sercomRXPad2,
 		MISOPinMode: PinSERCOM,
+		MOSIPinMode: PinSERCOM,
+		SCKPinMode:  PinSERCOM,
 	}
 )

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -1,0 +1,87 @@
+// +build sam,atsamd51,feather_m4
+
+package machine
+
+import "device/sam"
+
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0xf01669ef
+
+// GPIO Pins
+const (
+	D0  = PB17 // UART0 RX/PWM available
+	D1  = PB16 // UART0 TX/PWM available
+	D4  = PA14 // PWM available
+	D5  = PA16 // PWM available
+	D6  = PA18 // PWM available
+	D8  = PB03 // built-in neopixel
+	D9  = PA19 // PWM available
+	D10 = PA20 // can be used for PWM or UART1 TX
+	D11 = PA21 // can be used for PWM or UART1 RX
+	D12 = PA22 // PWM available
+	D13 = PA23 // PWM available
+	D21 = PA13 // PWM available
+	D22 = PA12 // PWM available
+	D23 = PB22 // PWM available
+	D24 = PB23 // PWM available
+	D25 = PA17 // PWM available
+)
+
+// Analog pins
+const (
+	A0 = PA02 // ADC/AIN[0]
+	A1 = PA05 // ADC/AIN[2]
+	A2 = PB08 // ADC/AIN[3]
+	A3 = PB09 // ADC/AIN[4]
+	A4 = PA04 // ADC/AIN[5]
+	A5 = PA06 // ADC/AIN[10]
+)
+
+const (
+	LED = D13
+)
+
+// UART0 aka USBCDC pins
+const (
+	USBCDC_DM_PIN = PA24
+	USBCDC_DP_PIN = PA25
+)
+
+// UART1 pins
+const (
+	UART_TX_PIN = D1
+	UART_RX_PIN = D0
+)
+
+// I2C pins
+const (
+	SDA_PIN = D22 // SDA: SERCOM2/PAD[0]
+	SCL_PIN = D21 // SCL: SERCOM2/PAD[1]
+)
+
+// I2C on the Feather M4.
+var (
+	I2C0 = I2C{Bus: sam.SERCOM2_I2CM,
+		SDA:     SDA_PIN,
+		SCL:     SCL_PIN,
+		PinMode: PinSERCOM}
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = D25 // SCK: SERCOM1/PAD[1]
+	SPI0_MOSI_PIN = D24 // MOSI: SERCOM1/PAD[3]
+	SPI0_MISO_PIN = D23 // MISO: SERCOM1/PAD[2]
+)
+
+// SPI on the Feather M4.
+var (
+	SPI0 = SPI{Bus: sam.SERCOM1_SPIM,
+		SCK:         SPI0_SCK_PIN,
+		MOSI:        SPI0_MOSI_PIN,
+		MISO:        SPI0_MISO_PIN,
+		DOpad:       spiTXPad3SCK1,
+		DIpad:       sercomRXPad2,
+		MISOPinMode: PinSERCOM,
+	}
+)

--- a/src/machine/machine_atsamd51j19.go
+++ b/src/machine/machine_atsamd51j19.go
@@ -1,0 +1,8 @@
+// +build sam,atsamd51,atsamd51j19
+
+// Peripheral abstraction layer for the atsamd51.
+//
+// Datasheet:
+// http://ww1.microchip.com/downloads/en/DeviceDoc/60001507C.pdf
+//
+package machine

--- a/src/runtime/runtime_atsamd51j19.go
+++ b/src/runtime/runtime_atsamd51j19.go
@@ -1,0 +1,43 @@
+// +build sam,atsamd51,atsamd51j19
+
+package runtime
+
+import (
+	"device/sam"
+)
+
+func initSERCOMClocks() {
+	// Turn on clock to SERCOM0 for UART0
+	sam.MCLK.APBAMASK.SetBits(sam.MCLK_APBAMASK_SERCOM0_)
+	sam.GCLK.PCHCTRL[7].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// sets the "slow" clock shared by all SERCOM
+	sam.GCLK.PCHCTRL[3].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// Turn on clock to SERCOM1
+	sam.MCLK.APBAMASK.SetBits(sam.MCLK_APBAMASK_SERCOM1_)
+	sam.GCLK.PCHCTRL[8].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// Turn on clock to SERCOM2
+	sam.MCLK.APBBMASK.SetBits(sam.MCLK_APBBMASK_SERCOM2_)
+	sam.GCLK.PCHCTRL[23].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// Turn on clock to SERCOM3
+	sam.MCLK.APBBMASK.SetBits(sam.MCLK_APBBMASK_SERCOM3_)
+	sam.GCLK.PCHCTRL[24].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// Turn on clock to SERCOM4
+	sam.MCLK.APBDMASK.SetBits(sam.MCLK_APBDMASK_SERCOM4_)
+	sam.GCLK.PCHCTRL[34].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+
+	// Turn on clock to SERCOM5
+	sam.MCLK.APBDMASK.SetBits(sam.MCLK_APBDMASK_SERCOM5_)
+	sam.GCLK.PCHCTRL[35].Set((sam.GCLK_PCHCTRL_GEN_GCLK1 << sam.GCLK_PCHCTRL_GEN_Pos) |
+		sam.GCLK_PCHCTRL_CHEN)
+}

--- a/targets/atsamd51j19a.json
+++ b/targets/atsamd51j19a.json
@@ -1,0 +1,15 @@
+{
+	"inherits": ["cortex-m"],
+	"llvm-target": "armv7em-none-eabi",
+	"build-tags": ["atsamd51j19", "atsamd51", "sam"],
+	"cflags": [
+		"--target=armv7em-none-eabi",
+		"-Qunused-arguments"
+	],
+	"ldflags": [
+		"-T", "targets/atsamd51.ld"
+	],
+	"extra-files": [
+		"src/device/sam/atsamd51j19a.s"
+	]
+}

--- a/targets/atsamd51j19a.json
+++ b/targets/atsamd51j19a.json
@@ -6,9 +6,7 @@
 		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
-	"ldflags": [
-		"-T", "targets/atsamd51.ld"
-	],
+	"linkerscript": "targets/atsamd51.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51j19a.s"
 	]

--- a/targets/feather-m4.json
+++ b/targets/feather-m4.json
@@ -1,0 +1,8 @@
+{
+    "inherits": ["atsamd51j19a"],
+    "build-tags": ["sam", "atsamd51j19a", "feather_m4"],
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "msd-volume-name": "FEATHERBOOT",
+    "msd-firmware-name": "firmware.uf2"
+}


### PR DESCRIPTION
Adding support for Adafruit Feather M4 Express: https://www.adafruit.com/product/3857

Schematic is here: https://cdn-learn.adafruit.com/assets/assets/000/057/242/original/arduino_compatibles_schem.png?1531010817

Currently WIP; the board/machine files are mostly copied from Itsy Bitsy M4 (with updated pin mappings of course) but this is the 64-pin version of the chip. It is mostly working except for SPI0.   I will do troubleshooting on what might be wrong with it a little later unless someone else notices what the problem might be before that.