### PR TITLE
transform: make reflection sidetables constant globals

### DIFF
--- a/transform/reflect.go
+++ b/transform/reflect.go
@@ -160,21 +160,25 @@ func assignTypeCodes(mod llvm.Module, typeSlice typeInfoSlice) {
 		global := replaceGlobalIntWithArray(mod, "reflect.namedNonBasicTypesSidetable", state.namedNonBasicTypesSidetable)
 		global.SetLinkage(llvm.InternalLinkage)
 		global.SetUnnamedAddr(true)
+		global.SetGlobalConstant(true)
 	}
 	if state.needsArrayTypesSidetable {
 		global := replaceGlobalIntWithArray(mod, "reflect.arrayTypesSidetable", state.arrayTypesSidetable)
 		global.SetLinkage(llvm.InternalLinkage)
 		global.SetUnnamedAddr(true)
+		global.SetGlobalConstant(true)
 	}
 	if state.needsStructTypesSidetable {
 		global := replaceGlobalIntWithArray(mod, "reflect.structTypesSidetable", state.structTypesSidetable)
 		global.SetLinkage(llvm.InternalLinkage)
 		global.SetUnnamedAddr(true)
+		global.SetGlobalConstant(true)
 	}
 	if state.needsStructNamesSidetable {
 		global := replaceGlobalIntWithArray(mod, "reflect.structNamesSidetable", state.structNamesSidetable)
 		global.SetLinkage(llvm.InternalLinkage)
 		global.SetUnnamedAddr(true)
+		global.SetGlobalConstant(true)
 	}
 }
 


### PR DESCRIPTION
These globals are (and must be!) never modified by the reflect package. By marking them as constant, they will be put in read-only memory. This reduces RAM consumption on microcontrollers.

Discovered while working on #796.