### PR TITLE
Added indexBytePortable from standard library to link as implementation for internal/bytealg.IndexByte

### DIFF
--- a/src/runtime/bytes.go
+++ b/src/runtime/bytes.go
@@ -1,0 +1,11 @@
+package runtime
+
+//go:linkname indexBytePortable internal/bytealg.IndexByte
+func indexBytePortable(s []byte, c byte) int {
+	for i, b := range s {
+		if b == c {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
This PR copies the indexBytePortable function from the standard library to fix a linker error similar to the one in https://github.com/tinygo-org/tinygo/issues/154