### PR TITLE
gameboy-advance: enable debugging with GDB

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,7 +299,11 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 		case "msd", "command", "":
 			if len(config.Target.Emulator) != 0 {
 				// Assume QEMU as an emulator.
-				gdbInterface = "qemu"
+				if config.Target.Emulator[0] == "mgba" {
+					gdbInterface = "mgba"
+				} else {
+					gdbInterface = "qemu"
+				}
 			} else if openocdInterface != "" && config.Target.OpenOCDTarget != "" {
 				gdbInterface = "openocd"
 			} else if config.Target.JLinkDevice != "" {
@@ -371,6 +375,26 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 
 			// Run in an emulator.
 			args := append(config.Target.Emulator[1:], tmppath, "-s", "-S")
+			daemon := exec.Command(config.Target.Emulator[0], args...)
+			daemon.Stdout = os.Stdout
+			daemon.Stderr = os.Stderr
+
+			// Make sure the daemon doesn't receive Ctrl-C that is intended for
+			// GDB (to break the currently executing program).
+			setCommandAsDaemon(daemon)
+
+			// Start now, and kill it on exit.
+			daemon.Start()
+			defer func() {
+				daemon.Process.Signal(os.Interrupt)
+				// Maybe we should send a .Kill() after x seconds?
+				daemon.Wait()
+			}()
+		case "mgba":
+			gdbCommands = append(gdbCommands, "target remote :2345")
+
+			// Run in an emulator.
+			args := append(config.Target.Emulator[1:], tmppath, "-g")
 			daemon := exec.Command(config.Target.Emulator[0], args...)
 			daemon.Stdout = os.Stdout
 			daemon.Stderr = os.Stderr

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -26,5 +26,6 @@
 	"extra-files": [
 		"targets/gameboy-advance.s"
 	],
-	"emulator": ["mgba-qt"]
+	"gdb": "gdb-multiarch",
+	"emulator": ["mgba", "-3"]
 }


### PR DESCRIPTION
With this patch I was able to run `tinygo gdb -target=gameboy-advance -size=short examples/gba-display`.

This also changes the standard mGBA from the Qt frontend to the SDL frontend, because `-g` appears to be broken with the Qt backend (@endrift). I'm not sure whether that's a good idea, but keeping `tinygo run` and `tinygo gdb` consistent seems reasonable to me.