### PR TITLE
compiler,runtime: support operations on nil map

### DIFF
--- a/testdata/map.go
+++ b/testdata/map.go
@@ -44,6 +44,8 @@ func main() {
 	var nilmap map[string]int
 	println(m == nil, m != nil, len(m))
 	println(nilmap == nil, nilmap != nil, len(nilmap))
+	delete(nilmap, "foo")
+	println("nilmap:", nilmap["bar"])
 	println(testmapIntInt[2])
 	testmapIntInt[2] = 42
 	println(testmapIntInt[2])

--- a/testdata/map.txt
+++ b/testdata/map.txt
@@ -50,6 +50,7 @@ lookup with comma-ok: eight 8 true
 lookup with comma-ok: nokey 0 false
 false true 2
 true false 0
+nilmap: 0
 4
 42
 4321


### PR DESCRIPTION
The index expression and delete keyword are valid on nil maps, so the runtime must be modified to support this.

This is one of the things necessary for JSON support.