### PR TITLE
arduino: make avrdude command line compatible with Windows

### DIFF
--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -15,5 +15,5 @@
 		"targets/avr.S",
 		"src/device/avr/atmega328p.s"
 	],
-	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}"
+	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i"
 }


### PR DESCRIPTION
On Windows, it is common that there is a colon in the path. `avrdude` will treat that as a separator and everything behind it as the file format specifier instead of defaulting to Intel hex format.

By explicitly specifying the Intel hex format (with `:i`), this issue should be fixed.

fixes #851 (hopefully)