### PR TITLE
cgo: improve handling of constants

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -42,7 +42,7 @@ type cgoPackage struct {
 // constantInfo stores some information about a CGo constant found by libclang
 // and declared in the Go AST.
 type constantInfo struct {
-	expr *ast.BasicLit
+	expr ast.Expr
 	pos  token.Pos
 }
 

--- a/cgo/const.go
+++ b/cgo/const.go
@@ -1,0 +1,59 @@
+package cgo
+
+// This file implements a parser of a subset of the C language, just enough to
+// parse common #define statements to Go constant expressions.
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+)
+
+// parseConst parses the given string as a C constant.
+func parseConst(pos token.Pos, value string) *ast.BasicLit {
+	for len(value) != 0 && value[0] == '(' && value[len(value)-1] == ')' {
+		value = strings.TrimSpace(value[1 : len(value)-1])
+	}
+	if len(value) == 0 {
+		// Pretend it doesn't exist at all.
+		return nil
+	}
+	// For information about integer literals:
+	// https://en.cppreference.com/w/cpp/language/integer_literal
+	if value[0] == '"' {
+		// string constant
+		return &ast.BasicLit{ValuePos: pos, Kind: token.STRING, Value: value}
+	}
+	if value[0] == '\'' {
+		// char constant
+		return &ast.BasicLit{ValuePos: pos, Kind: token.CHAR, Value: value}
+	}
+	// assume it's a number (int or float)
+	value = strings.Replace(value, "'", "", -1) // remove ' chars
+	value = strings.TrimRight(value, "lu")      // remove llu suffixes etc.
+	// find the first non-number
+	nonnum := byte(0)
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			nonnum = value[i]
+			break
+		}
+	}
+	// determine number type based on the first non-number
+	switch nonnum {
+	case 0:
+		// no non-number found, must be an integer
+		return &ast.BasicLit{ValuePos: pos, Kind: token.INT, Value: value}
+	case 'x', 'X':
+		// hex integer constant
+		// TODO: may also be a floating point number per C++17.
+		return &ast.BasicLit{ValuePos: pos, Kind: token.INT, Value: value}
+	case '.', 'e':
+		// float constant
+		value = strings.TrimRight(value, "fFlL")
+		return &ast.BasicLit{ValuePos: pos, Kind: token.FLOAT, Value: value}
+	default:
+		// unknown type, ignore
+	}
+	return nil
+}

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -1,0 +1,45 @@
+package cgo
+
+import (
+	"bytes"
+	"go/format"
+	"go/token"
+	"testing"
+)
+
+func TestParseConst(t *testing.T) {
+	// Test converting a C constant to a Go constant.
+	for _, tc := range []struct {
+		C  string
+		Go string
+	}{
+		{`5`, `5`},
+		{`(5)`, `5`},
+		{`(((5)))`, `5`},
+		{`5.8f`, `5.8`},
+		{`foo`, `<invalid>`}, // identifiers unimplemented
+		{``, `<invalid>`},    // empty constants not allowed in Go
+		{`"foo"`, `"foo"`},
+		{`'a'`, `'a'`},
+		{`0b10`, `<invalid>`}, // binary number literals unimplemented
+	} {
+		fset := token.NewFileSet()
+		startPos := fset.AddFile("test.c", -1, 1000).Pos(0)
+		expr := parseConst(startPos, tc.C)
+		s := "<invalid>"
+		if expr != nil {
+			// Serialize the Go constant to a string, for more readable test
+			// cases.
+			buf := &bytes.Buffer{}
+			err := format.Node(buf, fset, expr)
+			if err != nil {
+				t.Errorf("could not format expr from C constant %#v: %v", tc.C, err)
+				continue
+			}
+			s = buf.String()
+		}
+		if s != tc.Go {
+			t.Errorf("C constant %#v was parsed to %#v while expecting %#v", tc.C, s, tc.Go)
+		}
+	}
+}

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -245,9 +245,12 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 			p.addError(pos, fmt.Sprintf("internal error: expected macro value to start with %#v, got %#v", name, source))
 			break
 		}
-		value := strings.TrimSpace(source[len(name):])
+		value := source[len(name):]
 		// Try to convert this #define into a Go constant expression.
-		expr := parseConst(pos, value)
+		expr, err := parseConst(pos+token.Pos(len(name)), p.fset, value)
+		if err != nil {
+			p.errors = append(p.errors, err)
+		}
 		if expr != nil {
 			// Parsing was successful.
 			p.constants[name] = constantInfo{expr, pos}


### PR DESCRIPTION
This PR factors out constant handling (mapping C `#define` to Go constant expressions) and improves the parsing of such constants significantly. For example, for the following C code:

```c
#define CONST_INT 5)
```

You may get the following compile error:

```c
# ./testdata/cgo/
testdata/cgo/main.h:19:20: unexpected token )
```

Previously this error would be handled by simply not defining `CONST_INT`.

As a followup, I'd like to implement simple expressions like `SOME_CONST + 5`. This is required for SoftDevice support.