### PR TITLE
runtime: add AdjustTimeOffset to update current time

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -83,12 +83,25 @@ func nanotime() int64 {
 	return int64(ticks()) * tickMicros
 }
 
+// timeOffset is how long the monotonic clock started after the Unix epoch. It
+// should be a positive integer under normal operation or zero when it has not
+// been set.
+var timeOffset int64
+
 //go:linkname now time.now
 func now() (sec int64, nsec int32, mono int64) {
 	mono = nanotime()
-	sec = mono / (1000 * 1000 * 1000)
-	nsec = int32(mono - sec*(1000*1000*1000))
+	sec = (mono + timeOffset) / (1000 * 1000 * 1000)
+	nsec = int32((mono + timeOffset) - sec*(1000*1000*1000))
 	return
+}
+
+// AdjustTimeOffset adds the given offset to the built-in time offset. A
+// positive value adds to the time (skipping some time), a negative value moves
+// the clock into the past.
+func AdjustTimeOffset(offset int64) {
+	// TODO: do this atomically?
+	timeOffset += offset
 }
 
 // Copied from the Go runtime source code.


### PR DESCRIPTION
This function adjusts the time returned by `time.Now()` and similar functions. This is necessary on bare metal systems, where there would not be a way to adjust the time otherwise.