### PR TITLE
interp: fix inserting non-const values in a const aggregate

### DIFF
--- a/interp/testdata/basic.ll
+++ b/interp/testdata/basic.ll
@@ -2,6 +2,8 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
 @main.v1 = internal global i64 0
+@main.nonConst1 = global [4 x i64] zeroinitializer
+@main.nonConst2 = global i64 0
 
 declare void @runtime.printint64(i64) unnamed_addr
 
@@ -31,6 +33,20 @@ define internal void @main.init() unnamed_addr {
 entry:
   store i64 3, i64* @main.v1
   call void @"main.init#1"()
+
+  ; test the following pattern:
+  ;     func someValue() int // extern function
+  ;     var nonConst1 = [4]int{someValue(), 0, 0, 0}
+  %value1 = call i64 @someValue()
+  %gep1 = getelementptr [4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0
+  store i64 %value1, i64* %gep1
+
+  ; Test that the global really is marked dirty:
+  ;     var nonConst2 = nonConst1[0]
+  %gep2 = getelementptr [4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0
+  %value2 = load i64, i64* %gep2
+  store i64 %value2, i64* @main.nonConst2
+
   ret void
 }
 
@@ -40,3 +56,5 @@ entry:
   call void @runtime.printnl()
   ret void
 }
+
+declare i64 @someValue()

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -1,6 +1,9 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
+@main.nonConst1 = local_unnamed_addr global [4 x i64] zeroinitializer
+@main.nonConst2 = local_unnamed_addr global i64 0
+
 declare void @runtime.printint64(i64) unnamed_addr
 
 declare void @runtime.printnl() unnamed_addr
@@ -9,6 +12,10 @@ define void @runtime.initAll() unnamed_addr {
 entry:
   call void @runtime.printint64(i64 5)
   call void @runtime.printnl()
+  %value1 = call i64 @someValue()
+  store i64 %value1, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0)
+  %value2 = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0)
+  store i64 %value2, i64* @main.nonConst2
   ret void
 }
 
@@ -18,3 +25,5 @@ entry:
   call void @runtime.printnl()
   ret void
 }
+
+declare i64 @someValue() local_unnamed_addr

--- a/interp/utils.go
+++ b/interp/utils.go
@@ -76,3 +76,22 @@ func isPointerNil(v llvm.Value) (result bool, ok bool) {
 	}
 	return false, false // not valid
 }
+
+// unwrap returns the underlying value, with GEPs removed. This can be useful to
+// get the underlying global of a GEP pointer.
+func unwrap(value llvm.Value) llvm.Value {
+	for {
+		if !value.IsAConstantExpr().IsNil() {
+			switch value.Opcode() {
+			case llvm.GetElementPtr:
+				value = value.Operand(0)
+				continue
+			}
+		} else if !value.IsAGetElementPtrInst().IsNil() {
+			value = value.Operand(0)
+			continue
+		}
+		break
+	}
+	return value
+}


### PR DESCRIPTION
This bug was triggered by the following code:

    package main

    func foo() byte

    var array = [1]byte{foo()}

    func main() {
    }