### PR TITLE
compiler: add globaldce pass to start of optimization pipeline

### DIFF
--- a/compiler/optimizer.go
+++ b/compiler/optimizer.go
@@ -45,6 +45,7 @@ func (c *Compiler) Optimize(optLevel, sizeLevel int, inlinerThreshold uint) []er
 		// Run some preparatory passes for the Go optimizer.
 		goPasses := llvm.NewPassManager()
 		defer goPasses.Dispose()
+		goPasses.AddGlobalDCEPass()
 		goPasses.AddGlobalOptimizerPass()
 		goPasses.AddConstantPropagationPass()
 		goPasses.AddAggressiveDCEPass()


### PR DESCRIPTION
This reduces code size in a few cases when tested against the drivers smoketests (although there was one minor increase) without significantly increasing compile time. In fact, in my testing compile time appears to be going down a little bit (around 1%, within the noise).