### PR TITLE
machine/digispark: add clock speed and pin mappings

### DIFF
--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -2,6 +2,18 @@
 
 package machine
 
+// Return the current CPU frequency in hertz.
+func CPUFrequency() uint32 {
+	return 16000000
+}
+
 const (
-	LED Pin = 1
+	P0 Pin = 0
+	P1 Pin = 1
+	P2 Pin = 2
+	P3 Pin = 3
+	P4 Pin = 4
+	P5 Pin = 5
+
+	LED = P1
 )


### PR DESCRIPTION
This PR adds the clock speed and pin mappings to the existing Digispark board definition.