### PR TITLE
runtime: fix atsamd51 volatile usage

### DIFF
--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -6,6 +6,7 @@ import (
 	"device/arm"
 	"device/sam"
 	"machine"
+	"runtime/volatile"
 )
 
 type timeUnit int64
@@ -218,10 +219,7 @@ var (
 	timerLastCounter uint64
 )
 
-//go:volatile
-type isrFlag bool
-
-var timerWakeup isrFlag
+var timerWakeup volatile.Register8
 
 const asyncScheduler = false
 
@@ -248,7 +246,7 @@ func ticks() timeUnit {
 
 // ticks are in microseconds
 func timerSleep(ticks uint32) {
-	timerWakeup = false
+	timerWakeup.Set(0)
 	if ticks < 260 {
 		// due to delay waiting for the register value to sync, the minimum sleep value
 		// for the SAMD51 is 260us.
@@ -268,7 +266,7 @@ func timerSleep(ticks uint32) {
 	// enable IRQ for CMP0 compare
 	sam.RTC_MODE0.INTENSET.SetBits(sam.RTC_MODE0_INTENSET_CMP0)
 
-	for !timerWakeup {
+	for timerWakeup.Get() == 0 {
 		arm.Asm("wfi")
 	}
 }
@@ -278,7 +276,7 @@ func handleRTC() {
 	// disable IRQ for CMP0 compare
 	sam.RTC_MODE0.INTFLAG.SetBits(sam.RTC_MODE0_INTENSET_CMP0)
 
-	timerWakeup = true
+	timerWakeup.Set(1)
 }
 
 func initUSBClock() {


### PR DESCRIPTION
It was still using the (long removed) `//go:volatile` pragma for volatile variables, thus it was only accidentally working.

Tested with examples/blinky1 on an ItsyBitsy M4.