### PR TITLE
machine: rename CPU_FREQUENCY -> CPUFrequency()

### DIFF
--- a/src/examples/systick/systick.go
+++ b/src/examples/systick/systick.go
@@ -9,7 +9,7 @@ func main() {
 	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
 	// timer fires 10 times per second
-	arm.SetupSystemTimer(machine.CPU_FREQUENCY / 10)
+	arm.SetupSystemTimer(machine.CPUFrequency() / 10)
 
 	for {
 	}

--- a/src/machine/board_arduino.go
+++ b/src/machine/board_arduino.go
@@ -2,7 +2,10 @@
 
 package machine
 
-const CPU_FREQUENCY = 16000000
+// Return the current CPU frequency in hertz.
+func CPUFrequency() uint32 {
+	return 16000000
+}
 
 // LED on the Arduino
 const LED Pin = 13

--- a/src/machine/board_atsamd21.go
+++ b/src/machine/board_atsamd21.go
@@ -2,7 +2,10 @@
 
 package machine
 
-const CPU_FREQUENCY = 48000000
+// Return the current CPU frequency in hertz.
+func CPUFrequency() uint32 {
+	return 48000000
+}
 
 // Hardware pins
 const (

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -140,7 +140,7 @@ func (i2c I2C) Configure(config I2CConfig) {
 	// SCL Frequency = CPU Clock Frequency / (16 + (2 * TWBR))
 	// NOTE: TWBR should be 10 or higher for master mode.
 	// It is 72 for a 16mhz board with 100kHz TWI
-	avr.TWBR.Set(uint8(((CPU_FREQUENCY / config.Frequency) - 16) / 2))
+	avr.TWBR.Set(uint8(((CPUFrequency() / config.Frequency) - 16) / 2))
 
 	// Enable twi module.
 	avr.TWCR.Set(avr.TWCR_TWEN)
@@ -235,7 +235,7 @@ func (uart UART) Configure(config UARTConfig) {
 	// Set baud rate based on prescale formula from
 	// https://www.microchip.com/webdoc/AVRLibcReferenceManual/FAQ_1faq_wrong_baud_rate.html
 	// ((F_CPU + UART_BAUD_RATE * 8L) / (UART_BAUD_RATE * 16L) - 1)
-	ps := ((CPU_FREQUENCY+config.BaudRate*8)/(config.BaudRate*16) - 1)
+	ps := ((CPUFrequency()+config.BaudRate*8)/(config.BaudRate*16) - 1)
 	avr.UBRR0H.Set(uint8(ps >> 8))
 	avr.UBRR0L.Set(uint8(ps & 0xff))
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -415,7 +415,7 @@ func (uart UART) SetBaudRate(br uint32) {
 	//   BAUD = fref / (sampleRateValue * fbaud)
 	// (multiply by 8, to calculate fractional piece)
 	// uint32_t baudTimes8 = (SystemCoreClock * 8) / (16 * baudrate);
-	baud := (CPU_FREQUENCY * 8) / (sampleRate16X * br)
+	baud := (CPUFrequency() * 8) / (sampleRate16X * br)
 
 	// sercom->USART.BAUD.FRAC.FP   = (baudTimes8 % 8);
 	// sercom->USART.BAUD.FRAC.BAUD = (baudTimes8 / 8);
@@ -531,7 +531,7 @@ func (i2c I2C) Configure(config I2CConfig) error {
 func (i2c I2C) SetBaudRate(br uint32) {
 	// Synchronous arithmetic baudrate, via Arduino SAMD implementation:
 	// SystemCoreClock / ( 2 * baudrate) - 5 - (((SystemCoreClock / 1000000) * WIRE_RISE_TIME_NANOSECONDS) / (2 * 1000));
-	baud := CPU_FREQUENCY/(2*br) - 5 - (((CPU_FREQUENCY / 1000000) * riseTimeNanoseconds) / (2 * 1000))
+	baud := CPUFrequency()/(2*br) - 5 - (((CPUFrequency() / 1000000) * riseTimeNanoseconds) / (2 * 1000))
 	i2c.Bus.BAUD.Set(baud)
 }
 
@@ -723,7 +723,7 @@ func (i2s I2S) Configure(config I2SConfig) {
 	sam.PM.APBCMASK.SetBits(sam.PM_APBCMASK_I2S_)
 
 	// setting clock rate for sample.
-	division_factor := CPU_FREQUENCY / (config.AudioFrequency * uint32(config.DataFormat))
+	division_factor := CPUFrequency() / (config.AudioFrequency * uint32(config.DataFormat))
 
 	// Switch Generic Clock Generator 3 to DFLL48M.
 	sam.GCLK.GENDIV.Set((sam.GCLK_CLKCTRL_GEN_GCLK3 << sam.GCLK_GENDIV_ID_Pos) |
@@ -1043,7 +1043,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 	}
 
 	// Set synch speed for SPI
-	baudRate := (CPU_FREQUENCY / (2 * config.Frequency)) - 1
+	baudRate := (CPUFrequency() / (2 * config.Frequency)) - 1
 	spi.Bus.BAUD.Set(uint8(baudRate))
 
 	// Enable SPI port.

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -14,7 +14,9 @@ import (
 	"unsafe"
 )
 
-const CPU_FREQUENCY = 120000000
+func CPUFrequency() uint32 {
+	return 120000000
+}
 
 type PinMode uint8
 

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -6,7 +6,9 @@ import (
 	"device/sifive"
 )
 
-const CPU_FREQUENCY = 16000000
+func CPUFrequency() uint32 {
+	return 16000000
+}
 
 type PinMode uint8
 
@@ -108,7 +110,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 	}
 
 	// div = (SPI_CFG(dev)->f_sys / (2 * frequency)) - 1;
-	div := CPU_FREQUENCY/(2*config.Frequency) - 1
+	div := CPUFrequency()/(2*config.Frequency) - 1
 	spi.Bus.DIV.Set(div)
 
 	// set mode

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -6,7 +6,9 @@ import (
 	"device/nrf"
 )
 
-const CPU_FREQUENCY = 16000000
+func CPUFrequency() uint32 {
+	return 16000000
+}
 
 // Get peripheral and pin number for this GPIO pin.
 func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -7,7 +7,9 @@ import (
 	"unsafe"
 )
 
-const CPU_FREQUENCY = 64000000
+func CPUFrequency() uint32 {
+	return 64000000
+}
 
 // Get peripheral and pin number for this GPIO pin.
 func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -7,7 +7,9 @@ import (
 	"unsafe"
 )
 
-const CPU_FREQUENCY = 64000000
+func CPUFrequency() uint32 {
+	return 64000000
+}
 
 // Get peripheral and pin number for this GPIO pin.
 func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -10,7 +10,9 @@ import (
 	"errors"
 )
 
-const CPU_FREQUENCY = 72000000
+func CPUFrequency() uint32 {
+	return 72000000
+}
 
 const (
 	PinInput       PinMode = 0 // Input mode
@@ -163,10 +165,10 @@ func (uart UART) SetBaudRate(br uint32) {
 	var divider uint32
 	if uart.Bus == stm32.USART1 {
 		// first divide by PCLK2 prescaler (div 1) and then desired baudrate
-		divider = CPU_FREQUENCY / br
+		divider = CPUFrequency() / br
 	} else {
 		// first divide by PCLK1 prescaler (div 2) and then desired baudrate
-		divider = CPU_FREQUENCY / 2 / br
+		divider = CPUFrequency() / 2 / br
 	}
 	uart.Bus.BRR.Set(divider)
 }
@@ -360,7 +362,7 @@ func (i2c I2C) Configure(config I2CConfig) {
 	i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_PE)
 
 	// pclk1 clock speed is main frequency divided by PCLK1 prescaler (div 2)
-	pclk1 := uint32(CPU_FREQUENCY / 2)
+	pclk1 := CPUFrequency() / 2
 
 	// set freqency range to PCLK1 clock speed in MHz
 	// aka setting the value 36 means to use 36 MHz clock

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -9,7 +9,9 @@ import (
 	"device/stm32"
 )
 
-const CPU_FREQUENCY = 168000000
+func CPUFrequency() uint32 {
+	return 168000000
+}
 
 const (
 	// Mode Flag

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -163,7 +163,7 @@ func timerSleep(ticks uint32) {
 	// The current scaling only supports a range of 200 usec to 6553 msec.
 
 	// prescale counter down from 72mhz to 10khz aka 0.1 ms frequency.
-	stm32.TIM3.PSC.Set(machine.CPU_FREQUENCY/10000 - 1) // 7199
+	stm32.TIM3.PSC.Set(machine.CPUFrequency()/10000 - 1) // 7199
 
 	// Set duty aka duration.
 	// STM32 dividers use n-1, i.e. n counts from 0 to n-1.


### PR DESCRIPTION
These all-caps constants aren't in the Go style, so rename it to `CPUFrequency` (which is more aligned with Go style). Additionally, make it a function so that it is possible to add support for changing the frequency in the future.

Tested by running `make smoketest`. None of the outputs did change.