### PR TITLE
avr: support `tinygo run` with simavr

### DIFF
--- a/targets/atmega328p.json
+++ b/targets/atmega328p.json
@@ -10,5 +10,6 @@
 	"extra-files": [
 		"targets/avr.S",
 		"src/device/avr/atmega328p.s"
-	]
+	],
+	"emulator": ["simavr", "-m", "atmega328p", "-f", "16000000"]
 }

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -15,5 +15,6 @@
 		"targets/avr.S",
 		"src/device/avr/attiny85.s"
 	],
-	"flash-command": "micronucleus --run {hex}"
+	"flash-command": "micronucleus --run {hex}",
+	"emulator": ["simavr", "-m", "attiny85", "-f", "16000000"]
 }


### PR DESCRIPTION
This commit adds support for running both the Arduino Uno and the
DigiSpark under a simulator.

Running `tinygo gdb` under a simulator is different from (for example)
what `tinygo gdb` does for other boards such as the PCA10040. However, I
think this is the better option as probably very few people actually
have a hardware debugger and supporting GDB with the simulator is then
much more useful.