### PR TITLE
riscv: add support for compiler-rt

### DIFF
--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -236,7 +236,11 @@ func CompileBuiltins(target string, callback func(path string) error) error {
 		// Note: -fdebug-prefix-map is necessary to make the output archive
 		// reproducible. Otherwise the temporary directory is stored in the
 		// archive itself, which varies each run.
-		err := runCCompiler("clang", "-c", "-Oz", "-g", "-Werror", "-Wall", "-std=c11", "-fshort-enums", "-nostdlibinc", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir, "-o", objpath, srcpath)
+		args := []string{"-c", "-Oz", "-g", "-Werror", "-Wall", "-std=c11", "-fshort-enums", "-nostdlibinc", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target=" + target, "-fdebug-prefix-map=" + dir + "=" + remapDir}
+		if strings.HasPrefix(target, "riscv32-") {
+			args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")
+		}
+		err := runCCompiler("clang", append(args, "-o", objpath, srcpath)...)
 		if err != nil {
 			return &commandError{"failed to build", srcpath, err}
 		}

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -6,6 +6,7 @@
 	"gc": "conservative",
 	"compiler": "clang",
 	"linker": "ld.lld",
+	"rtlib": "compiler-rt",
 	"cflags": [
 		"--target=riscv32--none",
 		"-march=rv32imac",


### PR DESCRIPTION
This gets all the tests to compile and many of them to pass. There are some issues left, but those are probably unrelated to compiler-rt.

A simple way to test this PR is with the following command:

    tinygo run -target=hifive1-qemu ./testdata/float.go

It will fail with a linker error before this PR, and will run successfully after this PR.

Note: this PR will conflict with #769.