### PR TITLE
targets: explicitly mark the stack as NOLOAD

### DIFF
--- a/targets/arm.ld
+++ b/targets/arm.ld
@@ -19,7 +19,7 @@ SECTIONS
     /* Put the stack at the bottom of RAM, so that the application will
      * crash on stack overflow instead of silently corrupting memory.
      * See: http://blog.japaric.io/stack-overflow-protection/ */
-    .stack :
+    .stack (NOLOAD) :
     {
         . = ALIGN(4);
         . += _stack_size;

--- a/targets/avr.ld
+++ b/targets/avr.ld
@@ -17,7 +17,7 @@ SECTIONS
         *(.rodata.*)
     }
 
-    .stack :
+    .stack (NOLOAD) :
     {
         . += _stack_size;
         _stack_top = .;

--- a/targets/gameboy-advance.ld
+++ b/targets/gameboy-advance.ld
@@ -32,7 +32,7 @@ SECTIONS
     /* Put the stack at the bottom of RAM, so that the application will
      * crash on stack overflow instead of silently corrupting memory.
      * See: http://blog.japaric.io/stack-overflow-protection/ */
-    .stack :
+    .stack (NOLOAD) :
     {
         . = ALIGN(4);
         . += _stack_size;

--- a/targets/riscv.ld
+++ b/targets/riscv.ld
@@ -13,7 +13,7 @@ SECTIONS
     /* Put the stack at the bottom of RAM, so that the application will
      * crash on stack overflow instead of silently corrupting memory.
      * See: http://blog.japaric.io/stack-overflow-protection/ */
-    .stack :
+    .stack (NOLOAD) :
     {
         . = ALIGN(4);
         . += _stack_size;


### PR DESCRIPTION
This prevents it from being of type PROGBITS in lld 9, it should always be NOBITS. This should fix the following error in lld 9:

    ROM segments are non-contiguous

Note: I haven't yet tested this.

fixes #594