### PR TITLE
riscv: improve startup assembly

### DIFF
--- a/src/device/riscv/start.S
+++ b/src/device/riscv/start.S
@@ -3,11 +3,10 @@
 .type _start,@function
 
 _start:
-    // Workaround for missing support of the la pseudo-instruction in Clang 8:
-    // https://reviews.llvm.org/D55325
-    lui sp,      %hi(_stack_top)
-    addi sp, sp, %lo(_stack_top)
-    // see https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
-    lui gp,      %hi(__global_pointer$)
-    addi gp, gp, %lo(__global_pointer$)
+    // Load the stack pointer.
+    la sp,      _stack_top
+    // Load the globals pointer. The program will load pointers relative to this
+    // register, so it must be set to the right value on startup.
+    // See: https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
+    la gp,      __global_pointer$
     call main


### PR DESCRIPTION
Now that we've switched to LLVM 9, we don't need a workaround anymore for the 'la' pseudo-instruction.
The assembly is slightly different but should be functionally identical.

Tested locally with the PR in #765.