### PR TITLE
compiler: don't crash when encountering types.Invalid

### DIFF
--- a/compiler/sizes.go
+++ b/compiler/sizes.go
@@ -110,6 +110,9 @@ func (s *StdSizes) Sizeof(T types.Type) int64 {
 		if k == types.UnsafePointer {
 			return s.PtrSize
 		}
+		if k == types.Invalid {
+			return 0 // only relevant when there is a type error somewhere
+		}
 		panic("unknown basic type: " + t.String())
 	case *types.Array:
 		n := t.Len()


### PR DESCRIPTION
This commit fixes a crash when trying to compile the following (invalid) code:

    package main

    import "unsafe"

    func main() {
    }

    type Foo struct {
       x DoesNotExist
    }

    const foo = unsafe.Sizeof(Foo{})

This commit fixes this situation. The result is a regular error message, indicating that `DoesNotExist` is not defined.