### PR TITLE
builder: use builtin Clang when building statically

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,9 @@ Copyright (c) 2018-2019 TinyGo Authors. All rights reserved.
 TinyGo includes portions of the Go standard library.
 Copyright (c) 2009-2019 The Go Authors. All rights reserved.
 
+TinyGo includes portions of LLVM, which is under the Apache License v2.0 with
+LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 .PHONY: all tinygo test $(LLVM_BUILDDIR) llvm-source clean fmt gen-device gen-device-nrf gen-device-avr
 
-LLVM_COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core coroutines debuginfodwarf executionengine instrumentation interpreter ipo irreader linker lto mc mcjit objcarcopts option profiledata scalaropts support target
+LLVM_COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core coroutines coverage debuginfodwarf executionengine instrumentation interpreter ipo irreader linker lto mc mcjit objcarcopts option profiledata scalaropts support target
 
 ifeq ($(OS),Windows_NT)
     EXE = .exe
@@ -78,7 +78,7 @@ LLD_LIBS = $(START_GROUP) -llldCOFF -llldCommon -llldCore -llldDriver -llldELF -
 
 # For static linking.
 ifneq ("$(wildcard $(LLVM_BUILDDIR)/bin/llvm-config*)","")
-    CGO_CPPFLAGS=$(shell $(LLVM_BUILDDIR)/bin/llvm-config --cppflags) -I$(abspath $(CLANG_SRC))/include -I$(abspath $(LLD_SRC))/include
+    CGO_CPPFLAGS=$(shell $(LLVM_BUILDDIR)/bin/llvm-config --cppflags) -I$(abspath $(LLVM_BUILDDIR))/tools/clang/include -I$(abspath $(CLANG_SRC))/include -I$(abspath $(LLD_SRC))/include
     CGO_CXXFLAGS=-std=c++11
     CGO_LDFLAGS+=$(LIBCLANG_PATH) -std=c++11 -L$(abspath $(LLVM_BUILDDIR)/lib) $(CLANG_LIBS) $(LLD_LIBS) $(shell $(LLVM_BUILDDIR)/bin/llvm-config --ldflags --libs --system-libs $(LLVM_COMPONENTS)) -lstdc++ $(CGO_LDFLAGS_EXTRA)
 endif

