### PR TITLE
Fix ticks on 32-bit ARM on Linux

### DIFF
--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -22,7 +22,7 @@ func abort()
 func exit(code int)
 
 //go:export clock_gettime
-func clock_gettime(clk_id uint, ts *timespec)
+func clock_gettime(clk_id int32, ts *timespec)
 
 const heapSize = 1 * 1024 * 1024 // 1MB to start
 
@@ -37,8 +37,8 @@ const tickMicros = 1
 
 // TODO: Linux/amd64-specific
 type timespec struct {
-	tv_sec  int64
-	tv_nsec int64
+	tv_sec  timeT
+	tv_nsec timeT
 }
 
 const CLOCK_MONOTONIC_RAW = 4

--- a/src/runtime/runtime_unix32.go
+++ b/src/runtime/runtime_unix32.go
@@ -1,0 +1,6 @@
+// +build !baremetal
+// +build arm
+
+package runtime
+
+type timeT int32

--- a/src/runtime/runtime_unix64.go
+++ b/src/runtime/runtime_unix64.go
@@ -1,0 +1,6 @@
+// +build !baremetal
+// +build arm64 amd64 i386
+
+package runtime
+
+type timeT int64


### PR DESCRIPTION
The problem currently with #680 failing to pass tests appears to be that `ticks()` is returning corrupted time values. This PR fixes that by correcting some definitions for timing functions.