### PR TITLE
compiler: add support for debugging globals

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -60,14 +60,44 @@ func (c *Compiler) getGlobal(g *ssa.Global) llvm.Value {
 	info := c.getGlobalInfo(g)
 	llvmGlobal := c.mod.NamedGlobal(info.linkName)
 	if llvmGlobal.IsNil() {
-		llvmType := c.getLLVMType(g.Type().(*types.Pointer).Elem())
+		typ := g.Type().(*types.Pointer).Elem()
+		llvmType := c.getLLVMType(typ)
 		llvmGlobal = llvm.AddGlobal(c.mod, llvmType, info.linkName)
 		if !info.extern {
 			llvmGlobal.SetInitializer(llvm.ConstNull(llvmType))
 			llvmGlobal.SetLinkage(llvm.InternalLinkage)
 		}
-		if info.align > c.targetData.ABITypeAlignment(llvmType) {
-			llvmGlobal.SetAlignment(info.align)
+
+		// Set alignment from the //go:align comment.
+		var alignInBits uint32
+		if info.align < 0 || info.align&(info.align-1) != 0 {
+			// Check for power-of-two (or 0).
+			// See: https://stackoverflow.com/a/108360
+			c.addError(g.Pos(), "global variable alignment must be a positive power of two")
+		} else {
+			// Set the alignment only when it is a power of two.
+			alignInBits = uint32(info.align) ^ uint32(info.align-1)
+			if info.align > c.targetData.ABITypeAlignment(llvmType) {
+				llvmGlobal.SetAlignment(info.align)
+			}
+		}
+
+		if c.Debug() {
+			// Add debug info.
+			// TODO: this should be done for every global in the program, not just
+			// the ones that are referenced from some code.
+			pos := c.ir.Program.Fset.Position(g.Pos())
+			diglobal := c.dibuilder.CreateGlobalVariableExpression(c.difiles[pos.Filename], llvm.DIGlobalVariableExpression{
+				Name:        g.RelString(nil),
+				LinkageName: info.linkName,
+				File:        c.getDIFile(pos.Filename),
+				Line:        pos.Line,
+				Type:        c.getDIType(typ),
+				LocalToUnit: false,
+				Expr:        c.dibuilder.CreateExpression(nil),
+				AlignInBits: alignInBits,
+			})
+			llvmGlobal.AddMetadata(0, diglobal)
 		}
 	}
 	return llvmGlobal

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	golang.org/x/tools v0.0.0-20190227180812-8dcc6e70cdef
-	tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae
+	tinygo.org/x/go-llvm v0.0.0-20200104190746-1ff21df33566
 )

--- a/go.sum
+++ b/go.sum
@@ -32,3 +32,5 @@ tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257 h1:o8VDylrMN7gWemBMu8rEy
 tinygo.org/x/go-llvm v0.0.0-20191124211856-b2db3df3f257/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
 tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae h1:s8J5EyxCkHxXB08UI3gk9W9IS/ekizRvSX+PfZxnAB0=
 tinygo.org/x/go-llvm v0.0.0-20191215173731-ad71f3d24aae/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
+tinygo.org/x/go-llvm v0.0.0-20200104190746-1ff21df33566 h1:a4y30bTf7U0zDA75v2PTL+XQ2OzJetj19gK8XwQpUNY=
+tinygo.org/x/go-llvm v0.0.0-20200104190746-1ff21df33566/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=


### PR DESCRIPTION
This makes most globals visible from GDB, using `info variables`.

For example, without this PR:

```
$ tinygo gdb -target=cortex-m-qemu ./testdata/gc.go
[...]
(gdb) info variables
All defined variables:

Non-debugging symbols:
0x20001000  ./testdata/gc.go.xorshift32State
0x20001000  _globals_start
0x20001000  _sdata
0x20001004  _edata
0x20001010  _sbss
0x20001010  runtime.zeroSizedAlloc
0x20001014  runtime.nextAlloc
0x20001018  runtime.endBlock
0x20001019  runtime.poolStart
0x2000101c  ./testdata/gc.go.randSeeds
0x20001030  ./testdata/gc.go.scalarSlices
0x20001060  _ebss
0x20001060  _globals_end
0x20001060  _heap_start
```

With this PR:

```
$ tinygo gdb -target=cortex-m-qemu ./testdata/gc.go
[...]
(gdb) info variables
All defined variables:

File src/runtime/baremetal.go:
void *_globals_end;
void *_globals_start;
void *_heap_end;
void *_heap_start;
void *_stack_top;

File src/runtime/gc_conservative.go:
runtime.gcBlock runtime.endBlock;
runtime.gcBlock runtime.nextAlloc;
uintptr runtime.poolStart;
uint8 runtime.zeroSizedAlloc;

File src/runtime/runtime_cortexm.go:
void *_ebss;
void *_edata;
void *_sbss;
void *_sdata;
void *_sidata;

File testdata/gc.go:
uint32 ./testdata/gc.go.randSeeds[4];
struct []byte ./testdata/gc.go.scalarSlices[4];
uint32 ./testdata/gc.go.xorshift32State;
(gdb) list 'runtime.endBlock'
48	)
49	
50	var (
51		poolStart uintptr // the first heap pointer
52		nextAlloc gcBlock // the next block that should be tried by the allocator
53		endBlock  gcBlock // the block just past the end of the available space
54	)
55	
56	// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
57	var zeroSizedAlloc uint8
```

It isn't perfect yet. For example, variables should be listed per package instead of per file. But this is already much better than having almost nothing.

The code in this PR will also be needed for generating nice error messages on duplicate interrupt definitions in #782.