### PR TITLE
machine/atsamd51: refactor SPI pin configuration to only look at pin numbers

### DIFF
--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -82,14 +82,8 @@ const (
 
 // SPI on the Feather M4.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM1_SPIM,
-		SCK:         SPI0_SCK_PIN,
-		MOSI:        SPI0_MOSI_PIN,
-		MISO:        SPI0_MISO_PIN,
-		DOpad:       spiTXPad3SCK1,
-		DIpad:       sercomRXPad2,
-		MISOPinMode: PinSERCOM,
-		MOSIPinMode: PinSERCOM,
-		SCKPinMode:  PinSERCOM,
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
 	}
 )

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -84,12 +84,8 @@ const (
 
 // SPI on the ItsyBitsy M4.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM1_SPIM,
-		SCK:         SPI0_SCK_PIN,
-		MOSI:        SPI0_MOSI_PIN,
-		MISO:        SPI0_MISO_PIN,
-		DOpad:       spiTXPad2SCK3,
-		DIpad:       sercomRXPad3,
-		MISOPinMode: PinSERCOM,
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
 	}
 )

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -97,15 +97,8 @@ const (
 // SPI on the Metro M4.
 var (
 	SPI0 = SPI{
-		Bus:         sam.SERCOM2_SPIM,
-		SCK:         SPI0_SCK_PIN,
-		MOSI:        SPI0_MOSI_PIN,
-		MISO:        SPI0_MISO_PIN,
-		DOpad:       spiTXPad0SCK1,
-		DIpad:       sercomRXPad2,
-		MISOPinMode: PinSERCOM,
-		MOSIPinMode: PinSERCOM,
-		SCKPinMode:  PinSERCOM,
+		Bus:    sam.SERCOM2_SPIM,
+		SERCOM: 2,
 	}
 	NINA_SPI = SPI0
 )
@@ -119,14 +112,7 @@ const (
 // SPI1 on the Metro M4 on pins 11,12,13
 var (
 	SPI1 = SPI{
-		Bus:         sam.SERCOM1_SPIM,
-		SCK:         SPI1_SCK_PIN,
-		MOSI:        SPI1_MOSI_PIN,
-		MISO:        SPI1_MISO_PIN,
-		DOpad:       spiTXPad3SCK1,
-		DIpad:       sercomRXPad0,
-		MISOPinMode: PinSERCOM,
-		MOSIPinMode: PinSERCOM,
-		SCKPinMode:  PinSERCOM,
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
 	}
 )

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -120,15 +120,9 @@ const (
 
 // SPI on the PyBadge.
 var (
-	SPI0 = SPI{Bus: sam.SERCOM1_SPIM,
-		SCK:         SPI0_SCK_PIN,
-		MOSI:        SPI0_MOSI_PIN,
-		MISO:        SPI0_MISO_PIN,
-		DOpad:       spiTXPad3SCK1,
-		DIpad:       sercomRXPad2,
-		MISOPinMode: PinSERCOM,
-		MOSIPinMode: PinSERCOM,
-		SCKPinMode:  PinSERCOM,
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
 	}
 )
 
@@ -136,15 +130,13 @@ var (
 const (
 	SPI1_SCK_PIN  = PB13 // SCK: SERCOM4/PAD[1]
 	SPI1_MOSI_PIN = PB15 // MOSI: SERCOM4/PAD[3]
+	SPI1_MISO_PIN = NoPin
 )
 
 // TFT SPI on the PyBadge.
 var (
-	SPI1 = SPI{Bus: sam.SERCOM4_SPIM,
-		SCK:         SPI1_SCK_PIN,
-		MOSI:        SPI1_MOSI_PIN,
-		DOpad:       spiTXPad3SCK1,
-		MOSIPinMode: PinSERCOM,
-		SCKPinMode:  PinSERCOM,
+	SPI1 = SPI{
+		Bus:    sam.SERCOM4_SPIM,
+		SERCOM: 4,
 	}
 )


### PR DESCRIPTION
This commit does the same thing as https://github.com/tinygo-org/tinygo/pull/597 but for samd51 series chips. Pin mode and pad numbers are automatically calculated from pin numbers, returning an error if no valid pinout is possible.

Code that uses SPI1 and code that does not configure all pins (for example, leaving out MISO) may need to be updated. Therefore, I think it's best to merge this after the coming release to have a bigger chance of finding bugs. Also, it should be updated after #800 has been merged.