### PR TITLE
compiler: improve "function redeclared" error

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -806,7 +806,12 @@ func (c *Compiler) parseFunc(frame *Frame) {
 		fmt.Printf("\nfunc %s:\n", frame.fn.Function)
 	}
 	if !frame.fn.LLVMFn.IsDeclaration() {
-		c.addError(frame.fn.Pos(), "function is already defined:"+frame.fn.LLVMFn.Name())
+		errValue := frame.fn.LLVMFn.Name() + " redeclared in this program"
+		fnPos := getPosition(frame.fn.LLVMFn)
+		if fnPos.IsValid() {
+			errValue += "\n\tprevious declaration at " + fnPos.String()
+		}
+		c.addError(frame.fn.Pos(), errValue)
 		return
 	}
 	if !frame.fn.IsExported() {

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	golang.org/x/tools v0.0.0-20190227180812-8dcc6e70cdef
-	tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257
+	tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae
 )

--- a/go.sum
+++ b/go.sum
@@ -30,3 +30,5 @@ tinygo.org/x/go-llvm v0.0.0-20191113125529-bad6d01809e8 h1:9Bfvso+tTVQg16UzOA614
 tinygo.org/x/go-llvm v0.0.0-20191113125529-bad6d01809e8/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
 tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257 h1:o8VDylrMN7gWemBMu8rEyuogKPhcLTdx5KrUAp9macc=
 tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
+tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae h1:s8J5EyxCkHxXB08UI3gk9W9IS/ekizRvSX+PfZxnAB0=
+tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=


### PR DESCRIPTION
This error can normally only happen with `//go:linkname` and such, but it's nice to get an informative error message in that case.