### PR TITLE
machine/arduino-nano33: fix UART1 and UART2

### DIFF
--- a/src/machine/board_arduino_nano33_baremetal.go
+++ b/src/machine/board_arduino_nano33_baremetal.go
@@ -8,12 +8,12 @@ import "device/sam"
 var (
 	UART1 = UART{
 		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM5_USART,
-		SERCOM: 5,
+		Bus:    sam.SERCOM3_USART,
+		SERCOM: 3,
 	}
 )
 
-//go:export SERCOM5_IRQHandler
+//go:export SERCOM3_IRQHandler
 func handleUART1() {
 	defaultUART1Handler()
 }
@@ -22,12 +22,12 @@ func handleUART1() {
 var (
 	UART2 = UART{
 		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM3_USART,
-		SERCOM: 3,
+		Bus:    sam.SERCOM5_USART,
+		SERCOM: 5,
 	}
 )
 
-//go:export SERCOM3_IRQHandler
+//go:export SERCOM5_IRQHandler
 func handleUART2() {
 	// should reset IRQ
 	UART2.Receive(byte((UART2.Bus.DATA.Get() & 0xFF)))


### PR DESCRIPTION
UART2 was configured with the wrong SERCOM for the used pins (PB22 and
PB23). However, after changing the SERCOM from 3 to 5 that led to a
conflict with UART1 (used for the on-board WiFi). But the used pins are
also usable from SERCOM 3, so in the end I switched SERCOM5 and SERCOM3
around.

With this change, I was able to get examples/echo working (after changing the UART to UART2 and changing the used pins to RX0 and TX1). I also verified that the on-board WiFi chip is still usable with the espconsole example in the drivers repo.