### PR TITLE
ci: increase Azure Pipelines timeout to 4 hours

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ trigger:
 
 jobs:
 - job: Build
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240 # 4h
   pool:
     vmImage: 'VS2017-Win2016'
   steps:


### PR DESCRIPTION
3 hours is too close to the edge. Extend to 4 hours to make sure a build including LLVM build will finish before the deadline.