### PR TITLE
GBA interrupts

### DIFF
--- a/src/machine/machine_gameboyadvance.go
+++ b/src/machine/machine_gameboyadvance.go
@@ -8,6 +8,25 @@ import (
 	"unsafe"
 )
 
+// Interrupt numbers as used on the GameBoy Advance. Register them with
+// runtime/interrupt.New.
+const (
+	IRQ_VBLANK  = 0
+	IRQ_HBLANK  = 1
+	IRQ_VCOUNT  = 2
+	IRQ_TIMER0  = 3
+	IRQ_TIMER1  = 4
+	IRQ_TIMER2  = 5
+	IRQ_TIMER3  = 6
+	IRQ_COM     = 7
+	IRQ_DMA0    = 8
+	IRQ_DMA1    = 9
+	IRQ_DMA2    = 10
+	IRQ_DMA3    = 11
+	IRQ_KEYPAD  = 12
+	IRQ_GAMEPAK = 13
+)
+
 // Make it easier to directly write to I/O RAM.
 var ioram = (*[0x400]volatile.Register8)(unsafe.Pointer(uintptr(0x04000000)))
 

--- a/src/runtime/interrupt/interrupt_gameboyadvance.go
+++ b/src/runtime/interrupt/interrupt_gameboyadvance.go
@@ -1,0 +1,36 @@
+// +build gameboyadvance
+
+package interrupt
+
+import (
+	"runtime/volatile"
+	"unsafe"
+)
+
+var (
+	regInterruptEnable       = (*volatile.Register16)(unsafe.Pointer(uintptr(0x4000200)))
+	regInterruptRequestFlags = (*volatile.Register16)(unsafe.Pointer(uintptr(0x4000202)))
+	regInterruptMasterEnable = (*volatile.Register16)(unsafe.Pointer(uintptr(0x4000208)))
+)
+
+// Enable enables this interrupt. Right after calling this function, the
+// interrupt may be invoked if it was already pending.
+func (irq Interrupt) Enable() {
+	regInterruptEnable.SetBits(1 << uint(irq.num))
+}
+
+//export handleInterrupt
+func handleInterrupt() {
+	flags := regInterruptRequestFlags.Get()
+	for i := 0; i < 14; i++ {
+		if flags&(1<<uint(i)) != 0 {
+			regInterruptRequestFlags.Set(1 << uint(i)) // acknowledge interrupt
+			callInterruptHandler(i)
+		}
+	}
+}
+
+// callInterruptHandler is a compiler-generated function that calls the
+// appropriate interrupt handler for the given interrupt ID.
+//go:linkname callInterruptHandler runtime.callInterruptHandler
+func callInterruptHandler(id int)

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -3,6 +3,7 @@
 package runtime
 
 import (
+	_ "runtime/interrupt" // make sure the interrupt handler is defined
 	"unsafe"
 )
 

--- a/targets/gameboy-advance.ld
+++ b/targets/gameboy-advance.ld
@@ -7,10 +7,8 @@ MEMORY {
     rom     : ORIGIN = 0x08000000, LENGTH = 32M  /* flash ROM */
 }
 
-__iwram_top = ORIGIN(iwram) + LENGTH(iwram);;
-_stack_size = 3K;
-__sp_irq    = _stack_top;
-__sp_usr    = _stack_top - 1K;
+__stack_size_irq = 1K;
+__stack_size_usr = 2K;
 
 SECTIONS
 {
@@ -35,8 +33,10 @@ SECTIONS
     .stack (NOLOAD) :
     {
         . = ALIGN(4);
-        . += _stack_size;
+        _stack_top_irq = .;
+        . += __stack_size_irq;
         _stack_top = .;
+        . += __stack_size_usr;
     } >iwram
 
     /* Start address (in flash) of .data, used by startup code. */

--- a/targets/gameboy-advance.ld
+++ b/targets/gameboy-advance.ld
@@ -1,10 +1,13 @@
 OUTPUT_ARCH(arm)
 ENTRY(_start)
 
+/* Note: iwram is reduced by 96 bytes because the last part of that RAM
+ * (starting at 0x03007FA0) is used for interrupt handling.
+ */
 MEMORY {
-    ewram   : ORIGIN = 0x02000000, LENGTH = 256K /* on-board work RAM (2 wait states) */
-    iwram   : ORIGIN = 0x03000000, LENGTH = 32K  /* in-chip work RAM (faster) */
-    rom     : ORIGIN = 0x08000000, LENGTH = 32M  /* flash ROM */
+    ewram   : ORIGIN = 0x02000000, LENGTH = 256K   /* on-board work RAM (2 wait states) */
+    iwram   : ORIGIN = 0x03000000, LENGTH = 32K-96 /* in-chip work RAM (faster) */
+    rom     : ORIGIN = 0x08000000, LENGTH = 32M    /* flash ROM */
 }
 
 __stack_size_irq = 1K;

--- a/targets/gameboy-advance.s
+++ b/targets/gameboy-advance.s
@@ -22,10 +22,10 @@ start_vector:
 
     mov     r0, #0x12                      // Switch to IRQ Mode
     msr     cpsr, r0
-    ldr     sp, =__sp_irq                  // Set IRQ stack
+    ldr     sp, =_stack_top_irq            // Set IRQ stack
     mov     r0, #0x1f                      // Switch to System Mode
     msr     cpsr, r0
-    ldr     sp, =__sp_usr                  // Set user stack
+    ldr     sp, =_stack_top                // Set user stack
 
     // Jump to user code (switching to Thumb mode)
     ldr     r3, =main


### PR DESCRIPTION
This is based on #860.
By using the same vectoring method as RISC-V uses, this interrupt system does not need any RAM to store the interrupt vector table. Instead, it is implemented by the compiler as a big switch statement.
Other than that, this interrupt system is very bare bones. More features (such as priorities) could be added later if needed. However, I think it would be a good idea to consider interrupt priorities on RISC-V at the same time as the interrupt systems are very similar so that at least the design can be shared.

@kylelemons 