### PR TITLE
ci: build with Go 1.13 on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ tinygo-test:
 
 .PHONY: smoketest
 smoketest:
+	$(TINYGO) version
 	# test all examples
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,14 +50,16 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          export PATH="$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          export PATH="/c/Go1.13/bin:$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          unset GOROOT
           make test
     - task: Bash@3
       displayName: Build TinyGo release tarball
       inputs:
         targetType: inline
         script: |
-          export PATH="$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          export PATH="/c/Go1.13/bin:$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          unset GOROOT
           make release -j4
     - publish: $(System.DefaultWorkingDirectory)/build/release.tar.gz
       displayName: Publish tarball as artifact
@@ -67,5 +69,6 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          export PATH="$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          export PATH="/c/Go1.13/bin:$PATH:./llvm-build/bin:/c/Program Files/qemu"
+          unset GOROOT
           make smoketest TINYGO=build/tinygo AVR=0 RISCV=0


### PR DESCRIPTION
The default Go version is 1.12. Because Go 1.13 introduced language changes (improved numeric constants), TinyGo compiled with Go 1.12 cannot handle Go 1.13 code such as the Go 1.13 standard library.