### PR TITLE
cgo: add support for identifiers

### DIFF
--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -22,7 +22,7 @@ var flagUpdate = flag.Bool("update", false, "Update images based on test output.
 func TestCGo(t *testing.T) {
 	var cflags = []string{"--target=armv6m-none-eabi"}
 
-	for _, name := range []string{"basic", "errors", "types", "flags"} {
+	for _, name := range []string{"basic", "errors", "types", "flags", "const"} {
 		name := name // avoid a race condition
 		t.Run(name, func(t *testing.T) {
 			// Read the AST in memory.

--- a/cgo/const.go
+++ b/cgo/const.go
@@ -140,8 +140,10 @@ func (t *tokenizer) Next() {
 				if c == '.' {
 					hasDot = true
 				}
-				if (c >= '0' && c <= '9') || c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+				if c >= '0' && c <= '9' || c == '.' || c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' {
 					tokenLen = i + 1
+				} else {
+					break
 				}
 			}
 			t.value = t.buf[:tokenLen]

--- a/cgo/const.go
+++ b/cgo/const.go
@@ -52,6 +52,13 @@ func parseConstExpr(t *tokenizer) (ast.Expr, *scanner.Error) {
 		}
 		t.Next()
 		return expr, nil
+	case token.IDENT:
+		expr := &ast.Ident{
+			NamePos: t.pos,
+			Name:    "C." + t.value,
+		}
+		t.Next()
+		return expr, nil
 	case token.EOF:
 		return nil, &scanner.Error{
 			Pos: t.fset.Position(t.pos),
@@ -149,6 +156,21 @@ func (t *tokenizer) Next() {
 				t.token = token.INT
 				t.value = strings.TrimRight(t.value, "uUlL")
 			}
+			return
+		case c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c == '_':
+			// Identifier. Find all remaining tokens that are part of this
+			// identifier.
+			tokenLen := len(t.buf)
+			for i, c := range t.buf {
+				if c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c == '_' {
+					tokenLen = i + 1
+				} else {
+					break
+				}
+			}
+			t.value = t.buf[:tokenLen]
+			t.buf = t.buf[tokenLen:]
+			t.token = token.IDENT
 			return
 		case c == '"':
 			// String constant. Find the first '"' character that is not

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -21,8 +21,8 @@ func TestParseConst(t *testing.T) {
 		{`5)`, `error: 1:2: unexpected token )`},
 		{"  \t)", `error: 1:4: unexpected token )`},
 		{`5.8f`, `5.8`},
-		{`foo`, `error: 1:1: unexpected token ILLEGAL`}, // identifiers unimplemented
-		{``, `error: 1:1: empty constant`},              // empty constants not allowed in Go
+		{`foo`, `C.foo`},
+		{``, `error: 1:1: empty constant`}, // empty constants not allowed in Go
 		{`"foo"`, `"foo"`},
 		{`"a\\n"`, `"a\\n"`},
 		{`"a\n"`, `"a\n"`},

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -30,6 +30,7 @@ func TestParseConst(t *testing.T) {
 		{`'a'`, `'a'`},
 		{`0b10`, `0b10`},
 		{`0x1234_5678`, `0x1234_5678`},
+		{`5 5`, `error: 1:3: unexpected token INT`}, // test for a bugfix
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)

--- a/cgo/testdata/const.go
+++ b/cgo/testdata/const.go
@@ -1,0 +1,12 @@
+package main
+
+/*
+#define foo 3
+#define bar foo
+*/
+import "C"
+
+const (
+	Foo = C.foo
+	Bar = C.bar
+)

--- a/cgo/testdata/const.out.go
+++ b/cgo/testdata/const.out.go
@@ -1,0 +1,29 @@
+package main
+
+import "unsafe"
+
+var _ unsafe.Pointer
+
+const C.bar = C.foo
+const C.foo = 3
+
+type C.int16_t = int16
+type C.int32_t = int32
+type C.int64_t = int64
+type C.int8_t = int8
+type C.uint16_t = uint16
+type C.uint32_t = uint32
+type C.uint64_t = uint64
+type C.uint8_t = uint8
+type C.uintptr_t = uintptr
+type C.char uint8
+type C.int int32
+type C.long int32
+type C.longlong int64
+type C.schar int8
+type C.short int16
+type C.uchar uint8
+type C.uint uint32
+type C.ulong uint32
+type C.ulonglong uint64
+type C.ushort uint16


### PR DESCRIPTION
This doesn't yet support things like `#define foo foo` but that requires more complex compiler changes.