### PR TITLE
runtime/unix: simplify time functions

### DIFF
--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -35,10 +35,12 @@ type timeUnit int64
 
 const tickMicros = 1
 
-// TODO: Linux/amd64-specific
+// Note: tv_sec and tv_nsec vary in size by platform. They are 32-bit on 32-bit
+// systems and 64-bit on 64-bit systems (at least on macOS/Linux), so we can
+// simply use the 'int' type which does the same.
 type timespec struct {
-	tv_sec  timeT
-	tv_nsec timeT
+	tv_sec  int // time_t: follows the platform bitness
+	tv_nsec int // long: on Linux and macOS, follows the platform bitness
 }
 
 const CLOCK_MONOTONIC_RAW = 4

--- a/src/runtime/runtime_unix32.go
+++ b/src/runtime/runtime_unix32.go
@@ -1,6 +1,0 @@
-// +build !baremetal
-// +build arm
-
-package runtime
-
-type timeT int32

--- a/src/runtime/runtime_unix64.go
+++ b/src/runtime/runtime_unix64.go
@@ -1,6 +1,0 @@
-// +build !baremetal
-// +build arm64 amd64 i386
-
-package runtime
-
-type timeT int64


### PR DESCRIPTION
There is no need for separate datatypes for 32-bit and 64-bit *nix systems, because the int type already provides this.

See https://github.com/tinygo-org/tinygo/pull/710