### PR TITLE
add code to handle programs which use heap allocations but never hit the GC

### DIFF
--- a/testdata/zeroalloc.go
+++ b/testdata/zeroalloc.go
@@ -1,0 +1,7 @@
+package main
+func main() {
+	p := []byte{}
+	for len(p) >= 1 {
+		p = p[1:]
+	}
+}


### PR DESCRIPTION
Fixes the bug shown in https://github.com/tinygo-org/tinygo/issues/728#issuecomment-554684216, where a piece of code only calls `runtime.alloc` once and does a zero-size allocation.