### PR TITLE
riscv: print exception PC and code

### DIFF
--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -69,8 +69,10 @@ func handleInterrupt() {
 			riscv.MIE.ClearBits(1 << 7) // MTIE bit
 		}
 	} else {
-		// TODO: handle exceptions in a similar was as HardFault is handled on
-		// Cortex-M (by printing an error message with instruction address).
+		// Topmost bit is clear, so it is an exception of some sort.
+		// We could implement support for unsupported instructions here (such as
+		// misaligned loads). However, for now we'll just print a fatal error.
+		handleException(code)
 	}
 }
 
@@ -150,4 +152,18 @@ func sleepTicks(d timeUnit) {
 		}
 		riscv.Asm("wfi")
 	}
+}
+
+// handleException is called from the interrupt handler for any exception.
+// Exceptions can be things like illegal instructions, invalid memory
+// read/write, and similar issues.
+func handleException(code uint) {
+	// For a list of exception codes, see:
+	// https://content.riscv.org/wp-content/uploads/2019/08/riscv-privileged-20190608-1.pdf#page=49
+	print("fatal error: exception with mcause=")
+	print(code)
+	print(" pc=")
+	print(riscv.MEPC.Get())
+	println()
+	abort()
 }


### PR DESCRIPTION
This can be useful for debugging critical bugs in code. I haven't added human-readable exceptions (such as "illegal instruction" or "stack overflow") yet, they can be added when they happen in practice (to avoid increasing code size unnecessarily).

A program like this:

```go
    // ...
    riscv.Asm(".long 0") // undef
    // ...
```

will cause an error like the following:

    fatal error: exception with mcause=2 pc=0x204002ce

where code 2 means "illegal instruction" according to the RISC-V docs (as expected).

Tested both on hardware (HiFive1 rev B) and in QEMU.