### PR TITLE
Add initial FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ $(LIBCLANG_PATH): $(LIBCLANG_FILES)
 else ifeq ($(shell uname -s),Darwin)
     MD5SUM = md5
     LIBCLANG_PATH = $(abspath $(LLVM_BUILDDIR))/lib/libclang.a
+else ifeq ($(shell uname -s),FreeBSD)
+    MD5SUM = md5
+    LIBCLANG_PATH = $(abspath $(LLVM_BUILDDIR))/lib/libclang.a
+    START_GROUP = -Wl,--start-group
+    END_GROUP = -Wl,--end-group
 else
     LIBCLANG_PATH = $(abspath $(LLVM_BUILDDIR))/lib/libclang.a
     START_GROUP = -Wl,--start-group

--- a/builder/commands.go
+++ b/builder/commands.go
@@ -34,6 +34,12 @@ func init() {
 		commands["ld.lld"] = append(commands["ld.lld"], "lld", "C:\\Program Files\\LLVM\\bin\\lld.exe")
 		commands["wasm-ld"] = append(commands["wasm-ld"], "C:\\Program Files\\LLVM\\bin\\wasm-ld.exe")
 	}
+	// Add the path to the llvm90 installed from ports
+	if runtime.GOOS == "freebsd" {
+		commands["clang"] = append(commands["clang"], "/usr/local/llvm90/bin/clang-9")
+		commands["ld.lld"] = append(commands["ld.lld"], "/usr/local/llvm90/bin/ld.lld")
+		commands["wasm-ld"] = append(commands["wasm-ld"], "/usr/local/llvm90/bin/wasm-ld")
+	}
 }
 
 func execCommand(cmdNames []string, args ...string) error {

--- a/cgo/libclang_config.go
+++ b/cgo/libclang_config.go
@@ -5,7 +5,9 @@ package cgo
 /*
 #cgo linux  CFLAGS: -I/usr/lib/llvm-9/include
 #cgo darwin CFLAGS: -I/usr/local/opt/llvm@9/include
+#cgo freebsd CFLAGS: -I/usr/local/llvm90/include
 #cgo linux  LDFLAGS: -L/usr/lib/llvm-9/lib -lclang
 #cgo darwin LDFLAGS: -L/usr/local/opt/llvm@9/lib -lclang -lffi
+#cgo freebsd LDFLAGS: -L/usr/local/llvm90/lib -lclang
 */
 import "C"

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -152,7 +152,7 @@ func (c *Compiler) emitSyscall(frame *Frame, call *ssa.CallCommon) (llvm.Value, 
 		return llvm.Value{}, c.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+c.GOOS()+"/"+c.GOARCH())
 	}
 	switch c.GOOS() {
-	case "linux":
+	case "linux", "freebsd":
 		// Return values: r0, r1 uintptr, err Errno
 		// Pseudocode:
 		//     var err uintptr

--- a/main.go
+++ b/main.go
@@ -452,7 +452,7 @@ func flashUF2UsingMSD(volume, tmppath string) error {
 	// find standard UF2 info path
 	var infoPath string
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "freebsd":
 		infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
 	case "darwin":
 		infoPath = "/Volumes/" + volume + "/INFO_UF2.TXT"
@@ -479,7 +479,7 @@ func flashHexUsingMSD(volume, tmppath string) error {
 	// find expected volume path
 	var destPath string
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "freebsd":
 		destPath = "/media/*/" + volume
 	case "darwin":
 		destPath = "/Volumes/" + volume
@@ -558,6 +558,8 @@ func getDefaultPort() (port string, err error) {
 		portPath = "/dev/cu.usb*"
 	case "linux":
 		portPath = "/dev/ttyACM*"
+	case "freebsd":
+		portPath = "/dev/cuaU*"
 	case "windows":
 		cmd := exec.Command("wmic",
 			"PATH", "Win32_SerialPort", "WHERE", "Caption LIKE 'USB Serial%'", "GET", "DeviceID")

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal
+// +build darwin linux,!baremetal freebsd,!baremetal
 
 package os
 

--- a/src/runtime/os_freebsd.go
+++ b/src/runtime/os_freebsd.go
@@ -1,0 +1,5 @@
+// +build freebsd
+
+package runtime
+
+const GOOS = "freebsd"

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal
+// +build darwin linux,!baremetal freebsd,!baremetal
 
 package runtime
 


### PR DESCRIPTION
This PR adds initial support for running TinyGo on FreeBSD using self-built LLVM. Both `test` and `smoketest` pass and I'm working on adding it to the ports tree.