### PR TITLE
ci: produce zip as artifact in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,9 @@ jobs:
           export PATH="/c/Go1.13/bin:$PATH:./llvm-build/bin:/c/Program Files/qemu"
           unset GOROOT
           make release -j4
-    - publish: $(System.DefaultWorkingDirectory)/build/release.tar.gz
-      displayName: Publish tarball as artifact
-      artifact: tinygo.windows-amd64.tar.gz
+    - publish: $(System.DefaultWorkingDirectory)/build/release/tinygo
+      displayName: Publish zip as artifact
+      artifact: tinygo
     - task: Bash@3
       displayName: Smoke tests
       inputs:


### PR DESCRIPTION
Zip files are far more often used on Windows systems, so we provide zip files in releases. Unfortunately, previously the provided artifact in CI was really just a compressed .tar.gz file, which defeats the purpose.

This commit zips the release tarball itself so it can be downloaded as an artifact.