### PR TITLE
WIP: pybd-sf2: add the Pyboard D series SF2 variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=stm32f4disco        examples/blinky2
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pybd-sf2            examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-bluefruit examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/i2s

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following 28 microcontroller boards are currently supported:
 * [Digispark](http://digistump.com/products/1)
 * [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
 * [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
+* [MicroPython Pyboard D series SF2](https://store.micropython.org/product/PYBD-SF2-W4F2)
 * [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF51-Dongle)
 * [Nordic Semiconductor PCA10040](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52-DK)
 * [Nordic Semiconductor PCA10056](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)

--- a/src/machine/board_pybd-sf2.go
+++ b/src/machine/board_pybd-sf2.go
@@ -1,0 +1,13 @@
+// +build pybd_sf2
+
+package machine
+
+const (
+	LED_RED   = PF3
+	LED_GREEN = PF4
+	LED_BLUE  = PF5
+	LED1      = LED_RED
+	LED2      = LED_GREEN
+	LED3      = LED_BLUE
+	LED       = LED1
+)

--- a/src/machine/board_stm32.go
+++ b/src/machine/board_stm32.go
@@ -1,4 +1,4 @@
-// +build bluepill nucleof103rb stm32f4disco
+// +build stm32 bluepill nucleof103rb stm32f4disco
 
 package machine
 

--- a/src/machine/board_stm32f7x2.go
+++ b/src/machine/board_stm32f7x2.go
@@ -1,0 +1,139 @@
+// +build stm32f7x2
+
+package machine
+
+const (
+	PA0  = portA + 0
+	PA1  = portA + 1
+	PA2  = portA + 2
+	PA3  = portA + 3
+	PA4  = portA + 4
+	PA5  = portA + 5
+	PA6  = portA + 6
+	PA7  = portA + 7
+	PA8  = portA + 8
+	PA9  = portA + 9
+	PA10 = portA + 10
+	PA11 = portA + 11
+	PA12 = portA + 12
+	PA13 = portA + 13
+	PA14 = portA + 14
+	PA15 = portA + 15
+
+	PB0  = portB + 0
+	PB1  = portB + 1
+	PB2  = portB + 2
+	PB3  = portB + 3
+	PB4  = portB + 4
+	PB5  = portB + 5
+	PB6  = portB + 6
+	PB7  = portB + 7
+	PB8  = portB + 8
+	PB9  = portB + 9
+	PB10 = portB + 10
+	PB11 = portB + 11
+	PB12 = portB + 12
+	PB13 = portB + 13
+	PB14 = portB + 14
+	PB15 = portB + 15
+
+	PC0  = portC + 0
+	PC1  = portC + 1
+	PC2  = portC + 2
+	PC3  = portC + 3
+	PC4  = portC + 4
+	PC5  = portC + 5
+	PC6  = portC + 6
+	PC7  = portC + 7
+	PC8  = portC + 8
+	PC9  = portC + 9
+	PC10 = portC + 10
+	PC11 = portC + 11
+	PC12 = portC + 12
+	PC13 = portC + 13
+	PC14 = portC + 14
+	PC15 = portC + 15
+
+	PD0  = portD + 0
+	PD1  = portD + 1
+	PD2  = portD + 2
+	PD3  = portD + 3
+	PD4  = portD + 4
+	PD5  = portD + 5
+	PD6  = portD + 6
+	PD7  = portD + 7
+	PD8  = portD + 8
+	PD9  = portD + 9
+	PD10 = portD + 10
+	PD11 = portD + 11
+	PD12 = portD + 12
+	PD13 = portD + 13
+	PD14 = portD + 14
+	PD15 = portD + 15
+
+	PE0  = portE + 0
+	PE1  = portE + 1
+	PE2  = portE + 2
+	PE3  = portE + 3
+	PE4  = portE + 4
+	PE5  = portE + 5
+	PE6  = portE + 6
+	PE7  = portE + 7
+	PE8  = portE + 8
+	PE9  = portE + 9
+	PE10 = portE + 10
+	PE11 = portE + 11
+	PE12 = portE + 12
+	PE13 = portE + 13
+	PE14 = portE + 14
+	PE15 = portE + 15
+
+	PF0  = portF + 0
+	PF1  = portF + 1
+	PF2  = portF + 2
+	PF3  = portF + 3
+	PF4  = portF + 4
+	PF5  = portF + 5
+	PF6  = portF + 6
+	PF7  = portF + 7
+	PF8  = portF + 8
+	PF9  = portF + 9
+	PF10 = portF + 10
+	PF11 = portF + 11
+	PF12 = portF + 12
+	PF13 = portF + 13
+	PF14 = portF + 14
+	PF15 = portF + 15
+
+	PG0  = portG + 0
+	PG1  = portG + 1
+	PG2  = portG + 2
+	PG3  = portG + 3
+	PG4  = portG + 4
+	PG5  = portG + 5
+	PG6  = portG + 6
+	PG7  = portG + 7
+	PG8  = portG + 8
+	PG9  = portG + 9
+	PG10 = portG + 10
+	PG11 = portG + 11
+	PG12 = portG + 12
+	PG13 = portG + 13
+	PG14 = portG + 14
+	PG15 = portG + 15
+
+	PH2  = portH + 2
+	PH3  = portH + 3
+	PH4  = portH + 4
+	PH5  = portH + 5
+	PH6  = portH + 6
+	PH7  = portH + 7
+	PH8  = portH + 8
+	PH9  = portH + 9
+	PH10 = portH + 10
+	PH11 = portH + 11
+	PH12 = portH + 12
+	PH13 = portH + 13
+	PH14 = portH + 14
+	PH15 = portH + 15
+)

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf sam stm32,!stm32f4disco
+// +build avr nrf sam stm32,!stm32f4disco,!stm32f7x2
 
 package machine
 

--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -1,0 +1,75 @@
+// +build stm32f7x2
+
+package machine
+
+import "device/stm32"
+
+func (p Pin) getPort() *stm32.GPIO_Type {
+	switch p / 16 {
+	case 0:
+		return stm32.GPIOA
+	case 1:
+		return stm32.GPIOB
+	case 2:
+		return stm32.GPIOC
+	case 3:
+		return stm32.GPIOD
+	case 4:
+		return stm32.GPIOE
+	case 5:
+		return stm32.GPIOF
+	case 6:
+		return stm32.GPIOG
+	case 7:
+		return stm32.GPIOH
+	case 8:
+		return stm32.GPIOI
+	default:
+		panic("machine: unknown port")
+	}
+}
+
+// enableClock enables the clock for this desired GPIO port.
+func (p Pin) enableClock() {
+	switch p / 16 {
+	case 0:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOAEN)
+	case 1:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOBEN)
+	case 2:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOCEN)
+	case 3:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIODEN)
+	case 4:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOEEN)
+	case 5:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOFEN)
+	case 6:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOGEN)
+	case 7:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOHEN)
+	case 8:
+		stm32.RCC.AHB1ENR.SetBits(stm32.RCC_AHB1ENR_GPIOIEN)
+	default:
+		panic("machine: unknown port")
+	}
+}
+
+type UART struct {
+	Buffer          *RingBuffer
+	Bus             *stm32.USART_Type
+	AltFuncSelector stm32.AltFunc
+}
+
+var (
+//UART2 = UART{
+//	Buffer:          NewRingBuffer(),
+//	Bus:             stm32.USART2,
+//	AltFuncSelector: stm32.AF7_USART1_2_3,
+//}
+)
+
+func (uart UART) WriteByte(b byte) error {
+	// TODO: implement.
+	return nil
+}

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build !baremetal sam stm32,!stm32f407 fe310
+// +build !baremetal sam stm32,!stm32f407,!stm32f7x2 fe310
 
 package machine
 

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -1,0 +1,34 @@
+// +build stm32,stm32f7x2
+
+package runtime
+
+const tickMicros = 1000
+
+var (
+	// tick in milliseconds
+	tickCount timeUnit
+)
+
+func init() {
+	//initCLK()
+	//initTIM3()
+	//machine.UART2.Configure(machine.UARTConfig{})
+	//initTIM7()
+}
+
+func putchar(c byte) {
+	//machine.UART2.WriteByte(c)
+}
+
+const asyncScheduler = false
+
+// sleepTicks should sleep for specific number of microseconds.
+func sleepTicks(d timeUnit) {
+	//timerSleep(uint32(d))
+}
+
+// number of ticks (microseconds) since start.
+func ticks() timeUnit {
+	// milliseconds to microseconds
+	return tickCount * 1000
+}

