### PR TITLE
machine/usb: set the vid and pid to valid values supplied by Adafruit and Arduino

### DIFF
--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -90,3 +90,14 @@ const (
 	I2S_SD_PIN  Pin = PA08
 	I2S_WS_PIN      = NoPin // TODO: figure out what this is on Arduino Nano 33.
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Arduino NANO 33 IoT"
+	usb_STRING_MANUFACTURER = "Arduino"
+)
+
+var (
+	usb_VID uint16 = 0x2341
+	usb_PID uint16 = 0x8057
+)

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -76,3 +76,14 @@ const (
 	SPI0_MOSI_PIN = P0_21 // MOSI
 	SPI0_MISO_PIN = P0_23 // MISO
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit Circuit Playground Bluefruit"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8045
+)

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -88,3 +88,14 @@ const (
 	I2S_SD_PIN  = PA08
 	I2S_WS_PIN  = NoPin // no WS, instead uses SCK to sync
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Circuit Playground Express"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8018
+)

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -91,7 +91,7 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Circuit Playground Express"
+	usb_STRING_PRODUCT      = "Adafruit Circuit Playground Express"
 	usb_STRING_MANUFACTURER = "Adafruit"
 )
 

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -120,3 +120,14 @@ const (
 	SPI0_MOSI_PIN = D15 // MOSI
 	SPI0_MISO_PIN = D14 // MISO
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit CLUE"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8072
+)

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -102,3 +102,14 @@ const (
 	I2S_SD_PIN  = PA08
 	I2S_WS_PIN  = NoPin // TODO: figure out what this is on Feather M0.
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Feather M0 Express"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x801B
+)

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -105,7 +105,7 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Feather M0 Express"
+	usb_STRING_PRODUCT      = "Adafruit Feather M0 Express"
 	usb_STRING_MANUFACTURER = "Adafruit"
 )
 

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -87,3 +87,14 @@ var (
 		SERCOM: 1,
 	}
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit Feather M4"
+	usb_STRING_MANUFACTURER = "Adafruit LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8022
+)

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -91,7 +91,7 @@ var (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit Feather M4"
-	usb_STRING_MANUFACTURER = "Adafruit LLC"
+	usb_STRING_MANUFACTURER = "Adafruit"
 )
 
 var (

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -123,3 +123,14 @@ const (
 var (
 	I2S0 = I2S{Bus: sam.I2S}
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "ItsyBitsy M0 Express"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x800F
+)

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -126,7 +126,7 @@ var (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "ItsyBitsy M0 Express"
+	usb_STRING_PRODUCT      = "Adafruit ItsyBitsy M0 Express"
 	usb_STRING_MANUFACTURER = "Adafruit"
 )
 

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -89,3 +89,14 @@ var (
 		SERCOM: 1,
 	}
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit ItsyBitsy M4"
+	usb_STRING_MANUFACTURER = "Adafruit LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x802B
+)

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -93,7 +93,7 @@ var (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit ItsyBitsy M4"
-	usb_STRING_MANUFACTURER = "Adafruit LLC"
+	usb_STRING_MANUFACTURER = "Adafruit"
 )
 
 var (

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -116,3 +116,14 @@ var (
 		SERCOM: 1,
 	}
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit Metro M4 Airlift Lite"
+	usb_STRING_MANUFACTURER = "Adafruit LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8037
+)

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -120,7 +120,7 @@ var (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit Metro M4 Airlift Lite"
-	usb_STRING_MANUFACTURER = "Adafruit LLC"
+	usb_STRING_MANUFACTURER = "Adafruit"
 )
 
 var (

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -35,3 +35,14 @@ const (
 	SPI0_MOSI_PIN = NoPin
 	SPI0_MISO_PIN = NoPin
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Makerdiary nRF52840 MDK USB Dongle"
+	usb_STRING_MANUFACTURER = "Makerdiary"
+)
+
+var (
+	usb_VID uint16 = 0x1915
+	usb_PID uint16 = 0xCAFE
+)

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -94,3 +94,14 @@ const (
 	NFC1_PIN          Pin = 9
 	NFC2_PIN          Pin = 10
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Particle Argon"
+	usb_STRING_MANUFACTURER = "Particle"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8029
+)

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -97,3 +97,14 @@ const (
 	NFC1_PIN        Pin = 9
 	NFC2_PIN        Pin = 10
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Particle Boron"
+	usb_STRING_MANUFACTURER = "Particle"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8029
+)

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -83,3 +83,14 @@ const (
 	NFC1_PIN          Pin = 9
 	NFC2_PIN          Pin = 10
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Particle Xenon"
+	usb_STRING_MANUFACTURER = "Particle"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8029
+)

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -50,3 +50,14 @@ const (
 	SPI0_MOSI_PIN Pin = 45 // P1.13
 	SPI0_MISO_PIN Pin = 46 // P1.14
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Nordic nRF52840DK (PCA10056)"
+	usb_STRING_MANUFACTURER = "Nordic Semiconductor"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8029
+)

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -133,3 +133,14 @@ var (
 		SERCOM: 4,
 	}
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit pyBadge M4"
+	usb_STRING_MANUFACTURER = "Adafruit LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8033
+)

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -137,7 +137,7 @@ var (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit pyBadge M4"
-	usb_STRING_MANUFACTURER = "Adafruit LLC"
+	usb_STRING_MANUFACTURER = "Adafruit"
 )
 
 var (

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -143,3 +143,14 @@ var (
 	}
 	NINA_SPI = SPI0
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit PyPortal M4"
+	usb_STRING_MANUFACTURER = "Adafruit LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8035
+)

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -147,7 +147,7 @@ var (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit PyPortal M4"
-	usb_STRING_MANUFACTURER = "Adafruit LLC"
+	usb_STRING_MANUFACTURER = "Adafruit"
 )
 
 var (

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -59,3 +59,14 @@ func PowerSupplyActive(active bool) {
 		POWER_SUPPLY_PIN.Low()
 	}
 }
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "PHYTEC reelboard"
+	usb_STRING_MANUFACTURER = "PHYTEC"
+)
+
+var (
+	usb_VID uint16 = 0x2FE3
+	usb_PID uint16 = 0x100
+)

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -93,3 +93,14 @@ const (
 	I2S_SD_PIN  = PA08
 	I2S_WS_PIN  = NoPin // TODO: figure out what this is on Trinket M0.
 )
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Trinket M0"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x801E
+)

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -96,7 +96,7 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Trinket M0"
+	usb_STRING_PRODUCT      = "Adafruit Trinket M0"
 	usb_STRING_MANUFACTURER = "Adafruit"
 )
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1801,7 +1801,7 @@ func sendDescriptor(setup usbSetup) {
 			sendUSBPacket(0, dd.Bytes()[:8])
 		} else {
 			// complete descriptor requested so send entire packet
-			dd := NewDeviceDescriptor(0x00, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
+			dd := NewDeviceDescriptor(0x02, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
 			sendUSBPacket(0, dd.Bytes())
 		}
 		return
@@ -1810,11 +1810,12 @@ func sendDescriptor(setup usbSetup) {
 		switch setup.wValueL {
 		case 0:
 			b := make([]byte, 4)
-			b[0] = byte(usb_STRING_LANGUAGE[0] >> 8)
-			b[1] = byte(usb_STRING_LANGUAGE[0] & 0xff)
-			b[2] = byte(usb_STRING_LANGUAGE[1] >> 8)
-			b[3] = byte(usb_STRING_LANGUAGE[1] & 0xff)
+			b[0] = 0x04
+			b[1] = 0x03
+			b[2] = 0x09
+			b[3] = 0x04
 			sendUSBPacket(0, b)
+			return
 
 		case usb_IPRODUCT:
 			prod := []byte(usb_STRING_PRODUCT)
@@ -1823,11 +1824,12 @@ func sendDescriptor(setup usbSetup) {
 			b[1] = 0x03
 
 			for i, val := range prod {
-				b[i*2] = 0
-				b[i*2+1] = val
+				b[i*2+2] = val
+				b[i*2+3] = 0
 			}
 
 			sendUSBPacket(0, b)
+			return
 
 		case usb_IMANUFACTURER:
 			prod := []byte(usb_STRING_MANUFACTURER)
@@ -1836,11 +1838,12 @@ func sendDescriptor(setup usbSetup) {
 			b[1] = 0x03
 
 			for i, val := range prod {
-				b[i*2] = 0
-				b[i*2+1] = val
+				b[i*2+2] = val
+				b[i*2+3] = 0
 			}
 
 			sendUSBPacket(0, b)
+			return
 
 		case usb_ISERIAL:
 			// TODO: allow returning a product serial number

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1972,7 +1972,7 @@ func sendDescriptor(setup usbSetup) {
 			sendUSBPacket(0, dd.Bytes()[:8])
 		} else {
 			// complete descriptor requested so send entire packet
-			dd := NewDeviceDescriptor(0x00, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
+			dd := NewDeviceDescriptor(0x02, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
 			sendUSBPacket(0, dd.Bytes())
 		}
 		return
@@ -1981,11 +1981,12 @@ func sendDescriptor(setup usbSetup) {
 		switch setup.wValueL {
 		case 0:
 			b := make([]byte, 4)
-			b[0] = byte(usb_STRING_LANGUAGE[0] >> 8)
-			b[1] = byte(usb_STRING_LANGUAGE[0] & 0xff)
-			b[2] = byte(usb_STRING_LANGUAGE[1] >> 8)
-			b[3] = byte(usb_STRING_LANGUAGE[1] & 0xff)
+			b[0] = 0x04
+			b[1] = 0x03
+			b[2] = 0x09
+			b[3] = 0x04
 			sendUSBPacket(0, b)
+			return
 
 		case usb_IPRODUCT:
 			prod := []byte(usb_STRING_PRODUCT)
@@ -1994,11 +1995,12 @@ func sendDescriptor(setup usbSetup) {
 			b[1] = 0x03
 
 			for i, val := range prod {
-				b[i*2] = 0
-				b[i*2+1] = val
+				b[i*2+2] = val
+				b[i*2+3] = 0
 			}
 
 			sendUSBPacket(0, b)
+			return
 
 		case usb_IMANUFACTURER:
 			prod := []byte(usb_STRING_MANUFACTURER)
@@ -2007,11 +2009,12 @@ func sendDescriptor(setup usbSetup) {
 			b[1] = 0x03
 
 			for i, val := range prod {
-				b[i*2] = 0
-				b[i*2+1] = val
+				b[i*2+2] = val
+				b[i*2+3] = 0
 			}
 
 			sendUSBPacket(0, b)
+			return
 
 		case usb_ISERIAL:
 			// TODO: allow returning a product serial number

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -395,12 +395,7 @@ func strToUTF16LEDescriptor(in string) []byte {
 
 var (
 	// TODO: allow setting these
-	usb_STRING_LANGUAGE     = [2]uint16{(3 << 8) | (2 + 2), 0x0409} // English
-	usb_STRING_PRODUCT      = "Arduino Zero"
-	usb_STRING_MANUFACTURER = "Arduino"
-
-	usb_VID uint16 = 0x2341
-	usb_PID uint16 = 0x004d
+	usb_STRING_LANGUAGE = [2]uint16{(3 << 8) | (2 + 2), 0x0409} // English
 )
 
 const (

--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -413,7 +413,7 @@ func sendDescriptor(setup usbSetup) {
 			sendUSBPacket(0, dd.Bytes()[:8])
 		} else {
 			// complete descriptor requested so send entire packet
-			dd := NewDeviceDescriptor(0x00, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
+			dd := NewDeviceDescriptor(0x02, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
 			sendUSBPacket(0, dd.Bytes())
 		}
 		return
@@ -422,10 +422,10 @@ func sendDescriptor(setup usbSetup) {
 		switch setup.wValueL {
 		case 0:
 			b := make([]byte, 4)
-			b[0] = byte(usb_STRING_LANGUAGE[0] >> 8)
-			b[1] = byte(usb_STRING_LANGUAGE[0] & 0xff)
-			b[2] = byte(usb_STRING_LANGUAGE[1] >> 8)
-			b[3] = byte(usb_STRING_LANGUAGE[1] & 0xff)
+			b[0] = 0x04
+			b[1] = 0x03
+			b[2] = 0x09
+			b[3] = 0x04
 			sendUSBPacket(0, b)
 
 		case usb_IPRODUCT:


### PR DESCRIPTION
The PR sets the vid and pid to valid values supplied by Adafruit and Arduino for boards that support USB CDC.

It might be able to help Windows 10 users get their devices to auto-mount as USB CDC without special drivers. cc/ @torntrousers 