### PR TITLE
cgo: include all enums in the CGo Go AST

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -255,6 +255,11 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 			// Parsing was successful.
 			p.constants[name] = constantInfo{expr, pos}
 		}
+	case C.CXCursor_EnumDecl:
+		// Visit all enums, because the fields may be used even when the enum
+		// type itself is not.
+		typ := C.tinygo_clang_getCursorType(c)
+		p.makeASTType(typ, pos)
 	}
 	return C.CXChildVisit_Continue
 }

--- a/cgo/testdata/types.go
+++ b/cgo/testdata/types.go
@@ -26,6 +26,9 @@ typedef enum option {
 	optionF,
 	optionG,
 } option_t;
+enum unused {
+	unused1 = 5,
+};
 
 // Anonymous enum.
 typedef enum {

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -10,6 +10,7 @@ const C.optionD = -4
 const C.optionE = 10
 const C.optionF = 11
 const C.optionG = 12
+const C.unused1 = 5
 
 type C.int16_t = int16
 type C.int32_t = int32
@@ -73,3 +74,4 @@ type C.struct_point3d struct {
 	z C.int
 }
 type C.enum_option C.int
+type C.enum_unused C.uint


### PR DESCRIPTION
Not all enums may be used as a type anywhere, which was previously the only way to include an enum in the AST. This commit makes sure all enums are included.

One example where this is needed is the following enum:
https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s132.api.v6.1.1%2Fgroup___b_l_e___g_a_p___e_n_u_m_e_r_a_t_i_o_n_s.html&cp=3_5_2_2_2_1_1_1&anchor=gada486dd3c0cce897b23a887bed284fef