### PR TITLE
interp: remove accidental debug print

### DIFF
--- a/interp/values.go
+++ b/interp/values.go
@@ -367,8 +367,6 @@ func (v *MapValue) PutBinary(keyPtr, valPtr *LocalValue) {
 		}
 	}
 
-	keyPtr.Underlying.Dump()
-	println()
 	if !keyPtr.Underlying.IsAConstantExpr().IsNil() {
 		if keyPtr.Underlying.Opcode() == llvm.BitCast {
 			keyPtr = &LocalValue{v.Eval, keyPtr.Underlying.Operand(0)}


### PR DESCRIPTION
Accidentally left in the source in https://github.com/tinygo-org/tinygo/pull/787.