### PR TITLE
loader: improve error messages for failed imports

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -251,13 +251,17 @@ func (c *Compiler) Compile(mainPath string) []error {
 			return []error{err}
 		}
 	} else {
-		_, err = lprogram.Import(mainPath, wd)
+		_, err = lprogram.Import(mainPath, wd, token.Position{
+			Filename: "build command-line-arguments",
+		})
 		if err != nil {
 			return []error{err}
 		}
 	}
 
-	_, err = lprogram.Import("runtime", "")
+	_, err = lprogram.Import("runtime", "", token.Position{
+		Filename: "build default import",
+	})
 	if err != nil {
 		return []error{err}
 	}


### PR DESCRIPTION
Add location information (whenever possible) to failed imports. This helps in debugging where an incorrect import came from.

For example, show the following error message:

    /home/ayke/src/github.com/tinygo-org/tinygo/src/machine/machine.go:5:8: cannot find package "foobar" in any of:
        /usr/local/go/src/foobar (from $GOROOT)
        /home/ayke/src/foobar (from $GOPATH)

Instead of the following:

    error: cannot find package "foobar" in any of:
        /usr/local/go/src/foobar (from $GOROOT)
        /home/ayke/src/foobar (from $GOPATH)