### PR TITLE
Refactor compiler

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 	"github.com/tinygo-org/tinygo/interp"
 	"github.com/tinygo-org/tinygo/transform"
+	"tinygo.org/x/go-llvm"
 )
 
 // Build performs a single package to executable Go build. It takes in a package
@@ -26,34 +27,34 @@ import (
 // The error value may be of type *MultiError. Callers will likely want to check
 // for this case and print such errors individually.
 func Build(pkgName, outpath string, config *compileopts.Config, action func(string) error) error {
-	c, err := compiler.NewCompiler(pkgName, config)
+	// Compile Go code to IR.
+	machine, err := compiler.NewTargetMachine(config)
 	if err != nil {
 		return err
 	}
-
-	// Compile Go code to IR.
-	errs := c.Compile(pkgName)
-	if len(errs) != 0 {
+	mod, extraFiles, errs := compiler.Compile(pkgName, machine, config)
+	if errs != nil {
 		return newMultiError(errs)
 	}
+
 	if config.Options.PrintIR {
 		fmt.Println("; Generated LLVM IR:")
-		fmt.Println(c.IR())
+		fmt.Println(mod.String())
 	}
-	if err := c.Verify(); err != nil {
+	if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 		return errors.New("verification error after IR construction")
 	}
 
-	err = interp.Run(c.Module(), config.DumpSSA())
+	err = interp.Run(mod, config.DumpSSA())
 	if err != nil {
 		return err
 	}
-	if err := c.Verify(); err != nil {
+	if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 		return errors.New("verification error after interpreting runtime.initAll")
 	}
 
 	if config.GOOS() != "darwin" {
-		transform.ApplyFunctionSections(c.Module()) // -ffunction-sections
+		transform.ApplyFunctionSections(mod) // -ffunction-sections
 	}
 
 	// Browsers cannot handle external functions that have type i64 because it
@@ -62,7 +63,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	// stack-allocated values.
 	// Use -wasm-abi=generic to disable this behaviour.
 	if config.Options.WasmAbi == "js" && strings.HasPrefix(config.Triple(), "wasm") {
-		err := transform.ExternalInt64AsPtr(c.Module())
+		err := transform.ExternalInt64AsPtr(mod)
 		if err != nil {
 			return err
 		}
@@ -73,22 +74,22 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	errs = nil
 	switch config.Options.Opt {
 	case "none", "0":
-		errs = transform.Optimize(c.Module(), config, 0, 0, 0) // -O0
+		errs = transform.Optimize(mod, config, 0, 0, 0) // -O0
 	case "1":
-		errs = transform.Optimize(c.Module(), config, 1, 0, 0) // -O1
+		errs = transform.Optimize(mod, config, 1, 0, 0) // -O1
 	case "2":
-		errs = transform.Optimize(c.Module(), config, 2, 0, 225) // -O2
+		errs = transform.Optimize(mod, config, 2, 0, 225) // -O2
 	case "s":
-		errs = transform.Optimize(c.Module(), config, 2, 1, 225) // -Os
+		errs = transform.Optimize(mod, config, 2, 1, 225) // -Os
 	case "z":
-		errs = transform.Optimize(c.Module(), config, 2, 2, 5) // -Oz, default
+		errs = transform.Optimize(mod, config, 2, 2, 5) // -Oz, default
 	default:
 		errs = []error{errors.New("unknown optimization level: -opt=" + config.Options.Opt)}
 	}
 	if len(errs) > 0 {
 		return newMultiError(errs)
 	}
-	if err := c.Verify(); err != nil {
+	if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 		return errors.New("verification failure after LLVM optimization passes")
 	}
 
@@ -98,8 +99,8 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	// pointers are flash and which are in RAM so that pointers can have a
 	// correct address space parameter (address space 1 is for flash).
 	if strings.HasPrefix(config.Triple(), "avr") {
-		transform.NonConstGlobals(c.Module())
-		if err := c.Verify(); err != nil {
+		transform.NonConstGlobals(mod)
+		if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 			return errors.New("verification error after making all globals non-constant on AVR")
 		}
 	}
@@ -108,11 +109,17 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	outext := filepath.Ext(outpath)
 	switch outext {
 	case ".o":
-		return c.EmitObject(outpath)
+		llvmBuf, err := machine.EmitToMemoryBuffer(mod, llvm.ObjectFile)
+		if err != nil {
+			return err
+		}
+		return ioutil.WriteFile(outpath, llvmBuf.Bytes(), 0666)
 	case ".bc":
-		return c.EmitBitcode(outpath)
+		data := llvm.WriteBitcodeToMemoryBuffer(mod).Bytes()
+		return ioutil.WriteFile(outpath, data, 0666)
 	case ".ll":
-		return c.EmitText(outpath)
+		data := []byte(mod.String())
+		return ioutil.WriteFile(outpath, data, 0666)
 	default:
 		// Act as a compiler driver.
 
@@ -125,7 +132,11 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 
 		// Write the object file.
 		objfile := filepath.Join(dir, "main.o")
-		err = c.EmitObject(objfile)
+		llvmBuf, err := machine.EmitToMemoryBuffer(mod, llvm.ObjectFile)
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(objfile, llvmBuf.Bytes(), 0666)
 		if err != nil {
 			return err
 		}
@@ -161,16 +172,13 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		}
 
 		// Compile C files in packages.
-		for i, pkg := range c.Packages() {
-			for _, file := range pkg.CFiles {
-				path := filepath.Join(pkg.Package.Dir, file)
-				outpath := filepath.Join(dir, "pkg"+strconv.Itoa(i)+"-"+file+".o")
-				err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, path)...)
-				if err != nil {
-					return &commandError{"failed to build", path, err}
-				}
-				ldflags = append(ldflags, outpath)
+		for i, file := range extraFiles {
+			outpath := filepath.Join(dir, "pkg"+strconv.Itoa(i)+"-"+filepath.Base(file)+".o")
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, file)...)
+			if err != nil {
+				return &commandError{"failed to build", file, err}
 			}
+			ldflags = append(ldflags, outpath)
 		}
 
 		// Link the object files together.

--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -11,11 +11,11 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-// emitLookupBoundsCheck emits a bounds check before doing a lookup into a
+// createLookupBoundsCheck emits a bounds check before doing a lookup into a
 // slice. This is required by the Go language spec: an index out of bounds must
 // cause a panic.
-func (c *Compiler) emitLookupBoundsCheck(frame *Frame, arrayLen, index llvm.Value, indexType types.Type) {
-	if frame.fn.IsNoBounds() {
+func (b *builder) createLookupBoundsCheck(arrayLen, index llvm.Value, indexType types.Type) {
+	if b.fn.IsNoBounds() {
 		// The //go:nobounds pragma was added to the function to avoid bounds
 		// checking.
 		return
@@ -25,29 +25,29 @@ func (c *Compiler) emitLookupBoundsCheck(frame *Frame, arrayLen, index llvm.Valu
 		// Sometimes, the index can be e.g. an uint8 or int8, and we have to
 		// correctly extend that type.
 		if indexType.Underlying().(*types.Basic).Info()&types.IsUnsigned == 0 {
-			index = c.builder.CreateZExt(index, arrayLen.Type(), "")
+			index = b.CreateZExt(index, arrayLen.Type(), "")
 		} else {
-			index = c.builder.CreateSExt(index, arrayLen.Type(), "")
+			index = b.CreateSExt(index, arrayLen.Type(), "")
 		}
 	} else if index.Type().IntTypeWidth() > arrayLen.Type().IntTypeWidth() {
 		// The index is bigger than the array length type, so extend it.
-		arrayLen = c.builder.CreateZExt(arrayLen, index.Type(), "")
+		arrayLen = b.CreateZExt(arrayLen, index.Type(), "")
 	}
 
 	// Now do the bounds check: index >= arrayLen
-	outOfBounds := c.builder.CreateICmp(llvm.IntUGE, index, arrayLen, "")
-	c.createRuntimeAssert(frame, outOfBounds, "lookup", "lookupPanic")
+	outOfBounds := b.CreateICmp(llvm.IntUGE, index, arrayLen, "")
+	b.createRuntimeAssert(outOfBounds, "lookup", "lookupPanic")
 }
 
-// emitSliceBoundsCheck emits a bounds check before a slicing operation to make
+// createSliceBoundsCheck emits a bounds check before a slicing operation to make
 // sure it is within bounds.
 //
 // This function is both used for slicing a slice (low and high have their
 // normal meaning) and for creating a new slice, where 'capacity' means the
 // biggest possible slice capacity, 'low' means len and 'high' means cap. The
 // logic is the same in both cases.
-func (c *Compiler) emitSliceBoundsCheck(frame *Frame, capacity, low, high, max llvm.Value, lowType, highType, maxType *types.Basic) {
-	if frame.fn.IsNoBounds() {
+func (b *builder) createSliceBoundsCheck(capacity, low, high, max llvm.Value, lowType, highType, maxType *types.Basic) {
+	if b.fn.IsNoBounds() {
 		// The //go:nobounds pragma was added to the function to avoid bounds
 		// checking.
 		return
@@ -65,45 +65,45 @@ func (c *Compiler) emitSliceBoundsCheck(frame *Frame, capacity, low, high, max l
 		capacityType = max.Type()
 	}
 	if capacityType != capacity.Type() {
-		capacity = c.builder.CreateZExt(capacity, capacityType, "")
+		capacity = b.CreateZExt(capacity, capacityType, "")
 	}
 
 	// Extend low and high to be the same size as capacity.
 	if low.Type().IntTypeWidth() < capacityType.IntTypeWidth() {
 		if lowType.Info()&types.IsUnsigned != 0 {
-			low = c.builder.CreateZExt(low, capacityType, "")
+			low = b.CreateZExt(low, capacityType, "")
 		} else {
-			low = c.builder.CreateSExt(low, capacityType, "")
+			low = b.CreateSExt(low, capacityType, "")
 		}
 	}
 	if high.Type().IntTypeWidth() < capacityType.IntTypeWidth() {
 		if highType.Info()&types.IsUnsigned != 0 {
-			high = c.builder.CreateZExt(high, capacityType, "")
+			high = b.CreateZExt(high, capacityType, "")
 		} else {
-			high = c.builder.CreateSExt(high, capacityType, "")
+			high = b.CreateSExt(high, capacityType, "")
 		}
 	}
 	if max.Type().IntTypeWidth() < capacityType.IntTypeWidth() {
 		if maxType.Info()&types.IsUnsigned != 0 {
-			max = c.builder.CreateZExt(max, capacityType, "")
+			max = b.CreateZExt(max, capacityType, "")
 		} else {
-			max = c.builder.CreateSExt(max, capacityType, "")
+			max = b.CreateSExt(max, capacityType, "")
 		}
 	}
 
 	// Now do the bounds check: low > high || high > capacity
-	outOfBounds1 := c.builder.CreateICmp(llvm.IntUGT, low, high, "slice.lowhigh")
-	outOfBounds2 := c.builder.CreateICmp(llvm.IntUGT, high, max, "slice.highmax")
-	outOfBounds3 := c.builder.CreateICmp(llvm.IntUGT, max, capacity, "slice.maxcap")
-	outOfBounds := c.builder.CreateOr(outOfBounds1, outOfBounds2, "slice.lowmax")
-	outOfBounds = c.builder.CreateOr(outOfBounds, outOfBounds3, "slice.lowcap")
-	c.createRuntimeAssert(frame, outOfBounds, "slice", "slicePanic")
+	outOfBounds1 := b.CreateICmp(llvm.IntUGT, low, high, "slice.lowhigh")
+	outOfBounds2 := b.CreateICmp(llvm.IntUGT, high, max, "slice.highmax")
+	outOfBounds3 := b.CreateICmp(llvm.IntUGT, max, capacity, "slice.maxcap")
+	outOfBounds := b.CreateOr(outOfBounds1, outOfBounds2, "slice.lowmax")
+	outOfBounds = b.CreateOr(outOfBounds, outOfBounds3, "slice.lowcap")
+	b.createRuntimeAssert(outOfBounds, "slice", "slicePanic")
 }
 
-// emitChanBoundsCheck emits a bounds check before creating a new channel to
+// createChanBoundsCheck creates a bounds check before creating a new channel to
 // check that the value is not too big for runtime.chanMake.
-func (c *Compiler) emitChanBoundsCheck(frame *Frame, elementSize uint64, bufSize llvm.Value, bufSizeType *types.Basic, pos token.Pos) {
-	if frame.fn.IsNoBounds() {
+func (b *builder) createChanBoundsCheck(elementSize uint64, bufSize llvm.Value, bufSizeType *types.Basic, pos token.Pos) {
+	if b.fn.IsNoBounds() {
 		// The //go:nobounds pragma was added to the function to avoid bounds
 		// checking.
 		return
@@ -111,23 +111,23 @@ func (c *Compiler) emitChanBoundsCheck(frame *Frame, elementSize uint64, bufSize
 
 	// Check whether the bufSize parameter must be cast to a wider integer for
 	// comparison.
-	if bufSize.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
+	if bufSize.Type().IntTypeWidth() < b.uintptrType.IntTypeWidth() {
 		if bufSizeType.Info()&types.IsUnsigned != 0 {
 			// Unsigned, so zero-extend to uint type.
 			bufSizeType = types.Typ[types.Uint]
-			bufSize = c.builder.CreateZExt(bufSize, c.intType, "")
+			bufSize = b.CreateZExt(bufSize, b.intType, "")
 		} else {
 			// Signed, so sign-extend to int type.
 			bufSizeType = types.Typ[types.Int]
-			bufSize = c.builder.CreateSExt(bufSize, c.intType, "")
+			bufSize = b.CreateSExt(bufSize, b.intType, "")
 		}
 	}
 
 	// Calculate (^uintptr(0)) >> 1, which is the max value that fits in an
 	// uintptr if uintptrs were signed.
-	maxBufSize := llvm.ConstLShr(llvm.ConstNot(llvm.ConstInt(c.uintptrType, 0, false)), llvm.ConstInt(c.uintptrType, 1, false))
+	maxBufSize := llvm.ConstLShr(llvm.ConstNot(llvm.ConstInt(b.uintptrType, 0, false)), llvm.ConstInt(b.uintptrType, 1, false))
 	if elementSize > maxBufSize.ZExtValue() {
-		c.addError(pos, fmt.Sprintf("channel element type is too big (%v bytes)", elementSize))
+		b.addError(pos, fmt.Sprintf("channel element type is too big (%v bytes)", elementSize))
 		return
 	}
 	// Avoid divide-by-zero.
@@ -136,7 +136,7 @@ func (c *Compiler) emitChanBoundsCheck(frame *Frame, elementSize uint64, bufSize
 	}
 	// Make the maxBufSize actually the maximum allowed value (in number of
 	// elements in the channel buffer).
-	maxBufSize = llvm.ConstUDiv(maxBufSize, llvm.ConstInt(c.uintptrType, elementSize, false))
+	maxBufSize = llvm.ConstUDiv(maxBufSize, llvm.ConstInt(b.uintptrType, elementSize, false))
 
 	// Make sure maxBufSize has the same type as bufSize.
 	if maxBufSize.Type() != bufSize.Type() {
@@ -144,14 +144,14 @@ func (c *Compiler) emitChanBoundsCheck(frame *Frame, elementSize uint64, bufSize
 	}
 
 	// Do the check for a too large (or negative) buffer size.
-	bufSizeTooBig := c.builder.CreateICmp(llvm.IntUGE, bufSize, maxBufSize, "")
-	c.createRuntimeAssert(frame, bufSizeTooBig, "chan", "chanMakePanic")
+	bufSizeTooBig := b.CreateICmp(llvm.IntUGE, bufSize, maxBufSize, "")
+	b.createRuntimeAssert(bufSizeTooBig, "chan", "chanMakePanic")
 }
 
-// emitNilCheck checks whether the given pointer is nil, and panics if it is. It
-// has no effect in well-behaved programs, but makes sure no uncaught nil
+// createNilCheck checks whether the given pointer is nil, and panics if it is.
+// It has no effect in well-behaved programs, but makes sure no uncaught nil
 // pointer dereferences exist in valid Go code.
-func (c *Compiler) emitNilCheck(frame *Frame, ptr llvm.Value, blockPrefix string) {
+func (b *builder) createNilCheck(ptr llvm.Value, blockPrefix string) {
 	// Check whether we need to emit this check at all.
 	if !ptr.IsAGlobalValue().IsNil() {
 		return
@@ -167,22 +167,22 @@ func (c *Compiler) emitNilCheck(frame *Frame, ptr llvm.Value, blockPrefix string
 		// https://reviews.llvm.org/D60047 for details. Pointer capturing
 		// unfortunately breaks escape analysis, so we use this trick to let the
 		// functionattr pass know that this pointer doesn't really escape.
-		ptr = c.builder.CreateBitCast(ptr, c.i8ptrType, "")
-		isnil = c.createRuntimeCall("isnil", []llvm.Value{ptr}, "")
+		ptr = b.CreateBitCast(ptr, b.i8ptrType, "")
+		isnil = b.createRuntimeCall("isnil", []llvm.Value{ptr}, "")
 	} else {
 		// Do the nil check using a regular icmp. This can happen with function
 		// pointers on AVR, which don't benefit from escape analysis anyway.
 		nilptr := llvm.ConstPointerNull(ptr.Type())
-		isnil = c.builder.CreateICmp(llvm.IntEQ, ptr, nilptr, "")
+		isnil = b.CreateICmp(llvm.IntEQ, ptr, nilptr, "")
 	}
 
 	// Emit the nil check in IR.
-	c.createRuntimeAssert(frame, isnil, blockPrefix, "nilPanic")
+	b.createRuntimeAssert(isnil, blockPrefix, "nilPanic")
 }
 
 // createRuntimeAssert is a common function to create a new branch on an assert
 // bool, calling an assert func if the assert value is true (1).
-func (c *Compiler) createRuntimeAssert(frame *Frame, assert llvm.Value, blockPrefix, assertFunc string) {
+func (b *builder) createRuntimeAssert(assert llvm.Value, blockPrefix, assertFunc string) {
 	// Check whether we can resolve this check at compile time.
 	if !assert.IsAConstantInt().IsNil() {
 		val := assert.ZExtValue()
@@ -193,18 +193,18 @@ func (c *Compiler) createRuntimeAssert(frame *Frame, assert llvm.Value, blockPre
 		}
 	}
 
-	faultBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".throw")
-	nextBlock := c.ctx.AddBasicBlock(frame.fn.LLVMFn, blockPrefix+".next")
-	frame.blockExits[frame.currentBlock] = nextBlock // adjust outgoing block for phi nodes
+	faultBlock := b.ctx.AddBasicBlock(b.fn.LLVMFn, blockPrefix+".throw")
+	nextBlock := b.ctx.AddBasicBlock(b.fn.LLVMFn, blockPrefix+".next")
+	b.blockExits[b.currentBlock] = nextBlock // adjust outgoing block for phi nodes
 
 	// Now branch to the out-of-bounds or the regular block.
-	c.builder.CreateCondBr(assert, faultBlock, nextBlock)
+	b.CreateCondBr(assert, faultBlock, nextBlock)
 
 	// Fail: the assert triggered so panic.
-	c.builder.SetInsertPointAtEnd(faultBlock)
-	c.createRuntimeCall(assertFunc, nil, "")
-	c.builder.CreateUnreachable()
+	b.SetInsertPointAtEnd(faultBlock)
+	b.createRuntimeCall(assertFunc, nil, "")
+	b.CreateUnreachable()
 
 	// Ok: assert didn't trigger so continue normally.
-	c.builder.SetInsertPointAtEnd(nextBlock)
+	b.SetInsertPointAtEnd(nextBlock)
 }

--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -43,10 +43,10 @@ func (c *Compiler) createCall(fn llvm.Value, args []llvm.Value, name string) llv
 
 // Expand an argument type to a list that can be used in a function call
 // parameter list.
-func (c *Compiler) expandFormalParamType(t llvm.Type) []llvm.Type {
+func expandFormalParamType(t llvm.Type) []llvm.Type {
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
-		fields := c.flattenAggregateType(t)
+		fields := flattenAggregateType(t)
 		if len(fields) <= MaxFieldsPerParam {
 			return fields
 		} else {
@@ -82,7 +82,7 @@ func (c *Compiler) expandFormalParamOffsets(t llvm.Type) []uint64 {
 func (c *Compiler) expandFormalParam(v llvm.Value) []llvm.Value {
 	switch v.Type().TypeKind() {
 	case llvm.StructTypeKind:
-		fieldTypes := c.flattenAggregateType(v.Type())
+		fieldTypes := flattenAggregateType(v.Type())
 		if len(fieldTypes) <= MaxFieldsPerParam {
 			fields := c.flattenAggregate(v)
 			if len(fields) != len(fieldTypes) {
@@ -101,12 +101,12 @@ func (c *Compiler) expandFormalParam(v llvm.Value) []llvm.Value {
 
 // Try to flatten a struct type to a list of types. Returns a 1-element slice
 // with the passed in type if this is not possible.
-func (c *Compiler) flattenAggregateType(t llvm.Type) []llvm.Type {
+func flattenAggregateType(t llvm.Type) []llvm.Type {
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
 		fields := make([]llvm.Type, 0, t.StructElementTypesCount())
 		for _, subfield := range t.StructElementTypes() {
-			subfields := c.flattenAggregateType(subfield)
+			subfields := flattenAggregateType(subfield)
 			fields = append(fields, subfields...)
 		}
 		return fields
@@ -166,7 +166,7 @@ func (c *Compiler) collapseFormalParam(t llvm.Type, fields []llvm.Value) llvm.Va
 func (c *Compiler) collapseFormalParamInternal(t llvm.Type, fields []llvm.Value) (llvm.Value, []llvm.Value) {
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
-		if len(c.flattenAggregateType(t)) <= MaxFieldsPerParam {
+		if len(flattenAggregateType(t)) <= MaxFieldsPerParam {
 			value := llvm.ConstNull(t)
 			for i, subtyp := range t.StructElementTypes() {
 				structField, remaining := c.collapseFormalParamInternal(subtyp, fields)

--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -15,7 +15,7 @@ func (c *Compiler) emitMakeChan(frame *Frame, expr *ssa.MakeChan) llvm.Value {
 	elementSize := c.targetData.TypeAllocSize(c.getLLVMType(expr.Type().(*types.Chan).Elem()))
 	elementSizeValue := llvm.ConstInt(c.uintptrType, elementSize, false)
 	bufSize := frame.getValue(expr.Size)
-	c.emitChanBoundsCheck(frame, elementSize, bufSize, expr.Size.Type().Underlying().(*types.Basic), expr.Pos())
+	frame.createChanBoundsCheck(elementSize, bufSize, expr.Size.Type().Underlying().(*types.Basic), expr.Pos())
 	if bufSize.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 		bufSize = c.builder.CreateZExt(bufSize, c.uintptrType, "")
 	} else if bufSize.Type().IntTypeWidth() > c.uintptrType.IntTypeWidth() {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1071,7 +1071,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 				panic("StaticCallee returned an unexpected value")
 			}
 			params = append(params, context) // context parameter
-			c.emitStartGoroutine(calleeFn.LLVMFn, params)
+			frame.createGoInstruction(calleeFn.LLVMFn, params)
 		} else if !instr.Call.IsInvoke() {
 			// This is a function pointer.
 			// At the moment, two extra params are passed to the newly started
@@ -1089,7 +1089,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			default:
 				panic("unknown scheduler type")
 			}
-			c.emitStartGoroutine(funcPtr, params)
+			frame.createGoInstruction(funcPtr, params)
 		} else {
 			c.addError(instr.Pos(), "todo: go on interface call")
 		}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -53,6 +53,7 @@ type compilerContext struct {
 	uintptrType      llvm.Type
 	ir               *ir.Program
 	diagnostics      []error
+	astComments      map[string]*ast.CommentGroup
 }
 
 type Compiler struct {
@@ -60,7 +61,6 @@ type Compiler struct {
 	builder                 llvm.Builder
 	initFuncs               []llvm.Value
 	interfaceInvokeWrappers []interfaceInvokeWrapper
-	astComments             map[string]*ast.CommentGroup
 }
 
 type Frame struct {
@@ -513,7 +513,7 @@ func isPointer(typ types.Type) bool {
 }
 
 // Get the DWARF type for this Go type.
-func (c *Compiler) getDIType(typ types.Type) llvm.Metadata {
+func (c *compilerContext) getDIType(typ types.Type) llvm.Metadata {
 	if md, ok := c.ditypes[typ]; ok {
 		return md
 	}
@@ -524,7 +524,7 @@ func (c *Compiler) getDIType(typ types.Type) llvm.Metadata {
 
 // createDIType creates a new DWARF type. Don't call this function directly,
 // call getDIType instead.
-func (c *Compiler) createDIType(typ types.Type) llvm.Metadata {
+func (c *compilerContext) createDIType(typ types.Type) llvm.Metadata {
 	llvmType := c.getLLVMType(typ)
 	sizeInBytes := c.targetData.TypeAllocSize(llvmType)
 	switch typ := typ.(type) {
@@ -836,7 +836,7 @@ func (c *Compiler) attachDebugInfoRaw(f *ir.Function, llvmFn llvm.Value, suffix,
 // getDIFile returns a DIFile metadata node for the given filename. It tries to
 // use one that was already created, otherwise it falls back to creating a new
 // one.
-func (c *Compiler) getDIFile(filename string) llvm.Metadata {
+func (c *compilerContext) getDIFile(filename string) llvm.Metadata {
 	if _, ok := c.difiles[filename]; !ok {
 		dir, file := filepath.Split(filename)
 		if dir != "" {
@@ -988,7 +988,7 @@ func (c *Compiler) parseFunc(frame *Frame) {
 				}
 				dbgVar := c.getLocalVariable(frame, variable)
 				pos := c.ir.Program.Fset.Position(instr.Pos())
-				c.dibuilder.InsertValueAtEnd(c.getValue(frame, instr.X), dbgVar, c.dibuilder.CreateExpression(nil), llvm.DebugLoc{
+				c.dibuilder.InsertValueAtEnd(frame.getValue(instr.X), dbgVar, c.dibuilder.CreateExpression(nil), llvm.DebugLoc{
 					Line:  uint(pos.Line),
 					Col:   uint(pos.Column),
 					Scope: frame.difunc,
@@ -1013,7 +1013,7 @@ func (c *Compiler) parseFunc(frame *Frame) {
 	for _, phi := range frame.phis {
 		block := phi.ssa.Block()
 		for i, edge := range phi.ssa.Edges {
-			llvmVal := c.getValue(frame, edge)
+			llvmVal := frame.getValue(edge)
 			llvmBlock := frame.blockExits[block.Preds[i]]
 			phi.llvm.AddIncoming([]llvm.Value{llvmVal}, []llvm.BasicBlock{llvmBlock})
 		}
@@ -1051,7 +1051,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 		// Get all function parameters to pass to the goroutine.
 		var params []llvm.Value
 		for _, param := range instr.Call.Args {
-			params = append(params, c.getValue(frame, param))
+			params = append(params, frame.getValue(param))
 		}
 
 		// Start a new goroutine.
@@ -1067,7 +1067,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			case *ssa.MakeClosure:
 				// A goroutine call on a func value, but the callee is trivial to find. For
 				// example: immediately applied functions.
-				funcValue := c.getValue(frame, value)
+				funcValue := frame.getValue(value)
 				context = c.extractFuncContext(funcValue)
 			default:
 				panic("StaticCallee returned an unexpected value")
@@ -1080,7 +1080,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			// goroutine:
 			//   * The function context, for closures.
 			//   * The function pointer (for tasks).
-			funcPtr, context := c.decodeFuncValue(c.getValue(frame, instr.Call.Value), instr.Call.Value.Type().(*types.Signature))
+			funcPtr, context := c.decodeFuncValue(frame.getValue(instr.Call.Value), instr.Call.Value.Type().(*types.Signature))
 			params = append(params, context) // context parameter
 			switch c.Scheduler() {
 			case "none", "coroutines":
@@ -1096,7 +1096,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			c.addError(instr.Pos(), "todo: go on interface call")
 		}
 	case *ssa.If:
-		cond := c.getValue(frame, instr.Cond)
+		cond := frame.getValue(instr.Cond)
 		block := instr.Block()
 		blockThen := frame.blockEntries[block.Succs[0]]
 		blockElse := frame.blockEntries[block.Succs[1]]
@@ -1105,25 +1105,25 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 		blockJump := frame.blockEntries[instr.Block().Succs[0]]
 		c.builder.CreateBr(blockJump)
 	case *ssa.MapUpdate:
-		m := c.getValue(frame, instr.Map)
-		key := c.getValue(frame, instr.Key)
-		value := c.getValue(frame, instr.Value)
+		m := frame.getValue(instr.Map)
+		key := frame.getValue(instr.Key)
+		value := frame.getValue(instr.Value)
 		mapType := instr.Map.Type().Underlying().(*types.Map)
 		c.emitMapUpdate(mapType.Key(), m, key, value, instr.Pos())
 	case *ssa.Panic:
-		value := c.getValue(frame, instr.X)
+		value := frame.getValue(instr.X)
 		c.createRuntimeCall("_panic", []llvm.Value{value}, "")
 		c.builder.CreateUnreachable()
 	case *ssa.Return:
 		if len(instr.Results) == 0 {
 			c.builder.CreateRetVoid()
 		} else if len(instr.Results) == 1 {
-			c.builder.CreateRet(c.getValue(frame, instr.Results[0]))
+			c.builder.CreateRet(frame.getValue(instr.Results[0]))
 		} else {
 			// Multiple return values. Put them all in a struct.
 			retVal := llvm.ConstNull(frame.fn.LLVMFn.Type().ElementType().ReturnType())
 			for i, result := range instr.Results {
-				val := c.getValue(frame, result)
+				val := frame.getValue(result)
 				retVal = c.builder.CreateInsertValue(retVal, val, i, "")
 			}
 			c.builder.CreateRet(retVal)
@@ -1133,8 +1133,8 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 	case *ssa.Send:
 		c.emitChanSend(frame, instr)
 	case *ssa.Store:
-		llvmAddr := c.getValue(frame, instr.Addr)
-		llvmVal := c.getValue(frame, instr.Val)
+		llvmAddr := frame.getValue(instr.Addr)
+		llvmVal := frame.getValue(instr.Val)
 		c.emitNilCheck(frame, llvmAddr, "store")
 		if c.targetData.TypeAllocSize(llvmVal.Type()) == 0 {
 			// nothing to store
@@ -1149,8 +1149,8 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string, pos token.Pos) (llvm.Value, error) {
 	switch callName {
 	case "append":
-		src := c.getValue(frame, args[0])
-		elems := c.getValue(frame, args[1])
+		src := frame.getValue(args[0])
+		elems := frame.getValue(args[1])
 		srcBuf := c.builder.CreateExtractValue(src, 0, "append.srcBuf")
 		srcPtr := c.builder.CreateBitCast(srcBuf, c.i8ptrType, "append.srcPtr")
 		srcLen := c.builder.CreateExtractValue(src, 1, "append.srcLen")
@@ -1171,7 +1171,7 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		newSlice = c.builder.CreateInsertValue(newSlice, newCap, 2, "")
 		return newSlice, nil
 	case "cap":
-		value := c.getValue(frame, args[0])
+		value := frame.getValue(args[0])
 		var llvmCap llvm.Value
 		switch args[0].Type().(type) {
 		case *types.Chan:
@@ -1191,8 +1191,8 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		c.emitChanClose(frame, args[0])
 		return llvm.Value{}, nil
 	case "complex":
-		r := c.getValue(frame, args[0])
-		i := c.getValue(frame, args[1])
+		r := frame.getValue(args[0])
+		i := frame.getValue(args[1])
 		t := args[0].Type().Underlying().(*types.Basic)
 		var cplx llvm.Value
 		switch t.Kind() {
@@ -1207,8 +1207,8 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		cplx = c.builder.CreateInsertValue(cplx, i, 1, "")
 		return cplx, nil
 	case "copy":
-		dst := c.getValue(frame, args[0])
-		src := c.getValue(frame, args[1])
+		dst := frame.getValue(args[0])
+		src := frame.getValue(args[1])
 		dstLen := c.builder.CreateExtractValue(dst, 1, "copy.dstLen")
 		srcLen := c.builder.CreateExtractValue(src, 1, "copy.srcLen")
 		dstBuf := c.builder.CreateExtractValue(dst, 0, "copy.dstArray")
@@ -1219,14 +1219,14 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		elemSize := llvm.ConstInt(c.uintptrType, c.targetData.TypeAllocSize(elemType), false)
 		return c.createRuntimeCall("sliceCopy", []llvm.Value{dstBuf, srcBuf, dstLen, srcLen, elemSize}, "copy.n"), nil
 	case "delete":
-		m := c.getValue(frame, args[0])
-		key := c.getValue(frame, args[1])
+		m := frame.getValue(args[0])
+		key := frame.getValue(args[1])
 		return llvm.Value{}, c.emitMapDelete(args[1].Type(), m, key, pos)
 	case "imag":
-		cplx := c.getValue(frame, args[0])
+		cplx := frame.getValue(args[0])
 		return c.builder.CreateExtractValue(cplx, 1, "imag"), nil
 	case "len":
-		value := c.getValue(frame, args[0])
+		value := frame.getValue(args[0])
 		var llvmLen llvm.Value
 		switch args[0].Type().Underlying().(type) {
 		case *types.Basic, *types.Slice:
@@ -1250,7 +1250,7 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 			if i >= 1 && callName == "println" {
 				c.createRuntimeCall("printspace", nil, "")
 			}
-			value := c.getValue(frame, arg)
+			value := frame.getValue(arg)
 			typ := arg.Type().Underlying()
 			switch typ := typ.(type) {
 			case *types.Basic:
@@ -1303,13 +1303,13 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 		}
 		return llvm.Value{}, nil // print() or println() returns void
 	case "real":
-		cplx := c.getValue(frame, args[0])
+		cplx := frame.getValue(args[0])
 		return c.builder.CreateExtractValue(cplx, 0, "real"), nil
 	case "recover":
 		return c.createRuntimeCall("_recover", nil, ""), nil
 	case "ssa:wrapnilchk":
 		// TODO: do an actual nil check?
-		return c.getValue(frame, args[0]), nil
+		return frame.getValue(args[0]), nil
 	default:
 		return llvm.Value{}, c.makeError(pos, "todo: builtin: "+callName)
 	}
@@ -1318,7 +1318,7 @@ func (c *Compiler) parseBuiltin(frame *Frame, args []ssa.Value, callName string,
 func (c *Compiler) parseFunctionCall(frame *Frame, args []ssa.Value, llvmFn, context llvm.Value, exported bool) llvm.Value {
 	var params []llvm.Value
 	for _, param := range args {
-		params = append(params, c.getValue(frame, param))
+		params = append(params, frame.getValue(param))
 	}
 
 	if !exported {
@@ -1375,7 +1375,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 		case *ssa.MakeClosure:
 			// A call on a func value, but the callee is trivial to find. For
 			// example: immediately applied functions.
-			funcValue := c.getValue(frame, value)
+			funcValue := frame.getValue(value)
 			context = c.extractFuncContext(funcValue)
 		default:
 			panic("StaticCallee returned an unexpected value")
@@ -1388,7 +1388,7 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 	case *ssa.Builtin:
 		return c.parseBuiltin(frame, instr.Args, call.Name(), instr.Pos())
 	default: // function pointer
-		value := c.getValue(frame, instr.Value)
+		value := frame.getValue(instr.Value)
 		// This is a func value, which cannot be called directly. We have to
 		// extract the function pointer and context first from the func value.
 		funcPtr, context := c.decodeFuncValue(value, instr.Value.Type().Underlying().(*types.Signature))
@@ -1399,27 +1399,27 @@ func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, e
 
 // getValue returns the LLVM value of a constant, function value, global, or
 // already processed SSA expression.
-func (c *Compiler) getValue(frame *Frame, expr ssa.Value) llvm.Value {
+func (b *builder) getValue(expr ssa.Value) llvm.Value {
 	switch expr := expr.(type) {
 	case *ssa.Const:
-		return frame.createConst(frame.fn.LinkName(), expr)
+		return b.createConst(b.fn.LinkName(), expr)
 	case *ssa.Function:
-		fn := c.ir.GetFunction(expr)
+		fn := b.ir.GetFunction(expr)
 		if fn.IsExported() {
-			c.addError(expr.Pos(), "cannot use an exported function as value: "+expr.String())
-			return llvm.Undef(c.getLLVMType(expr.Type()))
+			b.addError(expr.Pos(), "cannot use an exported function as value: "+expr.String())
+			return llvm.Undef(b.getLLVMType(expr.Type()))
 		}
-		return c.createFuncValue(fn.LLVMFn, llvm.Undef(c.i8ptrType), fn.Signature)
+		return b.createFuncValue(fn.LLVMFn, llvm.Undef(b.i8ptrType), fn.Signature)
 	case *ssa.Global:
-		value := c.getGlobal(expr)
+		value := b.getGlobal(expr)
 		if value.IsNil() {
-			c.addError(expr.Pos(), "global not found: "+expr.RelString(nil))
-			return llvm.Undef(c.getLLVMType(expr.Type()))
+			b.addError(expr.Pos(), "global not found: "+expr.RelString(nil))
+			return llvm.Undef(b.getLLVMType(expr.Type()))
 		}
 		return value
 	default:
 		// other (local) SSA value
-		if value, ok := frame.locals[expr]; ok {
+		if value, ok := b.locals[expr]; ok {
 			return value
 		} else {
 			// indicates a compiler bug
@@ -1458,8 +1458,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return buf, nil
 		}
 	case *ssa.BinOp:
-		x := c.getValue(frame, expr.X)
-		y := c.getValue(frame, expr.Y)
+		x := frame.getValue(expr.X)
+		y := frame.getValue(expr.Y)
 		return frame.createBinOp(expr.Op, expr.X.Type(), x, y, expr.Pos())
 	case *ssa.Call:
 		// Passing the current task here to the subroutine. It is only used when
@@ -1472,12 +1472,12 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		// This is different from how the official Go compiler works, because of
 		// heap allocation and because it's easier to implement, see:
 		// https://research.swtch.com/interfaces
-		return c.getValue(frame, expr.X), nil
+		return frame.getValue(expr.X), nil
 	case *ssa.ChangeType:
 		// This instruction changes the type, but the underlying value remains
 		// the same. This is often a no-op, but sometimes we have to change the
 		// LLVM type as well.
-		x := c.getValue(frame, expr.X)
+		x := frame.getValue(expr.X)
 		llvmType := c.getLLVMType(expr.Type())
 		if x.Type() == llvmType {
 			// Different Go type but same LLVM type (for example, named int).
@@ -1506,20 +1506,20 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.Const:
 		panic("const is not an expression")
 	case *ssa.Convert:
-		x := c.getValue(frame, expr.X)
+		x := frame.getValue(expr.X)
 		return c.parseConvert(expr.X.Type(), expr.Type(), x, expr.Pos())
 	case *ssa.Extract:
 		if _, ok := expr.Tuple.(*ssa.Select); ok {
 			return c.getChanSelectResult(frame, expr), nil
 		}
-		value := c.getValue(frame, expr.Tuple)
+		value := frame.getValue(expr.Tuple)
 		return c.builder.CreateExtractValue(value, expr.Index, ""), nil
 	case *ssa.Field:
-		value := c.getValue(frame, expr.X)
+		value := frame.getValue(expr.X)
 		result := c.builder.CreateExtractValue(value, expr.Field, "")
 		return result, nil
 	case *ssa.FieldAddr:
-		val := c.getValue(frame, expr.X)
+		val := frame.getValue(expr.X)
 		// Check for nil pointer before calculating the address, from the spec:
 		// > For an operand x of type T, the address operation &x generates a
 		// > pointer of type *T to x. [...] If the evaluation of x would cause a
@@ -1536,8 +1536,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.Global:
 		panic("global is not an expression")
 	case *ssa.Index:
-		array := c.getValue(frame, expr.X)
-		index := c.getValue(frame, expr.Index)
+		array := frame.getValue(expr.X)
+		index := frame.getValue(expr.Index)
 
 		// Check bounds.
 		arrayLen := expr.X.Type().(*types.Array).Len()
@@ -1554,8 +1554,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		c.emitLifetimeEnd(allocaPtr, allocaSize)
 		return result, nil
 	case *ssa.IndexAddr:
-		val := c.getValue(frame, expr.X)
-		index := c.getValue(frame, expr.Index)
+		val := frame.getValue(expr.X)
+		index := frame.getValue(expr.Index)
 
 		// Get buffer pointer and length
 		var bufptr, buflen llvm.Value
@@ -1599,8 +1599,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			panic("unreachable")
 		}
 	case *ssa.Lookup:
-		value := c.getValue(frame, expr.X)
-		index := c.getValue(frame, expr.Index)
+		value := frame.getValue(expr.X)
+		index := frame.getValue(expr.Index)
 		switch xType := expr.X.Type().Underlying().(type) {
 		case *types.Basic:
 			// Value type must be a string, which is a basic type.
@@ -1630,13 +1630,13 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.MakeClosure:
 		return c.parseMakeClosure(frame, expr)
 	case *ssa.MakeInterface:
-		val := c.getValue(frame, expr.X)
+		val := frame.getValue(expr.X)
 		return c.parseMakeInterface(val, expr.X.Type(), expr.Pos()), nil
 	case *ssa.MakeMap:
 		return c.emitMakeMap(frame, expr)
 	case *ssa.MakeSlice:
-		sliceLen := c.getValue(frame, expr.Len)
-		sliceCap := c.getValue(frame, expr.Cap)
+		sliceLen := frame.getValue(expr.Len)
+		sliceCap := frame.getValue(expr.Cap)
 		sliceType := expr.Type().Underlying().(*types.Slice)
 		llvmElemType := c.getLLVMType(sliceType.Elem())
 		elemSize := c.targetData.TypeAllocSize(llvmElemType)
@@ -1688,8 +1688,8 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		return slice, nil
 	case *ssa.Next:
 		rangeVal := expr.Iter.(*ssa.Range).X
-		llvmRangeVal := c.getValue(frame, rangeVal)
-		it := c.getValue(frame, expr.Iter)
+		llvmRangeVal := frame.getValue(rangeVal)
+		it := frame.getValue(expr.Iter)
 		if expr.IsString {
 			return c.createRuntimeCall("stringNext", []llvm.Value{llvmRangeVal, it}, "range.next"), nil
 		} else { // map
@@ -1728,14 +1728,14 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 	case *ssa.Select:
 		return c.emitSelect(frame, expr), nil
 	case *ssa.Slice:
-		value := c.getValue(frame, expr.X)
+		value := frame.getValue(expr.X)
 
 		var lowType, highType, maxType *types.Basic
 		var low, high, max llvm.Value
 
 		if expr.Low != nil {
 			lowType = expr.Low.Type().Underlying().(*types.Basic)
-			low = c.getValue(frame, expr.Low)
+			low = frame.getValue(expr.Low)
 			if low.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 				if lowType.Info()&types.IsUnsigned != 0 {
 					low = c.builder.CreateZExt(low, c.uintptrType, "")
@@ -1750,7 +1750,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 		if expr.High != nil {
 			highType = expr.High.Type().Underlying().(*types.Basic)
-			high = c.getValue(frame, expr.High)
+			high = frame.getValue(expr.High)
 			if high.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 				if highType.Info()&types.IsUnsigned != 0 {
 					high = c.builder.CreateZExt(high, c.uintptrType, "")
@@ -1764,7 +1764,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 
 		if expr.Max != nil {
 			maxType = expr.Max.Type().Underlying().(*types.Basic)
-			max = c.getValue(frame, expr.Max)
+			max = frame.getValue(expr.Max)
 			if max.Type().IntTypeWidth() < c.uintptrType.IntTypeWidth() {
 				if maxType.Info()&types.IsUnsigned != 0 {
 					max = c.builder.CreateZExt(max, c.uintptrType, "")
@@ -2524,7 +2524,7 @@ func (c *Compiler) parseConvert(typeFrom, typeTo types.Type, value llvm.Value, p
 }
 
 func (c *Compiler) parseUnOp(frame *Frame, unop *ssa.UnOp) (llvm.Value, error) {
-	x := c.getValue(frame, unop.X)
+	x := frame.getValue(unop.X)
 	switch unop.Op {
 	case token.NOT: // !x
 		return c.builder.CreateNot(x, ""), nil

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1333,7 +1333,7 @@ func (c *Compiler) parseFunctionCall(frame *Frame, args []ssa.Value, llvmFn, con
 
 func (c *Compiler) parseCall(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
 	if instr.IsInvoke() {
-		fnCast, args := c.getInvokeCall(frame, instr)
+		fnCast, args := frame.getInvokeCall(instr)
 		return c.createCall(fnCast, args, ""), nil
 	}
 
@@ -1629,7 +1629,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		return c.parseMakeClosure(frame, expr)
 	case *ssa.MakeInterface:
 		val := frame.getValue(expr.X)
-		return c.parseMakeInterface(val, expr.X.Type(), expr.Pos()), nil
+		return frame.createMakeInterface(val, expr.X.Type(), expr.Pos()), nil
 	case *ssa.MakeMap:
 		return c.emitMakeMap(frame, expr)
 	case *ssa.MakeSlice:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -958,7 +958,7 @@ func (c *Compiler) parseFunc(frame *Frame) {
 	if frame.fn.Recover != nil {
 		// This function has deferred function calls. Set some things up for
 		// them.
-		c.deferInitFunc(frame)
+		frame.deferInitFunc()
 	}
 
 	// Fill blocks with instructions.
@@ -1044,7 +1044,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 	case *ssa.DebugRef:
 		// ignore
 	case *ssa.Defer:
-		c.emitDefer(frame, instr)
+		frame.createDefer(instr)
 	case *ssa.Go:
 		// Get all function parameters to pass to the goroutine.
 		var params []llvm.Value
@@ -1127,7 +1127,7 @@ func (c *Compiler) parseInstr(frame *Frame, instr ssa.Instruction) {
 			c.builder.CreateRet(retVal)
 		}
 	case *ssa.RunDefers:
-		c.emitRunDefers(frame)
+		frame.createRunDefers()
 	case *ssa.Send:
 		frame.createChanSend(instr)
 	case *ssa.Store:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1897,7 +1897,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 			return llvm.Value{}, c.makeError(expr.Pos(), "unknown slice type: "+typ.String())
 		}
 	case *ssa.TypeAssert:
-		return c.parseTypeAssert(frame, expr), nil
+		return frame.createTypeAssert(expr), nil
 	case *ssa.UnOp:
 		return c.parseUnOp(frame, expr)
 	default:

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -23,16 +23,16 @@ import (
 // deferInitFunc sets up this function for future deferred calls. It must be
 // called from within the entry block when this function contains deferred
 // calls.
-func (c *Compiler) deferInitFunc(frame *Frame) {
+func (b *builder) deferInitFunc() {
 	// Some setup.
-	frame.deferFuncs = make(map[*ir.Function]int)
-	frame.deferInvokeFuncs = make(map[string]int)
-	frame.deferClosureFuncs = make(map[*ir.Function]int)
+	b.deferFuncs = make(map[*ir.Function]int)
+	b.deferInvokeFuncs = make(map[string]int)
+	b.deferClosureFuncs = make(map[*ir.Function]int)
 
 	// Create defer list pointer.
-	deferType := llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)
-	frame.deferPtr = c.builder.CreateAlloca(deferType, "deferPtr")
-	c.builder.CreateStore(llvm.ConstPointerNull(deferType), frame.deferPtr)
+	deferType := llvm.PointerType(b.getLLVMRuntimeType("_defer"), 0)
+	b.deferPtr = b.CreateAlloca(deferType, "deferPtr")
+	b.CreateStore(llvm.ConstPointerNull(deferType), b.deferPtr)
 }
 
 // isInLoop checks if there is a path from a basic block to itself.
@@ -69,53 +69,53 @@ func isInLoop(start *ssa.BasicBlock) bool {
 	return false
 }
 
-// emitDefer emits a single defer instruction, to be run when this function
+// createDefer emits a single defer instruction, to be run when this function
 // returns.
-func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
+func (b *builder) createDefer(instr *ssa.Defer) {
 	// The pointer to the previous defer struct, which we will replace to
 	// make a linked list.
-	next := c.builder.CreateLoad(frame.deferPtr, "defer.next")
+	next := b.CreateLoad(b.deferPtr, "defer.next")
 
 	var values []llvm.Value
-	valueTypes := []llvm.Type{c.uintptrType, next.Type()}
+	valueTypes := []llvm.Type{b.uintptrType, next.Type()}
 	if instr.Call.IsInvoke() {
 		// Method call on an interface.
 
 		// Get callback type number.
 		methodName := instr.Call.Method.FullName()
-		if _, ok := frame.deferInvokeFuncs[methodName]; !ok {
-			frame.deferInvokeFuncs[methodName] = len(frame.allDeferFuncs)
-			frame.allDeferFuncs = append(frame.allDeferFuncs, &instr.Call)
+		if _, ok := b.deferInvokeFuncs[methodName]; !ok {
+			b.deferInvokeFuncs[methodName] = len(b.allDeferFuncs)
+			b.allDeferFuncs = append(b.allDeferFuncs, &instr.Call)
 		}
-		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferInvokeFuncs[methodName]), false)
+		callback := llvm.ConstInt(b.uintptrType, uint64(b.deferInvokeFuncs[methodName]), false)
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields, followed by the call parameters).
-		itf := frame.getValue(instr.Call.Value) // interface
-		receiverValue := c.builder.CreateExtractValue(itf, 1, "invoke.func.receiver")
+		itf := b.getValue(instr.Call.Value) // interface
+		receiverValue := b.CreateExtractValue(itf, 1, "invoke.func.receiver")
 		values = []llvm.Value{callback, next, receiverValue}
-		valueTypes = append(valueTypes, c.i8ptrType)
+		valueTypes = append(valueTypes, b.i8ptrType)
 		for _, arg := range instr.Call.Args {
-			val := frame.getValue(arg)
+			val := b.getValue(arg)
 			values = append(values, val)
 			valueTypes = append(valueTypes, val.Type())
 		}
 
 	} else if callee, ok := instr.Call.Value.(*ssa.Function); ok {
 		// Regular function call.
-		fn := c.ir.GetFunction(callee)
+		fn := b.ir.GetFunction(callee)
 
-		if _, ok := frame.deferFuncs[fn]; !ok {
-			frame.deferFuncs[fn] = len(frame.allDeferFuncs)
-			frame.allDeferFuncs = append(frame.allDeferFuncs, fn)
+		if _, ok := b.deferFuncs[fn]; !ok {
+			b.deferFuncs[fn] = len(b.allDeferFuncs)
+			b.allDeferFuncs = append(b.allDeferFuncs, fn)
 		}
-		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferFuncs[fn]), false)
+		callback := llvm.ConstInt(b.uintptrType, uint64(b.deferFuncs[fn]), false)
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := frame.getValue(param)
+			llvmParam := b.getValue(param)
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
@@ -127,23 +127,23 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 		// pointer.
 		// TODO: ignore this closure entirely and put pointers to the free
 		// variables directly in the defer struct, avoiding a memory allocation.
-		closure := frame.getValue(instr.Call.Value)
-		context := c.builder.CreateExtractValue(closure, 0, "")
+		closure := b.getValue(instr.Call.Value)
+		context := b.CreateExtractValue(closure, 0, "")
 
 		// Get the callback number.
-		fn := c.ir.GetFunction(makeClosure.Fn.(*ssa.Function))
-		if _, ok := frame.deferClosureFuncs[fn]; !ok {
-			frame.deferClosureFuncs[fn] = len(frame.allDeferFuncs)
-			frame.allDeferFuncs = append(frame.allDeferFuncs, makeClosure)
+		fn := b.ir.GetFunction(makeClosure.Fn.(*ssa.Function))
+		if _, ok := b.deferClosureFuncs[fn]; !ok {
+			b.deferClosureFuncs[fn] = len(b.allDeferFuncs)
+			b.allDeferFuncs = append(b.allDeferFuncs, makeClosure)
 		}
-		callback := llvm.ConstInt(c.uintptrType, uint64(frame.deferClosureFuncs[fn]), false)
+		callback := llvm.ConstInt(b.uintptrType, uint64(b.deferClosureFuncs[fn]), false)
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields, followed by all parameters including the
 		// context pointer).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := frame.getValue(param)
+			llvmParam := b.getValue(param)
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
@@ -151,41 +151,41 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 		valueTypes = append(valueTypes, context.Type())
 
 	} else {
-		c.addError(instr.Pos(), "todo: defer on uncommon function call type")
+		b.addError(instr.Pos(), "todo: defer on uncommon function call type")
 		return
 	}
 
 	// Make a struct out of the collected values to put in the defer frame.
-	deferFrameType := c.ctx.StructType(valueTypes, false)
+	deferFrameType := b.ctx.StructType(valueTypes, false)
 	deferFrame := llvm.ConstNull(deferFrameType)
 	for i, value := range values {
-		deferFrame = c.builder.CreateInsertValue(deferFrame, value, i, "")
+		deferFrame = b.CreateInsertValue(deferFrame, value, i, "")
 	}
 
 	// Put this struct in an allocation.
 	var alloca llvm.Value
 	if !isInLoop(instr.Block()) {
 		// This can safely use a stack allocation.
-		alloca = llvmutil.CreateEntryBlockAlloca(c.builder, deferFrameType, "defer.alloca")
+		alloca = llvmutil.CreateEntryBlockAlloca(b.Builder, deferFrameType, "defer.alloca")
 	} else {
 		// This may be hit a variable number of times, so use a heap allocation.
-		size := c.targetData.TypeAllocSize(deferFrameType)
-		sizeValue := llvm.ConstInt(c.uintptrType, size, false)
-		allocCall := c.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "defer.alloc.call")
-		alloca = c.builder.CreateBitCast(allocCall, llvm.PointerType(deferFrameType, 0), "defer.alloc")
+		size := b.targetData.TypeAllocSize(deferFrameType)
+		sizeValue := llvm.ConstInt(b.uintptrType, size, false)
+		allocCall := b.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "defer.alloc.call")
+		alloca = b.CreateBitCast(allocCall, llvm.PointerType(deferFrameType, 0), "defer.alloc")
 	}
-	if c.NeedsStackObjects() {
-		c.trackPointer(alloca)
+	if b.NeedsStackObjects() {
+		b.trackPointer(alloca)
 	}
-	c.builder.CreateStore(deferFrame, alloca)
+	b.CreateStore(deferFrame, alloca)
 
 	// Push it on top of the linked list by replacing deferPtr.
-	allocaCast := c.builder.CreateBitCast(alloca, next.Type(), "defer.alloca.cast")
-	c.builder.CreateStore(allocaCast, frame.deferPtr)
+	allocaCast := b.CreateBitCast(alloca, next.Type(), "defer.alloca.cast")
+	b.CreateStore(allocaCast, b.deferPtr)
 }
 
-// emitRunDefers emits code to run all deferred functions.
-func (c *Compiler) emitRunDefers(frame *Frame) {
+// createRunDefers emits code to run all deferred functions.
+func (b *builder) createRunDefers() {
 	// Add a loop like the following:
 	//     for stack != nil {
 	//         _stack := stack
@@ -202,44 +202,44 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 	//     }
 
 	// Create loop.
-	loophead := c.ctx.AddBasicBlock(frame.fn.LLVMFn, "rundefers.loophead")
-	loop := c.ctx.AddBasicBlock(frame.fn.LLVMFn, "rundefers.loop")
-	unreachable := c.ctx.AddBasicBlock(frame.fn.LLVMFn, "rundefers.default")
-	end := c.ctx.AddBasicBlock(frame.fn.LLVMFn, "rundefers.end")
-	c.builder.CreateBr(loophead)
+	loophead := b.ctx.AddBasicBlock(b.fn.LLVMFn, "rundefers.loophead")
+	loop := b.ctx.AddBasicBlock(b.fn.LLVMFn, "rundefers.loop")
+	unreachable := b.ctx.AddBasicBlock(b.fn.LLVMFn, "rundefers.default")
+	end := b.ctx.AddBasicBlock(b.fn.LLVMFn, "rundefers.end")
+	b.CreateBr(loophead)
 
 	// Create loop head:
 	//     for stack != nil {
-	c.builder.SetInsertPointAtEnd(loophead)
-	deferData := c.builder.CreateLoad(frame.deferPtr, "")
-	stackIsNil := c.builder.CreateICmp(llvm.IntEQ, deferData, llvm.ConstPointerNull(deferData.Type()), "stackIsNil")
-	c.builder.CreateCondBr(stackIsNil, end, loop)
+	b.SetInsertPointAtEnd(loophead)
+	deferData := b.CreateLoad(b.deferPtr, "")
+	stackIsNil := b.CreateICmp(llvm.IntEQ, deferData, llvm.ConstPointerNull(deferData.Type()), "stackIsNil")
+	b.CreateCondBr(stackIsNil, end, loop)
 
 	// Create loop body:
 	//     _stack := stack
 	//     stack = stack.next
 	//     switch stack.callback {
-	c.builder.SetInsertPointAtEnd(loop)
-	nextStackGEP := c.builder.CreateInBoundsGEP(deferData, []llvm.Value{
-		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
-		llvm.ConstInt(c.ctx.Int32Type(), 1, false), // .next field
+	b.SetInsertPointAtEnd(loop)
+	nextStackGEP := b.CreateInBoundsGEP(deferData, []llvm.Value{
+		llvm.ConstInt(b.ctx.Int32Type(), 0, false),
+		llvm.ConstInt(b.ctx.Int32Type(), 1, false), // .next field
 	}, "stack.next.gep")
-	nextStack := c.builder.CreateLoad(nextStackGEP, "stack.next")
-	c.builder.CreateStore(nextStack, frame.deferPtr)
-	gep := c.builder.CreateInBoundsGEP(deferData, []llvm.Value{
-		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
-		llvm.ConstInt(c.ctx.Int32Type(), 0, false), // .callback field
+	nextStack := b.CreateLoad(nextStackGEP, "stack.next")
+	b.CreateStore(nextStack, b.deferPtr)
+	gep := b.CreateInBoundsGEP(deferData, []llvm.Value{
+		llvm.ConstInt(b.ctx.Int32Type(), 0, false),
+		llvm.ConstInt(b.ctx.Int32Type(), 0, false), // .callback field
 	}, "callback.gep")
-	callback := c.builder.CreateLoad(gep, "callback")
-	sw := c.builder.CreateSwitch(callback, unreachable, len(frame.allDeferFuncs))
+	callback := b.CreateLoad(gep, "callback")
+	sw := b.CreateSwitch(callback, unreachable, len(b.allDeferFuncs))
 
-	for i, callback := range frame.allDeferFuncs {
+	for i, callback := range b.allDeferFuncs {
 		// Create switch case, for example:
 		//     case 0:
 		//         // run first deferred call
-		block := c.ctx.AddBasicBlock(frame.fn.LLVMFn, "rundefers.callback")
-		sw.AddCase(llvm.ConstInt(c.uintptrType, uint64(i), false), block)
-		c.builder.SetInsertPointAtEnd(block)
+		block := b.ctx.AddBasicBlock(b.fn.LLVMFn, "rundefers.callback")
+		sw.AddCase(llvm.ConstInt(b.uintptrType, uint64(i), false), block)
+		b.SetInsertPointAtEnd(block)
 		switch callback := callback.(type) {
 		case *ssa.CallCommon:
 			// Call on an interface value.
@@ -248,50 +248,50 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 			}
 
 			// Get the real defer struct type and cast to it.
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0), c.i8ptrType}
+			valueTypes := []llvm.Type{b.uintptrType, llvm.PointerType(b.getLLVMRuntimeType("_defer"), 0), b.i8ptrType}
 			for _, arg := range callback.Args {
-				valueTypes = append(valueTypes, c.getLLVMType(arg.Type()))
+				valueTypes = append(valueTypes, b.getLLVMType(arg.Type()))
 			}
-			deferFrameType := c.ctx.StructType(valueTypes, false)
-			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+			deferFrameType := b.ctx.StructType(valueTypes, false)
+			deferFramePtr := b.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
 
 			// Extract the params from the struct (including receiver).
 			forwardParams := []llvm.Value{}
-			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			zero := llvm.ConstInt(b.ctx.Int32Type(), 0, false)
 			for i := 2; i < len(valueTypes); i++ {
-				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "gep")
-				forwardParam := c.builder.CreateLoad(gep, "param")
+				gep := b.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(b.ctx.Int32Type(), uint64(i), false)}, "gep")
+				forwardParam := b.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}
 
 			// Add the context parameter. An interface call cannot also be a
 			// closure but we have to supply the parameter anyway for platforms
 			// with a strict calling convention.
-			forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+			forwardParams = append(forwardParams, llvm.Undef(b.i8ptrType))
 
 			// Parent coroutine handle.
-			forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+			forwardParams = append(forwardParams, llvm.Undef(b.i8ptrType))
 
-			fnPtr, _ := frame.getInvokeCall(callback)
-			c.createCall(fnPtr, forwardParams, "")
+			fnPtr, _ := b.getInvokeCall(callback)
+			b.createCall(fnPtr, forwardParams, "")
 
 		case *ir.Function:
 			// Direct call.
 
 			// Get the real defer struct type and cast to it.
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)}
+			valueTypes := []llvm.Type{b.uintptrType, llvm.PointerType(b.getLLVMRuntimeType("_defer"), 0)}
 			for _, param := range callback.Params {
-				valueTypes = append(valueTypes, c.getLLVMType(param.Type()))
+				valueTypes = append(valueTypes, b.getLLVMType(param.Type()))
 			}
-			deferFrameType := c.ctx.StructType(valueTypes, false)
-			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+			deferFrameType := b.ctx.StructType(valueTypes, false)
+			deferFramePtr := b.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
 
 			// Extract the params from the struct.
 			forwardParams := []llvm.Value{}
-			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			zero := llvm.ConstInt(b.ctx.Int32Type(), 0, false)
 			for i := range callback.Params {
-				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i+2), false)}, "gep")
-				forwardParam := c.builder.CreateLoad(gep, "param")
+				gep := b.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(b.ctx.Int32Type(), uint64(i+2), false)}, "gep")
+				forwardParam := b.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}
 
@@ -300,57 +300,57 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 			if !callback.IsExported() {
 				// Add the context parameter. We know it is ignored by the receiving
 				// function, but we have to pass one anyway.
-				forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+				forwardParams = append(forwardParams, llvm.Undef(b.i8ptrType))
 
 				// Parent coroutine handle.
-				forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+				forwardParams = append(forwardParams, llvm.Undef(b.i8ptrType))
 			}
 
 			// Call real function.
-			c.createCall(callback.LLVMFn, forwardParams, "")
+			b.createCall(callback.LLVMFn, forwardParams, "")
 
 		case *ssa.MakeClosure:
 			// Get the real defer struct type and cast to it.
-			fn := c.ir.GetFunction(callback.Fn.(*ssa.Function))
-			valueTypes := []llvm.Type{c.uintptrType, llvm.PointerType(c.getLLVMRuntimeType("_defer"), 0)}
+			fn := b.ir.GetFunction(callback.Fn.(*ssa.Function))
+			valueTypes := []llvm.Type{b.uintptrType, llvm.PointerType(b.getLLVMRuntimeType("_defer"), 0)}
 			params := fn.Signature.Params()
 			for i := 0; i < params.Len(); i++ {
-				valueTypes = append(valueTypes, c.getLLVMType(params.At(i).Type()))
+				valueTypes = append(valueTypes, b.getLLVMType(params.At(i).Type()))
 			}
-			valueTypes = append(valueTypes, c.i8ptrType) // closure
-			deferFrameType := c.ctx.StructType(valueTypes, false)
-			deferFramePtr := c.builder.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
+			valueTypes = append(valueTypes, b.i8ptrType) // closure
+			deferFrameType := b.ctx.StructType(valueTypes, false)
+			deferFramePtr := b.CreateBitCast(deferData, llvm.PointerType(deferFrameType, 0), "deferFrame")
 
 			// Extract the params from the struct.
 			forwardParams := []llvm.Value{}
-			zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
+			zero := llvm.ConstInt(b.ctx.Int32Type(), 0, false)
 			for i := 2; i < len(valueTypes); i++ {
-				gep := c.builder.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(c.ctx.Int32Type(), uint64(i), false)}, "")
-				forwardParam := c.builder.CreateLoad(gep, "param")
+				gep := b.CreateInBoundsGEP(deferFramePtr, []llvm.Value{zero, llvm.ConstInt(b.ctx.Int32Type(), uint64(i), false)}, "")
+				forwardParam := b.CreateLoad(gep, "param")
 				forwardParams = append(forwardParams, forwardParam)
 			}
 
 			// Parent coroutine handle.
-			forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
+			forwardParams = append(forwardParams, llvm.Undef(b.i8ptrType))
 
 			// Call deferred function.
-			c.createCall(fn.LLVMFn, forwardParams, "")
+			b.createCall(fn.LLVMFn, forwardParams, "")
 
 		default:
 			panic("unknown deferred function type")
 		}
 
 		// Branch back to the start of the loop.
-		c.builder.CreateBr(loophead)
+		b.CreateBr(loophead)
 	}
 
 	// Create default unreachable block:
 	//     default:
 	//         unreachable
 	//     }
-	c.builder.SetInsertPointAtEnd(unreachable)
-	c.builder.CreateUnreachable()
+	b.SetInsertPointAtEnd(unreachable)
+	b.CreateUnreachable()
 
 	// End of loop.
-	c.builder.SetInsertPointAtEnd(end)
+	b.SetInsertPointAtEnd(end)
 }

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -272,7 +272,7 @@ func (c *Compiler) emitRunDefers(frame *Frame) {
 			// Parent coroutine handle.
 			forwardParams = append(forwardParams, llvm.Undef(c.i8ptrType))
 
-			fnPtr, _ := c.getInvokeCall(frame, callback)
+			fnPtr, _ := frame.getInvokeCall(callback)
 			c.createCall(fnPtr, forwardParams, "")
 
 		case *ir.Function:

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -91,12 +91,12 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields, followed by the call parameters).
-		itf := c.getValue(frame, instr.Call.Value) // interface
+		itf := frame.getValue(instr.Call.Value) // interface
 		receiverValue := c.builder.CreateExtractValue(itf, 1, "invoke.func.receiver")
 		values = []llvm.Value{callback, next, receiverValue}
 		valueTypes = append(valueTypes, c.i8ptrType)
 		for _, arg := range instr.Call.Args {
-			val := c.getValue(frame, arg)
+			val := frame.getValue(arg)
 			values = append(values, val)
 			valueTypes = append(valueTypes, val.Type())
 		}
@@ -115,7 +115,7 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 		// runtime._defer fields).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := c.getValue(frame, param)
+			llvmParam := frame.getValue(param)
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
@@ -127,7 +127,7 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 		// pointer.
 		// TODO: ignore this closure entirely and put pointers to the free
 		// variables directly in the defer struct, avoiding a memory allocation.
-		closure := c.getValue(frame, instr.Call.Value)
+		closure := frame.getValue(instr.Call.Value)
 		context := c.builder.CreateExtractValue(closure, 0, "")
 
 		// Get the callback number.
@@ -143,7 +143,7 @@ func (c *Compiler) emitDefer(frame *Frame, instr *ssa.Defer) {
 		// context pointer).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := c.getValue(frame, param)
+			llvmParam := frame.getValue(param)
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}

--- a/compiler/errors.go
+++ b/compiler/errors.go
@@ -20,7 +20,7 @@ func (c *compilerContext) makeError(pos token.Pos, msg string) types.Error {
 	}
 }
 
-func (c *Compiler) addError(pos token.Pos, msg string) {
+func (c *compilerContext) addError(pos token.Pos, msg string) {
 	c.diagnostics = append(c.diagnostics, c.makeError(pos, msg))
 }
 

--- a/compiler/errors.go
+++ b/compiler/errors.go
@@ -1,5 +1,7 @@
 package compiler
 
+// This file contains some utility functions related to error handling.
+
 import (
 	"go/scanner"
 	"go/token"
@@ -9,7 +11,8 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-func (c *Compiler) makeError(pos token.Pos, msg string) types.Error {
+// makeError makes it easy to create an error from a token.Pos with a message.
+func (c *compilerContext) makeError(pos token.Pos, msg string) types.Error {
 	return types.Error{
 		Fset: c.ir.Program.Fset,
 		Pos:  pos,

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -76,7 +76,7 @@ func (c *Compiler) decodeFuncValue(funcValue llvm.Value, sig *types.Signature) (
 }
 
 // getFuncType returns the type of a func value given a signature.
-func (c *Compiler) getFuncType(typ *types.Signature) llvm.Type {
+func (c *compilerContext) getFuncType(typ *types.Signature) llvm.Type {
 	switch c.FuncImplementation() {
 	case compileopts.FuncValueDoubleword:
 		rawPtr := c.getRawFuncType(typ)
@@ -89,7 +89,7 @@ func (c *Compiler) getFuncType(typ *types.Signature) llvm.Type {
 }
 
 // getRawFuncType returns a LLVM function pointer type for a given signature.
-func (c *Compiler) getRawFuncType(typ *types.Signature) llvm.Type {
+func (c *compilerContext) getRawFuncType(typ *types.Signature) llvm.Type {
 	// Get the return type.
 	var returnType llvm.Type
 	switch typ.Results().Len() {
@@ -119,11 +119,11 @@ func (c *Compiler) getRawFuncType(typ *types.Signature) llvm.Type {
 			// The receiver is not an interface, but a i8* type.
 			recv = c.i8ptrType
 		}
-		paramTypes = append(paramTypes, c.expandFormalParamType(recv)...)
+		paramTypes = append(paramTypes, expandFormalParamType(recv)...)
 	}
 	for i := 0; i < typ.Params().Len(); i++ {
 		subType := c.getLLVMType(typ.Params().At(i).Type())
-		paramTypes = append(paramTypes, c.expandFormalParamType(subType)...)
+		paramTypes = append(paramTypes, expandFormalParamType(subType)...)
 	}
 	// All functions take these parameters at the end.
 	paramTypes = append(paramTypes, c.i8ptrType) // context

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -13,12 +13,6 @@ import (
 
 // createFuncValue creates a function value from a raw function pointer with no
 // context.
-func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
-	return c.compilerContext.createFuncValue(c.builder, funcPtr, context, sig)
-}
-
-// createFuncValue creates a function value from a raw function pointer with no
-// context.
 func (b *builder) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
 	return b.compilerContext.createFuncValue(b.Builder, funcPtr, context, sig)
 }
@@ -55,12 +49,6 @@ func (c *compilerContext) createFuncValue(builder llvm.Builder, funcPtr, context
 	funcValue = builder.CreateInsertValue(funcValue, context, 0, "")
 	funcValue = builder.CreateInsertValue(funcValue, funcValueScalar, 1, "")
 	return funcValue
-}
-
-// extractFuncScalar returns some scalar that can be used in comparisons. It is
-// a cheap operation.
-func (c *Compiler) extractFuncScalar(funcValue llvm.Value) llvm.Value {
-	return c.builder.CreateExtractValue(funcValue, 1, "")
 }
 
 // extractFuncScalar returns some scalar that can be used in comparisons. It is

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -51,6 +51,12 @@ func (c *Compiler) extractFuncScalar(funcValue llvm.Value) llvm.Value {
 	return c.builder.CreateExtractValue(funcValue, 1, "")
 }
 
+// extractFuncScalar returns some scalar that can be used in comparisons. It is
+// a cheap operation.
+func (b *builder) extractFuncScalar(funcValue llvm.Value) llvm.Value {
+	return b.CreateExtractValue(funcValue, 1, "")
+}
+
 // extractFuncContext extracts the context pointer from this function value. It
 // is a cheap operation.
 func (c *Compiler) extractFuncContext(funcValue llvm.Value) llvm.Value {

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -71,22 +71,22 @@ func (b *builder) extractFuncScalar(funcValue llvm.Value) llvm.Value {
 
 // extractFuncContext extracts the context pointer from this function value. It
 // is a cheap operation.
-func (c *Compiler) extractFuncContext(funcValue llvm.Value) llvm.Value {
-	return c.builder.CreateExtractValue(funcValue, 0, "")
+func (b *builder) extractFuncContext(funcValue llvm.Value) llvm.Value {
+	return b.CreateExtractValue(funcValue, 0, "")
 }
 
 // decodeFuncValue extracts the context and the function pointer from this func
 // value. This may be an expensive operation.
-func (c *Compiler) decodeFuncValue(funcValue llvm.Value, sig *types.Signature) (funcPtr, context llvm.Value) {
-	context = c.builder.CreateExtractValue(funcValue, 0, "")
-	switch c.FuncImplementation() {
+func (b *builder) decodeFuncValue(funcValue llvm.Value, sig *types.Signature) (funcPtr, context llvm.Value) {
+	context = b.CreateExtractValue(funcValue, 0, "")
+	switch b.FuncImplementation() {
 	case compileopts.FuncValueDoubleword:
-		funcPtr = c.builder.CreateExtractValue(funcValue, 1, "")
+		funcPtr = b.CreateExtractValue(funcValue, 1, "")
 	case compileopts.FuncValueSwitch:
-		llvmSig := c.getRawFuncType(sig)
-		sigGlobal := c.getTypeCode(sig)
-		funcPtr = c.createRuntimeCall("getFuncPtr", []llvm.Value{funcValue, sigGlobal}, "")
-		funcPtr = c.builder.CreateIntToPtr(funcPtr, llvmSig, "")
+		llvmSig := b.getRawFuncType(sig)
+		sigGlobal := b.getTypeCode(sig)
+		funcPtr = b.createRuntimeCall("getFuncPtr", []llvm.Value{funcValue, sigGlobal}, "")
+		funcPtr = b.CreateIntToPtr(funcPtr, llvmSig, "")
 	default:
 		panic("unimplemented func value variant")
 	}

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -14,6 +14,18 @@ import (
 // createFuncValue creates a function value from a raw function pointer with no
 // context.
 func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
+	return c.compilerContext.createFuncValue(c.builder, funcPtr, context, sig)
+}
+
+// createFuncValue creates a function value from a raw function pointer with no
+// context.
+func (b *builder) createFuncValue(funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
+	return b.compilerContext.createFuncValue(b.Builder, funcPtr, context, sig)
+}
+
+// createFuncValue creates a function value from a raw function pointer with no
+// context.
+func (c *compilerContext) createFuncValue(builder llvm.Builder, funcPtr, context llvm.Value, sig *types.Signature) llvm.Value {
 	var funcValueScalar llvm.Value
 	switch c.FuncImplementation() {
 	case compileopts.FuncValueDoubleword:
@@ -40,8 +52,8 @@ func (c *Compiler) createFuncValue(funcPtr, context llvm.Value, sig *types.Signa
 	}
 	funcValueType := c.getFuncType(sig)
 	funcValue := llvm.Undef(funcValueType)
-	funcValue = c.builder.CreateInsertValue(funcValue, context, 0, "")
-	funcValue = c.builder.CreateInsertValue(funcValue, funcValueScalar, 1, "")
+	funcValue = builder.CreateInsertValue(funcValue, context, 0, "")
+	funcValue = builder.CreateInsertValue(funcValue, funcValueScalar, 1, "")
 	return funcValue
 }
 
@@ -151,7 +163,7 @@ func (c *Compiler) parseMakeClosure(frame *Frame, expr *ssa.MakeClosure) (llvm.V
 	boundVars := make([]llvm.Value, len(expr.Bindings))
 	for i, binding := range expr.Bindings {
 		// The context stores the bound variables.
-		llvmBoundVar := c.getValue(frame, binding)
+		llvmBoundVar := frame.getValue(binding)
 		boundVars[i] = llvmBoundVar
 	}
 

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -153,24 +153,24 @@ func (c *compilerContext) getRawFuncType(typ *types.Signature) llvm.Type {
 
 // parseMakeClosure makes a function value (with context) from the given
 // closure expression.
-func (c *Compiler) parseMakeClosure(frame *Frame, expr *ssa.MakeClosure) (llvm.Value, error) {
+func (b *builder) parseMakeClosure(expr *ssa.MakeClosure) (llvm.Value, error) {
 	if len(expr.Bindings) == 0 {
 		panic("unexpected: MakeClosure without bound variables")
 	}
-	f := c.ir.GetFunction(expr.Fn.(*ssa.Function))
+	f := b.ir.GetFunction(expr.Fn.(*ssa.Function))
 
 	// Collect all bound variables.
 	boundVars := make([]llvm.Value, len(expr.Bindings))
 	for i, binding := range expr.Bindings {
 		// The context stores the bound variables.
-		llvmBoundVar := frame.getValue(binding)
+		llvmBoundVar := b.getValue(binding)
 		boundVars[i] = llvmBoundVar
 	}
 
 	// Store the bound variables in a single object, allocating it on the heap
 	// if necessary.
-	context := c.emitPointerPack(boundVars)
+	context := b.emitPointerPack(boundVars)
 
 	// Create the closure.
-	return c.createFuncValue(f.LLVMFn, context, f.Signature), nil
+	return b.createFuncValue(f.LLVMFn, context, f.Signature), nil
 }

--- a/compiler/gc.go
+++ b/compiler/gc.go
@@ -81,6 +81,15 @@ func (c *Compiler) trackPointer(value llvm.Value) {
 	c.createRuntimeCall("trackPointer", []llvm.Value{value}, "")
 }
 
+// trackPointer creates a call to runtime.trackPointer, bitcasting the poitner
+// first if needed. The input value must be of LLVM pointer type.
+func (b *builder) trackPointer(value llvm.Value) {
+	if value.Type() != b.i8ptrType {
+		value = b.CreateBitCast(value, b.i8ptrType, "")
+	}
+	b.createRuntimeCall("trackPointer", []llvm.Value{value}, "")
+}
+
 // typeHasPointers returns whether this type is a pointer or contains pointers.
 // If the type is an aggregate type, it will check whether there is a pointer
 // inside.

--- a/compiler/gc.go
+++ b/compiler/gc.go
@@ -74,15 +74,6 @@ func (b *builder) trackValue(value llvm.Value) {
 
 // trackPointer creates a call to runtime.trackPointer, bitcasting the poitner
 // first if needed. The input value must be of LLVM pointer type.
-func (c *Compiler) trackPointer(value llvm.Value) {
-	if value.Type() != c.i8ptrType {
-		value = c.builder.CreateBitCast(value, c.i8ptrType, "")
-	}
-	c.createRuntimeCall("trackPointer", []llvm.Value{value}, "")
-}
-
-// trackPointer creates a call to runtime.trackPointer, bitcasting the poitner
-// first if needed. The input value must be of LLVM pointer type.
 func (b *builder) trackPointer(value llvm.Value) {
 	if value.Type() != b.i8ptrType {
 		value = b.CreateBitCast(value, b.i8ptrType, "")

--- a/compiler/goroutine.go
+++ b/compiler/goroutine.go
@@ -3,27 +3,30 @@ package compiler
 // This file implements the 'go' keyword to start a new goroutine. See
 // goroutine-lowering.go for more details.
 
-import "tinygo.org/x/go-llvm"
+import (
+	"github.com/tinygo-org/tinygo/compiler/llvmutil"
+	"tinygo.org/x/go-llvm"
+)
 
-// emitStartGoroutine starts a new goroutine with the provided function pointer
+// createGoInstruction starts a new goroutine with the provided function pointer
 // and parameters.
 // In general, you should pass all regular parameters plus the context parameter.
 // There is one exception: the task-based scheduler needs to have the function
 // pointer passed in as a parameter too in addition to the context.
 //
 // Because a go statement doesn't return anything, return undef.
-func (c *Compiler) emitStartGoroutine(funcPtr llvm.Value, params []llvm.Value) llvm.Value {
-	paramBundle := c.emitPointerPack(params)
+func (b *builder) createGoInstruction(funcPtr llvm.Value, params []llvm.Value) llvm.Value {
+	paramBundle := b.emitPointerPack(params)
 	var callee llvm.Value
-	switch c.Scheduler() {
+	switch b.Scheduler() {
 	case "none", "tasks":
-		callee = c.createGoroutineStartWrapper(funcPtr)
+		callee = b.createGoroutineStartWrapper(funcPtr)
 	case "coroutines":
-		callee = c.builder.CreatePtrToInt(funcPtr, c.uintptrType, "")
+		callee = b.CreatePtrToInt(funcPtr, b.uintptrType, "")
 	default:
 		panic("unreachable")
 	}
-	c.createCall(c.mod.NamedFunction("internal/task.start"), []llvm.Value{callee, paramBundle, llvm.Undef(c.i8ptrType), llvm.ConstPointerNull(c.i8ptrType)}, "")
+	b.createCall(b.mod.NamedFunction("internal/task.start"), []llvm.Value{callee, paramBundle, llvm.Undef(b.i8ptrType), llvm.ConstPointerNull(b.i8ptrType)}, "")
 	return llvm.Undef(funcPtr.Type().ElementType().ReturnType())
 }
 
@@ -45,20 +48,18 @@ func (c *Compiler) emitStartGoroutine(funcPtr llvm.Value, params []llvm.Value) l
 // allows a single (pointer) argument to the newly started goroutine. Also, it
 // ignores the return value because newly started goroutines do not have a
 // return value.
-func (c *Compiler) createGoroutineStartWrapper(fn llvm.Value) llvm.Value {
+func (c *compilerContext) createGoroutineStartWrapper(fn llvm.Value) llvm.Value {
 	var wrapper llvm.Value
+
+	builder := c.ctx.NewBuilder()
 
 	if !fn.IsAFunction().IsNil() {
 		// See whether this wrapper has already been created. If so, return it.
 		name := fn.Name()
 		wrapper = c.mod.NamedFunction(name + "$gowrapper")
 		if !wrapper.IsNil() {
-			return c.builder.CreatePtrToInt(wrapper, c.uintptrType, "")
+			return llvm.ConstPtrToInt(wrapper, c.uintptrType)
 		}
-
-		// Save the current position in the IR builder.
-		currentBlock := c.builder.GetInsertBlock()
-		defer c.builder.SetInsertPointAtEnd(currentBlock)
 
 		// Create the wrapper.
 		wrapperType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{c.i8ptrType}, false)
@@ -66,15 +67,15 @@ func (c *Compiler) createGoroutineStartWrapper(fn llvm.Value) llvm.Value {
 		wrapper.SetLinkage(llvm.PrivateLinkage)
 		wrapper.SetUnnamedAddr(true)
 		entry := c.ctx.AddBasicBlock(wrapper, "entry")
-		c.builder.SetInsertPointAtEnd(entry)
+		builder.SetInsertPointAtEnd(entry)
 
 		// Create the list of params for the call.
 		paramTypes := fn.Type().ElementType().ParamTypes()
-		params := c.emitPointerUnpack(wrapper.Param(0), paramTypes[:len(paramTypes)-1])
+		params := llvmutil.EmitPointerUnpack(builder, c.mod, wrapper.Param(0), paramTypes[:len(paramTypes)-1])
 		params = append(params, llvm.Undef(c.i8ptrType))
 
 		// Create the call.
-		c.builder.CreateCall(fn, params, "")
+		builder.CreateCall(fn, params, "")
 
 	} else {
 		// For a function pointer like this:
@@ -94,22 +95,18 @@ func (c *Compiler) createGoroutineStartWrapper(fn llvm.Value) llvm.Value {
 		// With a bit of luck, identical wrapper functions like these can be
 		// merged into one.
 
-		// Save the current position in the IR builder.
-		currentBlock := c.builder.GetInsertBlock()
-		defer c.builder.SetInsertPointAtEnd(currentBlock)
-
 		// Create the wrapper.
 		wrapperType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{c.i8ptrType}, false)
 		wrapper = llvm.AddFunction(c.mod, ".gowrapper", wrapperType)
 		wrapper.SetLinkage(llvm.InternalLinkage)
 		wrapper.SetUnnamedAddr(true)
 		entry := c.ctx.AddBasicBlock(wrapper, "entry")
-		c.builder.SetInsertPointAtEnd(entry)
+		builder.SetInsertPointAtEnd(entry)
 
 		// Get the list of parameters, with the extra parameters at the end.
 		paramTypes := fn.Type().ElementType().ParamTypes()
 		paramTypes[len(paramTypes)-1] = fn.Type() // the last element is the function pointer
-		params := c.emitPointerUnpack(wrapper.Param(0), paramTypes)
+		params := llvmutil.EmitPointerUnpack(builder, c.mod, wrapper.Param(0), paramTypes)
 
 		// Get the function pointer.
 		fnPtr := params[len(params)-1]
@@ -119,13 +116,13 @@ func (c *Compiler) createGoroutineStartWrapper(fn llvm.Value) llvm.Value {
 		params[len(params)-1] = llvm.Undef(c.i8ptrType)
 
 		// Create the call.
-		c.builder.CreateCall(fnPtr, params, "")
+		builder.CreateCall(fnPtr, params, "")
 	}
 
 	// Finish the function. Every basic block must end in a terminator, and
 	// because goroutines never return a value we can simply return void.
-	c.builder.CreateRetVoid()
+	builder.CreateRetVoid()
 
 	// Return a ptrtoint of the wrapper, not the function itself.
-	return c.builder.CreatePtrToInt(wrapper, c.uintptrType, "")
+	return builder.CreatePtrToInt(wrapper, c.uintptrType, "")
 }

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -445,7 +445,7 @@ func (c *Compiler) getInterfaceInvokeWrapper(f *ir.Function) llvm.Value {
 
 	// Get the expanded receiver type.
 	receiverType := c.getLLVMType(f.Params[0].Type())
-	expandedReceiverType := c.expandFormalParamType(receiverType)
+	expandedReceiverType := expandFormalParamType(receiverType)
 
 	// Does this method even need any wrapping?
 	if len(expandedReceiverType) == 1 && receiverType.TypeKind() == llvm.PointerTypeKind {

--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -8,62 +8,62 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-// emitInterruptGlobal creates a new runtime/interrupt.Interrupt struct that
+// createInterruptGlobal creates a new runtime/interrupt.Interrupt struct that
 // will be lowered to a real interrupt during interrupt lowering.
 //
 // This two-stage approach allows unused interrupts to be optimized away if
 // necessary.
-func (c *Compiler) emitInterruptGlobal(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
+func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, error) {
 	// Get the interrupt number, which must be a compile-time constant.
 	id, ok := instr.Args[0].(*ssa.Const)
 	if !ok {
-		return llvm.Value{}, c.makeError(instr.Pos(), "interrupt ID is not a constant")
+		return llvm.Value{}, b.makeError(instr.Pos(), "interrupt ID is not a constant")
 	}
 
 	// Get the func value, which also must be a compile time constant.
 	// Note that bound functions are allowed if the function has a pointer
 	// receiver and is a global. This is rather strict but still allows for
 	// idiomatic Go code.
-	funcValue := frame.getValue(instr.Args[1])
+	funcValue := b.getValue(instr.Args[1])
 	if funcValue.IsAConstant().IsNil() {
 		// Try to determine the cause of the non-constantness for a nice error
 		// message.
 		switch instr.Args[1].(type) {
 		case *ssa.MakeClosure:
 			// This may also be a bound method.
-			return llvm.Value{}, c.makeError(instr.Pos(), "closures are not supported in interrupt.New")
+			return llvm.Value{}, b.makeError(instr.Pos(), "closures are not supported in interrupt.New")
 		}
 		// Fall back to a generic error.
-		return llvm.Value{}, c.makeError(instr.Pos(), "interrupt function must be constant")
+		return llvm.Value{}, b.makeError(instr.Pos(), "interrupt function must be constant")
 	}
 
 	// Create a new global of type runtime/interrupt.handle. Globals of this
 	// type are lowered in the interrupt lowering pass.
-	globalType := c.ir.Program.ImportedPackage("runtime/interrupt").Type("handle").Type()
-	globalLLVMType := c.getLLVMType(globalType)
+	globalType := b.ir.Program.ImportedPackage("runtime/interrupt").Type("handle").Type()
+	globalLLVMType := b.getLLVMType(globalType)
 	globalName := "runtime/interrupt.$interrupt" + strconv.FormatInt(id.Int64(), 10)
-	if global := c.mod.NamedGlobal(globalName); !global.IsNil() {
-		return llvm.Value{}, c.makeError(instr.Pos(), "interrupt redeclared in this program")
+	if global := b.mod.NamedGlobal(globalName); !global.IsNil() {
+		return llvm.Value{}, b.makeError(instr.Pos(), "interrupt redeclared in this program")
 	}
-	global := llvm.AddGlobal(c.mod, globalLLVMType, globalName)
+	global := llvm.AddGlobal(b.mod, globalLLVMType, globalName)
 	global.SetLinkage(llvm.PrivateLinkage)
 	global.SetGlobalConstant(true)
 	global.SetUnnamedAddr(true)
 	initializer := llvm.ConstNull(globalLLVMType)
 	initializer = llvm.ConstInsertValue(initializer, funcValue, []uint32{0})
-	initializer = llvm.ConstInsertValue(initializer, llvm.ConstInt(c.intType, uint64(id.Int64()), true), []uint32{1, 0})
+	initializer = llvm.ConstInsertValue(initializer, llvm.ConstInt(b.intType, uint64(id.Int64()), true), []uint32{1, 0})
 	global.SetInitializer(initializer)
 
 	// Add debug info to the interrupt global.
-	if c.Debug() {
-		pos := c.ir.Program.Fset.Position(instr.Pos())
-		diglobal := c.dibuilder.CreateGlobalVariableExpression(c.difiles[pos.Filename], llvm.DIGlobalVariableExpression{
+	if b.Debug() {
+		pos := b.ir.Program.Fset.Position(instr.Pos())
+		diglobal := b.dibuilder.CreateGlobalVariableExpression(b.getDIFile(pos.Filename), llvm.DIGlobalVariableExpression{
 			Name:        "interrupt" + strconv.FormatInt(id.Int64(), 10),
 			LinkageName: globalName,
-			File:        c.getDIFile(pos.Filename),
+			File:        b.getDIFile(pos.Filename),
 			Line:        pos.Line,
-			Type:        c.getDIType(globalType),
-			Expr:        c.dibuilder.CreateExpression(nil),
+			Type:        b.getDIType(globalType),
+			Expr:        b.dibuilder.CreateExpression(nil),
 			LocalToUnit: false,
 		})
 		global.AddMetadata(0, diglobal)
@@ -71,21 +71,21 @@ func (c *Compiler) emitInterruptGlobal(frame *Frame, instr *ssa.CallCommon) (llv
 
 	// Create the runtime/interrupt.Interrupt type. It is a struct with a single
 	// member of type int.
-	num := llvm.ConstPtrToInt(global, c.intType)
-	interrupt := llvm.ConstNamedStruct(c.mod.GetTypeByName("runtime/interrupt.Interrupt"), []llvm.Value{num})
+	num := llvm.ConstPtrToInt(global, b.intType)
+	interrupt := llvm.ConstNamedStruct(b.mod.GetTypeByName("runtime/interrupt.Interrupt"), []llvm.Value{num})
 
 	// Add dummy "use" call for AVR, because interrupts may be used even though
 	// they are never referenced again. This is unlike Cortex-M or the RISC-V
 	// PLIC where each interrupt must be enabled using the interrupt number, and
 	// thus keeps the Interrupt object alive.
 	// This call is removed during interrupt lowering.
-	if strings.HasPrefix(c.Triple(), "avr") {
-		useFn := c.mod.NamedFunction("runtime/interrupt.use")
+	if strings.HasPrefix(b.Triple(), "avr") {
+		useFn := b.mod.NamedFunction("runtime/interrupt.use")
 		if useFn.IsNil() {
-			useFnType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{interrupt.Type()}, false)
-			useFn = llvm.AddFunction(c.mod, "runtime/interrupt.use", useFnType)
+			useFnType := llvm.FunctionType(b.ctx.VoidType(), []llvm.Type{interrupt.Type()}, false)
+			useFn = llvm.AddFunction(b.mod, "runtime/interrupt.use", useFnType)
 		}
-		c.builder.CreateCall(useFn, []llvm.Value{interrupt}, "")
+		b.CreateCall(useFn, []llvm.Value{interrupt}, "")
 	}
 
 	return interrupt, nil

--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -24,7 +24,7 @@ func (c *Compiler) emitInterruptGlobal(frame *Frame, instr *ssa.CallCommon) (llv
 	// Note that bound functions are allowed if the function has a pointer
 	// receiver and is a global. This is rather strict but still allows for
 	// idiomatic Go code.
-	funcValue := c.getValue(frame, instr.Args[1])
+	funcValue := frame.getValue(instr.Args[1])
 	if funcValue.IsAConstant().IsNil() {
 		// Try to determine the cause of the non-constantness for a nice error
 		// message.

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -64,6 +64,13 @@ func (c *Compiler) emitPointerPack(values []llvm.Value) llvm.Value {
 	return llvmutil.EmitPointerPack(c.builder, c.mod, c.Config, values)
 }
 
+// emitPointerPack packs the list of values into a single pointer value using
+// bitcasts, or else allocates a value on the heap if it cannot be packed in the
+// pointer value directly. It returns the pointer with the packed data.
+func (b *builder) emitPointerPack(values []llvm.Value) llvm.Value {
+	return llvmutil.EmitPointerPack(b.Builder, b.mod, b.Config, values)
+}
+
 // emitPointerUnpack extracts a list of values packed using emitPointerPack.
 func (c *Compiler) emitPointerUnpack(ptr llvm.Value, valueTypes []llvm.Type) []llvm.Value {
 	return llvmutil.EmitPointerUnpack(c.builder, c.mod, ptr, valueTypes)

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -33,11 +33,28 @@ func (c *Compiler) createTemporaryAlloca(t llvm.Type, name string) (alloca, bitc
 	return llvmutil.CreateTemporaryAlloca(c.builder, c.mod, t, name)
 }
 
+// createTemporaryAlloca creates a new alloca in the entry block and adds
+// lifetime start infromation in the IR signalling that the alloca won't be used
+// before this point.
+//
+// This is useful for creating temporary allocas for intrinsics. Don't forget to
+// end the lifetime using emitLifetimeEnd after you're done with it.
+func (b *builder) createTemporaryAlloca(t llvm.Type, name string) (alloca, bitcast, size llvm.Value) {
+	return llvmutil.CreateTemporaryAlloca(b.Builder, b.mod, t, name)
+}
+
 // emitLifetimeEnd signals the end of an (alloca) lifetime by calling the
 // llvm.lifetime.end intrinsic. It is commonly used together with
 // createTemporaryAlloca.
 func (c *Compiler) emitLifetimeEnd(ptr, size llvm.Value) {
 	llvmutil.EmitLifetimeEnd(c.builder, c.mod, ptr, size)
+}
+
+// emitLifetimeEnd signals the end of an (alloca) lifetime by calling the
+// llvm.lifetime.end intrinsic. It is commonly used together with
+// createTemporaryAlloca.
+func (b *builder) emitLifetimeEnd(ptr, size llvm.Value) {
+	llvmutil.EmitLifetimeEnd(b.Builder, b.mod, ptr, size)
 }
 
 // emitPointerPack packs the list of values into a single pointer value using

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -52,6 +52,11 @@ func (c *Compiler) emitPointerUnpack(ptr llvm.Value, valueTypes []llvm.Type) []l
 	return llvmutil.EmitPointerUnpack(c.builder, c.mod, ptr, valueTypes)
 }
 
+// emitPointerUnpack extracts a list of values packed using emitPointerPack.
+func (b *builder) emitPointerUnpack(ptr llvm.Value, valueTypes []llvm.Type) []llvm.Value {
+	return llvmutil.EmitPointerUnpack(b.Builder, b.mod, ptr, valueTypes)
+}
+
 // makeGlobalArray creates a new LLVM global with the given name and integers as
 // contents, and returns the global.
 // Note that it is left with the default linkage etc., you should set

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -56,7 +56,7 @@ func (c *Compiler) emitPointerUnpack(ptr llvm.Value, valueTypes []llvm.Type) []l
 // contents, and returns the global.
 // Note that it is left with the default linkage etc., you should set
 // linkage/constant/etc properties yourself.
-func (c *Compiler) makeGlobalArray(buf []byte, name string, elementType llvm.Type) llvm.Value {
+func (c *compilerContext) makeGlobalArray(buf []byte, name string, elementType llvm.Type) llvm.Value {
 	globalType := llvm.ArrayType(elementType, len(buf))
 	global := llvm.AddGlobal(c.mod, globalType, name)
 	value := llvm.Undef(globalType)

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -29,25 +29,8 @@ func getUses(value llvm.Value) []llvm.Value {
 //
 // This is useful for creating temporary allocas for intrinsics. Don't forget to
 // end the lifetime using emitLifetimeEnd after you're done with it.
-func (c *Compiler) createTemporaryAlloca(t llvm.Type, name string) (alloca, bitcast, size llvm.Value) {
-	return llvmutil.CreateTemporaryAlloca(c.builder, c.mod, t, name)
-}
-
-// createTemporaryAlloca creates a new alloca in the entry block and adds
-// lifetime start infromation in the IR signalling that the alloca won't be used
-// before this point.
-//
-// This is useful for creating temporary allocas for intrinsics. Don't forget to
-// end the lifetime using emitLifetimeEnd after you're done with it.
 func (b *builder) createTemporaryAlloca(t llvm.Type, name string) (alloca, bitcast, size llvm.Value) {
 	return llvmutil.CreateTemporaryAlloca(b.Builder, b.mod, t, name)
-}
-
-// emitLifetimeEnd signals the end of an (alloca) lifetime by calling the
-// llvm.lifetime.end intrinsic. It is commonly used together with
-// createTemporaryAlloca.
-func (c *Compiler) emitLifetimeEnd(ptr, size llvm.Value) {
-	llvmutil.EmitLifetimeEnd(c.builder, c.mod, ptr, size)
 }
 
 // emitLifetimeEnd signals the end of an (alloca) lifetime by calling the
@@ -60,20 +43,8 @@ func (b *builder) emitLifetimeEnd(ptr, size llvm.Value) {
 // emitPointerPack packs the list of values into a single pointer value using
 // bitcasts, or else allocates a value on the heap if it cannot be packed in the
 // pointer value directly. It returns the pointer with the packed data.
-func (c *Compiler) emitPointerPack(values []llvm.Value) llvm.Value {
-	return llvmutil.EmitPointerPack(c.builder, c.mod, c.Config, values)
-}
-
-// emitPointerPack packs the list of values into a single pointer value using
-// bitcasts, or else allocates a value on the heap if it cannot be packed in the
-// pointer value directly. It returns the pointer with the packed data.
 func (b *builder) emitPointerPack(values []llvm.Value) llvm.Value {
 	return llvmutil.EmitPointerPack(b.Builder, b.mod, b.Config, values)
-}
-
-// emitPointerUnpack extracts a list of values packed using emitPointerPack.
-func (c *Compiler) emitPointerUnpack(ptr llvm.Value, valueTypes []llvm.Type) []llvm.Value {
-	return llvmutil.EmitPointerUnpack(c.builder, c.mod, ptr, valueTypes)
 }
 
 // emitPointerUnpack extracts a list of values packed using emitPointerPack.

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -36,7 +36,7 @@ func (c *Compiler) emitMakeMap(frame *Frame, expr *ssa.MakeMap) (llvm.Value, err
 	if expr.Reserve != nil {
 		sizeHint = frame.getValue(expr.Reserve)
 		var err error
-		sizeHint, err = c.parseConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
+		sizeHint, err = frame.createConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
 		if err != nil {
 			return llvm.Value{}, err
 		}

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -10,56 +10,58 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-// emitMakeMap creates a new map object (runtime.hashmap) by allocating and
+// createMakeMap creates a new map object (runtime.hashmap) by allocating and
 // initializing an appropriately sized object.
-func (c *Compiler) emitMakeMap(frame *Frame, expr *ssa.MakeMap) (llvm.Value, error) {
+func (b *builder) createMakeMap(expr *ssa.MakeMap) (llvm.Value, error) {
 	mapType := expr.Type().Underlying().(*types.Map)
 	keyType := mapType.Key().Underlying()
-	llvmValueType := c.getLLVMType(mapType.Elem().Underlying())
+	llvmValueType := b.getLLVMType(mapType.Elem().Underlying())
 	var llvmKeyType llvm.Type
 	if t, ok := keyType.(*types.Basic); ok && t.Info()&types.IsString != 0 {
 		// String keys.
-		llvmKeyType = c.getLLVMType(keyType)
+		llvmKeyType = b.getLLVMType(keyType)
 	} else if hashmapIsBinaryKey(keyType) {
 		// Trivially comparable keys.
-		llvmKeyType = c.getLLVMType(keyType)
+		llvmKeyType = b.getLLVMType(keyType)
 	} else {
 		// All other keys. Implemented as map[interface{}]valueType for ease of
 		// implementation.
-		llvmKeyType = c.getLLVMRuntimeType("_interface")
+		llvmKeyType = b.getLLVMRuntimeType("_interface")
 	}
-	keySize := c.targetData.TypeAllocSize(llvmKeyType)
-	valueSize := c.targetData.TypeAllocSize(llvmValueType)
-	llvmKeySize := llvm.ConstInt(c.ctx.Int8Type(), keySize, false)
-	llvmValueSize := llvm.ConstInt(c.ctx.Int8Type(), valueSize, false)
-	sizeHint := llvm.ConstInt(c.uintptrType, 8, false)
+	keySize := b.targetData.TypeAllocSize(llvmKeyType)
+	valueSize := b.targetData.TypeAllocSize(llvmValueType)
+	llvmKeySize := llvm.ConstInt(b.ctx.Int8Type(), keySize, false)
+	llvmValueSize := llvm.ConstInt(b.ctx.Int8Type(), valueSize, false)
+	sizeHint := llvm.ConstInt(b.uintptrType, 8, false)
 	if expr.Reserve != nil {
-		sizeHint = frame.getValue(expr.Reserve)
+		sizeHint = b.getValue(expr.Reserve)
 		var err error
-		sizeHint, err = frame.createConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
+		sizeHint, err = b.createConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
 		if err != nil {
 			return llvm.Value{}, err
 		}
 	}
-	hashmap := c.createRuntimeCall("hashmapMake", []llvm.Value{llvmKeySize, llvmValueSize, sizeHint}, "")
+	hashmap := b.createRuntimeCall("hashmapMake", []llvm.Value{llvmKeySize, llvmValueSize, sizeHint}, "")
 	return hashmap, nil
 }
 
-func (c *Compiler) emitMapLookup(keyType, valueType types.Type, m, key llvm.Value, commaOk bool, pos token.Pos) (llvm.Value, error) {
-	llvmValueType := c.getLLVMType(valueType)
+// createMapLookup returns the value in a map. It calls a runtime function
+// depending on the map key type to load the map value and its comma-ok value.
+func (b *builder) createMapLookup(keyType, valueType types.Type, m, key llvm.Value, commaOk bool, pos token.Pos) (llvm.Value, error) {
+	llvmValueType := b.getLLVMType(valueType)
 
 	// Allocate the memory for the resulting type. Do not zero this memory: it
 	// will be zeroed by the hashmap get implementation if the key is not
 	// present in the map.
-	mapValueAlloca, mapValuePtr, mapValueAllocaSize := c.createTemporaryAlloca(llvmValueType, "hashmap.value")
+	mapValueAlloca, mapValuePtr, mapValueAllocaSize := b.createTemporaryAlloca(llvmValueType, "hashmap.value")
 
 	// We need the map size (with type uintptr) to pass to the hashmap*Get
 	// functions. This is necessary because those *Get functions are valid on
 	// nil maps, and they'll need to zero the value pointer by that number of
 	// bytes.
 	mapValueSize := mapValueAllocaSize
-	if mapValueSize.Type().IntTypeWidth() > c.uintptrType.IntTypeWidth() {
-		mapValueSize = llvm.ConstTrunc(mapValueSize, c.uintptrType)
+	if mapValueSize.Type().IntTypeWidth() > b.uintptrType.IntTypeWidth() {
+		mapValueSize = llvm.ConstTrunc(mapValueSize, b.uintptrType)
 	}
 
 	// Do the lookup. How it is done depends on the key type.
@@ -68,84 +70,88 @@ func (c *Compiler) emitMapLookup(keyType, valueType types.Type, m, key llvm.Valu
 	if t, ok := keyType.(*types.Basic); ok && t.Info()&types.IsString != 0 {
 		// key is a string
 		params := []llvm.Value{m, key, mapValuePtr, mapValueSize}
-		commaOkValue = c.createRuntimeCall("hashmapStringGet", params, "")
+		commaOkValue = b.createRuntimeCall("hashmapStringGet", params, "")
 	} else if hashmapIsBinaryKey(keyType) {
 		// key can be compared with runtime.memequal
 		// Store the key in an alloca, in the entry block to avoid dynamic stack
 		// growth.
-		mapKeyAlloca, mapKeyPtr, mapKeySize := c.createTemporaryAlloca(key.Type(), "hashmap.key")
-		c.builder.CreateStore(key, mapKeyAlloca)
+		mapKeyAlloca, mapKeyPtr, mapKeySize := b.createTemporaryAlloca(key.Type(), "hashmap.key")
+		b.CreateStore(key, mapKeyAlloca)
 		// Fetch the value from the hashmap.
 		params := []llvm.Value{m, mapKeyPtr, mapValuePtr, mapValueSize}
-		commaOkValue = c.createRuntimeCall("hashmapBinaryGet", params, "")
-		c.emitLifetimeEnd(mapKeyPtr, mapKeySize)
+		commaOkValue = b.createRuntimeCall("hashmapBinaryGet", params, "")
+		b.emitLifetimeEnd(mapKeyPtr, mapKeySize)
 	} else {
 		// Not trivially comparable using memcmp. Make it an interface instead.
 		itfKey := key
 		if _, ok := keyType.(*types.Interface); !ok {
 			// Not already an interface, so convert it to an interface now.
-			itfKey = c.parseMakeInterface(key, keyType, pos)
+			itfKey = b.createMakeInterface(key, keyType, pos)
 		}
 		params := []llvm.Value{m, itfKey, mapValuePtr, mapValueSize}
-		commaOkValue = c.createRuntimeCall("hashmapInterfaceGet", params, "")
+		commaOkValue = b.createRuntimeCall("hashmapInterfaceGet", params, "")
 	}
 
 	// Load the resulting value from the hashmap. The value is set to the zero
 	// value if the key doesn't exist in the hashmap.
-	mapValue := c.builder.CreateLoad(mapValueAlloca, "")
-	c.emitLifetimeEnd(mapValuePtr, mapValueAllocaSize)
+	mapValue := b.CreateLoad(mapValueAlloca, "")
+	b.emitLifetimeEnd(mapValuePtr, mapValueAllocaSize)
 
 	if commaOk {
-		tuple := llvm.Undef(c.ctx.StructType([]llvm.Type{llvmValueType, c.ctx.Int1Type()}, false))
-		tuple = c.builder.CreateInsertValue(tuple, mapValue, 0, "")
-		tuple = c.builder.CreateInsertValue(tuple, commaOkValue, 1, "")
+		tuple := llvm.Undef(b.ctx.StructType([]llvm.Type{llvmValueType, b.ctx.Int1Type()}, false))
+		tuple = b.CreateInsertValue(tuple, mapValue, 0, "")
+		tuple = b.CreateInsertValue(tuple, commaOkValue, 1, "")
 		return tuple, nil
 	} else {
 		return mapValue, nil
 	}
 }
 
-func (c *Compiler) emitMapUpdate(keyType types.Type, m, key, value llvm.Value, pos token.Pos) {
-	valueAlloca, valuePtr, valueSize := c.createTemporaryAlloca(value.Type(), "hashmap.value")
-	c.builder.CreateStore(value, valueAlloca)
+// createMapUpdate updates a map key to a given value, by creating an
+// appropriate runtime call.
+func (b *builder) createMapUpdate(keyType types.Type, m, key, value llvm.Value, pos token.Pos) {
+	valueAlloca, valuePtr, valueSize := b.createTemporaryAlloca(value.Type(), "hashmap.value")
+	b.CreateStore(value, valueAlloca)
 	keyType = keyType.Underlying()
 	if t, ok := keyType.(*types.Basic); ok && t.Info()&types.IsString != 0 {
 		// key is a string
 		params := []llvm.Value{m, key, valuePtr}
-		c.createRuntimeCall("hashmapStringSet", params, "")
+		b.createRuntimeCall("hashmapStringSet", params, "")
 	} else if hashmapIsBinaryKey(keyType) {
 		// key can be compared with runtime.memequal
-		keyAlloca, keyPtr, keySize := c.createTemporaryAlloca(key.Type(), "hashmap.key")
-		c.builder.CreateStore(key, keyAlloca)
+		keyAlloca, keyPtr, keySize := b.createTemporaryAlloca(key.Type(), "hashmap.key")
+		b.CreateStore(key, keyAlloca)
 		params := []llvm.Value{m, keyPtr, valuePtr}
-		c.createRuntimeCall("hashmapBinarySet", params, "")
-		c.emitLifetimeEnd(keyPtr, keySize)
+		b.createRuntimeCall("hashmapBinarySet", params, "")
+		b.emitLifetimeEnd(keyPtr, keySize)
 	} else {
 		// Key is not trivially comparable, so compare it as an interface instead.
 		itfKey := key
 		if _, ok := keyType.(*types.Interface); !ok {
 			// Not already an interface, so convert it to an interface first.
-			itfKey = c.parseMakeInterface(key, keyType, pos)
+			itfKey = b.createMakeInterface(key, keyType, pos)
 		}
 		params := []llvm.Value{m, itfKey, valuePtr}
-		c.createRuntimeCall("hashmapInterfaceSet", params, "")
+		b.createRuntimeCall("hashmapInterfaceSet", params, "")
 	}
-	c.emitLifetimeEnd(valuePtr, valueSize)
+	b.emitLifetimeEnd(valuePtr, valueSize)
 }
 
-func (c *Compiler) emitMapDelete(keyType types.Type, m, key llvm.Value, pos token.Pos) error {
+// createMapDelete deletes a key from a map by calling the appropriate runtime
+// function. It is the implementation of the Go delete() builtin.
+func (b *builder) createMapDelete(keyType types.Type, m, key llvm.Value, pos token.Pos) error {
 	keyType = keyType.Underlying()
 	if t, ok := keyType.(*types.Basic); ok && t.Info()&types.IsString != 0 {
 		// key is a string
 		params := []llvm.Value{m, key}
-		c.createRuntimeCall("hashmapStringDelete", params, "")
+		b.createRuntimeCall("hashmapStringDelete", params, "")
 		return nil
 	} else if hashmapIsBinaryKey(keyType) {
-		keyAlloca, keyPtr, keySize := c.createTemporaryAlloca(key.Type(), "hashmap.key")
-		c.builder.CreateStore(key, keyAlloca)
+		keyAlloca, keyPtr, keySize := b.createTemporaryAlloca(key.Type(), "hashmap.key")
+		b.CreateStore(key, keyAlloca)
 		params := []llvm.Value{m, keyPtr}
-		c.createRuntimeCall("hashmapBinaryDelete", params, "")
-		c.emitLifetimeEnd(keyPtr, keySize)
+		b.createRuntimeCall("hashmapBinaryDelete", params, "")
+		b.emitLifetimeEnd(keyPtr, keySize)
 		return nil
 	} else {
 		// Key is not trivially comparable, so compare it as an interface
@@ -153,10 +159,10 @@ func (c *Compiler) emitMapDelete(keyType types.Type, m, key llvm.Value, pos toke
 		itfKey := key
 		if _, ok := keyType.(*types.Interface); !ok {
 			// Not already an interface, so convert it to an interface first.
-			itfKey = c.parseMakeInterface(key, keyType, pos)
+			itfKey = b.createMakeInterface(key, keyType, pos)
 		}
 		params := []llvm.Value{m, itfKey}
-		c.createRuntimeCall("hashmapInterfaceDelete", params, "")
+		b.createRuntimeCall("hashmapInterfaceDelete", params, "")
 		return nil
 	}
 }

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -34,7 +34,7 @@ func (c *Compiler) emitMakeMap(frame *Frame, expr *ssa.MakeMap) (llvm.Value, err
 	llvmValueSize := llvm.ConstInt(c.ctx.Int8Type(), valueSize, false)
 	sizeHint := llvm.ConstInt(c.uintptrType, 8, false)
 	if expr.Reserve != nil {
-		sizeHint = c.getValue(frame, expr.Reserve)
+		sizeHint = frame.getValue(expr.Reserve)
 		var err error
 		sizeHint, err = c.parseConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
 		if err != nil {

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -26,7 +26,7 @@ type globalInfo struct {
 
 // loadASTComments loads comments on globals from the AST, for use later in the
 // program. In particular, they are required for //go:extern pragmas on globals.
-func (c *Compiler) loadASTComments(lprogram *loader.Program) {
+func (c *compilerContext) loadASTComments(lprogram *loader.Program) {
 	c.astComments = map[string]*ast.CommentGroup{}
 	for _, pkgInfo := range lprogram.Sorted() {
 		for _, file := range pkgInfo.Files {

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -56,7 +56,7 @@ func (c *Compiler) loadASTComments(lprogram *loader.Program) {
 
 // getGlobal returns a LLVM IR global value for a Go SSA global. It is added to
 // the LLVM IR if it has not been added already.
-func (c *Compiler) getGlobal(g *ssa.Global) llvm.Value {
+func (c *compilerContext) getGlobal(g *ssa.Global) llvm.Value {
 	info := c.getGlobalInfo(g)
 	llvmGlobal := c.mod.NamedGlobal(info.linkName)
 	if llvmGlobal.IsNil() {
@@ -104,7 +104,7 @@ func (c *Compiler) getGlobal(g *ssa.Global) llvm.Value {
 }
 
 // getGlobalInfo returns some information about a specific global.
-func (c *Compiler) getGlobalInfo(g *ssa.Global) globalInfo {
+func (c *compilerContext) getGlobalInfo(g *ssa.Global) globalInfo {
 	info := globalInfo{}
 	if strings.HasPrefix(g.Name(), "C.") {
 		// Created by CGo: such a name cannot be created by regular C code.

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -13,7 +13,7 @@ import (
 // emitSyscall emits an inline system call instruction, depending on the target
 // OS/arch.
 func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, error) {
-	num := c.getValue(frame, call.Args[0])
+	num := frame.getValue(call.Args[0])
 	var syscallResult llvm.Value
 	switch {
 	case c.GOARCH() == "amd64":
@@ -50,7 +50,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{r12}",
 				"{r13}",
 			}[i]
-			llvmValue := c.getValue(frame, arg)
+			llvmValue := frame.getValue(arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -77,7 +77,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{edi}",
 				"{ebp}",
 			}[i]
-			llvmValue := c.getValue(frame, arg)
+			llvmValue := frame.getValue(arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -102,7 +102,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{r5}",
 				"{r6}",
 			}[i]
-			llvmValue := c.getValue(frame, arg)
+			llvmValue := frame.getValue(arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -132,7 +132,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 				"{x4}",
 				"{x5}",
 			}[i]
-			llvmValue := c.getValue(frame, arg)
+			llvmValue := frame.getValue(arg)
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -10,7 +10,7 @@ import (
 
 func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
 	addr := frame.getValue(instr.Args[0])
-	c.emitNilCheck(frame, addr, "deref")
+	frame.createNilCheck(addr, "deref")
 	val := c.builder.CreateLoad(addr, "")
 	val.SetVolatile(true)
 	return val, nil
@@ -19,7 +19,7 @@ func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.V
 func (c *Compiler) emitVolatileStore(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
 	addr := frame.getValue(instr.Args[0])
 	val := frame.getValue(instr.Args[1])
-	c.emitNilCheck(frame, addr, "deref")
+	frame.createNilCheck(addr, "deref")
 	store := c.builder.CreateStore(val, addr)
 	store.SetVolatile(true)
 	return llvm.Value{}, nil

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := c.getValue(frame, instr.Args[0])
+	addr := frame.getValue(instr.Args[0])
 	c.emitNilCheck(frame, addr, "deref")
 	val := c.builder.CreateLoad(addr, "")
 	val.SetVolatile(true)
@@ -17,8 +17,8 @@ func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.V
 }
 
 func (c *Compiler) emitVolatileStore(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := c.getValue(frame, instr.Args[0])
-	val := c.getValue(frame, instr.Args[1])
+	addr := frame.getValue(instr.Args[0])
+	val := frame.getValue(instr.Args[1])
 	c.emitNilCheck(frame, addr, "deref")
 	store := c.builder.CreateStore(val, addr)
 	store.SetVolatile(true)

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -8,19 +8,23 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-func (c *Compiler) emitVolatileLoad(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := frame.getValue(instr.Args[0])
-	frame.createNilCheck(addr, "deref")
-	val := c.builder.CreateLoad(addr, "")
+// createVolatileLoad is the implementation of the intrinsic function
+// runtime/volatile.LoadT().
+func (b *builder) createVolatileLoad(instr *ssa.CallCommon) (llvm.Value, error) {
+	addr := b.getValue(instr.Args[0])
+	b.createNilCheck(addr, "deref")
+	val := b.CreateLoad(addr, "")
 	val.SetVolatile(true)
 	return val, nil
 }
 
-func (c *Compiler) emitVolatileStore(frame *Frame, instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := frame.getValue(instr.Args[0])
-	val := frame.getValue(instr.Args[1])
-	frame.createNilCheck(addr, "deref")
-	store := c.builder.CreateStore(val, addr)
+// createVolatileStore is the implementation of the intrinsic function
+// runtime/volatile.StoreT().
+func (b *builder) createVolatileStore(instr *ssa.CallCommon) (llvm.Value, error) {
+	addr := b.getValue(instr.Args[0])
+	val := b.getValue(instr.Args[1])
+	b.createNilCheck(addr, "deref")
+	store := b.CreateStore(val, addr)
 	store.SetVolatile(true)
 	return llvm.Value{}, nil
 }


### PR DESCRIPTION
Work-in-progress to refactor the compiler.

Not nearly finished, but sharing here for initial review to make sure this is the right direction. The main goal is to remove `Compiler.builder`, which is almost like a global variable (shared throughout the entire compiler instance). Instead, an IR builder should be made per function. This will make the structure of the compiler a lot simpler and should avoid lots of jumping around, for example to create wrapper functions. The last time I tried to remove the `SimpleDCE` mechanism (a blocker for building packages independently), wrapper functions were a major pain and resulted in needing to add a worklist for functions to be built after the current one is finished.

This change will be huge, so I decided to split it in many steps to make it reviewable. It could even be done in multiple PRs (if needed I could also split this PR up in multiple pieces). Most commits should be easy to review as the vast majority of the changes are mechanical (search+replace).

Some code is duplicated while the refactor is in progress. This duplication will be removed once it is finished.