### PR TITLE
runtime: fix external address declarations

### DIFF
--- a/src/runtime/arch_wasm.go
+++ b/src/runtime/arch_wasm.go
@@ -12,7 +12,7 @@ const GOARCH = "wasm"
 const TargetBits = 32
 
 //go:extern __heap_base
-var heapStartSymbol unsafe.Pointer
+var heapStartSymbol [0]byte
 
 //go:export llvm.wasm.memory.size.i32
 func wasm_memory_size(index int32) int32

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -7,19 +7,19 @@ import (
 )
 
 //go:extern _heap_start
-var heapStartSymbol unsafe.Pointer
+var heapStartSymbol [0]byte
 
 //go:extern _heap_end
-var heapEndSymbol unsafe.Pointer
+var heapEndSymbol [0]byte
 
 //go:extern _globals_start
-var globalsStartSymbol unsafe.Pointer
+var globalsStartSymbol [0]byte
 
 //go:extern _globals_end
-var globalsEndSymbol unsafe.Pointer
+var globalsEndSymbol [0]byte
 
 //go:extern _stack_top
-var stackTopSymbol unsafe.Pointer
+var stackTopSymbol [0]byte
 
 var (
 	heapStart    = uintptr(unsafe.Pointer(&heapStartSymbol))

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -15,19 +15,19 @@ func putchar(c byte) {
 }
 
 //go:extern _sbss
-var _sbss unsafe.Pointer
+var _sbss [0]byte
 
 //go:extern _ebss
-var _ebss unsafe.Pointer
+var _ebss [0]byte
 
 //go:extern _sdata
-var _sdata unsafe.Pointer
+var _sdata [0]byte
 
 //go:extern _sidata
-var _sidata unsafe.Pointer
+var _sidata [0]byte
 
 //go:extern _edata
-var _edata unsafe.Pointer
+var _edata [0]byte
 
 // Entry point for Go. Initialize all packages and call main.main().
 //go:export main

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -8,19 +8,19 @@ import (
 )
 
 //go:extern _sbss
-var _sbss unsafe.Pointer
+var _sbss [0]byte
 
 //go:extern _ebss
-var _ebss unsafe.Pointer
+var _ebss [0]byte
 
 //go:extern _sdata
-var _sdata unsafe.Pointer
+var _sdata [0]byte
 
 //go:extern _sidata
-var _sidata unsafe.Pointer
+var _sidata [0]byte
 
 //go:extern _edata
-var _edata unsafe.Pointer
+var _edata [0]byte
 
 func preinit() {
 	// Initialize .bss: zero-initialized global variables.

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -17,19 +17,19 @@ import (
 type timeUnit int64
 
 //go:extern _sbss
-var _sbss unsafe.Pointer
+var _sbss [0]byte
 
 //go:extern _ebss
-var _ebss unsafe.Pointer
+var _ebss [0]byte
 
 //go:extern _sdata
-var _sdata unsafe.Pointer
+var _sdata [0]byte
 
 //go:extern _sidata
-var _sidata unsafe.Pointer
+var _sidata [0]byte
 
 //go:extern _edata
-var _edata unsafe.Pointer
+var _edata [0]byte
 
 //go:export main
 func main() {


### PR DESCRIPTION
This is the same problem as in https://github.com/tinygo-org/tinygo/pull/605, but other targets also suffer from it.

Discovered with the GBA target, but as pointed out in https://bugs.llvm.org/show_bug.cgi?id=42881#c1 this appears to be a bug in the way external globals are declared, not in LLVM. Therefore I decided that fixing it everywhere would be the best thing to do.