--- a/README.md
+++ b/README.md
@@ -125,3 +125,5 @@ The original reasoning was: if [Python](https://micropython.org/) can run on mic
 ## License
 
 This project is licensed under the BSD 3-clause license, just like the [Go project](https://golang.org/LICENSE) itself.
+
+Some code has been copied from the LLVM project and is therefore licensed under [a variant of the Apache 2.0 license](http://releases.llvm.org/9.0.0/LICENSE.TXT). This has been clearly indicated in the header of these files.

--- a/builder/build.go
+++ b/builder/build.go
@@ -154,11 +154,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		for i, path := range config.ExtraFiles() {
 			abspath := filepath.Join(root, path)
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			cmdNames := []string{config.Target.Compiler}
-			if names, ok := commands[config.Target.Compiler]; ok {
-				cmdNames = names
-			}
-			err := execCommand(cmdNames, append(config.CFlags(), "-c", "-o", outpath, abspath)...)
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, abspath)...)
 			if err != nil {
 				return &commandError{"failed to build", path, err}
 			}
@@ -170,11 +166,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 			for _, file := range pkg.CFiles {
 				path := filepath.Join(pkg.Package.Dir, file)
 				outpath := filepath.Join(dir, "pkg"+strconv.Itoa(i)+"-"+file+".o")
-				cmdNames := []string{config.Target.Compiler}
-				if names, ok := commands[config.Target.Compiler]; ok {
-					cmdNames = names
-				}
-				err := execCommand(cmdNames, append(config.CFlags(), "-c", "-o", outpath, path)...)
+				err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, path)...)
 				if err != nil {
 					return &commandError{"failed to build", path, err}
 				}

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -236,7 +236,7 @@ func CompileBuiltins(target string, callback func(path string) error) error {
 		// Note: -fdebug-prefix-map is necessary to make the output archive
 		// reproducible. Otherwise the temporary directory is stored in the
 		// archive itself, which varies each run.
-		err := execCommand(commands["clang"], "-c", "-Oz", "-g", "-Werror", "-Wall", "-std=c11", "-fshort-enums", "-nostdlibinc", "-ffunction-sections", "-fdata-sections", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir, "-o", objpath, srcpath)
+		err := runCCompiler("clang", "-c", "-Oz", "-g", "-Werror", "-Wall", "-std=c11", "-fshort-enums", "-nostdlibinc", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir, "-o", objpath, srcpath)
 		if err != nil {
 			return &commandError{"failed to build", srcpath, err}
 		}

--- a/builder/cc1as.cpp
+++ b/builder/cc1as.cpp
@@ -1,0 +1,504 @@
+// +build byollvm
+
+//===-- cc1as.cpp - Clang Assembler  --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the entry point to the clang -cc1as functionality, which implements
+// the direct interface to the LLVM MC based assembler.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Driver/DriverDiagnostic.h"
+#include "clang/Driver/Options.h"
+#include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/Frontend/Utils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCParser/MCAsmParser.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSectionMachO.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/OptTable.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/Host.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/Timer.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+#include <system_error>
+using namespace clang;
+using namespace clang::driver;
+using namespace clang::driver::options;
+using namespace llvm;
+using namespace llvm::opt;
+
+#include "cc1as.h"
+
+bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
+                                         ArrayRef<const char *> Argv,
+                                         DiagnosticsEngine &Diags) {
+  bool Success = true;
+
+  // Parse the arguments.
+  std::unique_ptr<OptTable> OptTbl(createDriverOptTable());
+
+  const unsigned IncludedFlagsBitmask = options::CC1AsOption;
+  unsigned MissingArgIndex, MissingArgCount;
+  InputArgList Args = OptTbl->ParseArgs(Argv, MissingArgIndex, MissingArgCount,
+                                        IncludedFlagsBitmask);
+
+  // Check for missing argument error.
+  if (MissingArgCount) {
+    Diags.Report(diag::err_drv_missing_argument)
+        << Args.getArgString(MissingArgIndex) << MissingArgCount;
+    Success = false;
+  }
+
+  // Issue errors on unknown arguments.
+  for (const Arg *A : Args.filtered(OPT_UNKNOWN)) {
+    auto ArgString = A->getAsString(Args);
+    std::string Nearest;
+    if (OptTbl->findNearest(ArgString, Nearest, IncludedFlagsBitmask) > 1)
+      Diags.Report(diag::err_drv_unknown_argument) << ArgString;
+    else
+      Diags.Report(diag::err_drv_unknown_argument_with_suggestion)
+          << ArgString << Nearest;
+    Success = false;
+  }
+
+  // Construct the invocation.
+
+  // Target Options
+  Opts.Triple = llvm::Triple::normalize(Args.getLastArgValue(OPT_triple));
+  Opts.CPU = Args.getLastArgValue(OPT_target_cpu);
+  Opts.Features = Args.getAllArgValues(OPT_target_feature);
+
+  // Use the default target triple if unspecified.
+  if (Opts.Triple.empty())
+    Opts.Triple = llvm::sys::getDefaultTargetTriple();
+
+  // Language Options
+  Opts.IncludePaths = Args.getAllArgValues(OPT_I);
+  Opts.NoInitialTextSection = Args.hasArg(OPT_n);
+  Opts.SaveTemporaryLabels = Args.hasArg(OPT_msave_temp_labels);
+  // Any DebugInfoKind implies GenDwarfForAssembly.
+  Opts.GenDwarfForAssembly = Args.hasArg(OPT_debug_info_kind_EQ);
+
+  if (const Arg *A = Args.getLastArg(OPT_compress_debug_sections,
+                                     OPT_compress_debug_sections_EQ)) {
+    if (A->getOption().getID() == OPT_compress_debug_sections) {
+      // TODO: be more clever about the compression type auto-detection
+      Opts.CompressDebugSections = llvm::DebugCompressionType::GNU;
+    } else {
+      Opts.CompressDebugSections =
+          llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
+              .Case("none", llvm::DebugCompressionType::None)
+              .Case("zlib", llvm::DebugCompressionType::Z)
+              .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
+              .Default(llvm::DebugCompressionType::None);
+    }
+  }
+
+  Opts.RelaxELFRelocations = Args.hasArg(OPT_mrelax_relocations);
+  Opts.DwarfVersion = getLastArgIntValue(Args, OPT_dwarf_version_EQ, 2, Diags);
+  Opts.DwarfDebugFlags = Args.getLastArgValue(OPT_dwarf_debug_flags);
+  Opts.DwarfDebugProducer = Args.getLastArgValue(OPT_dwarf_debug_producer);
+  Opts.DebugCompilationDir = Args.getLastArgValue(OPT_fdebug_compilation_dir);
+  Opts.MainFileName = Args.getLastArgValue(OPT_main_file_name);
+
+  for (const auto &Arg : Args.getAllArgValues(OPT_fdebug_prefix_map_EQ))
+    Opts.DebugPrefixMap.insert(StringRef(Arg).split('='));
+
+  // Frontend Options
+  if (Args.hasArg(OPT_INPUT)) {
+    bool First = true;
+    for (const Arg *A : Args.filtered(OPT_INPUT)) {
+      if (First) {
+        Opts.InputFile = A->getValue();
+        First = false;
+      } else {
+        Diags.Report(diag::err_drv_unknown_argument) << A->getAsString(Args);
+        Success = false;
+      }
+    }
+  }
+  Opts.LLVMArgs = Args.getAllArgValues(OPT_mllvm);
+  Opts.OutputPath = Args.getLastArgValue(OPT_o);
+  Opts.SplitDwarfOutput = Args.getLastArgValue(OPT_split_dwarf_output);
+  if (Arg *A = Args.getLastArg(OPT_filetype)) {
+    StringRef Name = A->getValue();
+    unsigned OutputType = StringSwitch<unsigned>(Name)
+      .Case("asm", FT_Asm)
+      .Case("null", FT_Null)
+      .Case("obj", FT_Obj)
+      .Default(~0U);
+    if (OutputType == ~0U) {
+      Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+      Success = false;
+    } else
+      Opts.OutputType = FileType(OutputType);
+  }
+  Opts.ShowHelp = Args.hasArg(OPT_help);
+  Opts.ShowVersion = Args.hasArg(OPT_version);
+
+  // Transliterate Options
+  Opts.OutputAsmVariant =
+      getLastArgIntValue(Args, OPT_output_asm_variant, 0, Diags);
+  Opts.ShowEncoding = Args.hasArg(OPT_show_encoding);
+  Opts.ShowInst = Args.hasArg(OPT_show_inst);
+
+  // Assemble Options
+  Opts.RelaxAll = Args.hasArg(OPT_mrelax_all);
+  Opts.NoExecStack = Args.hasArg(OPT_mno_exec_stack);
+  Opts.FatalWarnings = Args.hasArg(OPT_massembler_fatal_warnings);
+  Opts.RelocationModel = Args.getLastArgValue(OPT_mrelocation_model, "pic");
+  Opts.TargetABI = Args.getLastArgValue(OPT_target_abi);
+  Opts.IncrementalLinkerCompatible =
+      Args.hasArg(OPT_mincremental_linker_compatible);
+  Opts.SymbolDefs = Args.getAllArgValues(OPT_defsym);
+
+  // EmbedBitcode Option. If -fembed-bitcode is enabled, set the flag.
+  // EmbedBitcode behaves the same for all embed options for assembly files.
+  if (auto *A = Args.getLastArg(OPT_fembed_bitcode_EQ)) {
+    Opts.EmbedBitcode = llvm::StringSwitch<unsigned>(A->getValue())
+                            .Case("all", 1)
+                            .Case("bitcode", 1)
+                            .Case("marker", 1)
+                            .Default(0);
+  }
+
+  return Success;
+}
+
+static std::unique_ptr<raw_fd_ostream>
+getOutputStream(StringRef Path, DiagnosticsEngine &Diags, bool Binary) {
+  // Make sure that the Out file gets unlinked from the disk if we get a
+  // SIGINT.
+  if (Path != "-")
+    sys::RemoveFileOnSignal(Path);
+
+  std::error_code EC;
+  auto Out = llvm::make_unique<raw_fd_ostream>(
+      Path, EC, (Binary ? sys::fs::F_None : sys::fs::F_Text));
+  if (EC) {
+    Diags.Report(diag::err_fe_unable_to_open_output) << Path << EC.message();
+    return nullptr;
+  }
+
+  return Out;
+}
+
+bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
+  // Get the target specific parser.
+  std::string Error;
+  const Target *TheTarget = TargetRegistry::lookupTarget(Opts.Triple, Error);
+  if (!TheTarget)
+    return Diags.Report(diag::err_target_unknown_triple) << Opts.Triple;
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> Buffer =
+      MemoryBuffer::getFileOrSTDIN(Opts.InputFile);
+
+  if (std::error_code EC = Buffer.getError()) {
+    Error = EC.message();
+    return Diags.Report(diag::err_fe_error_reading) << Opts.InputFile;
+  }
+
+  SourceMgr SrcMgr;
+
+  // Tell SrcMgr about this buffer, which is what the parser will pick up.
+  unsigned BufferIndex = SrcMgr.AddNewSourceBuffer(std::move(*Buffer), SMLoc());
+
+  // Record the location of the include directories so that the lexer can find
+  // it later.
+  SrcMgr.setIncludeDirs(Opts.IncludePaths);
+
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(Opts.Triple));
+  assert(MRI && "Unable to create target register info!");
+
+  std::unique_ptr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(*MRI, Opts.Triple));
+  assert(MAI && "Unable to create target asm info!");
+
+  // Ensure MCAsmInfo initialization occurs before any use, otherwise sections
+  // may be created with a combination of default and explicit settings.
+  MAI->setCompressDebugSections(Opts.CompressDebugSections);
+
+  MAI->setRelaxELFRelocations(Opts.RelaxELFRelocations);
+
+  bool IsBinary = Opts.OutputType == AssemblerInvocation::FT_Obj;
+  if (Opts.OutputPath.empty())
+    Opts.OutputPath = "-";
+  std::unique_ptr<raw_fd_ostream> FDOS =
+      getOutputStream(Opts.OutputPath, Diags, IsBinary);
+  if (!FDOS)
+    return true;
+  std::unique_ptr<raw_fd_ostream> DwoOS;
+  if (!Opts.SplitDwarfOutput.empty())
+    DwoOS = getOutputStream(Opts.SplitDwarfOutput, Diags, IsBinary);
+
+  // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
+  // MCObjectFileInfo needs a MCContext reference in order to initialize itself.
+  std::unique_ptr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
+
+  MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr);
+
+  bool PIC = false;
+  if (Opts.RelocationModel == "static") {
+    PIC = false;
+  } else if (Opts.RelocationModel == "pic") {
+    PIC = true;
+  } else {
+    assert(Opts.RelocationModel == "dynamic-no-pic" &&
+           "Invalid PIC model!");
+    PIC = false;
+  }
+
+  MOFI->InitMCObjectFileInfo(Triple(Opts.Triple), PIC, Ctx);
+  if (Opts.SaveTemporaryLabels)
+    Ctx.setAllowTemporaryLabels(false);
+  if (Opts.GenDwarfForAssembly)
+    Ctx.setGenDwarfForAssembly(true);
+  if (!Opts.DwarfDebugFlags.empty())
+    Ctx.setDwarfDebugFlags(StringRef(Opts.DwarfDebugFlags));
+  if (!Opts.DwarfDebugProducer.empty())
+    Ctx.setDwarfDebugProducer(StringRef(Opts.DwarfDebugProducer));
+  if (!Opts.DebugCompilationDir.empty())
+    Ctx.setCompilationDir(Opts.DebugCompilationDir);
+  else {
+    // If no compilation dir is set, try to use the current directory.
+    SmallString<128> CWD;
+    if (!sys::fs::current_path(CWD))
+      Ctx.setCompilationDir(CWD);
+  }
+  if (!Opts.DebugPrefixMap.empty())
+    for (const auto &KV : Opts.DebugPrefixMap)
+      Ctx.addDebugPrefixMapEntry(KV.first, KV.second);
+  if (!Opts.MainFileName.empty())
+    Ctx.setMainFileName(StringRef(Opts.MainFileName));
+  Ctx.setDwarfVersion(Opts.DwarfVersion);
+  if (Opts.GenDwarfForAssembly)
+    Ctx.setGenDwarfRootFile(Opts.InputFile,
+                            SrcMgr.getMemoryBuffer(BufferIndex)->getBuffer());
+
+  // Build up the feature string from the target feature list.
+  std::string FS;
+  if (!Opts.Features.empty()) {
+    FS = Opts.Features[0];
+    for (unsigned i = 1, e = Opts.Features.size(); i != e; ++i)
+      FS += "," + Opts.Features[i];
+  }
+
+  std::unique_ptr<MCStreamer> Str;
+
+  std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
+  std::unique_ptr<MCSubtargetInfo> STI(
+      TheTarget->createMCSubtargetInfo(Opts.Triple, Opts.CPU, FS));
+
+  raw_pwrite_stream *Out = FDOS.get();
+  std::unique_ptr<buffer_ostream> BOS;
+
+  MCTargetOptions MCOptions;
+  MCOptions.ABIName = Opts.TargetABI;
+
+  // FIXME: There is a bit of code duplication with addPassesToEmitFile.
+  if (Opts.OutputType == AssemblerInvocation::FT_Asm) {
+    MCInstPrinter *IP = TheTarget->createMCInstPrinter(
+        llvm::Triple(Opts.Triple), Opts.OutputAsmVariant, *MAI, *MCII, *MRI);
+
+    std::unique_ptr<MCCodeEmitter> CE;
+    if (Opts.ShowEncoding)
+      CE.reset(TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx));
+    std::unique_ptr<MCAsmBackend> MAB(
+        TheTarget->createMCAsmBackend(*STI, *MRI, MCOptions));
+
+    auto FOut = llvm::make_unique<formatted_raw_ostream>(*Out);
+    Str.reset(TheTarget->createAsmStreamer(
+        Ctx, std::move(FOut), /*asmverbose*/ true,
+        /*useDwarfDirectory*/ true, IP, std::move(CE), std::move(MAB),
+        Opts.ShowInst));
+  } else if (Opts.OutputType == AssemblerInvocation::FT_Null) {
+    Str.reset(createNullStreamer(Ctx));
+  } else {
+    assert(Opts.OutputType == AssemblerInvocation::FT_Obj &&
+           "Invalid file type!");
+    if (!FDOS->supportsSeeking()) {
+      BOS = make_unique<buffer_ostream>(*FDOS);
+      Out = BOS.get();
+    }
+
+    std::unique_ptr<MCCodeEmitter> CE(
+        TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx));
+    std::unique_ptr<MCAsmBackend> MAB(
+        TheTarget->createMCAsmBackend(*STI, *MRI, MCOptions));
+    std::unique_ptr<MCObjectWriter> OW =
+        DwoOS ? MAB->createDwoObjectWriter(*Out, *DwoOS)
+              : MAB->createObjectWriter(*Out);
+
+    Triple T(Opts.Triple);
+    Str.reset(TheTarget->createMCObjectStreamer(
+        T, Ctx, std::move(MAB), std::move(OW), std::move(CE), *STI,
+        Opts.RelaxAll, Opts.IncrementalLinkerCompatible,
+        /*DWARFMustBeAtTheEnd*/ true));
+    Str.get()->InitSections(Opts.NoExecStack);
+  }
+
+  // When -fembed-bitcode is passed to clang_as, a 1-byte marker
+  // is emitted in __LLVM,__asm section if the object file is MachO format.
+  if (Opts.EmbedBitcode && Ctx.getObjectFileInfo()->getObjectFileType() ==
+                               MCObjectFileInfo::IsMachO) {
+    MCSection *AsmLabel = Ctx.getMachOSection(
+        "__LLVM", "__asm", MachO::S_REGULAR, 4, SectionKind::getReadOnly());
+    Str.get()->SwitchSection(AsmLabel);
+    Str.get()->EmitZeros(1);
+  }
+
+  // Assembly to object compilation should leverage assembly info.
+  Str->setUseAssemblerInfoForParsing(true);
+
+  bool Failed = false;
+
+  std::unique_ptr<MCAsmParser> Parser(
+      createMCAsmParser(SrcMgr, Ctx, *Str.get(), *MAI));
+
+  // FIXME: init MCTargetOptions from sanitizer flags here.
+  std::unique_ptr<MCTargetAsmParser> TAP(
+      TheTarget->createMCAsmParser(*STI, *Parser, *MCII, MCOptions));
+  if (!TAP)
+    Failed = Diags.Report(diag::err_target_unknown_triple) << Opts.Triple;
+
+  // Set values for symbols, if any.
+  for (auto &S : Opts.SymbolDefs) {
+    auto Pair = StringRef(S).split('=');
+    auto Sym = Pair.first;
+    auto Val = Pair.second;
+    int64_t Value;
+    // We have already error checked this in the driver.
+    Val.getAsInteger(0, Value);
+    Ctx.setSymbolValue(Parser->getStreamer(), Sym, Value);
+  }
+
+  if (!Failed) {
+    Parser->setTargetParser(*TAP.get());
+    Failed = Parser->Run(Opts.NoInitialTextSection);
+  }
+
+  // Close Streamer first.
+  // It might have a reference to the output stream.
+  Str.reset();
+  // Close the output stream early.
+  BOS.reset();
+  FDOS.reset();
+
+  // Delete output file if there were errors.
+  if (Failed) {
+    if (Opts.OutputPath != "-")
+      sys::fs::remove(Opts.OutputPath);
+    if (!Opts.SplitDwarfOutput.empty() && Opts.SplitDwarfOutput != "-")
+      sys::fs::remove(Opts.SplitDwarfOutput);
+  }
+
+  return Failed;
+}
+
+static void LLVMErrorHandler(void *UserData, const std::string &Message,
+                             bool GenCrashDiag) {
+  DiagnosticsEngine &Diags = *static_cast<DiagnosticsEngine*>(UserData);
+
+  Diags.Report(diag::err_fe_error_backend) << Message;
+
+  // We cannot recover from llvm errors.
+  exit(1);
+}
+
+int cc1as_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
+  // Initialize targets and assembly printers/parsers.
+  InitializeAllTargetInfos();
+  InitializeAllTargetMCs();
+  InitializeAllAsmParsers();
+
+  // Construct our diagnostic client.
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
+  TextDiagnosticPrinter *DiagClient
+    = new TextDiagnosticPrinter(errs(), &*DiagOpts);
+  DiagClient->setPrefix("clang -cc1as");
+  IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
+  DiagnosticsEngine Diags(DiagID, &*DiagOpts, DiagClient);
+
+  // Set an error handler, so that any LLVM backend diagnostics go through our
+  // error handler.
+  ScopedFatalErrorHandler FatalErrorHandler
+    (LLVMErrorHandler, static_cast<void*>(&Diags));
+
+  // Parse the arguments.
+  AssemblerInvocation Asm;
+  if (!AssemblerInvocation::CreateFromArgs(Asm, Argv, Diags))
+    return 1;
+
+  if (Asm.ShowHelp) {
+    std::unique_ptr<OptTable> Opts(driver::createDriverOptTable());
+    Opts->PrintHelp(llvm::outs(), "clang -cc1as [options] file...",
+                    "Clang Integrated Assembler",
+                    /*Include=*/driver::options::CC1AsOption, /*Exclude=*/0,
+                    /*ShowAllAliases=*/false);
+    return 0;
+  }
+
+  // Honor -version.
+  //
+  // FIXME: Use a better -version message?
+  if (Asm.ShowVersion) {
+    llvm::cl::PrintVersionMessage();
+    return 0;
+  }
+
+  // Honor -mllvm.
+  //
+  // FIXME: Remove this, one day.
+  if (!Asm.LLVMArgs.empty()) {
+    unsigned NumArgs = Asm.LLVMArgs.size();
+    auto Args = llvm::make_unique<const char*[]>(NumArgs + 2);
+    Args[0] = "clang (LLVM option parsing)";
+    for (unsigned i = 0; i != NumArgs; ++i)
+      Args[i + 1] = Asm.LLVMArgs[i].c_str();
+    Args[NumArgs + 1] = nullptr;
+    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
+  }
+
+  // Execute the invocation, unless there were parsing errors.
+  bool Failed = Diags.hasErrorOccurred() || ExecuteAssembler(Asm, Diags);
+
+  // If any timers were active but haven't been destroyed yet, print their
+  // results now.
+  TimerGroup::printAll(errs());
+
+  return !!Failed;
+}

