### PR TITLE
WIP: runtime: add internal/bytealg.IndexByte function

### DIFF
--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -205,6 +205,18 @@ func decodeUTF8(s string, index uintptr) (rune, uintptr) {
 	}
 }
 
+// indexByte returns the index of the first instance of c in the byte slice b,
+// or -1 if c is not present in the byte slice.
+//go:linkname indexByte internal/bytealg.IndexByte
+func indexByte(b []byte, c byte) int {
+	for i, x := range b {
+		if x == c {
+			return i
+		}
+	}
+	return -1
+}
+
 // indexByteString returns the index of the first instance of c in s, or -1 if c
 // is not present in s.
 //go:linkname indexByteString internal/bytealg.IndexByteString


### PR DESCRIPTION
WIP for now.  Needs tests added.

--

This is to work around the wasm runtime error: `LinkError: import object field 'internal/bytealg.IndexByte' is not a Function`.