### PR TITLE
gameboy-advance: include compiler-rt in build

### DIFF
--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -158,7 +158,7 @@ var aeabiBuiltins = []string{
 
 func builtinFiles(target string) []string {
 	builtins := append([]string{}, genericBuiltins...) // copy genericBuiltins
-	if strings.HasPrefix(target, "arm") {
+	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
 		builtins = append(builtins, aeabiBuiltins...)
 	}
 	return builtins

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -6,6 +6,7 @@
 	"goarch": "arm",
 	"compiler": "clang",
 	"linker": "ld.lld",
+	"rtlib": "compiler-rt",
 	"cflags": [
 		"-g",
 		"--target=thumb4-none-eabi",


### PR DESCRIPTION
This avoids errors like the following:

    ld.lld-9: error: undefined symbol: __umodsi3
    ld.lld-9: error: undefined symbol: __aeabi_uidivmod