### PR TITLE
cgo: make -I and -L paths absolute

### DIFF
--- a/cgo/testdata/flags.go
+++ b/cgo/testdata/flags.go
@@ -9,6 +9,9 @@ package main
 
 #cgo CFLAGS: -DFOO
 
+#cgo CFLAGS: -Iinclude
+#include "foo.h"
+
 #if defined(FOO)
 #define BAR 3
 #else
@@ -23,4 +26,5 @@ import "C"
 
 var (
 	_ = C.BAR
+	_ = C.FOO_H
 )

--- a/cgo/testdata/flags.out.go
+++ b/cgo/testdata/flags.out.go
@@ -9,6 +9,7 @@ import "unsafe"
 var _ unsafe.Pointer
 
 const C.BAR = 3
+const C.FOO_H = 1
 
 type C.int16_t = int16
 type C.int32_t = int32

--- a/cgo/testdata/include/foo.h
+++ b/cgo/testdata/include/foo.h
@@ -1,0 +1,1 @@
+#define FOO_H 1


### PR DESCRIPTION
This is very useful for (conditionally) adding extra include paths relative to the package path.