### PR TITLE
main: improve error reporting while running go test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/tinygo-org/tinygo/compileopts"
-	"github.com/tinygo-org/tinygo/loader"
 )
 
 const TESTDATA = "testdata"
@@ -131,13 +130,7 @@ func runTest(path, target string, t *testing.T) {
 	binary := filepath.Join(tmpdir, "test")
 	err = runBuild("./"+path, binary, config)
 	if err != nil {
-		if errLoader, ok := err.(loader.Errors); ok {
-			for _, err := range errLoader.Errs {
-				t.Log("failed to build:", err)
-			}
-		} else {
-			t.Log("failed to build:", err)
-		}
+		printCompilerError(t.Log, err)
 		t.Fail()
 		return
 	}


### PR DESCRIPTION
This commit switches integration tests to use the same error reporting
mechanism as the tinygo compiler normally uses. It replaces errors like
this:

    main_test.go:139: failed to build: interp: branch on a non-constant

With this:

    main.go:693: # math/rand
    main.go:695: interp: branch on a non-constant

In this particular case the error isn't much better (it gives the
relevant package, though) but other errors should also include the
source location where they happen.