### PR TITLE
wasm: add runtime.NumCPU

### DIFF
--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -79,3 +79,9 @@ func ticks() timeUnit
 func abort() {
 	trap()
 }
+
+// WebAssembly supports only a single thread (at present)
+//go:export NumCPU()
+func NumCPU() int {
+	return 1
+}


### PR DESCRIPTION
Noticed this function call is missing, and - at least for wasm - it's trivial to implement. :wink: