### PR TITLE
all: use compiler-rt from the llvm-project directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,3 @@
 [submodule "lib/cmsis-svd"]
 	path = lib/cmsis-svd
 	url = https://github.com/tinygo-org/cmsis-svd
-[submodule "lib/compiler-rt"]
-	path = lib/compiler-rt
-	url = https://github.com/llvm-mirror/compiler-rt.git
-	branch = release_80

--- a/Makefile
+++ b/Makefile
@@ -254,16 +254,16 @@ release: tinygo gen-device
 	@mkdir -p build/release/tinygo/pkg/armv7m-none-eabi
 	@mkdir -p build/release/tinygo/pkg/armv7em-none-eabi
 	@echo copying source files
-	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
+	@cp -p  build/tinygo$(EXE)                     build/release/tinygo/bin
 	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
-	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
-	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
-	@cp -rp lib/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt/lib
-	@cp -rp lib/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt
-	@cp -rp lib/compiler-rt/README.txt   build/release/tinygo/lib/compiler-rt
-	@cp -rp lib/nrfx/*                   build/release/tinygo/lib/nrfx
-	@cp -rp src                          build/release/tinygo/src
-	@cp -rp targets                      build/release/tinygo/targets
+	@cp -rp lib/CMSIS/CMSIS/Include                build/release/tinygo/lib/CMSIS/CMSIS
+	@cp -rp lib/CMSIS/README.md                    build/release/tinygo/lib/CMSIS
+	@cp -rp llvm-project/compiler-rt/lib/builtins  build/release/tinygo/lib/compiler-rt/lib
+	@cp -rp llvm-project/compiler-rt/LICENSE.TXT   build/release/tinygo/lib/compiler-rt
+	@cp -rp llvm-project/compiler-rt/README.txt    build/release/tinygo/lib/compiler-rt
+	@cp -rp lib/nrfx/*                             build/release/tinygo/lib/nrfx
+	@cp -rp src                                    build/release/tinygo/src
+	@cp -rp targets                                build/release/tinygo/targets
 	./build/tinygo build-builtins -target=armv6m-none-eabi  -o build/release/tinygo/pkg/armv6m-none-eabi/compiler-rt.a
 	./build/tinygo build-builtins -target=armv7m-none-eabi  -o build/release/tinygo/pkg/armv7m-none-eabi/compiler-rt.a
 	./build/tinygo build-builtins -target=armv7em-none-eabi -o build/release/tinygo/pkg/armv7em-none-eabi/compiler-rt.a

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -166,6 +166,12 @@ func builtinFiles(target string) []string {
 
 // builtinsDir returns the directory where the sources for compiler-rt are kept.
 func builtinsDir() string {
+	// Path from within the development directory.
+	path := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project", "compiler-rt", "lib", "builtins")
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	// Path from within an installation directory (bundled in the release tarball).
 	return filepath.Join(goenv.Get("TINYGOROOT"), "lib", "compiler-rt", "lib", "builtins")
 }
 


### PR DESCRIPTION
We don't need the separate submodule: compiler-rt is already included in the llvm-project repository.

This should hopefully make CI slightly faster too. Also, it will make sure compiler-rt is automatically upgraded on each LLVM version upgrade.