### PR TITLE
fix incorrect starting value for optimized allocations in a loop

### DIFF
--- a/transform/testdata/allocs.ll
+++ b/transform/testdata/allocs.ll
@@ -54,6 +54,20 @@ define i32* @testEscapingReturn() {
   ret i32* %2
 }
 
+; Do a non-escaping allocation in a loop.
+define void @testNonEscapingLoop() {
+entry:
+  br label %loop
+loop:
+  %0 = call i8* @runtime.alloc(i32 4)
+  %1 = bitcast i8* %0 to i32*
+  %2 = call i32* @noescapeIntPtr(i32* %1)
+  %3 = icmp eq i32* null, %2
+  br i1 %3, label %loop, label %end
+end:
+  ret void
+}
+
 declare i32* @escapeIntPtr(i32*)
 
 declare i32* @noescapeIntPtr(i32* nocapture)

--- a/transform/testdata/allocs.out.ll
+++ b/transform/testdata/allocs.out.ll
@@ -50,6 +50,20 @@ define i32* @testEscapingReturn() {
   ret i32* %2
 }
 
+define void @testNonEscapingLoop() {
+entry:
+  %stackalloc.alloca = alloca [1 x i32]
+  br label %loop
+loop:
+  store [1 x i32] zeroinitializer, [1 x i32]* %stackalloc.alloca
+  %stackalloc = bitcast [1 x i32]* %stackalloc.alloca to i32*
+  %0 = call i32* @noescapeIntPtr(i32* %stackalloc)
+  %1 = icmp eq i32* null, %0
+  br i1 %1, label %loop, label %end
+end:
+  ret void
+}
+
 declare i32* @escapeIntPtr(i32*)
 
 declare i32* @noescapeIntPtr(i32* nocapture)

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -70,8 +70,9 @@ func fuzzyEqualIR(s1, s2 string) bool {
 func filterIrrelevantIRLines(lines []string) []string {
 	var out []string
 	for _, line := range lines {
-		line = strings.TrimSpace(line) // drop '\r' on Windows
-		if line == "" || line[0] == ';' {
+		line = strings.Split(line, ";")[0]    // strip out comments/info
+		line = strings.TrimRight(line, "\r ") // drop '\r' on Windows and remove trailing spaces from comments
+		if line == "" {
 			continue
 		}
 		if strings.HasPrefix(line, "source_filename = ") {


### PR DESCRIPTION
Previously, we only zeroed stack allocations once in the entry block. However, when the original allocation is in a loop, it is necessary to zero the allocation on every iteration. This PR moves the allocation zeroing into the location where the `runtime.alloc` call used to be.