### PR TITLE
wasm: include wasi-libc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,18 @@ commands:
           key: llvm-source-9-v0
           paths:
             - llvm-project
+  build-wasi-libc:
+    steps:
+      - restore_cache:
+          keys:
+            - wasi-libc-sysroot-v0
+      - run:
+          name: "Build wasi-libc"
+          command: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+      - save_cache:
+          key: wasi-libc-sysroot-v0
+          paths:
+            - lib/wasi-libc/sysroot
   test-linux:
     steps:
       - checkout
@@ -64,6 +76,14 @@ commands:
             - go-cache-v2-{{ checksum "go.mod" }}
       - llvm-source-linux
       - run: go install .
+      - restore_cache:
+          keys:
+            - wasi-libc-sysroot-systemclang-v0
+      - run: make wasi-libc
+      - save_cache:
+          key: wasi-libc-sysroot-systemclang-v0
+          paths:
+            - lib/wasi-libc/sysroot
       - run: go test -v ./cgo ./compileopts ./interp ./transform .
       - run: make gen-device -j4
       - run: make smoketest
@@ -121,6 +141,7 @@ commands:
           paths:
             llvm-build
       - run: make ASSERT=1
+      - build-wasi-libc
       - run:
           name: "Test TinyGo"
           command: make ASSERT=1 test
@@ -178,6 +199,7 @@ commands:
           key: llvm-build-9-linux-v0
           paths:
             llvm-build
+      - build-wasi-libc
       - run:
           name: "Test TinyGo"
           command: make test
@@ -244,6 +266,16 @@ commands:
           key: llvm-build-9-macos-v0
           paths:
             llvm-build
+      - restore_cache:
+          keys:
+            - wasi-libc-sysroot-macos-v0
+      - run:
+          name: "Build wasi-libc"
+          command: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+      - save_cache:
+          key: wasi-libc-sysroot-macos-v0
+          paths:
+            - lib/wasi-libc/sysroot
       - run:
           name: "Test TinyGo"
           command: make test

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = lib/compiler-rt
 	url = https://github.com/llvm-mirror/compiler-rt.git
 	branch = release_80
+[submodule "lib/wasi-libc"]
+	path = lib/wasi-libc
+	url = https://github.com/CraneStation/wasi-libc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,16 @@ jobs:
       inputs:
         targetType: inline
         script: choco install qemu
+    - task: CacheBeta@0
+      displayName: Cache wasi-libc sysroot
+      inputs:
+        key: wasi-libc-sysroot-v0
+        path: lib/wasi-libc/sysroot
+    - task: Bash@3
+      displayName: Build wasi-libc
+      inputs:
+        targetType: inline
+        script: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
     - task: Bash@3
       displayName: Test TinyGo
       inputs:

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -2,10 +2,6 @@
 
 package runtime
 
-import (
-	"unsafe"
-)
-
 type timeUnit float64 // time in milliseconds, just like Date.now() in JavaScript
 
 const tickMicros = 1000000
@@ -67,26 +63,4 @@ func ticks() timeUnit
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
-}
-
-//go:export memset
-func memset(ptr unsafe.Pointer, c byte, size uintptr) unsafe.Pointer {
-	for i := uintptr(0); i < size; i++ {
-		*(*byte)(unsafe.Pointer(uintptr(ptr) + i)) = c
-	}
-	return ptr
-}
-
-// Implement memmove for LLVM and compiler-rt.
-//go:export memmove
-func libc_memmove(dst, src unsafe.Pointer, size uintptr) unsafe.Pointer {
-	memmove(dst, src, size)
-	return dst
-}
-
-// Implement memcpy for LLVM and compiler-rt.
-//go:export memcpy
-func libc_memcpy(dst, src unsafe.Pointer, size uintptr) unsafe.Pointer {
-	memcpy(dst, src, size)
-	return dst
 }

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,21 +1,21 @@
 {
-	"llvm-target":   "wasm32-unknown-unknown-wasm",
+	"llvm-target":   "wasm32--wasi",
 	"build-tags":    ["js", "wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
 	"compiler":      "clang",
 	"linker":        "wasm-ld",
 	"cflags": [
-		"--target=wasm32",
-		"-nostdlibinc",
-		"-Wno-macro-redefined",
+		"--target=wasm32--wasi",
+		"--sysroot={root}/lib/wasi-libc/sysroot",
 		"-Oz"
 	],
 	"ldflags": [
 		"--allow-undefined",
 		"--no-threads",
 		"--stack-first",
-		"--export-all"
+		"--export-all",
+		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"]
 }


### PR DESCRIPTION
This allows CGo code to call some libc functions.

Fixes part of #844.