### PR TITLE
runtime: fix channels on AVR

### DIFF
--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -50,6 +50,11 @@ func slicePanic() {
 	runtimePanic("slice out of range")
 }
 
+// Panic when trying to create a new channel that is too big.
+func chanMakePanic() {
+	runtimePanic("new channel is too big")
+}
+
 func blockingPanic() {
 	runtimePanic("trying to do blocking operation in exported function")
 }

--- a/testdata/channel.go
+++ b/testdata/channel.go
@@ -54,6 +54,16 @@ func main() {
 	n, ok = <-ch
 	println("recv from closed channel:", n, ok)
 
+	// Test various channel size types.
+	_ = make(chan int, int8(2))
+	_ = make(chan int, int16(2))
+	_ = make(chan int, int32(2))
+	_ = make(chan int, int64(2))
+	_ = make(chan int, uint8(2))
+	_ = make(chan int, uint16(2))
+	_ = make(chan int, uint32(2))
+	_ = make(chan int, uint64(2))
+
 	// Test bigger values
 	ch2 := make(chan complex128)
 	wg.add(1)


### PR DESCRIPTION
This commit makes channel code compilable on AVR, for when goroutines are supported on that platform. I have in fact managed to get initial support for channels working with this patch on a local branch that adds support for the stack-based scheduler.