### PR TITLE
arm: fix linker script

### DIFF
--- a/targets/arm.ld
+++ b/targets/arm.ld
@@ -10,9 +10,9 @@ SECTIONS
     {
         KEEP(*(.isr_vector))
         *(.text)
-        *(.text*)
+        *(.text.*)
         *(.rodata)
-        *(.rodata*)
+        *(.rodata.*)
         . = ALIGN(4);
     } >FLASH_TEXT
 
@@ -35,7 +35,7 @@ SECTIONS
         . = ALIGN(4);
         _sdata = .;        /* used by startup code */
         *(.data)
-        *(.data*)
+        *(.data.*)
         . = ALIGN(4);
         _edata = .;        /* used by startup code */
     } >RAM AT>FLASH_TEXT
@@ -46,7 +46,7 @@ SECTIONS
         . = ALIGN(4);
         _sbss = .;         /* used by startup code */
         *(.bss)
-        *(.bss*)
+        *(.bss.*)
         *(COMMON)
         . = ALIGN(4);
         _ebss = .;         /* used by startup code */


### PR DESCRIPTION
There were a few instances like `.text` and `.text*`. The first was redundant with the second, but the intention was to write `.text.*`.

This doesn't change anything (tested with `make smoketest`) but should avoid propagating this error in the future.

See: https://github.com/tinygo-org/tinygo/pull/863#discussion_r386060173