### PR TITLE
cgo: don't run tests in parallel

### DIFF
--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -25,8 +25,6 @@ func TestCGo(t *testing.T) {
 	for _, name := range []string{"basic", "errors", "types", "flags"} {
 		name := name // avoid a race condition
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			// Read the AST in memory.
 			path := filepath.Join("testdata", name+".go")
 			fset := token.NewFileSet()


### PR DESCRIPTION
Since LLVM 9, CGo sometimes randomly breaks with weird error messages on
Windows. I'm not sure why this is the case, but it might be related to
concurrency.

Disable concurrency for now, and hope that will make the errors go away.

---

This PR is for the issue described here: https://github.com/tinygo-org/tinygo/pull/763#issuecomment-562865172
I'm not sure whether it'll fix it, but I hope so.