### PR TITLE
Go module support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,4 +354,4 @@ deb: build/release
 	@mkdir -p build/release-deb/usr/local/lib
 	cp -ar build/release/tinygo build/release-deb/usr/local/lib/tinygo
 	ln -sf ../lib/tinygo/bin/tinygo build/release-deb/usr/local/bin/tinygo
-	fpm -f -s dir -t deb -n tinygo -v $(shell grep "version = " version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb
+	fpm -f -s dir -t deb -n tinygo -v $(shell grep "const Version = " goenv/version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb

--- a/builder/config.go
+++ b/builder/config.go
@@ -21,7 +21,7 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if goroot == "" {
 		return nil, errors.New("cannot locate $GOROOT, please set it manually")
 	}
-	major, minor, err := getGorootVersion(goroot)
+	major, minor, err := goenv.GetGorootVersion(goroot)
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}

--- a/builder/env.go
+++ b/builder/env.go
@@ -1,70 +1,12 @@
 package builder
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strings"
 )
-
-// getGorootVersion returns the major and minor version for a given GOROOT path.
-// If the goroot cannot be determined, (0, 0) is returned.
-func getGorootVersion(goroot string) (major, minor int, err error) {
-	s, err := GorootVersionString(goroot)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if s == "" || s[:2] != "go" {
-		return 0, 0, errors.New("could not parse Go version: version does not start with 'go' prefix")
-	}
-
-	parts := strings.Split(s[2:], ".")
-	if len(parts) < 2 {
-		return 0, 0, errors.New("could not parse Go version: version has less than two parts")
-	}
-
-	// Ignore the errors, we don't really handle errors here anyway.
-	var trailing string
-	n, err := fmt.Sscanf(s, "go%d.%d%s", &major, &minor, &trailing)
-	if n == 2 && err == io.EOF {
-		// Means there were no trailing characters (i.e., not an alpha/beta)
-		err = nil
-	}
-	if err != nil {
-		return 0, 0, fmt.Errorf("failed to parse version: %s", err)
-	}
-	return
-}
-
-// GorootVersionString returns the version string as reported by the Go
-// toolchain for the given GOROOT path. It is usually of the form `go1.x.y` but
-// can have some variations (for beta releases, for example).
-func GorootVersionString(goroot string) (string, error) {
-	if data, err := ioutil.ReadFile(filepath.Join(
-		goroot, "src", "runtime", "internal", "sys", "zversion.go")); err == nil {
-
-		r := regexp.MustCompile("const TheVersion = `(.*)`")
-		matches := r.FindSubmatch(data)
-		if len(matches) != 2 {
-			return "", errors.New("Invalid go version output:\n" + string(data))
-		}
-
-		return string(matches[1]), nil
-
-	} else if data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION")); err == nil {
-		return string(data), nil
-
-	} else {
-		return "", err
-	}
-}
 
 // getClangHeaderPath returns the path to the built-in Clang headers. It tries
 // multiple locations, which should make it find the directory when installed in

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -143,7 +143,7 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 	}
 	goroot, err := loader.GetCachedGoroot(c.Config)
 	if err != nil {
-		return c.mod, nil, []error{err}
+		return c.mod, nil, nil, []error{err}
 	}
 	lprogram := &loader.Program{
 		Build: &build.Context{
@@ -156,6 +156,7 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 			Compiler:    "gc", // must be one of the recognized compilers
 			BuildTags:   c.BuildTags(),
 		},
+		Tests: c.TestConfig.CompileTestBinary,
 		TypeChecker: types.Config{
 			Sizes: &stdSizes{
 				IntSize:  int64(c.targetData.TypeAllocSize(c.intType)),
@@ -169,33 +170,17 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 		ClangHeaders: c.ClangHeaders,
 	}
 
-	if strings.HasSuffix(pkgName, ".go") {
-		_, err = lprogram.ImportFile(pkgName)
-		if err != nil {
-			return c.mod, nil, nil, []error{err}
-		}
-	} else {
-		_, err = lprogram.Import(pkgName, wd, token.Position{
-			Filename: "build command-line-arguments",
-		})
-		if err != nil {
-			return c.mod, nil, nil, []error{err}
-		}
-	}
-
-	_, err = lprogram.Import("runtime", "", token.Position{
-		Filename: "build default import",
-	})
+	err = lprogram.Load(pkgName)
 	if err != nil {
 		return c.mod, nil, nil, []error{err}
 	}
 
-	err = lprogram.Parse(c.TestConfig.CompileTestBinary)
+	err = lprogram.Parse()
 	if err != nil {
 		return c.mod, nil, nil, []error{err}
 	}
 
-	c.ir = ir.NewProgram(lprogram, pkgName)
+	c.ir = ir.NewProgram(lprogram)
 
 	// Run a simple dead code elimination pass.
 	err = c.ir.SimpleDCE()
@@ -339,8 +324,11 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 	// Gather the list of (C) file paths that should be included in the build.
 	var extraFiles []string
 	for _, pkg := range c.ir.LoaderProgram.Sorted() {
-		for _, file := range pkg.CFiles {
-			extraFiles = append(extraFiles, filepath.Join(pkg.Package.Dir, file))
+		for _, file := range pkg.OtherFiles {
+			switch strings.ToLower(filepath.Ext(file)) {
+			case ".c":
+				extraFiles = append(extraFiles, file)
+			}
 		}
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -137,63 +137,24 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 	c.funcPtrAddrSpace = dummyFunc.Type().PointerAddressSpace()
 	dummyFunc.EraseFromParentAsFunction()
 
-	// Prefix the GOPATH with the system GOROOT, as GOROOT is already set to
-	// the TinyGo root.
-	overlayGopath := goenv.Get("GOPATH")
-	if overlayGopath == "" {
-		overlayGopath = goenv.Get("GOROOT")
-	} else {
-		overlayGopath = goenv.Get("GOROOT") + string(filepath.ListSeparator) + overlayGopath
-	}
-
 	wd, err := os.Getwd()
 	if err != nil {
 		return c.mod, nil, nil, []error{err}
+	}
+	goroot, err := loader.GetCachedGoroot(c.Config)
+	if err != nil {
+		return c.mod, nil, []error{err}
 	}
 	lprogram := &loader.Program{
 		Build: &build.Context{
 			GOARCH:      c.GOARCH(),
 			GOOS:        c.GOOS(),
-			GOROOT:      goenv.Get("GOROOT"),
+			GOROOT:      goroot,
 			GOPATH:      goenv.Get("GOPATH"),
 			CgoEnabled:  c.CgoEnabled(),
 			UseAllFiles: false,
 			Compiler:    "gc", // must be one of the recognized compilers
 			BuildTags:   c.BuildTags(),
-		},
-		OverlayBuild: &build.Context{
-			GOARCH:      c.GOARCH(),
-			GOOS:        c.GOOS(),
-			GOROOT:      goenv.Get("TINYGOROOT"),
-			GOPATH:      overlayGopath,
-			CgoEnabled:  c.CgoEnabled(),
-			UseAllFiles: false,
-			Compiler:    "gc", // must be one of the recognized compilers
-			BuildTags:   c.BuildTags(),
-		},
-		OverlayPath: func(path string) string {
-			// Return the (overlay) import path when it should be overlaid, and
-			// "" if it should not.
-			if strings.HasPrefix(path, tinygoPath+"/src/") {
-				// Avoid issues with packages that are imported twice, one from
-				// GOPATH and one from TINYGOPATH.
-				path = path[len(tinygoPath+"/src/"):]
-			}
-			switch path {
-			case "machine", "os", "reflect", "runtime", "runtime/interrupt", "runtime/volatile", "sync", "testing", "internal/reflectlite", "internal/bytealg", "internal/task":
-				return path
-			default:
-				if strings.HasPrefix(path, "device/") || strings.HasPrefix(path, "examples/") {
-					return path
-				} else if path == "syscall" {
-					for _, tag := range c.BuildTags() {
-						if tag == "baremetal" || tag == "darwin" {
-							return path
-						}
-					}
-				}
-			}
-			return ""
 		},
 		TypeChecker: types.Config{
 			Sizes: &stdSizes{

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -1,0 +1,64 @@
+package goenv
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// GetGorootVersion returns the major and minor version for a given GOROOT path.
+// If the goroot cannot be determined, (0, 0) is returned.
+func GetGorootVersion(goroot string) (major, minor int, err error) {
+	s, err := GorootVersionString(goroot)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if s == "" || s[:2] != "go" {
+		return 0, 0, errors.New("could not parse Go version: version does not start with 'go' prefix")
+	}
+
+	parts := strings.Split(s[2:], ".")
+	if len(parts) < 2 {
+		return 0, 0, errors.New("could not parse Go version: version has less than two parts")
+	}
+
+	// Ignore the errors, we don't really handle errors here anyway.
+	var trailing string
+	n, err := fmt.Sscanf(s, "go%d.%d%s", &major, &minor, &trailing)
+	if n == 2 && err == io.EOF {
+		// Means there were no trailing characters (i.e., not an alpha/beta)
+		err = nil
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse version: %s", err)
+	}
+	return
+}
+
+// GorootVersionString returns the version string as reported by the Go
+// toolchain for the given GOROOT path. It is usually of the form `go1.x.y` but
+// can have some variations (for beta releases, for example).
+func GorootVersionString(goroot string) (string, error) {
+	if data, err := ioutil.ReadFile(filepath.Join(
+		goroot, "src", "runtime", "internal", "sys", "zversion.go")); err == nil {
+
+		r := regexp.MustCompile("const TheVersion = `(.*)`")
+		matches := r.FindSubmatch(data)
+		if len(matches) != 2 {
+			return "", errors.New("Invalid go version output:\n" + string(data))
+		}
+
+		return string(matches[1]), nil
+
+	} else if data, err := ioutil.ReadFile(filepath.Join(goroot, "VERSION")); err == nil {
+		return string(data), nil
+
+	} else {
+		return "", err
+	}
+}

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 )
 
+// Version of TinyGo.
+// Update this value before release of new version of software.
+const Version = "0.14.0-dev"
+
 // GetGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.
 func GetGorootVersion(goroot string) (major, minor int, err error) {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -63,73 +63,14 @@ const (
 )
 
 // Create and initialize a new *Program from a *ssa.Program.
-func NewProgram(lprogram *loader.Program, mainPath string) *Program {
+func NewProgram(lprogram *loader.Program) *Program {
 	program := lprogram.LoadSSA()
 	program.Build()
 
-	// Find the main package, which is a bit difficult when running a .go file
-	// directly.
-	mainPkg := program.ImportedPackage(mainPath)
-	if mainPkg == nil {
-		for _, pkgInfo := range program.AllPackages() {
-			if pkgInfo.Pkg.Name() == "main" {
-				if mainPkg != nil {
-					panic("more than one main package found")
-				}
-				mainPkg = pkgInfo
-			}
-		}
-	}
+	mainPkg := program.ImportedPackage(lprogram.MainPkg.PkgPath)
 	if mainPkg == nil {
 		panic("could not find main package")
 	}
-
-	// Make a list of packages in import order.
-	packageList := []*ssa.Package{}
-	packageSet := map[string]struct{}{}
-	worklist := []string{"runtime", mainPath}
-	for len(worklist) != 0 {
-		pkgPath := worklist[0]
-		var pkg *ssa.Package
-		if pkgPath == mainPath {
-			pkg = mainPkg // necessary for compiling individual .go files
-		} else {
-			pkg = program.ImportedPackage(pkgPath)
-		}
-		if pkg == nil {
-			// Non-SSA package (e.g. cgo).
-			packageSet[pkgPath] = struct{}{}
-			worklist = worklist[1:]
-			continue
-		}
-		if _, ok := packageSet[pkgPath]; ok {
-			// Package already in the final package list.
-			worklist = worklist[1:]
-			continue
-		}
-
-		unsatisfiedImports := make([]string, 0)
-		imports := pkg.Pkg.Imports()
-		for _, pkg := range imports {
-			if _, ok := packageSet[pkg.Path()]; ok {
-				continue
-			}
-			unsatisfiedImports = append(unsatisfiedImports, pkg.Path())
-		}
-		if len(unsatisfiedImports) == 0 {
-			// All dependencies of this package are satisfied, so add this
-			// package to the list.
-			packageList = append(packageList, pkg)
-			packageSet[pkgPath] = struct{}{}
-			worklist = worklist[1:]
-		} else {
-			// Prepend all dependencies to the worklist and reconsider this
-			// package (by not removing it from the worklist). At that point, it
-			// must be possible to add it to packageList.
-			worklist = append(unsatisfiedImports, worklist...)
-		}
-	}
-
 	p := &Program{
 		Program:       program,
 		LoaderProgram: lprogram,
@@ -137,8 +78,8 @@ func NewProgram(lprogram *loader.Program, mainPath string) *Program {
 		functionMap:   make(map[*ssa.Function]*Function),
 	}
 
-	for _, pkg := range packageList {
-		p.AddPackage(pkg)
+	for _, pkg := range lprogram.Sorted() {
+		p.AddPackage(program.ImportedPackage(pkg.PkgPath))
 	}
 
 	return p

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,10 +1,5 @@
 package loader
 
-import (
-	"go/token"
-	"strings"
-)
-
 // Errors contains a list of parser errors or a list of typechecker errors for
 // the given package.
 type Errors struct {
@@ -14,26 +9,4 @@ type Errors struct {
 
 func (e Errors) Error() string {
 	return "could not compile: " + e.Errs[0].Error()
-}
-
-// ImportCycleErrors is returned when encountering an import cycle. The list of
-// packages is a list from the root package to the leaf package that imports one
-// of the packages in the list.
-type ImportCycleError struct {
-	Packages        []string
-	ImportPositions []token.Position
-}
-
-func (e *ImportCycleError) Error() string {
-	var msg strings.Builder
-	msg.WriteString("import cycle:\n\t")
-	msg.WriteString(strings.Join(e.Packages, "\n\t"))
-	msg.WriteString("\n at ")
-	for i, pos := range e.ImportPositions {
-		if i > 0 {
-			msg.WriteString(", ")
-		}
-		msg.WriteString(pos.String())
-	}
-	return msg.String()
 }

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -1,0 +1,240 @@
+package loader
+
+// This file constructs a new temporary GOROOT directory by merging both the
+// standard Go GOROOT and the GOROOT from TinyGo using symlinks.
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/goenv"
+)
+
+// GetCachedGoroot creates a new GOROOT by merging both the standard GOROOT and
+// the GOROOT from TinyGo using lots of symbolic links.
+func GetCachedGoroot(config *compileopts.Config) (string, error) {
+	goroot := goenv.Get("GOROOT")
+	if goroot == "" {
+		return "", errors.New("could not determine GOROOT")
+	}
+	tinygoroot := goenv.Get("TINYGOROOT")
+	if tinygoroot == "" {
+		return "", errors.New("could not determine TINYGOROOT")
+	}
+
+	// Determine the location of the cached GOROOT.
+	version, err := goenv.GorootVersionString(goroot)
+	if err != nil {
+		return "", err
+	}
+	// This hash is really a cache key, that contains (hopefully) enough
+	// information to make collisions unlikely during development.
+	// By including the Go version and TinyGo version, cache collisions should
+	// not happen outside of development.
+	hash := sha512.New512_256()
+	fmt.Fprintln(hash, goroot)
+	fmt.Fprintln(hash, version)
+	fmt.Fprintln(hash, goenv.Version)
+	fmt.Fprintln(hash, tinygoroot)
+	gorootsHash := hash.Sum(nil)
+	gorootsHashHex := hex.EncodeToString(gorootsHash[:])
+	cachedgoroot := filepath.Join(goenv.Get("GOCACHE"), "goroot-"+version+"-"+gorootsHashHex)
+	if needsSyscallPackage(config.BuildTags()) {
+		cachedgoroot += "-syscall"
+	}
+
+	if _, err := os.Stat(cachedgoroot); err == nil {
+		return cachedgoroot, nil
+	}
+	tmpgoroot := cachedgoroot + ".tmp" + strconv.Itoa(rand.Int())
+	err = os.MkdirAll(tmpgoroot, 0777)
+	if err != nil {
+		return "", err
+	}
+
+	// Remove the temporary directory if it wasn't moved to the right place
+	// (for example, when there was an error).
+	defer os.RemoveAll(tmpgoroot)
+
+	for _, name := range []string{"bin", "lib", "pkg"} {
+		err = symlink(filepath.Join(goroot, name), filepath.Join(tmpgoroot, name))
+		if err != nil {
+			return "", err
+		}
+	}
+	err = mergeDirectory(goroot, tinygoroot, tmpgoroot, "", pathsToOverride(needsSyscallPackage(config.BuildTags())))
+	if err != nil {
+		return "", err
+	}
+	err = os.Rename(tmpgoroot, cachedgoroot)
+	if err != nil {
+		if os.IsExist(err) {
+			// Another invocation of TinyGo also seems to have created a GOROOT.
+			// Use that one instead. Our new GOROOT will be automatically
+			// deleted by the defer above.
+			return cachedgoroot, nil
+		}
+		return "", err
+	}
+	return cachedgoroot, nil
+}
+
+// mergeDirectory merges two roots recursively. The tmpgoroot is the directory
+// that will be created by this call by either symlinking the directory from
+// goroot or tinygoroot, or by creating the directory and merging the contents.
+func mergeDirectory(goroot, tinygoroot, tmpgoroot, importPath string, overrides map[string]bool) error {
+	if mergeSubdirs, ok := overrides[importPath+"/"]; ok {
+		if !mergeSubdirs {
+			// This directory and all subdirectories should come from the TinyGo
+			// root, so simply make a symlink.
+			newname := filepath.Join(tmpgoroot, "src", importPath)
+			oldname := filepath.Join(tinygoroot, "src", importPath)
+			return symlink(oldname, newname)
+		}
+
+		// Merge subdirectories. Start by making the directory to merge.
+		err := os.Mkdir(filepath.Join(tmpgoroot, "src", importPath), 0777)
+		if err != nil {
+			return err
+		}
+
+		// Symlink all files from TinyGo, and symlink directories from TinyGo
+		// that need to be overridden.
+		tinygoEntries, err := ioutil.ReadDir(filepath.Join(tinygoroot, "src", importPath))
+		if err != nil {
+			return err
+		}
+		for _, e := range tinygoEntries {
+			if e.IsDir() {
+				// A directory, so merge this thing.
+				err := mergeDirectory(goroot, tinygoroot, tmpgoroot, path.Join(importPath, e.Name()), overrides)
+				if err != nil {
+					return err
+				}
+			} else {
+				// A file, so symlink this.
+				newname := filepath.Join(tmpgoroot, "src", importPath, e.Name())
+				oldname := filepath.Join(tinygoroot, "src", importPath, e.Name())
+				err := symlink(oldname, newname)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Symlink all directories from $GOROOT that are not part of the TinyGo
+		// overrides.
+		gorootEntries, err := ioutil.ReadDir(filepath.Join(goroot, "src", importPath))
+		if err != nil {
+			return err
+		}
+		for _, e := range gorootEntries {
+			if !e.IsDir() {
+				// Don't merge in files from Go. Otherwise we'd end up with a
+				// weird syscall package with files from both roots.
+				continue
+			}
+			if _, ok := overrides[path.Join(importPath, e.Name())+"/"]; ok {
+				// Already included above, so don't bother trying to create this
+				// symlink.
+				continue
+			}
+			newname := filepath.Join(tmpgoroot, "src", importPath, e.Name())
+			oldname := filepath.Join(goroot, "src", importPath, e.Name())
+			err := symlink(oldname, newname)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// needsSyscallPackage returns whether the syscall package should be overriden
+// with the TinyGo version. This is the case on some targets.
+func needsSyscallPackage(buildTags []string) bool {
+	for _, tag := range buildTags {
+		if tag == "baremetal" || tag == "darwin" {
+			return true
+		}
+	}
+	return false
+}
+
+// The boolean indicates whether to merge the subdirs. True means merge, false
+// means use the TinyGo version.
+func pathsToOverride(needsSyscallPackage bool) map[string]bool {
+	paths := map[string]bool{
+		"/":                     true,
+		"device/":               false,
+		"examples/":             false,
+		"internal/":             true,
+		"internal/bytealg/":     false,
+		"internal/reflectlite/": false,
+		"internal/task/":        false,
+		"machine/":              false,
+		"os/":                   true,
+		"reflect/":              false,
+		"runtime/":              false,
+		"sync/":                 true,
+		"testing/":              false,
+	}
+	if needsSyscallPackage {
+		paths["syscall/"] = true // include syscall/js
+	}
+	return paths
+}
+
+// symlink creates a symlink or something similar. On Unix-like systems, it
+// always creates a symlink. On Windows, it tries to create a symlink and if
+// that fails, creates a hardlink or directory junction instead.
+//
+// Note that while Windows 10 does support symlinks and allows them to be
+// created using os.Symlink, it requires developer mode to be enabled.
+// Therefore provide a fallback for when symlinking is not possible.
+// Unfortunately this fallback only works when TinyGo is installed on the same
+// filesystem as the TinyGo cache and the Go installation (which is usually the
+// C drive).
+func symlink(oldname, newname string) error {
+	symlinkErr := os.Symlink(oldname, newname)
+	if runtime.GOOS == "windows" && symlinkErr != nil {
+		// Fallback for when developer mode is disabled.
+		// Note that we return the symlink error even if something else fails
+		// later on. This is because symlinks are the easiest to support
+		// (they're also used on Linux and MacOS) and enabling them is easy:
+		// just enable developer mode.
+		st, err := os.Stat(oldname)
+		if err != nil {
+			return symlinkErr
+		}
+		if st.IsDir() {
+			// Make a directory junction. There may be a way to do this
+			// programmatically, but it involves a lot of magic. Use the mklink
+			// command built into cmd instead (mklink is a builtin, not an
+			// external command).
+			err := exec.Command("cmd", "/k", "mklink", "/J", newname, oldname).Run()
+			if err != nil {
+				return symlinkErr
+			}
+		} else {
+			// Make a hard link.
+			err := os.Link(oldname, newname)
+			if err != nil {
+				return symlinkErr
+			}
+		}
+		return nil // success
+	}
+	return symlinkErr
+}

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func Build(pkgName, outpath string, options *compileopts.Options) error {
 
 // Test runs the tests in the given package.
 func Test(pkgName string, options *compileopts.Options) error {
+	options.TestConfig.CompileTestBinary = true
 	config, err := builder.NewConfig(options)
 	if err != nil {
 		return err
@@ -135,7 +136,6 @@ func Test(pkgName string, options *compileopts.Options) error {
 	// For details: https://github.com/golang/go/issues/21360
 	config.Target.BuildTags = append(config.Target.BuildTags, "test")
 
-	options.TestConfig.CompileTestBinary = true
 	return builder.Build(pkgName, ".elf", config, func(tmppath string) error {
 		cmd := exec.Command(tmppath)
 		cmd.Stdout = os.Stdout

--- a/main.go
+++ b/main.go
@@ -733,7 +733,7 @@ func printCompilerError(logln func(...interface{}), err error) {
 			}
 		}
 	case loader.Errors:
-		logln("#", err.Pkg.ImportPath)
+		logln("#", err.Pkg.PkgPath)
 		for _, err := range err.Errs {
 			printCompilerError(logln, err)
 		}

--- a/main.go
+++ b/main.go
@@ -897,7 +897,7 @@ func main() {
 		usage()
 	case "version":
 		goversion := "<unknown>"
-		if s, err := builder.GorootVersionString(goenv.Get("GOROOT")); err == nil {
+		if s, err := goenv.GorootVersionString(goenv.Get("GOROOT")); err == nil {
 			goversion = s
 		}
 		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)

--- a/main.go
+++ b/main.go
@@ -632,7 +632,7 @@ func getDefaultPort() (port string, err error) {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "TinyGo is a Go compiler for small places.")
-	fmt.Fprintln(os.Stderr, "version:", version)
+	fmt.Fprintln(os.Stderr, "version:", goenv.Version)
 	fmt.Fprintf(os.Stderr, "usage: %s command [-printir] [-target=<target>] -o <output> <input>\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "\ncommands:")
 	fmt.Fprintln(os.Stderr, "  build: compile packages and dependencies")
@@ -900,7 +900,7 @@ func main() {
 		if s, err := goenv.GorootVersionString(goenv.Get("GOROOT")); err == nil {
 			goversion = s
 		}
-		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
 	case "env":
 		if flag.NArg() == 0 {
 			// Show all environment variables.

--- a/main_test.go
+++ b/main_test.go
@@ -73,7 +73,7 @@ func TestCompiler(t *testing.T) {
 		t.Run("ARM64Linux", func(t *testing.T) {
 			runPlatTests("aarch64--linux-gnu", matches, t)
 		})
-		goVersion, err := builder.GorootVersionString(goenv.Get("GOROOT"))
+		goVersion, err := goenv.GorootVersionString(goenv.Get("GOROOT"))
 		if err != nil {
 			t.Error("could not get Go version:", err)
 			return

--- a/version.go
+++ b/version.go
@@ -1,5 +1,0 @@
-package main
-
-// version of this package.
-// Update this value before release of new version of software.
-const version = "0.14.0-dev"


### PR DESCRIPTION
This is more of a mockup than anything serious. I want to see whether creating a new GOROOT per build is feasible. Right now creating such a GOROOT costs about 4ms on my system (after a warmed-up cache) so is not a significant overhead per build.

I'm not sure whether the current approach (with symlinks) is going to be viable on Windows.

The first commit adds the `go list` command, which might be enough to support TinyGo in IDEs such as VS Code.