### PR TITLE
machine: add Tx method to simulated SPI bus

### DIFF
--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build sam stm32,!stm32f407 fe310
+// +build !baremetal sam stm32,!stm32f407 fe310
 
 package machine
 


### PR DESCRIPTION
This allows display drivers like st7789 to be used on the TinyGo Playground.