--- a/targets/pybd-sf2.json
+++ b/targets/pybd-sf2.json
@@ -1,0 +1,5 @@
+{
+    "inherits": ["stm32f7x2"],
+    "build-tags": ["pybd_sf2"],
+    "linkerscript": "targets/pybd-sf2.ld"
+}

--- a/targets/pybd-sf2.ld
+++ b/targets/pybd-sf2.ld
@@ -1,0 +1,10 @@
+MEMORY
+{
+    /* Note: the bootloader lives in the first two sectors (32K) of flash). */
+    FLASH_TEXT (rw) : ORIGIN = 0x08008000, LENGTH = 480K /* Sector 2-7 */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 256K /* DTCM + SRAM1 + SRAM2 */
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/arm.ld"

--- a/targets/stm32f7x2.json
+++ b/targets/stm32f7x2.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["cortex-m"],
+    "llvm-target": "armv7em-none-eabi",
+    "build-tags": ["stm32f7x2", "stm32"],
+    "cflags": [
+        "--target=armv7em-none-eabi",
+        "-Qunused-arguments"
+    ],
+    "extra-files": [
+        "src/device/stm32/stm32f7x2.s"
+    ]
+}


### PR DESCRIPTION
Product page: https://store.micropython.org/product/PYBD-SF2-W4F2

Definitely not finished: blinky1 doesn't even work correctly (it only seems to turn on the red LED). If you want to use it, first [put the device in DFU mode](http://micropython.org/download). Then run the following commands (assuming the MicroPython repository was cloned in ~/src/micropython):

```
tinygo build -o test.elf -target=pybd-sf2 -size=short examples/blinky1
arm-none-eabi-objcopy -O binary test.elf test.bin
~/src/micropython/tools/dfu.py -b 0x08008000:test.bin test.dfu
~/src/micropython/tools/pydfu.py -u test.dfu
```

EDIT: forgot to mark this PR as a draft.