### PR TITLE
interp: replace many panics with error messages

### DIFF
--- a/interp/errors.go
+++ b/interp/errors.go
@@ -78,6 +78,9 @@ func errorAt(inst llvm.Value, msg string) scanner.Error {
 // getPosition returns the position information for the given instruction, as
 // far as it is available.
 func getPosition(inst llvm.Value) token.Position {
+	if inst.IsAInstruction().IsNil() {
+		return token.Position{}
+	}
 	loc := inst.InstructionDebugLoc()
 	if loc.IsNil() {
 		return token.Position{}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -27,7 +27,6 @@ type Eval struct {
 type evalPackage struct {
 	*Eval
 	packagePath string
-	errors      []error
 }
 
 // Run evaluates the function with the given name and then eliminates all

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -38,33 +38,33 @@ type sideEffectResult struct {
 // hasSideEffects scans this function and all descendants, recursively. It
 // returns whether this function has side effects and if it does, which globals
 // it mentions anywhere in this function or any called functions.
-func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
+func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, error) {
 	switch fn.Name() {
 	case "runtime.alloc":
 		// Cannot be scanned but can be interpreted.
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	case "runtime.nanotime":
 		// Fixed value at compile time.
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	case "runtime._panic":
-		return &sideEffectResult{severity: sideEffectLimited}
+		return &sideEffectResult{severity: sideEffectLimited}, nil
 	case "runtime.interfaceImplements":
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	case "runtime.sliceCopy":
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	case "runtime.trackPointer":
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	case "llvm.dbg.value":
-		return &sideEffectResult{severity: sideEffectNone}
+		return &sideEffectResult{severity: sideEffectNone}, nil
 	}
 	if fn.IsDeclaration() {
-		return &sideEffectResult{severity: sideEffectLimited}
+		return &sideEffectResult{severity: sideEffectLimited}, nil
 	}
 	if e.sideEffectFuncs == nil {
 		e.sideEffectFuncs = make(map[llvm.Value]*sideEffectResult)
 	}
 	if se, ok := e.sideEffectFuncs[fn]; ok {
-		return se
+		return se, nil
 	}
 	result := &sideEffectResult{
 		severity:        sideEffectInProgress,
@@ -75,6 +75,7 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 	for bb := fn.EntryBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
 		for inst := bb.FirstInstruction(); !inst.IsNil(); inst = llvm.NextInstruction(inst) {
 			if inst.IsAInstruction().IsNil() {
+				// Should not happen in valid IR.
 				panic("not an instruction")
 			}
 
@@ -91,7 +92,7 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 			switch inst.InstructionOpcode() {
 			case llvm.IndirectBr, llvm.Invoke:
 				// Not emitted by the compiler.
-				panic("unknown instructions")
+				return nil, e.errorAt(inst, "unknown instructions")
 			case llvm.Call:
 				child := inst.CalledValue()
 				if !child.IsAInlineAsm().IsNil() {
@@ -117,7 +118,10 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 					}
 					continue
 				}
-				childSideEffects := e.hasSideEffects(child)
+				childSideEffects, err := e.hasSideEffects(child)
+				if err != nil {
+					return nil, err
+				}
 				switch childSideEffects.severity {
 				case sideEffectInProgress, sideEffectNone:
 					// no side effects or recursive function - continue scanning
@@ -159,7 +163,7 @@ func (e *Eval) hasSideEffects(fn llvm.Value) *sideEffectResult {
 		// No side effect was reported for this function.
 		result.severity = sideEffectNone
 	}
-	return result
+	return result, nil
 }
 
 // hasLocalSideEffects checks whether the given instruction flows into a branch
@@ -174,6 +178,7 @@ func (e *Eval) hasLocalSideEffects(dirtyLocals map[llvm.Value]struct{}, inst llv
 	for use := inst.FirstUse(); !use.IsNil(); use = use.NextUse() {
 		user := use.User()
 		if user.IsAInstruction().IsNil() {
+			// Should not happen in valid IR.
 			panic("user not an instruction")
 		}
 		switch user.InstructionOpcode() {

--- a/interp/scan_test.go
+++ b/interp/scan_test.go
@@ -59,7 +59,11 @@ func TestScan(t *testing.T) {
 			t.Errorf("scan test: could not find tested function %s in the IR", tc.name)
 			continue
 		}
-		result := e.hasSideEffects(fn)
+		evalPkg := &evalPackage{e, "testdata"}
+		result, err := evalPkg.hasSideEffects(fn)
+		if err != nil {
+			t.Errorf("scan test: failed to scan %s for side effects: %v", fn.Name(), err)
+		}
 
 		// Check whether the result is what we expect.
 		if result.severity != tc.severity {


### PR DESCRIPTION
This PR replaces most panics in interp/frame.go and interp/scan.go with real error messages. The remaining ones are panics that should not happen when working with valid IR. It builds upon #748 to improve error handling in the interp package.

There are a number of panics left in interp/value.go, but replacing them will require some more restructuring so I will do that at a later time.