--- a/builder/cc1as.h
+++ b/builder/cc1as.h
@@ -1,0 +1,120 @@
+//===-- cc1as.h - Clang Assembler  ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the entry point to the clang -cc1as functionality, which implements
+// the direct interface to the LLVM MC based assembler.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ArrayRef.h"
+
+/// Helper class for representing a single invocation of the assembler.
+struct AssemblerInvocation {
+  /// @name Target Options
+  /// @{
+
+  /// The name of the target triple to assemble for.
+  std::string Triple;
+
+  /// If given, the name of the target CPU to determine which instructions
+  /// are legal.
+  std::string CPU;
+
+  /// The list of target specific features to enable or disable -- this should
+  /// be a list of strings starting with '+' or '-'.
+  std::vector<std::string> Features;
+
+  /// The list of symbol definitions.
+  std::vector<std::string> SymbolDefs;
+
+  /// @}
+  /// @name Language Options
+  /// @{
+
+  std::vector<std::string> IncludePaths;
+  unsigned NoInitialTextSection : 1;
+  unsigned SaveTemporaryLabels : 1;
+  unsigned GenDwarfForAssembly : 1;
+  unsigned RelaxELFRelocations : 1;
+  unsigned DwarfVersion;
+  std::string DwarfDebugFlags;
+  std::string DwarfDebugProducer;
+  std::string DebugCompilationDir;
+  std::map<const std::string, const std::string> DebugPrefixMap;
+  llvm::DebugCompressionType CompressDebugSections =
+      llvm::DebugCompressionType::None;
+  std::string MainFileName;
+  std::string SplitDwarfOutput;
+
+  /// @}
+  /// @name Frontend Options
+  /// @{
+
+  std::string InputFile;
+  std::vector<std::string> LLVMArgs;
+  std::string OutputPath;
+  enum FileType {
+    FT_Asm,  ///< Assembly (.s) output, transliterate mode.
+    FT_Null, ///< No output, for timing purposes.
+    FT_Obj   ///< Object file output.
+  };
+  FileType OutputType;
+  unsigned ShowHelp : 1;
+  unsigned ShowVersion : 1;
+
+  /// @}
+  /// @name Transliterate Options
+  /// @{
+
+  unsigned OutputAsmVariant;
+  unsigned ShowEncoding : 1;
+  unsigned ShowInst : 1;
+
+  /// @}
+  /// @name Assembler Options
+  /// @{
+
+  unsigned RelaxAll : 1;
+  unsigned NoExecStack : 1;
+  unsigned FatalWarnings : 1;
+  unsigned IncrementalLinkerCompatible : 1;
+  unsigned EmbedBitcode : 1;
+
+  /// The name of the relocation model to use.
+  std::string RelocationModel;
+
+  /// The ABI targeted by the backend. Specified using -target-abi. Empty
+  /// otherwise.
+  std::string TargetABI;
+
+  /// @}
+
+public:
+  AssemblerInvocation() {
+    Triple = "";
+    NoInitialTextSection = 0;
+    InputFile = "-";
+    OutputPath = "-";
+    OutputType = FT_Asm;
+    OutputAsmVariant = 0;
+    ShowInst = 0;
+    ShowEncoding = 0;
+    RelaxAll = 0;
+    NoExecStack = 0;
+    FatalWarnings = 0;
+    IncrementalLinkerCompatible = 0;
+    DwarfVersion = 0;
+    EmbedBitcode = 0;
+  }
+
+  static bool CreateFromArgs(AssemblerInvocation &Res,
+                             ArrayRef<const char *> Argv,
+                             DiagnosticsEngine &Diags);
+};
+
+bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags);

