### PR TITLE
main: fix race condition in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -72,6 +72,8 @@ func runPlatTests(target string, matches []string, t *testing.T) {
 	t.Parallel()
 
 	for _, path := range matches {
+		path := path // redefine to avoid race condition
+
 		switch {
 		case target == "wasm":
 			// testdata/gc.go is known not to work on WebAssembly


### PR DESCRIPTION
This caused most tests to run the zeroalloc.go test instead of what they should have been tested, and in turn explains most of the performance gains of parallel testing.

This commit fixes it by avoiding race conditions. Luckily, no tests started failing since then due to this.

@jaddr2line