### PR TITLE
Adding Adafruit CLUE Alpha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/i2s
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=clue_alpha          examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.gba -target=gameboy-advance     examples/gba-display
 	@$(MD5SUM) test.gba
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m4        examples/blinky1

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 27 microcontroller boards are currently supported:
+The following 28 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
+* [Adafruit CLUE Alpha](https://www.adafruit.com/product/4500)
 * [Adafruit Feather M0](https://www.adafruit.com/product/2772)
 * [Adafruit Feather M4](https://www.adafruit.com/product/3857)
 * [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727)

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -1,0 +1,117 @@
+// +build clue_alpha
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// GPIO Pins
+const (
+	D0  = P0_04
+	D1  = P0_05
+	D2  = P0_03
+	D3  = P0_28
+	D4  = P0_02
+	D5  = P1_02
+	D6  = P1_09
+	D7  = P0_07
+	D8  = P1_07
+	D9  = P0_27
+	D10 = P0_30
+	D11 = P1_10
+	D12 = P0_31
+	D13 = P0_08
+	D14 = P0_06
+	D15 = P0_26
+	D16 = P0_29
+	D17 = P1_01
+	D18 = P0_16
+	D19 = P0_25
+	D20 = P0_24
+	D21 = A0
+	D22 = A1
+	D23 = A2
+	D24 = A3
+	D25 = A4
+	D26 = A5
+	D27 = A6
+	D28 = A7
+	D29 = P0_14
+	D30 = P0_15
+	D31 = P0_12
+	D32 = P0_13
+	D33 = P1_03
+	D34 = P1_05
+	D35 = P0_00
+	D36 = P0_01
+	D37 = P0_19
+	D38 = P0_20
+	D39 = P0_17
+	D40 = P0_22
+	D41 = P0_23
+	D42 = P0_21
+	D43 = P0_10
+	D44 = P0_09
+	D45 = P1_06
+	D46 = P1_00
+)
+
+// Analog Pins
+const (
+	A0 = D12
+	A1 = D16
+	A2 = D0
+	A3 = D1
+	A4 = D2
+	A5 = D3
+	A6 = D4
+	A7 = D10
+)
+
+const (
+	LED      = D17
+	LED1     = LED
+	LED2     = D43
+	NEOPIXEL = D18
+
+	BUTTON_LEFT  = D5
+	BUTTON_RIGHT = D11
+
+	// 240x240 ST7789 display is connected to these pins (use RowOffset = 80)
+	TFT_SCK   = D29
+	TFT_MOSI  = D30
+	TFT_CS    = D31
+	TFT_DC    = D32
+	TFT_RESET = D33
+	TFT_LITE  = D34
+
+	PDM_DAT = D35
+	PDM_CLK = D36
+
+	QSPI_SCK   = D37
+	QSPI_CS    = D38
+	QSPI_DATA0 = D39
+	QSPI_DATA1 = D40
+	QSPI_DATA2 = D41
+	QSPI_DATA3 = D42
+
+	SPEAKER = D46
+)
+
+// UART0 pins (logical UART1)
+const (
+	UART_RX_PIN = D0
+	UART_TX_PIN = D1
+)
+
+// I2C pins
+const (
+	SDA_PIN = D20 // I2C0 external
+	SCL_PIN = D19 // I2C0 external
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = D13 // SCK
+	SPI0_MOSI_PIN = D15 // MOSI
+	SPI0_MISO_PIN = D14 // MISO
+)

--- a/targets/clue_alpha.json
+++ b/targets/clue_alpha.json
@@ -1,0 +1,9 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["clue_alpha"],
+    "flash-method": "msd",
+    "msd-volume-name": "FTHR840BOOT",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
https://www.adafruit.com/clue

They note that this is an alpha release of the board and that the pinout/sensors could change, so I've named this target "clue_alpha" in case such changes do occur.