### PR TITLE
main: check for error after starting the OCD daemon

### DIFF
--- a/main.go
+++ b/main.go
@@ -335,7 +335,10 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 			// GDB (to break the currently executing program).
 			setCommandAsDaemon(daemon)
 			// Start now, and kill it on exit.
-			daemon.Start()
+			err = daemon.Start()
+			if err != nil {
+				return &commandError{"failed to run", daemon.Path, err}
+			}
 			defer func() {
 				daemon.Process.Signal(os.Interrupt)
 				// Maybe we should send a .Kill() after x seconds?
@@ -360,7 +363,10 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 			// GDB (to break the currently executing program).
 			setCommandAsDaemon(daemon)
 			// Start now, and kill it on exit.
-			daemon.Start()
+			err = daemon.Start()
+			if err != nil {
+				return &commandError{"failed to run", daemon.Path, err}
+			}
 			defer func() {
 				daemon.Process.Signal(os.Interrupt)
 				// Maybe we should send a .Kill() after x seconds?
@@ -380,7 +386,10 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 			setCommandAsDaemon(daemon)
 
 			// Start now, and kill it on exit.
-			daemon.Start()
+			err = daemon.Start()
+			if err != nil {
+				return &commandError{"failed to run", daemon.Path, err}
+			}
 			defer func() {
 				daemon.Process.Signal(os.Interrupt)
 				// Maybe we should send a .Kill() after x seconds?


### PR DESCRIPTION
This replaces a panic with an informative error message if the right tool (such as OpenOCD) is not installed.