### PR TITLE
nrf: fix nrf52-s132v6 config

### DIFF
--- a/targets/nrf52-s132v6.json
+++ b/targets/nrf52-s132v6.json
@@ -1,4 +1,4 @@
 {
-	"build-tags": ["softdevice"],
+	"build-tags": ["softdevice", "s132v6"],
 	"linkerscript": "targets/nrf52-s132v6.ld"
 }

--- a/targets/pca10040-s132v6.json
+++ b/targets/pca10040-s132v6.json
@@ -1,4 +1,3 @@
 {
-	"inherits": ["pca10040", "nrf52-s132v6"],
-	"ldscript": "targets/nrf52-s132v6.ld"
+	"inherits": ["pca10040", "nrf52-s132v6"]
 }


### PR DESCRIPTION
In my excitement to get the SoftDevice PR ready, I made two mistakes. They're fixed in this commit.

  * Add the `s132v6` build tag.
  * Remove the (old) `ldscript` property.

This fixes the following issue: https://github.com/aykevl/go-bluetooth/issues/1