### PR TITLE
Support maps with arbitrary key types

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1586,24 +1586,7 @@ func (c *Compiler) parseExpr(frame *Frame, expr ssa.Value) (llvm.Value, error) {
 		val := c.getValue(frame, expr.X)
 		return c.parseMakeInterface(val, expr.X.Type(), expr.Pos()), nil
 	case *ssa.MakeMap:
-		mapType := expr.Type().Underlying().(*types.Map)
-		llvmKeyType := c.getLLVMType(mapType.Key().Underlying())
-		llvmValueType := c.getLLVMType(mapType.Elem().Underlying())
-		keySize := c.targetData.TypeAllocSize(llvmKeyType)
-		valueSize := c.targetData.TypeAllocSize(llvmValueType)
-		llvmKeySize := llvm.ConstInt(c.ctx.Int8Type(), keySize, false)
-		llvmValueSize := llvm.ConstInt(c.ctx.Int8Type(), valueSize, false)
-		sizeHint := llvm.ConstInt(c.uintptrType, 8, false)
-		if expr.Reserve != nil {
-			sizeHint = c.getValue(frame, expr.Reserve)
-			var err error
-			sizeHint, err = c.parseConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
-			if err != nil {
-				return llvm.Value{}, err
-			}
-		}
-		hashmap := c.createRuntimeCall("hashmapMake", []llvm.Value{llvmKeySize, llvmValueSize, sizeHint}, "")
-		return hashmap, nil
+		return c.emitMakeMap(frame, expr)
 	case *ssa.MakeSlice:
 		sliceLen := c.getValue(frame, expr.Len)
 		sliceCap := c.getValue(frame, expr.Cap)

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -152,28 +152,6 @@ func (c *Compiler) emitMapDelete(keyType types.Type, m, key llvm.Value, pos toke
 	}
 }
 
-// Get FNV-1a hash of this string.
-//
-// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
-func hashmapHash(data []byte) uint32 {
-	var result uint32 = 2166136261 // FNV offset basis
-	for _, c := range data {
-		result ^= uint32(c)
-		result *= 16777619 // FNV prime
-	}
-	return result
-}
-
-// Get the topmost 8 bits of the hash, without using a special value (like 0).
-func hashmapTopHash(hash uint32) uint8 {
-	tophash := uint8(hash >> 24)
-	if tophash < 1 {
-		// 0 means empty slot, so make it bigger.
-		tophash += 1
-	}
-	return tophash
-}
-
 // Returns true if this key type does not contain strings, interfaces etc., so
 // can be compared with runtime.memequal.
 func hashmapIsBinaryKey(keyType types.Type) bool {

--- a/testdata/map.go
+++ b/testdata/map.go
@@ -24,6 +24,11 @@ var testMapArrayKey = map[ArrayKey]int{
 }
 var testmapIntInt = map[int]int{1: 1, 2: 4, 3: 9}
 
+type namedFloat struct {
+	s string
+	f float32
+}
+
 func main() {
 	m := map[string]int{"answer": 42, "foo": 3}
 	readMap(m, "answer")
@@ -47,6 +52,44 @@ func main() {
 	println(testMapArrayKey[arrKey])
 	testMapArrayKey[arrKey] = 5555
 	println(testMapArrayKey[arrKey])
+
+	// test maps with interface keys
+	itfMap := map[interface{}]int{
+		3.14:         3,
+		8:            8,
+		uint8(8):     80,
+		"eight":      800,
+		[2]int{5, 2}: 52,
+		true:         1,
+	}
+	println("itfMap[3]:", itfMap[3]) // doesn't exist
+	println("itfMap[3.14]:", itfMap[3.14])
+	println("itfMap[8]:", itfMap[8])
+	println("itfMap[uint8(8)]:", itfMap[uint8(8)])
+	println(`itfMap["eight"]:`, itfMap["eight"])
+	println(`itfMap[[2]int{5, 2}]:`, itfMap[[2]int{5, 2}])
+	println("itfMap[true]:", itfMap[true])
+	delete(itfMap, 8)
+	println("itfMap[8]:", itfMap[8])
+
+	// test map with float keys
+	floatMap := map[float32]int{
+		42: 84,
+	}
+	println("floatMap[42]:", floatMap[42])
+	println("floatMap[43]:", floatMap[43])
+	delete(floatMap, 42)
+	println("floatMap[42]:", floatMap[42])
+
+	// test maps with struct keys
+	structMap := map[namedFloat]int{
+		namedFloat{"tau", 6.28}: 5,
+	}
+	println(`structMap[{"tau", 6.28}]:`, structMap[namedFloat{"tau", 6.28}])
+	println(`structMap[{"Tau", 6.28}]:`, structMap[namedFloat{"Tau", 6.28}])
+	println(`structMap[{"tau", 3.14}]:`, structMap[namedFloat{"tau", 3.14}])
+	delete(structMap, namedFloat{"tau", 6.28})
+	println(`structMap[{"tau", 6.28}]:`, structMap[namedFloat{"tau", 6.28}])
 
 	// test preallocated map
 	squares := make(map[int]int, 200)
@@ -79,7 +122,7 @@ func testBigMap(squares map[int]int, n int) {
 		if len(squares) != i {
 			println("unexpected length:", len(squares), "at i =", i)
 		}
-		squares[i] = i*i
+		squares[i] = i * i
 		for j := 0; j <= i; j++ {
 			if v, ok := squares[j]; !ok || v != j*j {
 				if !ok {

--- a/testdata/map.txt
+++ b/testdata/map.txt
@@ -54,5 +54,20 @@ true false 0
 42
 4321
 5555
+itfMap[3]: 0
+itfMap[3.14]: 3
+itfMap[8]: 8
+itfMap[uint8(8)]: 80
+itfMap["eight"]: 800
+itfMap[[2]int{5, 2}]: 52
+itfMap[true]: 1
+itfMap[8]: 0
+floatMap[42]: 84
+floatMap[43]: 0
+floatMap[42]: 0
+structMap[{"tau", 6.28}]: 5
+structMap[{"Tau", 6.28}]: 0
+structMap[{"tau", 3.14}]: 0
+structMap[{"tau", 6.28}]: 0
 tested preallocated map
 tested growing of a map


### PR DESCRIPTION
This implementation simply casts types without special support to an interface, to make the implementation simpler and possibly reducing the code size too. It will likely be slower than the canonical Go implementation though (which builds special compare and hash functions at compile time).