### PR TITLE
interp: fix "interp: branch on a non-const-propagated constant expression"

### DIFF
--- a/interp/frame.go
+++ b/interp/frame.go
@@ -198,20 +198,28 @@ func (fr *frame) evalBasicBlock(bb, incoming llvm.BasicBlock, indent string) (re
 			lhs := fr.getLocal(inst.Operand(0)).(*LocalValue).Underlying
 			rhs := fr.getLocal(inst.Operand(1)).(*LocalValue).Underlying
 			predicate := inst.IntPredicate()
-			if predicate == llvm.IntEQ && lhs.Type().TypeKind() == llvm.PointerTypeKind {
-				// Unfortunately, the const propagation in the IR builder
-				// doesn't handle pointer compares of inttoptr values. So we
-				// implement it manually here.
-				lhsNil, ok1 := isPointerNil(lhs)
-				rhsNil, ok2 := isPointerNil(rhs)
+			if predicate == llvm.IntEQ {
+				var lhsZero, rhsZero bool
+				var ok1, ok2 bool
+				if lhs.Type().TypeKind() == llvm.PointerTypeKind {
+					// Unfortunately, the const propagation in the IR builder
+					// doesn't handle pointer compares of inttoptr values. So we
+					// implement it manually here.
+					lhsZero, ok1 = isPointerNil(lhs)
+					rhsZero, ok2 = isPointerNil(rhs)
+				}
+				if lhs.Type().TypeKind() == llvm.IntegerTypeKind {
+					lhsZero, ok1 = isZero(lhs)
+					rhsZero, ok2 = isZero(rhs)
+				}
 				if ok1 && ok2 {
-					if lhsNil && rhsNil {
-						// Both are nil, so this icmp is always evaluated to true.
+					if lhsZero && rhsZero {
+						// Both are zero, so this icmp is always evaluated to true.
 						fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstInt(fr.Mod.Context().Int1Type(), 1, false)}
 						continue
 					}
-					if lhsNil != rhsNil {
-						// Only one of them is nil, so this comparison must return false.
+					if lhsZero != rhsZero {
+						// Only one of them is zero, so this comparison must return false.
 						fr.locals[inst] = &LocalValue{fr.Eval, llvm.ConstInt(fr.Mod.Context().Int1Type(), 0, false)}
 						continue
 					}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -13,6 +13,7 @@ func TestInterp(t *testing.T) {
 	for _, name := range []string{
 		"basic",
 		"slice-copy",
+		"consteval",
 	} {
 		name := name // make tc local to this closure
 		t.Run(name, func(t *testing.T) {

--- a/interp/testdata/consteval.ll
+++ b/interp/testdata/consteval.ll
@@ -2,6 +2,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
 @intToPtrResult = global i8 0
+@ptrToIntResult = global i8 0
 
 define void @runtime.initAll() {
   call void @main.init()
@@ -10,6 +11,7 @@ define void @runtime.initAll() {
 
 define internal void @main.init() {
   call void @testIntToPtr()
+  call void @testPtrToInt()
   ret void
 }
 
@@ -23,5 +25,18 @@ a:
 b:
   ; should be reached
   store i8 2, i8* @intToPtrResult
+  ret void
+}
+
+define internal void @testPtrToInt() {
+  %zero = icmp eq i64 ptrtoint (i8* @ptrToIntResult to i64), 0
+  br i1 %zero, label %a, label %b
+a:
+  ; should not be reached
+  store i8 1, i8* @ptrToIntResult
+  ret void
+b:
+  ; should be reached
+  store i8 2, i8* @ptrToIntResult
   ret void
 }

--- a/interp/testdata/consteval.ll
+++ b/interp/testdata/consteval.ll
@@ -1,0 +1,27 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@intToPtrResult = global i8 0
+
+define void @runtime.initAll() {
+  call void @main.init()
+  ret void
+}
+
+define internal void @main.init() {
+  call void @testIntToPtr()
+  ret void
+}
+
+define internal void @testIntToPtr() {
+  %nil = icmp eq i8* inttoptr (i64 1024 to i8*), null
+  br i1 %nil, label %a, label %b
+a:
+  ; should not be reached
+  store i8 1, i8* @intToPtrResult
+  ret void
+b:
+  ; should be reached
+  store i8 2, i8* @intToPtrResult
+  ret void
+}

--- a/interp/testdata/consteval.out.ll
+++ b/interp/testdata/consteval.out.ll
@@ -2,6 +2,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
 @intToPtrResult = local_unnamed_addr global i8 2
+@ptrToIntResult = local_unnamed_addr global i8 2
 
 define void @runtime.initAll() local_unnamed_addr {
   ret void

--- a/interp/testdata/consteval.out.ll
+++ b/interp/testdata/consteval.out.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@intToPtrResult = local_unnamed_addr global i8 2
+
+define void @runtime.initAll() local_unnamed_addr {
+  ret void
+}


### PR DESCRIPTION
This PR should fix the following error when trying to compile the tinygo branch of vugu:

```
# github.com/vugu/vugu/domrender
src/sync/pool.go: interp: branch on a non-const-propagated constant expression
```

(The improved error message comes from #748).