### PR TITLE
hifive1b: add support for gdb subcommand

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -47,6 +47,7 @@ type TargetSpec struct {
 	OpenOCDInterface string   `json:"openocd-interface"`
 	OpenOCDTarget    string   `json:"openocd-target"`
 	OpenOCDTransport string   `json:"openocd-transport"`
+	JLinkDevice      string   `json:"jlink-device"`
 }
 
 // copyProperties copies all properties that are set in spec2 into itself.
@@ -121,6 +122,9 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	}
 	if spec2.OpenOCDTransport != "" {
 		spec.OpenOCDTransport = spec2.OpenOCDTransport
+	}
+	if spec2.JLinkDevice != "" {
+		spec.JLinkDevice = spec2.JLinkDevice
 	}
 }
 

--- a/targets/hifive1b.json
+++ b/targets/hifive1b.json
@@ -4,5 +4,6 @@
 	"linkerscript": "targets/hifive1b.ld",
 	"flash-method": "msd",
 	"msd-volume-name": "HiFive",
-	"msd-firmware-name": "firmware.hex"
+	"msd-firmware-name": "firmware.hex",
+	"jlink-device": "fe310"
 }


### PR DESCRIPTION
This makes debugging on the HiFive1 rev B much easier:

    tinygo gdb -target=hifive1b examples/echo