### PR TITLE
main: update cmsis-svd module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/avr-rust/avr-mcu.git
 [submodule "lib/cmsis-svd"]
 	path = lib/cmsis-svd
-	url = https://github.com/tinygo-org/cmsis-svd
+	url = https://github.com/posborne/cmsis-svd
 [submodule "lib/compiler-rt"]
 	path = lib/compiler-rt
 	url = https://github.com/llvm-mirror/compiler-rt.git


### PR DESCRIPTION
This reverts back to the upstream repository which has merged all necessary updates (including https://github.com/posborne/cmsis-svd/pull/85 and https://github.com/posborne/cmsis-svd/pull/93).