### PR TITLE
main: use gdb-multiarch for debugging Cortex-M chips

### DIFF
--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -24,5 +24,5 @@
 		"src/device/arm/cortexm.s",
 		"src/runtime/scheduler_cortexm.S"
 	],
-	"gdb": "arm-none-eabi-gdb"
+	"gdb": "gdb-multiarch"
 }


### PR DESCRIPTION
Previously this was set to `arm-none-eabi-gdb`, but that has been replaced by `gdb-multiarch` in recent Debian/Ubuntu versions.