### PR TITLE
builder: protect against unsupported concurrency in lld

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -20,7 +20,9 @@ import (
 
 // Build performs a single package to executable Go build. It takes in a package
 // name, an output path, and set of compile options and from that it manages the
-// whole compilation process.
+// whole compilation process. It is safe to be called concurrently. However,
+// because of limitations in LLVM you may not call into LLVM functions while
+// Build is running.
 //
 // The error value may be of type *MultiError. Callers will likely want to check
 // for this case and print such errors individually.


### PR DESCRIPTION
LLD does not support concurrency, and cannot be run at the same time as compiles. Therefore, use a `RWMutex` to read-lock compiles and write-lock links.

This commit moves the locking from the full program tests to the builder package itself, to provide a cleaner API boundary: users of `builder.Build` do not have to think about concurrency. This move also makes the above mentioned compile concurrency possible.

On my system, this results in about 36% faster tests.

---

Note: I've been busy with allowing packages to be compiled independently. When that is ready, `lldLock` will probably be locked per package.