### PR TITLE
ci: remove symlink creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,12 +120,6 @@ commands:
           key: llvm-build-9-linux-v0-assert
           paths:
             llvm-build
-      - run:
-          name: "Create LLVM symlinks"
-          command: |
-            ln -s $PWD/llvm-build/bin/clang-9 /go/bin/clang-9
-            ln -s $PWD/llvm-build/bin/ld.lld  /go/bin/ld.lld-9
-            ln -s $PWD/llvm-build/bin/wasm-ld /go/bin/wasm-ld-9
       - run: make ASSERT=1
       - run:
           name: "Test TinyGo"
@@ -184,12 +178,6 @@ commands:
           key: llvm-build-9-linux-v0
           paths:
             llvm-build
-      - run:
-          name: "Create LLVM symlinks"
-          command: |
-            ln -s $PWD/llvm-build/bin/clang-9 /go/bin/clang-9
-            ln -s $PWD/llvm-build/bin/ld.lld  /go/bin/ld.lld-9
-            ln -s $PWD/llvm-build/bin/wasm-ld /go/bin/wasm-ld-9
       - run:
           name: "Test TinyGo"
           command: make test
@@ -256,10 +244,6 @@ commands:
           key: llvm-build-9-macos-v0
           paths:
             llvm-build
-      - run:
-          name: "Create LLVM symlinks"
-          command: |
-            ln -s $PWD/llvm-build/bin/clang-9 /usr/local/bin/clang-9
       - run:
           name: "Test TinyGo"
           command: make test

--- a/builder/compiler-builtin.go
+++ b/builder/compiler-builtin.go
@@ -26,7 +26,11 @@ func runCCompiler(command string, flags ...string) error {
 	switch command {
 	case "clang":
 		// Compile this with the internal Clang compiler.
-		flags = append(flags, "-I"+getClangHeaderPath(goenv.Get("TINYGOROOT")))
+		headerPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
+		if headerPath == "" {
+			return errors.New("could not locate Clang headers")
+		}
+		flags = append(flags, "-I"+headerPath)
 		flags = append([]string{"tinygo:" + command}, flags...)
 		var cflag *C.char
 		buf := C.calloc(C.size_t(len(flags)), C.size_t(unsafe.Sizeof(cflag)))

--- a/builder/env.go
+++ b/builder/env.go
@@ -71,7 +71,7 @@ func GorootVersionString(goroot string) (string, error) {
 // various ways.
 func getClangHeaderPath(TINYGOROOT string) string {
 	// Check whether we're running from the source directory.
-	path := filepath.Join(TINYGOROOT, "llvm", "tools", "clang", "lib", "Headers")
+	path := filepath.Join(TINYGOROOT, "llvm-project", "clang", "lib", "Headers")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return path
 	}


### PR DESCRIPTION
These symlinks are now unnecessary because Clang (and previously lld) have been integrated into TinyGo.