### PR TITLE
runtime: return the correct type from the copy builtin

### DIFF
--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -42,12 +42,12 @@ func sliceAppend(srcBuf, elemsBuf unsafe.Pointer, srcLen, srcCap, elemsLen uintp
 }
 
 // Builtin copy(dst, src) function: copy bytes from dst to src.
-func sliceCopy(dst, src unsafe.Pointer, dstLen, srcLen uintptr, elemSize uintptr) uintptr {
+func sliceCopy(dst, src unsafe.Pointer, dstLen, srcLen uintptr, elemSize uintptr) int {
 	// n = min(srcLen, dstLen)
 	n := srcLen
 	if n > dstLen {
 		n = dstLen
 	}
 	memmove(dst, src, n*elemSize)
-	return n
+	return int(n)
 }


### PR DESCRIPTION
The copy builtin is defined as follows by the Go language spec:

    copy(dst, src []T) int
    copy(dst []byte, src string) int

In other words, it returns an `int`. The `runtime.sliceCopy` compiler intrinsic returned a `uintptr` instead, which led to a problem while compiling the strings package for AVR.

No other architecture should be affected by this change as the conversion from an `uintptr` to an `int` is a no-op on most architectures.