### PR TITLE
machine: remove old comment on volatile behavior

### DIFF
--- a/src/machine/buffer.go
+++ b/src/machine/buffer.go
@@ -8,10 +8,6 @@ const bufferSize = 128
 
 // RingBuffer is ring buffer implementation inspired by post at
 // https://www.embeddedrelated.com/showthread/comp.arch.embedded/77084-1.php
-//
-// It has some limitations currently due to how "volatile" variables that are
-// members of a struct are not compiled correctly by TinyGo.
-// See https://github.com/tinygo-org/tinygo/issues/151 for details.
 type RingBuffer struct {
 	rxbuffer [bufferSize]volatile.Register8
 	head     volatile.Register8


### PR DESCRIPTION
The volatile pragma has long since been replaced by builtins, so this commentis now outdated.

See: https://github.com/tinygo-org/tinygo/issues/151#issuecomment-588023760