### PR TITLE
interp: error location for "unknown GEP" error

### DIFF
--- a/interp/utils.go
+++ b/interp/utils.go
@@ -24,7 +24,11 @@ func getStringBytes(strPtr Value, strLen llvm.Value) []byte {
 	}
 	buf := make([]byte, strLen.ZExtValue())
 	for i := range buf {
-		c := strPtr.GetElementPtr([]uint32{uint32(i)}).Load()
+		gep, err := strPtr.GetElementPtr([]uint32{uint32(i)})
+		if err != nil {
+			panic(err) // TODO
+		}
+		c := gep.Load()
 		buf[i] = byte(c.ZExtValue())
 	}
 	return buf

--- a/interp/values.go
+++ b/interp/values.go
@@ -3,6 +3,7 @@ package interp
 // This file provides a litte bit of abstraction around LLVM values.
 
 import (
+	"errors"
 	"strconv"
 
 	"tinygo.org/x/go-llvm"
@@ -11,13 +12,13 @@ import (
 // A Value is a LLVM value with some extra methods attached for easier
 // interpretation.
 type Value interface {
-	Value() llvm.Value            // returns a LLVM value
-	Type() llvm.Type              // equal to Value().Type()
-	IsConstant() bool             // returns true if this value is a constant value
-	Load() llvm.Value             // dereference a pointer
-	Store(llvm.Value)             // store to a pointer
-	GetElementPtr([]uint32) Value // returns an interior pointer
-	String() string               // string representation, for debugging
+	Value() llvm.Value                     // returns a LLVM value
+	Type() llvm.Type                       // equal to Value().Type()
+	IsConstant() bool                      // returns true if this value is a constant value
+	Load() llvm.Value                      // dereference a pointer
+	Store(llvm.Value)                      // store to a pointer
+	GetElementPtr([]uint32) (Value, error) // returns an interior pointer
+	String() string                        // string representation, for debugging
 }
 
 // A type that simply wraps a LLVM constant value.
@@ -97,21 +98,21 @@ func (v *LocalValue) Store(value llvm.Value) {
 }
 
 // GetElementPtr returns a GEP when the underlying value is of pointer type.
-func (v *LocalValue) GetElementPtr(indices []uint32) Value {
+func (v *LocalValue) GetElementPtr(indices []uint32) (Value, error) {
 	if !v.Underlying.IsAGlobalVariable().IsNil() {
 		int32Type := v.Underlying.Type().Context().Int32Type()
 		gep := llvm.ConstGEP(v.Underlying, getLLVMIndices(int32Type, indices))
-		return &LocalValue{v.Eval, gep}
+		return &LocalValue{v.Eval, gep}, nil
 	}
 	if !v.Underlying.IsAConstantExpr().IsNil() {
 		switch v.Underlying.Opcode() {
 		case llvm.GetElementPtr, llvm.IntToPtr, llvm.BitCast:
 			int32Type := v.Underlying.Type().Context().Int32Type()
 			llvmIndices := getLLVMIndices(int32Type, indices)
-			return &LocalValue{v.Eval, llvm.ConstGEP(v.Underlying, llvmIndices)}
+			return &LocalValue{v.Eval, llvm.ConstGEP(v.Underlying, llvmIndices)}, nil
 		}
 	}
-	panic("interp: unknown GEP")
+	return nil, errors.New("interp: unknown GEP")
 }
 
 // stripPointerCasts removes all const bitcasts from pointer values, if there
@@ -309,8 +310,8 @@ func (v *MapValue) Store(value llvm.Value) {
 
 // GetElementPtr panics: maps are of reference type so their (interior)
 // addresses cannot be calculated.
-func (v *MapValue) GetElementPtr(indices []uint32) Value {
-	panic("interp: GEP on a map")
+func (v *MapValue) GetElementPtr(indices []uint32) (Value, error) {
+	return nil, errors.New("interp: GEP on a map")
 }
 
 // PutString does a map assign operation, assuming that the map is of type


### PR DESCRIPTION
This commit removes a panic and replaces it with a proper source
location. The message still isn't very helpful, but at least it points
to a location in the source code.

I'm not very happy with all the `err.Error()` calls, but that's the way
to fit this in a `scanner.Error`. Eventually we should make a
replacement for `scanner.Error` that does proper wrapping of the
original error message.