### PR TITLE
riscv: use LLVM tools instead of GNU toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
       - run: go install .
       - run: go test -v ./cgo ./compileopts ./interp ./transform .
       - run: make gen-device -j4
-      - run: make smoketest RISCV=0
+      - run: make smoketest
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
@@ -139,7 +139,7 @@ commands:
             - ~/.cache/tinygo
             - /go/pkg/mod
       - run: make gen-device -j4
-      - run: make smoketest TINYGO=build/tinygo RISCV=0
+      - run: make smoketest TINYGO=build/tinygo
   build-linux:
     steps:
       - checkout
@@ -216,11 +216,6 @@ commands:
             tar -C ~/lib -xf /tmp/tinygo.linux-amd64.tar.gz
             ln -s ~/lib/tinygo/bin/tinygo /go/bin/tinygo
             tinygo version
-      - run:
-          name: "Download SiFive GNU toolchain"
-          command: |
-            curl -O https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.2.0-2019.05.3-x86_64-linux-ubuntu14.tar.gz
-            sudo tar -C /usr/local --strip-components=1 -xf riscv64-unknown-elf-gcc-8.2.0-2019.05.3-x86_64-linux-ubuntu14.tar.gz
       - run: make smoketest
   build-macos:
     steps:

--- a/Makefile
+++ b/Makefile
@@ -242,10 +242,8 @@ ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=digispark           examples/blinky1
 	@$(MD5SUM) test.hex
 endif
-ifneq ($(RISCV), 0)
 	$(TINYGO) build -size short -o test.hex -target=hifive1b            examples/blinky1
 	@$(MD5SUM) test.hex
-endif
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/export
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/main
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,4 +71,4 @@ jobs:
         script: |
           export PATH="/c/Go1.13/bin:$PATH:./llvm-build/bin:/c/Program Files/qemu"
           unset GOROOT
-          make smoketest TINYGO=build/tinygo AVR=0 RISCV=0
+          make smoketest TINYGO=build/tinygo AVR=0

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -4,9 +4,10 @@
 	"goarch": "arm",
 	"build-tags": ["tinygo.riscv", "baremetal", "linux", "arm"],
 	"gc": "conservative",
-	"compiler": "riscv64-unknown-elf-gcc",
-	"linker": "riscv64-unknown-elf-ld",
+	"compiler": "clang",
+	"linker": "ld.lld",
 	"cflags": [
+		"--target=riscv32--none",
 		"-march=rv32imac",
 		"-mabi=ilp32",
 		"-Os",

--- a/targets/riscv.ld
+++ b/targets/riscv.ld
@@ -47,6 +47,11 @@ SECTIONS
         . = ALIGN(4);
         _ebss = .;         /* used by startup code */
     } >RAM
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)       /* causes 'no memory region specified' error in lld */
+    }
 }
 
 /* For the memory allocator. */


### PR DESCRIPTION
Now that we use LLVM 9, RISC-V support in LLVM has far fewer bugs and we can avoid the GNU toolchain.

  * replace GNU linker with lld
  * replace GCC with clang

Additionally, RISC-V was promoted to stable so it can be enabled by default in CI.

WARNING: not confirmed to work on real hardware.