### PR TITLE
Add support for debugging RISC-V using QEMU

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -50,7 +50,7 @@ func TestCompiler(t *testing.T) {
 	}
 
 	t.Run("EmulatedCortexM3", func(t *testing.T) {
-		runPlatTests("qemu", matches, t)
+		runPlatTests("cortex-m-qemu", matches, t)
 	})
 
 	if runtime.GOOS == "linux" {
@@ -76,7 +76,7 @@ func runPlatTests(target string, matches []string, t *testing.T) {
 			}
 		case target == "":
 			// run all tests on host
-		case target == "qemu":
+		case target == "cortex-m-qemu":
 			// all tests are supported
 		default:
 			// cross-compilation of cgo is not yet supported

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -1,4 +1,4 @@
-// +build qemu
+// +build cortexm,qemu
 
 package runtime
 

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -9,7 +9,6 @@ import (
 	"machine"
 	"unsafe"
 
-	"device/riscv"
 	"device/sifive"
 )
 
@@ -104,12 +103,5 @@ const asyncScheduler = false
 func sleepTicks(d timeUnit) {
 	target := ticks() + d
 	for ticks() < target {
-	}
-}
-
-func abort() {
-	// lock up forever
-	for {
-		riscv.Asm("wfi")
 	}
 }

--- a/src/runtime/runtime_fe310_baremetal.go
+++ b/src/runtime/runtime_fe310_baremetal.go
@@ -1,0 +1,14 @@
+// +build fe310,!qemu
+
+package runtime
+
+import (
+	"device/riscv"
+)
+
+func abort() {
+	// lock up forever
+	for {
+		riscv.Asm("wfi")
+	}
+}

--- a/src/runtime/runtime_fe310_qemu.go
+++ b/src/runtime/runtime_fe310_qemu.go
@@ -1,0 +1,16 @@
+// +build fe310,qemu
+
+package runtime
+
+import (
+	"runtime/volatile"
+	"unsafe"
+)
+
+// Special memory-mapped device to exit tests, created by SiFive.
+var testExit = (*volatile.Register32)(unsafe.Pointer(uintptr(0x100000)))
+
+func abort() {
+	// Signal a successful exit.
+	testExit.Set(0x5555)
+}

--- a/targets/cortex-m-qemu.json
+++ b/targets/cortex-m-qemu.json
@@ -8,7 +8,7 @@
 	],
 	"linkerscript": "targets/lm3s6965.ld",
 	"extra-files": [
-		"targets/qemu.s"
+		"targets/cortex-m-qemu.s"
 	],
 	"emulator": ["qemu-system-arm", "-machine", "lm3s6965evb", "-semihosting", "-nographic", "-kernel"]
 }

--- a/targets/cortex-m-qemu.s
+++ b/targets/cortex-m-qemu.s
@@ -1,5 +1,5 @@
 // Generic Cortex-M interrupt vector.
-// This vector is used by the QEMU target.
+// This vector is used by the Cortex-M QEMU target.
 
 .syntax unified
 

--- a/targets/hifive1-qemu.json
+++ b/targets/hifive1-qemu.json
@@ -1,0 +1,6 @@
+{
+	"inherits": ["fe310"],
+	"build-tags": ["hifive1b", "qemu"],
+	"linkerscript": "targets/hifive1-qemu.ld",
+	"emulator": ["qemu-system-riscv32", "-machine", "sifive_e", "-nographic", "-kernel"]
+}

--- a/targets/hifive1-qemu.ld
+++ b/targets/hifive1-qemu.ld
@@ -1,0 +1,13 @@
+
+/* memory map:
+ * https://github.com/sifive/freedom-e-sdk/blob/v201908-branch/bsp/sifive-hifive1/metal.default.lds
+ */
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x20400000, LENGTH = 0x1fc00000
+    RAM (xrw)       : ORIGIN = 0x80000000, LENGTH = 0x4000
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/riscv.ld"

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -21,5 +21,6 @@
 	],
 	"extra-files": [
 		"src/device/riscv/start.S"
-	]
+	],
+	"gdb": "riscv64-unknown-elf-gdb"
 }


### PR DESCRIPTION
With this PR, you can easily debug RISC-V code in QEMU. For example:

```
$ tinygo gdb -target=hifive1-qemu ./testdata/alias.go 
GNU gdb (GDB) 8.2.90.20190228-git
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=riscv64-unknown-elf".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /tmp/tinygo689867347/main...
Remote debugging using :1234
0x00001000 in ?? ()
(gdb) c
Continuing.
x
apple
true
false
Remote connection closed
(gdb) 
```

You will currently need to have the following installed: `qemu-system-riscv` and `riscv64-unknown-elf-gdb`, both downloadable from SiFive: https://www.sifive.com/boards (scroll down to "Prebuilt RISC‑V GCC Toolchain and Emulator").