--- a/builder/clang.cpp
+++ b/builder/clang.cpp
@@ -1,0 +1,97 @@
+// +build byollvm
+
+#include <clang/Basic/DiagnosticOptions.h>
+#include <clang/CodeGen/CodeGenAction.h>
+#include <clang/Driver/Compilation.h>
+#include <clang/Driver/Driver.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/CompilerInvocation.h>
+#include <clang/Frontend/FrontendDiagnostic.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
+#include <clang/FrontendTool/Utils.h>
+#include <llvm/ADT/IntrusiveRefCntPtr.h>
+#include <llvm/Option/Option.h>
+
+using namespace llvm;
+using namespace clang;
+
+#include "cc1as.h"
+
+// This file provides C wrappers for the builtin tools cc1 and cc1as
+// provided by Clang, and calls them as the driver would call them.
+
+extern "C" {
+
+bool tinygo_clang_driver(int argc, char **argv) {
+	std::vector<const char*> args(argv, argv + argc);
+
+	// The compiler invocation needs a DiagnosticsEngine so it can report problems
+	llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> DiagOpts = new clang::DiagnosticOptions();
+	clang::TextDiagnosticPrinter DiagnosticPrinter(llvm::errs(), &*DiagOpts);
+	clang::DiagnosticsEngine Diags(llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs>(new clang::DiagnosticIDs()), &*DiagOpts, &DiagnosticPrinter, false);
+
+	// Create the clang driver
+	clang::driver::Driver TheDriver(args[0], llvm::sys::getDefaultTargetTriple(), Diags);
+
+	// Create the set of actions to perform
+	std::unique_ptr<clang::driver::Compilation> C(TheDriver.BuildCompilation(args));
+	if (!C) {
+		return false;
+	}
+	const clang::driver::JobList &Jobs = C->getJobs();
+
+	// There may be more than one job, for example for .S files
+	// (preprocessor + assembler).
+	for (auto Cmd : Jobs) {
+		// Select the tool: cc1 or cc1as.
+		const llvm::opt::ArgStringList &CCArgs = Cmd.getArguments();
+
+		if (strcmp(*CCArgs.data(), "-cc1") == 0) {
+			// This is the C frontend.
+			// Initialize a compiler invocation object from the clang (-cc1) arguments.
+			std::unique_ptr<clang::CompilerInstance> Clang(new clang::CompilerInstance());
+			bool success = clang::CompilerInvocation::CreateFromArgs(
+					Clang->getInvocation(),
+					const_cast<const char **>(CCArgs.data()),
+					const_cast<const char **>(CCArgs.data()) + CCArgs.size(),
+					Diags);
+			if (!success) {
+				return false;
+			}
+
+			// Create the actual diagnostics engine.
+			Clang->createDiagnostics();
+			if (!Clang->hasDiagnostics()) {
+				return false;
+			}
+
+			// Execute the frontend actions.
+			success = ExecuteCompilerInvocation(Clang.get());
+			if (!success) {
+				return false;
+			}
+
+		} else if (strcmp(*CCArgs.data(), "-cc1as") == 0) {
+			// This is the assembler frontend. Parse the arguments.
+			AssemblerInvocation Asm;
+			if (!AssemblerInvocation::CreateFromArgs(Asm, llvm::ArrayRef<const char*>(CCArgs).slice(1), Diags))
+				return false;
+
+			// Execute the invocation, unless there were parsing errors.
+			bool failed = Diags.hasErrorOccurred() || ExecuteAssembler(Asm, Diags);
+			if (failed) {
+				return false;
+			}
+
+		} else {
+			// Unknown tool, print the tool and exit.
+			fprintf(stderr, "unknown tool: %s\n", *CCArgs.data());
+			return false;
+		}
+	}
+
+	// Commands executed successfully.
+	return true;
+}
+
+} // extern "C"

