### PR TITLE
interp: add runtime fallback for mapassign operations

### DIFF
--- a/interp/testdata/map.ll
+++ b/interp/testdata/map.ll
@@ -5,10 +5,13 @@ target triple = "armv6m-none-eabi"
 %runtime.hashmap = type { %runtime.hashmap*, i8*, i32, i8, i8, i8 }
 
 @main.m = global %runtime.hashmap* null
+@main.binaryMap = global %runtime.hashmap* null
+@main.stringMap = global %runtime.hashmap* null
 @main.init.string = internal unnamed_addr constant [7 x i8] c"CONNECT"
 
 declare %runtime.hashmap* @runtime.hashmapMake(i8, i8, i32, i8* %context, i8* %parentHandle)
 declare void @runtime.hashmapBinarySet(%runtime.hashmap*, i8*, i8*, i8* %context, i8* %parentHandle)
+declare void @runtime.hashmapStringSet(%runtime.hashmap*, i8*, i32, i8*, i8* %context, i8* %parentHandle)
 declare void @llvm.lifetime.end.p0i8(i64, i8*)
 declare void @llvm.lifetime.start.p0i8(i64, i8*)
 
@@ -20,6 +23,7 @@ entry:
 
 define internal void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
+; Test that hashmap optimizations generally work (even with lifetimes).
   %hashmap.key = alloca i8
   %hashmap.value = alloca %runtime._string
   %0 = call %runtime.hashmap* @runtime.hashmapMake(i8 1, i8 8, i32 1, i8* undef, i8* null)
@@ -32,5 +36,41 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 1, i8* %hashmap.key)
   call void @llvm.lifetime.end.p0i8(i64 8, i8* %hashmap.value.bitcast)
   store %runtime.hashmap* %0, %runtime.hashmap** @main.m
+
+  ; Other tests, that can be done in a separate function.
+  call void @main.testNonConstantBinarySet()
+  call void @main.testNonConstantStringSet()
+  ret void
+}
+
+; Test that a map loaded from a global can still be used for mapassign
+; operations (with binary keys).
+define internal void @main.testNonConstantBinarySet() {
+  %hashmap.key = alloca i8
+  %hashmap.value = alloca i8
+  ; Create hashmap from global. This breaks the normal hashmapBinarySet
+  ; optimization, to test the fallback.
+  %map.new = call %runtime.hashmap* @runtime.hashmapMake(i8 1, i8 1, i32 1, i8* undef, i8* null)
+  store %runtime.hashmap* %map.new, %runtime.hashmap** @main.binaryMap
+  %map = load %runtime.hashmap*, %runtime.hashmap** @main.binaryMap
+  ; Do the binary set to the newly loaded map.
+  store i8 1, i8* %hashmap.key
+  store i8 2, i8* %hashmap.value
+  call void @runtime.hashmapBinarySet(%runtime.hashmap* %map, i8* %hashmap.key, i8* %hashmap.value, i8* undef, i8* null)
+  ret void
+}
+
+; Test that a map loaded from a global can still be used for mapassign
+; operations (with string keys).
+define internal void @main.testNonConstantStringSet() {
+  %hashmap.value = alloca i8
+  ; Create hashmap from global. This breaks the normal hashmapStringSet
+  ; optimization, to test the fallback.
+  %map.new = call %runtime.hashmap* @runtime.hashmapMake(i8 8, i8 1, i32 1, i8* undef, i8* null)
+  store %runtime.hashmap* %map.new, %runtime.hashmap** @main.stringMap
+  %map = load %runtime.hashmap*, %runtime.hashmap** @main.stringMap
+  ; Do the string set to the newly loaded map.
+  store i8 2, i8* %hashmap.value
+  call void @runtime.hashmapStringSet(%runtime.hashmap* %map, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @main.init.string, i32 0, i32 0), i32 7, i8* %hashmap.value, i8* undef, i8* null)
   ret void
 }

--- a/interp/testdata/map.out.ll
+++ b/interp/testdata/map.out.ll
@@ -5,11 +5,24 @@ target triple = "armv6m-none-eabi"
 %runtime._string = type { i8*, i32 }
 
 @main.m = local_unnamed_addr global %runtime.hashmap* @"main$map"
+@main.binaryMap = local_unnamed_addr global %runtime.hashmap* @"main$map.4"
+@main.stringMap = local_unnamed_addr global %runtime.hashmap* @"main$map.6"
 @main.init.string = internal unnamed_addr constant [7 x i8] c"CONNECT"
 @"main$mapbucket" = internal unnamed_addr global { [8 x i8], i8*, [8 x i8], [8 x %runtime._string] } { [8 x i8] c"\04\00\00\00\00\00\00\00", i8* null, [8 x i8] c"\01\00\00\00\00\00\00\00", [8 x %runtime._string] [%runtime._string { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @main.init.string, i32 0, i32 0), i32 7 }, %runtime._string zeroinitializer, %runtime._string zeroinitializer, %runtime._string zeroinitializer, %runtime._string zeroinitializer, %runtime._string zeroinitializer, %runtime._string zeroinitializer, %runtime._string zeroinitializer] }
 @"main$map" = internal unnamed_addr global %runtime.hashmap { %runtime.hashmap* null, i8* getelementptr inbounds ({ [8 x i8], i8*, [8 x i8], [8 x %runtime._string] }, { [8 x i8], i8*, [8 x i8], [8 x %runtime._string] }* @"main$mapbucket", i32 0, i32 0, i32 0), i32 1, i8 1, i8 8, i8 0 }
+@"main$alloca.2" = internal global i8 1
+@"main$alloca.3" = internal global i8 2
+@"main$map.4" = internal unnamed_addr global %runtime.hashmap { %runtime.hashmap* null, i8* null, i32 0, i8 1, i8 1, i8 0 }
+@"main$alloca.5" = internal global i8 2
+@"main$map.6" = internal unnamed_addr global %runtime.hashmap { %runtime.hashmap* null, i8* null, i32 0, i8 8, i8 1, i8 0 }
+
+declare void @runtime.hashmapBinarySet(%runtime.hashmap*, i8*, i8*, i8*, i8*) local_unnamed_addr
+
+declare void @runtime.hashmapStringSet(%runtime.hashmap*, i8*, i32, i8*, i8*, i8*) local_unnamed_addr
 
 define void @runtime.initAll() unnamed_addr {
 entry:
+  call void @runtime.hashmapBinarySet(%runtime.hashmap* @"main$map.4", i8* @"main$alloca.2", i8* @"main$alloca.3", i8* undef, i8* null)
+  call void @runtime.hashmapStringSet(%runtime.hashmap* @"main$map.6", i8* getelementptr inbounds ([7 x i8], [7 x i8]* @main.init.string, i32 0, i32 0), i32 7, i8* @"main$alloca.5", i8* undef, i8* null)
   ret void
 }


### PR DESCRIPTION
Some mapassign operations cannot (yet) be done by the interp package. Implement a fallback mechanism so that these operations can still be performed at runtime. In the future, this might be optimized further where possible.

---

This makes a few more packages importable: go/ast, go/format, go/parser, go/printer, go/scanner, and go/token (but probably all because the common dependency go/token became importable).

Eventually I'd like to add support for running gofmt in the playground (without network request!) but go/printer doesn't yet compile due to missing support for interfaces in map keys.