### PR TITLE
Blocking interface calls

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -461,7 +461,9 @@ func (c *Compiler) getInterfaceInvokeWrapper(f *ir.Function) llvm.Value {
 	paramTypes := append([]llvm.Type{c.i8ptrType}, fnType.ParamTypes()[len(expandedReceiverType):]...)
 	wrapFnType := llvm.FunctionType(fnType.ReturnType(), paramTypes, false)
 	wrapper = llvm.AddFunction(c.mod, wrapperName, wrapFnType)
-	wrapper.LastParam().SetName("parentHandle")
+	if f.LLVMFn.LastParam().Name() == "parentHandle" {
+		wrapper.LastParam().SetName("parentHandle")
+	}
 	c.interfaceInvokeWrappers = append(c.interfaceInvokeWrappers, interfaceInvokeWrapper{
 		fn:           f,
 		wrapper:      wrapper,

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -461,6 +461,7 @@ func (c *Compiler) getInterfaceInvokeWrapper(f *ir.Function) llvm.Value {
 	paramTypes := append([]llvm.Type{c.i8ptrType}, fnType.ParamTypes()[len(expandedReceiverType):]...)
 	wrapFnType := llvm.FunctionType(fnType.ReturnType(), paramTypes, false)
 	wrapper = llvm.AddFunction(c.mod, wrapperName, wrapFnType)
+	wrapper.LastParam().SetName("parentHandle")
 	c.interfaceInvokeWrappers = append(c.interfaceInvokeWrappers, interfaceInvokeWrapper{
 		fn:           f,
 		wrapper:      wrapper,

--- a/testdata/interface.go
+++ b/testdata/interface.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 func main() {
 	thing := &Thing{"foo"}
 	println("thing:", thing.String())
@@ -87,6 +89,14 @@ func main() {
 			println("test", i, "of interfaceEqualTests failed")
 		}
 	}
+
+	// test interface blocking
+	blockDynamic(NonBlocker{})
+	println("non-blocking call on sometimes-blocking interface")
+	blockDynamic(SleepBlocker(time.Millisecond))
+	println("slept 1ms")
+	blockStatic(SleepBlocker(time.Millisecond))
+	println("slept 1ms")
 }
 
 func printItf(val interface{}) {
@@ -132,6 +142,14 @@ func nestedSwitch(verb rune, arg interface{}) bool {
 		}
 	}
 	return false
+}
+
+func blockDynamic(blocker DynamicBlocker) {
+	blocker.Block()
+}
+
+func blockStatic(blocker StaticBlocker) {
+	blocker.Sleep()
 }
 
 type Thing struct {
@@ -210,4 +228,26 @@ type Unmatched interface {
 
 type linkedList struct {
 	addr *linkedList
+}
+
+type DynamicBlocker interface {
+	Block()
+}
+
+type NonBlocker struct{}
+
+func (b NonBlocker) Block() {}
+
+type SleepBlocker time.Duration
+
+func (s SleepBlocker) Block() {
+	time.Sleep(time.Duration(s))
+}
+
+func (s SleepBlocker) Sleep() {
+	s.Block()
+}
+
+type StaticBlocker interface {
+	Sleep()
 }

--- a/testdata/interface.txt
+++ b/testdata/interface.txt
@@ -19,3 +19,6 @@ SmallPair.Print: 3 5
 Stringer.String(): foo
 Stringer.(*Thing).String(): foo
 nested switch: true
+non-blocking call on sometimes-blocking interface
+slept 1ms
+slept 1ms

--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -13,7 +13,7 @@ target triple = "armv7m-none-eabi"
 @"Unmatched$interface" = private constant [1 x i8*] [i8* @"func NeverImplementedMethod()"]
 @"func Double() int" = external constant i8
 @"Doubler$interface" = private constant [1 x i8*] [i8* @"func Double() int"]
-@"Number$methodset" = private constant [1 x %runtime.interfaceMethodInfo] [%runtime.interfaceMethodInfo { i8* @"func Double() int", i32 ptrtoint (i32 (i8*)* @"(Number).Double$invoke" to i32) }]
+@"Number$methodset" = private constant [1 x %runtime.interfaceMethodInfo] [%runtime.interfaceMethodInfo { i8* @"func Double() int", i32 ptrtoint (i32 (i8*, i8*)* @"(Number).Double$invoke" to i32) }]
 @"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0 }
 @"typeInInterface:reflect/types.type:named:Number" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:named:Number", %runtime.interfaceMethodInfo* getelementptr inbounds ([1 x %runtime.interfaceMethodInfo], [1 x %runtime.interfaceMethodInfo]* @"Number$methodset", i32 0, i32 0) }
 
@@ -49,8 +49,8 @@ typeswitch.notUnmatched:
 
 typeswitch.Doubler:
   %doubler.func = call i32 @runtime.interfaceMethod(i32 %typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"Doubler$interface", i32 0, i32 0), i8* nonnull @"func Double() int")
-  %doubler.func.cast = inttoptr i32 %doubler.func to i32 (i8*)*
-  %doubler.result = call i32 %doubler.func.cast(i8* %value)
+  %doubler.func.cast = inttoptr i32 %doubler.func to i32 (i8*, i8*)*
+  %doubler.result = call i32 %doubler.func.cast(i8* %value, i8* null)
   call void @runtime.printint32(i32 %doubler.result)
   ret void
 
@@ -68,13 +68,13 @@ typeswitch.notByte:
   ret void
 }
 
-define i32 @"(Number).Double"(i32 %receiver) {
+define i32 @"(Number).Double"(i32 %receiver, i8* %parentHandle) {
   %ret = mul i32 %receiver, 2
   ret i32 %ret
 }
 
-define i32 @"(Number).Double$invoke"(i8* %receiverPtr) {
+define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %parentHandle) {
   %receiver = ptrtoint i8* %receiverPtr to i32
-  %ret = call i32 @"(Number).Double"(i32 %receiver)
+  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* null)
   ret i32 %ret
 }

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -47,7 +47,7 @@ typeswitch.notUnmatched:
   br i1 %typeassert.ok, label %typeswitch.Doubler, label %typeswitch.notDoubler
 
 typeswitch.Doubler:
-  %doubler.result = call i32 @"(Number).Double$invoke"(i8* %value)
+  %doubler.result = call i32 @"(Number).Double$invoke"(i8* %value, i8* null)
   call void @runtime.printint32(i32 %doubler.result)
   ret void
 
@@ -65,14 +65,14 @@ typeswitch.notByte:
   ret void
 }
 
-define i32 @"(Number).Double"(i32 %receiver) {
+define i32 @"(Number).Double"(i32 %receiver, i8* %parentHandle) {
   %ret = mul i32 %receiver, 2
   ret i32 %ret
 }
 
-define i32 @"(Number).Double$invoke"(i8* %receiverPtr) {
+define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %parentHandle) {
   %receiver = ptrtoint i8* %receiverPtr to i32
-  %ret = call i32 @"(Number).Double"(i32 %receiver)
+  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* null)
   ret i32 %ret
 }
 


### PR DESCRIPTION
This PR fixes up function typing so that the interface `$invoke` and dispatch functions can be processed by the goroutine lowering pass. As this is currently structured, these functions will never need to be turned into coroutines because all blocking calls are tail calls.