### PR TITLE
Do not track const globals

### DIFF
--- a/transform/gc.go
+++ b/transform/gc.go
@@ -271,7 +271,7 @@ func AddGlobalsBitmap(mod llvm.Module) bool {
 	var trackedGlobals []llvm.Value
 	var trackedGlobalTypes []llvm.Type
 	for global := mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
-		if global.IsDeclaration() {
+		if global.IsDeclaration() || global.IsGlobalConstant() {
 			continue
 		}
 		typ := global.Type().ElementType()

--- a/transform/testdata/gc-globals.ll
+++ b/transform/testdata/gc-globals.ll
@@ -4,9 +4,11 @@ target triple = "wasm32-unknown-unknown-wasm"
 %runtime._string = type { i8*, i32 }
 %runtime._interface = type { i32, i8* }
 
-@globalInt = constant i32 5
-@globalString = constant %runtime._string zeroinitializer
-@globalInterface = constant %runtime._interface zeroinitializer
+@globalInt = global i32 5
+@globalString = global %runtime._string zeroinitializer
+@globalInterface = global %runtime._interface zeroinitializer
+@constString = constant %runtime._string zeroinitializer
+@constInterface = constant %runtime._interface zeroinitializer
 @runtime.trackedGlobalsLength = external global i32
 @runtime.trackedGlobalsBitmap = external global [0 x i8]
 @runtime.trackedGlobalsStart = external global i32
@@ -15,6 +17,8 @@ define void @main() {
   %1 = load i32, i32* @globalInt
   %2 = load %runtime._string, %runtime._string* @globalString
   %3 = load %runtime._interface, %runtime._interface* @globalInterface
+  %4 = load %runtime._string, %runtime._string* @constString
+  %5 = load %runtime._interface, %runtime._interface* @constInterface
   ret void
 }
 

--- a/transform/testdata/gc-globals.out.ll
+++ b/transform/testdata/gc-globals.out.ll
@@ -4,7 +4,9 @@ target triple = "wasm32-unknown-unknown-wasm"
 %runtime._string = type { i8*, i32 }
 %runtime._interface = type { i32, i8* }
 
-@globalInt = constant i32 5
+@globalInt = global i32 5
+@constString = constant %runtime._string zeroinitializer
+@constInterface = constant %runtime._interface zeroinitializer
 @runtime.trackedGlobalsLength = global i32 4
 @runtime.trackedGlobalsBitmap = external global [0 x i8]
 @runtime.trackedGlobalsStart = global i32 ptrtoint ({ %runtime._string, %runtime._interface }* @tinygo.trackedGlobals to i32)
@@ -15,6 +17,8 @@ define void @main() {
   %1 = load i32, i32* @globalInt
   %2 = load %runtime._string, %runtime._string* getelementptr inbounds ({ %runtime._string, %runtime._interface }, { %runtime._string, %runtime._interface }* @tinygo.trackedGlobals, i32 0, i32 0)
   %3 = load %runtime._interface, %runtime._interface* getelementptr inbounds ({ %runtime._string, %runtime._interface }, { %runtime._string, %runtime._interface }* @tinygo.trackedGlobals, i32 0, i32 1)
+  %4 = load %runtime._string, %runtime._string* @constString
+  %5 = load %runtime._interface, %runtime._interface* @constInterface
   ret void
 }
 


### PR DESCRIPTION
We are currently tracking constant globals with the garbage collector, which is incorrect behavior. If a value is pointed to by a constant global, then it must either be another global or a constant user-defined address (which is not part of the heap). I discovered this because it was breaking optimizations in #910, and caused a size regression.