### PR TITLE
1200 baud auto-reset over USB for nrf52840

### DIFF
--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -384,12 +384,6 @@ func cdcSetup(setup usbSetup) bool {
 	return false
 }
 
-func checkShouldReset() {
-	if usbLineInfo.dwDTERate == 1200 && usbLineInfo.lineState&usb_CDC_LINESTATE_DTR == 0 {
-		// TODO: reset here
-	}
-}
-
 func sendUSBPacket(ep uint32, data []byte) {
 	count := len(data)
 	copy(udd_ep_in_cache_buffer[ep][:], data)

--- a/src/machine/usb_nrf52840_reset_none.go
+++ b/src/machine/usb_nrf52840_reset_none.go
@@ -1,0 +1,6 @@
+// +build nrf52840,!nrf52840_reset_uf2
+
+package machine
+
+func checkShouldReset() {
+}

--- a/src/machine/usb_nrf52840_reset_uf2.go
+++ b/src/machine/usb_nrf52840_reset_uf2.go
@@ -13,32 +13,34 @@ const (
 	DFU_MAGIC_OTA_RESET         = 0xA8
 )
 
+// checkShouldReset is called by the USB-CDC implementation to check whether to
+// reset into the bootloader/OTA and if so, resets the chip appropriately.
 func checkShouldReset() {
 	if usbLineInfo.dwDTERate == 1200 && usbLineInfo.lineState&usb_CDC_LINESTATE_DTR == 0 {
 		EnterUF2Bootloader()
 	}
 }
 
-// EnterSerialBootloader should perform a system reset in preparation
-// to switch to the bootloader to flash new firmware via serial/nrfutil
+// EnterSerialBootloader resets the chip into the serial bootloader. After
+// reset, it can be flashed using serial/nrfutil.
 func EnterSerialBootloader() {
 	arm.DisableInterrupts()
-	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_SERIAL_ONLY_RESET)
+	nrf.POWER.GPREGRET.Set(DFU_MAGIC_SERIAL_ONLY_RESET)
 	arm.SystemReset()
 }
 
-// EnterUF2Bootloader should perform a system reset in preparation
-// to switch to the bootloader to flash new firmware via MSD/UF2
+// EnterUF2Bootloader resets the chip into the UF2 bootloader. After reset, it
+// can be flashed via nrfutil or by copying a UF2 file to the mass storage device
 func EnterUF2Bootloader() {
 	arm.DisableInterrupts()
-	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_UF2_RESET)
+	nrf.POWER.GPREGRET.Set(DFU_MAGIC_UF2_RESET)
 	arm.SystemReset()
 }
 
-// EnterOTABootloader should perform a system reset in preparation
-// to switch to the bootloader to flash new firmware via OTA update
+// EnterOTABootloader resets the chip into the bootloader so that it can be
+// flashed via an OTA update
 func EnterOTABootloader() {
 	arm.DisableInterrupts()
-	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_OTA_RESET)
+	nrf.POWER.GPREGRET.Set(DFU_MAGIC_OTA_RESET)
 	arm.SystemReset()
 }

--- a/src/machine/usb_nrf52840_reset_uf2.go
+++ b/src/machine/usb_nrf52840_reset_uf2.go
@@ -1,0 +1,44 @@
+// +build nrf52840,nrf52840_reset_uf2
+
+package machine
+
+import (
+	"device/arm"
+	"device/nrf"
+)
+
+const (
+	DFU_MAGIC_SERIAL_ONLY_RESET = 0x4e
+	DFU_MAGIC_UF2_RESET         = 0x57
+	DFU_MAGIC_OTA_RESET         = 0xA8
+)
+
+func checkShouldReset() {
+	if usbLineInfo.dwDTERate == 1200 && usbLineInfo.lineState&usb_CDC_LINESTATE_DTR == 0 {
+		EnterUF2Bootloader()
+	}
+}
+
+// EnterSerialBootloader should perform a system reset in preparation
+// to switch to the bootloader to flash new firmware via serial/nrfutil
+func EnterSerialBootloader() {
+	arm.DisableInterrupts()
+	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_SERIAL_ONLY_RESET)
+	arm.SystemReset()
+}
+
+// EnterUF2Bootloader should perform a system reset in preparation
+// to switch to the bootloader to flash new firmware via MSD/UF2
+func EnterUF2Bootloader() {
+	arm.DisableInterrupts()
+	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_UF2_RESET)
+	arm.SystemReset()
+}
+
+// EnterOTABootloader should perform a system reset in preparation
+// to switch to the bootloader to flash new firmware via OTA update
+func EnterOTABootloader() {
+	arm.DisableInterrupts()
+	nrf.POWER.GPREGRET.Reg = uint32(DFU_MAGIC_OTA_RESET)
+	arm.SystemReset()
+}

--- a/targets/circuitplay-bluefruit.json
+++ b/targets/circuitplay-bluefruit.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
-    "build-tags": ["circuitplay_bluefruit"],
+    "build-tags": ["circuitplay_bluefruit","nrf52840_reset_uf2"],
+    "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "CPLAYBTBOOT",
     "msd-firmware-name": "firmware.uf2",

--- a/targets/clue_alpha.json
+++ b/targets/clue_alpha.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
-    "build-tags": ["clue_alpha"],
+    "build-tags": ["clue_alpha","nrf52840_reset_uf2"],
+    "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHR840BOOT",
     "msd-firmware-name": "firmware.uf2",


### PR DESCRIPTION
This PR depends on https://github.com/tinygo-org/tinygo/pull/883, and should be rebased once that one is merged.  It implements the functionality for auto-resetting into the UF2 bootloader when a 1200 baud signal is received.

I protected this functionality with build tags since it depends on the UF2 bootloader, and also to enable disabling this functionality if desired.  If preferable however it could be included in the firmware by default without build tags.