### PR TITLE
ci: move Go version tests to buster containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
       - run:
           name: "Install apt dependencies"
           command: |
-            echo 'deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch<<parameters.llvm>> main' | sudo tee /etc/apt/sources.list.d/llvm.list
+            echo 'deb https://apt.llvm.org/buster/ llvm-toolchain-buster<<parameters.llvm>> main' | sudo tee /etc/apt/sources.list.d/llvm.list
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
             sudo apt-get update
             sudo apt-get install \
@@ -308,17 +308,17 @@ commands:
 jobs:
   test-llvm9-go111:
     docker:
-      - image: circleci/golang:1.11-stretch
+      - image: circleci/golang:1.11-buster
     steps:
       - test-linux
   test-llvm9-go112:
     docker:
-      - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.12-buster
     steps:
       - test-linux
   test-llvm9-go113:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.13-buster
     steps:
       - test-linux
   assert-test-linux:


### PR DESCRIPTION
This fixes an error like the following:

    E: The method driver /usr/lib/apt/methods/https could not be found.
    N: Is the package apt-transport-https installed?

Apparently apt.llvm.org has been switched over to HTTPS. One solution could be to install apt-transport-https, but another (easier) solution is to switch to a newer container.

Note: I did not switch the other containers, to make sure TinyGo is still built with an older Debian release. That ensures the resulting binaries are relatively portable across distros, even relatively old distros.