### PR TITLE
Warn about unsafe calls to yield

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -56,6 +56,8 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		c.ApplyFunctionSections() // -ffunction-sections
 	}
 
+	c.CheckInvalidYield()
+
 	// Browsers cannot handle external functions that have type i64 because it
 	// cannot be represented exactly in JavaScript (JS only has doubles). To
 	// keep functions interoperable, pass int64 types as pointers to


### PR DESCRIPTION
As I discovered while working on #863 (#912 has additional details), calling `yield` from `sleepTicks` is unsafe due to possible infinite recursion and/or nil pointer dereference, and calling `yield` from `putchar` is unsafe because the latter is called in contexts where the former is not safe to call. In my specific circumstances, calling `yield` from `putchar` meant I did not see panic messages on the console, when panics occurred.

This change adds some call graph analysis that checks if the function(s) of concern, `yield`, is called directly or indirectly by the target functions, `sleepTicks` or `putchar`. This is done by recursively constructing a call graph of all the callees of the target functions and 'coloring' all nodes that can reach a/the function of concern. If `sleepTicks` or `putchar` are colored, there is a path from them to `yield`, and a warning is issued. This algorithm works for arbitrary functions of concern and target functions.

The warnings appear thus:

```
unsafe call to runtime.yield from runtime.sleepTicks: yield may call sleepTicks, which could lead to a stack overflow
       runtime.sleepTicks calls
       runtime.Gosched calls
       runtime.yield
unsafe call to runtime.yield from runtime.putchar: putchar must work in contexts where calling the scheduler is not safe
       runtime.putchar calls
       (*machine.UART).WriteByte calls
       runtime.Gosched calls
       runtime.yield
```