### PR TITLE
Makefile: fix LLVM tools detection for wasi-libc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-v0
+            - wasi-libc-sysroot-v1
       - run:
           name: "Build wasi-libc"
-          command: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+          command: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-v0
+          key: wasi-libc-sysroot-v1
           paths:
             - lib/wasi-libc/sysroot
   test-linux:
@@ -266,12 +266,12 @@ commands:
             llvm-build
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-macos-v0
+            - wasi-libc-sysroot-macos-v1
       - run:
           name: "Build wasi-libc"
-          command: make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+          command: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-macos-v0
+          key: wasi-libc-sysroot-macos-v1
           paths:
             - lib/wasi-libc/sysroot
       - run:

--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,25 @@ LLVM_BUILDDIR ?= llvm-build
 CLANG_SRC ?= llvm-project/clang
 LLD_SRC ?= llvm-project/lld
 
-# Default tool selection.
-CLANG ?= clang-9
-
-# Try to autodetect llvm-ar and llvm-nm
-ifneq (, $(shell command -v llvm-ar-9 2> /dev/null))
+# Try to autodetect LLVM build tools.
+ifneq (, $(shell command -v llvm-build/bin/clang 2> /dev/null))
+    CLANG ?= $(abspath llvm-build/bin/clang)
+else
+    CLANG ?= clang-9
+endif
+ifneq (, $(shell command -v llvm-build/bin/llvm-ar 2> /dev/null))
+    LLVM_AR ?= $(abspath llvm-build/bin/llvm-ar)
+else ifneq (, $(shell command -v llvm-ar-9 2> /dev/null))
     LLVM_AR ?= llvm-ar-9
-else ifneq (, $(shell command -v llvm-ar 2> /dev/null))
+else
     LLVM_AR ?= llvm-ar
 endif
-ifneq (, $(shell command -v llvm-nm-9 2> /dev/null))
+ifneq (, $(shell command -v llvm-build/bin/llvm-nm 2> /dev/null))
+    LLVM_NM ?= $(abspath llvm-build/bin/llvm-nm)
+else ifneq (, $(shell command -v llvm-nm-9 2> /dev/null))
     LLVM_NM ?= llvm-nm-9
-else ifneq (, $(shell command -v llvm-nm 2> /dev/null))
+else
     LLVM_NM ?= llvm-nm
-endif
-ifndef LLVM_AR
-    $(warning llvm-ar not found)
-endif
-ifndef LLVM_NM
-    $(warning llvm-nm not found)
 endif
 
 # Go binary and GOROOT to select

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,13 +48,13 @@ jobs:
     - task: CacheBeta@0
       displayName: Cache wasi-libc sysroot
       inputs:
-        key: wasi-libc-sysroot-v0
+        key: wasi-libc-sysroot-v1
         path: lib/wasi-libc/sysroot
     - task: Bash@3
       displayName: Build wasi-libc
       inputs:
         targetType: inline
-        script: PATH=/usr/bin:$PATH make wasi-libc CLANG=$PWD/llvm-build/bin/clang LLVM_AR=$PWD/llvm-build/bin/llvm-ar LLVM_NM=$PWD/llvm-build/bin/llvm-nm
+        script: PATH=/usr/bin:$PATH make wasi-libc
     - task: Bash@3
       displayName: Test TinyGo
       inputs:


### PR DESCRIPTION
This makes the `make wasi-libc` command much more reliable and makes the CI configuration simpler. Also, it avoids warnings when they are not relevant.

Now let's hope CI will accept this.