### PR TITLE
runtime/atsamd21: i2s initialization fixes

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -877,29 +877,29 @@ func (i2s I2S) Configure(config I2SConfig) {
 	// now set serializer data size.
 	switch config.DataFormat {
 	case I2SDataFormat8bit:
-		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_8)
+		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_8 << sam.I2S_SERCTRL_DATASIZE_Pos)
 
 	case I2SDataFormat16bit:
-		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_16)
+		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_16 << sam.I2S_SERCTRL_DATASIZE_Pos)
 
 	case I2SDataFormat24bit:
-		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_24)
+		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_24 << sam.I2S_SERCTRL_DATASIZE_Pos)
 
 	case I2SDataFormat32bit:
 	case I2SDataFormatDefault:
-		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_32)
+		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_DATASIZE_32 << sam.I2S_SERCTRL_DATASIZE_Pos)
 	}
 
 	// set serializer slot adjustment
 	if config.Standard == I2SStandardLSB {
 		// adjust right
 		i2s.Bus.SERCTRL1.ClearBits(sam.I2S_SERCTRL_SLOTADJ)
+
+		// transfer LSB first
+		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_BITREV)
 	} else {
 		// adjust left
 		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_SLOTADJ)
-
-		// reverse bit order?
-		i2s.Bus.SERCTRL1.SetBits(sam.I2S_SERCTRL_BITREV)
 	}
 
 	// set serializer mode.


### PR DESCRIPTION
I found these during code review, they look like bugs to me.  Unfortunately, I don't have atsamd21 hardware to test against, so please review carefully.

1. The I2S_SERCTRL_DATASIZE_* constants are 0-based, but DATASIZE is not at offset 0 within the SERCTRL register.  It should be shifted by 8, otherwise it will clobber the SERMODE and TXDEFAULT fields.
2. The Philips I2S spec is MSB-first.  The BITREV flag, when set, causes LSB-first operation.  I think the flag should be should be set in I2SStandardLSB mode, and clear in I2SStandardMSB and I2SStandardPhilips modes.

I think this PR will cause the `src/examples/i2s/i2s.go` example to print samples in the opposite order.  Were the samples printed correctly before?
