### PR TITLE
runtime: implement comparing uintptr values in interfaces

### DIFF
--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -47,7 +47,7 @@ func reflectValueEqual(x, y reflect.Value) bool {
 		return x.Bool() == y.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return x.Int() == y.Int()
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return x.Uint() == y.Uint()
 	case reflect.Float32, reflect.Float64:
 		return x.Float() == y.Float()

--- a/testdata/interface.go
+++ b/testdata/interface.go
@@ -50,6 +50,7 @@ func main() {
 		{true, uint16(1), uint16(1)},
 		{true, uint32(1), uint32(1)},
 		{true, uint64(1), uint64(1)},
+		{true, uintptr(1), uintptr(1)},
 		{true, float32(1.1), float32(1.1)},
 		{true, float64(1.1), float64(1.1)},
 		{true, complex(100, 8), complex(100, 8)},


### PR DESCRIPTION
This was an oversight in https://github.com/tinygo-org/tinygo/pull/686. With this PR, it's possible to compare interface values that contain values/fields of type `uintptr`.

This makes `time.Now().Format()` work on baremetal systems (although it seems to fall back to UTC).