### PR TITLE
ci: fix Windows build failure for wasi-libc

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       displayName: Build wasi-libc
       inputs:
         targetType: inline
-        script: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+        script: PATH=/usr/bin:$PATH make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
     - task: Bash@3
       displayName: Test TinyGo
       inputs:


### PR DESCRIPTION
The wasi-libc Makefile uses the `find` command line tool. Unfortunately, it was using the Windows find version instead of the MinGW version, leading to lots of errors at a later stage.

This commit prepends /usr/bin to `$PATH` to make sure the MinGW version is found first.