### PR TITLE
interp: improve error reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	golang.org/x/tools v0.0.0-20190227180812-8dcc6e70cdef
-	tinygo.org/x/go-llvm v0.0.0-20191113125529-bad6d01809e8
+	tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257
 )

--- a/go.sum
+++ b/go.sum
@@ -26,3 +26,5 @@ tinygo.org/x/go-llvm v0.0.0-20191103200204-37e93e3f04e2 h1:Q5Hv3e5cLMGkiYwYgZL1Z
 tinygo.org/x/go-llvm v0.0.0-20191103200204-37e93e3f04e2/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
 tinygo.org/x/go-llvm v0.0.0-20191113125529-bad6d01809e8 h1:9Bfvso+tTVQg16UzOA614NaYA4x8vsRBNtd3eBrXwp0=
 tinygo.org/x/go-llvm v0.0.0-20191113125529-bad6d01809e8/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
+tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257 h1:o8VDylrMN7gWemBMu8rEyuogKPhcLTdx5KrUAp9macc=
+tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=

--- a/interp/errors.go
+++ b/interp/errors.go
@@ -3,15 +3,89 @@ package interp
 // This file provides useful types for errors encountered during IR evaluation.
 
 import (
+	"errors"
+	"go/scanner"
+	"go/token"
+	"path/filepath"
+
 	"tinygo.org/x/go-llvm"
 )
 
+// errUnreachable is returned when an unreachable instruction is executed. This
+// error should not be visible outside of the interp package.
+var errUnreachable = errors.New("interp: unreachable executed")
+
+// Unsupported is the specific error that is returned when an unsupported
+// instruction is hit while trying to interpret all initializers.
 type Unsupported struct {
-	Inst llvm.Value
+	ImportPath string
+	Inst       llvm.Value
+	Pos        token.Position
 }
 
 func (e Unsupported) Error() string {
 	// TODO: how to return the actual instruction string?
 	// It looks like LLVM provides no function for that...
-	return "interp: unsupported instruction"
+	return scanner.Error{
+		Pos: e.Pos,
+		Msg: "interp: unsupported instruction",
+	}.Error()
+}
+
+// unsupportedInstructionError returns a new "unsupported instruction" error for
+// the given instruction. It includes source location information, when
+// available.
+func (e *evalPackage) unsupportedInstructionError(inst llvm.Value) *Unsupported {
+	return &Unsupported{
+		ImportPath: e.packagePath,
+		Inst:       inst,
+		Pos:        getPosition(inst),
+	}
+}
+
+// Error encapsulates compile-time interpretation errors with an associated
+// import path. The errors may not have a precise location attached.
+type Error struct {
+	ImportPath string
+	Errs       []scanner.Error
+}
+
+// Error returns the string of the first error in the list of errors.
+func (e Error) Error() string {
+	return e.Errs[0].Error()
+}
+
+// errorAt returns an error value for the currently interpreted package at the
+// location of the instruction. The location information may not be complete as
+// it depends on debug information in the IR.
+func (e *evalPackage) errorAt(inst llvm.Value, msg string) Error {
+	return Error{
+		ImportPath: e.packagePath,
+		Errs:       []scanner.Error{errorAt(inst, msg)},
+	}
+}
+
+// errorAt returns an error value at the location of the instruction.
+// The location information may not be complete as it depends on debug
+// information in the IR.
+func errorAt(inst llvm.Value, msg string) scanner.Error {
+	return scanner.Error{
+		Pos: getPosition(inst),
+		Msg: msg,
+	}
+}
+
+// getPosition returns the position information for the given instruction, as
+// far as it is available.
+func getPosition(inst llvm.Value) token.Position {
+	loc := inst.InstructionDebugLoc()
+	if loc.IsNil() {
+		return token.Position{}
+	}
+	file := loc.LocationScope().ScopeFile()
+	return token.Position{
+		Filename: filepath.Join(file.FileDirectory(), file.FileFilename()),
+		Line:     int(loc.LocationLine()),
+		Column:   int(loc.LocationColumn()),
+	}
 }


### PR DESCRIPTION
This commit improves error reporting in several ways:

  * Location information is read from the intruction that causes the
    error, as far as that's available.
  * The package that is being interpreted is included in the error
    message. This may be the most useful part of the improvements.
  * The hashmap update intrinsics now doesn't panic, instead it logs a
    clear error (with location information, as in the first bullet
    point).

This is possible thanks to improvements in LLVM 9. This means that after
this change, TinyGo will depend on LLVM 9.

Example of the hashmap error improvement, before:

    panic: interface conversion: interp.Value is *interp.LocalValue, not *interp.MapValue

After:

```
# go/token
../../../../../usr/local/go/src/go/token/token.go:282:17: could not update map with string key
```

(Reading the relevant source code, this looks like a fixable error).