### PR TITLE
riscv: fix heap corruption

### DIFF
--- a/targets/riscv.ld
+++ b/targets/riscv.ld
@@ -30,8 +30,8 @@ SECTIONS
         /* see https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register */
         PROVIDE( __global_pointer$ = . + (4K / 2) );
         _sdata = .;        /* used by startup code */
-        *(.data)
-        *(.data*)
+        *(.sdata)
+        *(.data .data.*)
         . = ALIGN(4);
         _edata = .;        /* used by startup code */
     } >RAM AT>FLASH_TEXT
@@ -41,8 +41,8 @@ SECTIONS
     {
         . = ALIGN(4);
         _sbss = .;         /* used by startup code */
-        *(.bss)
-        *(.bss*)
+        *(.sbss)
+        *(.bss .bss.*)
         *(COMMON)
         . = ALIGN(4);
         _ebss = .;         /* used by startup code */


### PR DESCRIPTION
The .sdata and .sbss sections are created by the compiler, but were not
present in the linker script. That means that the compiler put them
after all other data/bss section, which happens to be where the heap
also resides.

This commit adds the .sdata and .sbss sections to the linker script,
which gets the blinky examples to work again on RISC-V.