--- a/builder/compiler-builtin.go
+++ b/builder/compiler-builtin.go
@@ -1,0 +1,56 @@
+// +build byollvm
+
+package builder
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"unsafe"
+
+	"github.com/tinygo-org/tinygo/goenv"
+)
+
+/*
+#cgo CXXFLAGS: -fno-rtti
+#include <stdbool.h>
+#include <stdlib.h>
+bool tinygo_clang_driver(int argc, char **argv);
+*/
+import "C"
+
+// runCCompiler invokes a C compiler with the given arguments.
+//
+// This version invokes the built-in Clang when trying to run the Clang compiler.
+func runCCompiler(command string, flags ...string) error {
+	switch command {
+	case "clang":
+		// Compile this with the internal Clang compiler.
+		flags = append(flags, "-I"+getClangHeaderPath(goenv.Get("TINYGOROOT")))
+		flags = append([]string{"tinygo:" + command}, flags...)
+		var cflag *C.char
+		buf := C.calloc(C.size_t(len(flags)), C.size_t(unsafe.Sizeof(cflag)))
+		cflags := (*[1 << 10]*C.char)(unsafe.Pointer(buf))[:len(flags):len(flags)]
+		for i, flag := range flags {
+			cflag := C.CString(flag)
+			cflags[i] = cflag
+			defer C.free(unsafe.Pointer(cflag))
+		}
+		ok := C.tinygo_clang_driver(C.int(len(flags)), (**C.char)(buf))
+		if !ok {
+			return errors.New("failed to compile using built-in clang")
+		}
+		return nil
+	default:
+		// Running some other compiler. Maybe it has been defined in the
+		// commands map (unlikely).
+		if cmdNames, ok := commands[command]; ok {
+			return execCommand(cmdNames, flags...)
+		}
+		// Alternatively, run the compiler directly.
+		cmd := exec.Command(command, flags...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+}

--- a/builder/compiler-external.go
+++ b/builder/compiler-external.go
@@ -1,0 +1,24 @@
+// +build !byollvm
+
+package builder
+
+// This file provides a way to a C compiler as an external command. See also:
+// clang-external.go
+
+import (
+	"os"
+	"os/exec"
+)
+
+// runCCompiler invokes a C compiler with the given arguments.
+//
+// This version always runs the compiler as an external command.
+func runCCompiler(command string, flags ...string) error {
+	if cmdNames, ok := commands[command]; ok {
+		return execCommand(cmdNames, flags...)
+	}
+	cmd := exec.Command(command, flags...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
This will be a huge help for people installing TinyGo that don't have LLVM/Clang 9 already installed and in the `$PATH` variable.

Replaces #184.

I added an extra note to the LICENSE part of the README, would that be enough to cover the new code under the different license? I don't think adding it to the LICENSE file would be necessary as the files themselves already say that they are under a different license.