### PR TITLE
compiler: add support for CGO_ENABLED environment variable

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -65,6 +65,12 @@ func (c *Config) BuildTags() []string {
 	return tags
 }
 
+// CgoEnabled returns true if (and only if) CGo is enabled. It is true by
+// default and false if CGO_ENABLED is set to "0".
+func (c *Config) CgoEnabled() bool {
+	return goenv.Get("CGO_ENABLED") == "1"
+}
+
 // GC returns the garbage collection strategy in use on this platform. Valid
 // values are "none", "leaking", and "conservative".
 func (c *Config) GC() string {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -193,7 +193,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 			GOOS:        c.GOOS(),
 			GOROOT:      goenv.Get("GOROOT"),
 			GOPATH:      goenv.Get("GOPATH"),
-			CgoEnabled:  true,
+			CgoEnabled:  c.CgoEnabled(),
 			UseAllFiles: false,
 			Compiler:    "gc", // must be one of the recognized compilers
 			BuildTags:   c.BuildTags(),
@@ -203,7 +203,7 @@ func (c *Compiler) Compile(mainPath string) []error {
 			GOOS:        c.GOOS(),
 			GOROOT:      goenv.Get("TINYGOROOT"),
 			GOPATH:      overlayGopath,
-			CgoEnabled:  true,
+			CgoEnabled:  c.CgoEnabled(),
 			UseAllFiles: false,
 			Compiler:    "gc", // must be one of the recognized compilers
 			BuildTags:   c.BuildTags(),

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -18,6 +18,7 @@ var Keys = []string{
 	"GOROOT",
 	"GOPATH",
 	"GOCACHE",
+	"CGO_ENABLED",
 	"TINYGOROOT",
 }
 
@@ -57,6 +58,13 @@ func Get(name string) string {
 			panic("could not find cache dir: " + err.Error())
 		}
 		return filepath.Join(dir, "tinygo")
+	case "CGO_ENABLED":
+		val := os.Getenv("CGO_ENABLED")
+		if val == "1" || val == "0" {
+			return val
+		}
+		// Default to enabling CGo.
+		return "1"
 	case "TINYGOROOT":
 		return sourceDir()
 	default:


### PR DESCRIPTION
This should fix #771. Not sure how to test it, but you can test locally by running tinygo with the ./testdata/cgo package with the following extra file (main2.go):

```go
// +build !cgo

package main

func main() {
    println("no cgo")
}
```

and run with `CGO_ENABLED` set to `1` or `0` to test the difference.