### PR TITLE
Fixes for UART2 on Metro M4 Airlift Lite

### DIFF
--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -53,6 +53,12 @@ const (
 	UART_RX_PIN = D0
 )
 
+// UART2 pins
+const (
+	UART2_TX_PIN = A4
+	UART2_RX_PIN = A5
+)
+
 // I2C pins
 const (
 	SDA_PIN = D22 // SDA: SERCOM2/PAD[0]

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -51,10 +51,20 @@ const (
 	UART_RX_PIN = D0
 )
 
+// UART1 var is on SERCOM3, defined in atsamd51.go
+
+// UART2 pins
+const (
+	UART2_TX_PIN = A4
+	UART2_RX_PIN = D2
+)
+
+// UART2 var is on SERCOM0, defined in atsamd51.go
+
 // I2C pins
 const (
-	SDA_PIN = PA12 // SDA: SERCOM3/PAD[0]
-	SCL_PIN = PA13 // SCL: SERCOM3/PAD[1]
+	SDA_PIN = PA12 // SDA: SERCOM2/PAD[0]
+	SCL_PIN = PA13 // SCL: SERCOM2/PAD[1]
 )
 
 // I2C on the ItsyBitsy M4.

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -66,14 +66,8 @@ const (
 	NINA_RTS = PB23
 )
 
-// UART2 on the Metro M4 Airlift Lite connects to the onboard ESP32-WROOM chip.
-var (
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		Mode:   PinSERCOMAlt,
-	}
-)
+// UART2 is on SERCOM0,  defined in machine_atsamd51.go, and connects to the
+// onboard ESP32-WROOM chip.
 
 // I2C pins
 const (

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -75,12 +75,6 @@ var (
 	}
 )
 
-//go:export SERCOM0_IRQHandler
-func handleUART2() {
-	UART2.Receive(byte((UART2.Bus.DATA.Get() & 0xFF)))
-	UART2.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
-}
-
 // I2C pins
 const (
 	SDA_PIN = PB02 // SDA: SERCOM5/PAD[0]
@@ -100,6 +94,10 @@ const (
 	SPI0_SCK_PIN  = PA13 // SCK:  SERCOM2/PAD[1]
 	SPI0_MOSI_PIN = PA12 // MOSI: SERCOM2/PAD[0]
 	SPI0_MISO_PIN = PA14 // MISO: SERCOM2/PAD[2]
+
+	NINA_MOSI = SPI0_MOSI_PIN
+	NINA_MISO = SPI0_MISO_PIN
+	NINA_SCK  = SPI0_SCK_PIN
 )
 
 // SPI on the Metro M4.
@@ -115,6 +113,7 @@ var (
 		MOSIPinMode: PinSERCOM,
 		SCKPinMode:  PinSERCOM,
 	}
+	NINA_SPI = SPI0
 )
 
 const (

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -473,6 +473,13 @@ var (
 		Buffer: NewRingBuffer(),
 		Mode:   PinSERCOMAlt,
 	}
+
+	// The second hardware serial port on the SAMD51. Uses the SERCOM0 interface.
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		Mode:   PinSERCOMAlt,
+	}
 )
 
 const (
@@ -522,6 +529,8 @@ func (uart UART) Configure(config UARTConfig) {
 	}
 
 	switch config.RX {
+	case PA06:
+		rxpad = sercomRXPad2
 	case PA07:
 		rxpad = sercomRXPad3
 	case PA11:
@@ -677,6 +686,7 @@ func handleSERCOM0_OTHER() {
 }
 
 func handleUART2() {
+	// should reset IRQ
 	UART2.Receive(byte((UART2.Bus.DATA.Get() & 0xFF)))
 	UART2.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
 }

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -591,11 +591,20 @@ func (uart UART) Configure(config UARTConfig) {
 	// setup interrupt on receive
 	uart.Bus.INTENSET.Set(sam.SERCOM_USART_INT_INTENSET_RXC)
 
-	// Enable RX IRQ. Currently assumes SERCOM3.
-	arm.EnableIRQ(sam.IRQ_SERCOM3_0)
-	arm.EnableIRQ(sam.IRQ_SERCOM3_1)
-	arm.EnableIRQ(sam.IRQ_SERCOM3_2)
-	arm.EnableIRQ(sam.IRQ_SERCOM3_OTHER)
+	// Enable RX IRQ.
+	switch uart.Bus {
+	case sam.SERCOM0_USART_INT:
+		arm.EnableIRQ(sam.IRQ_SERCOM0_0)
+		arm.EnableIRQ(sam.IRQ_SERCOM0_1)
+		arm.EnableIRQ(sam.IRQ_SERCOM0_2)
+		arm.EnableIRQ(sam.IRQ_SERCOM0_OTHER)
+	default:
+		// Currently assumes SERCOM3
+		arm.EnableIRQ(sam.IRQ_SERCOM3_0)
+		arm.EnableIRQ(sam.IRQ_SERCOM3_1)
+		arm.EnableIRQ(sam.IRQ_SERCOM3_2)
+		arm.EnableIRQ(sam.IRQ_SERCOM3_OTHER)
+	}
 }
 
 // SetBaudRate sets the communication speed for the UART.
@@ -645,6 +654,31 @@ func handleUART1() {
 	// should reset IRQ
 	UART1.Receive(byte((UART1.Bus.DATA.Get() & 0xFF)))
 	UART1.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
+}
+
+//go:export SERCOM0_0_IRQHandler
+func handleSERCOM0_0() {
+	handleUART2()
+}
+
+//go:export SERCOM0_1_IRQHandler
+func handleSERCOM0_1() {
+	handleUART2()
+}
+
+//go:export SERCOM0_2_IRQHandler
+func handleSERCOM0_2() {
+	handleUART2()
+}
+
+//go:export SERCOM0_OTHER_IRQHandler
+func handleSERCOM0_OTHER() {
+	handleUART2()
+}
+
+func handleUART2() {
+	UART2.Receive(byte((UART2.Bus.DATA.Get() & 0xFF)))
+	UART2.Bus.INTFLAG.SetBits(sam.SERCOM_USART_INT_INTFLAG_RXC)
 }
 
 // I2C on the SAMD51.


### PR DESCRIPTION
My initial implementation for UART2 on this Metro M4 Airlift Lite was simply incorrect.  This PR adds handlers to atsamd51.go so that this actually works.