### PR TITLE
Makefile: allow overriding the llvm-project directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ all: tinygo
 
 # Default build and source directories, as created by `make llvm-build`.
 LLVM_BUILDDIR ?= llvm-build
-CLANG_SRC ?= llvm-project/clang
-LLD_SRC ?= llvm-project/lld
+LLVM_PROJECTDIR ?= llvm-project
+CLANG_SRC ?= $(LLVM_PROJECTDIR)/clang
+LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
 # Try to autodetect LLVM build tools.
 ifneq (, $(shell command -v llvm-build/bin/clang 2> /dev/null))
@@ -146,14 +147,14 @@ gen-device-stm32: build/gen-device-svd
 
 
 # Get LLVM sources.
-llvm-project/README.md:
-	git clone -b release/9.x https://github.com/llvm/llvm-project
-llvm-source: llvm-project/README.md
+$(LLVM_PROJECTDIR)/README.md:
+	git clone -b release/9.x https://github.com/llvm/llvm-project $(LLVM_PROJECTDIR)
+llvm-source: $(LLVM_PROJECTDIR)/README.md
 
 # Configure LLVM.
 TINYGO_SOURCE_DIR=$(shell pwd)
 $(LLVM_BUILDDIR)/build.ninja: llvm-source
-	mkdir -p $(LLVM_BUILDDIR); cd $(LLVM_BUILDDIR); cmake -G Ninja $(TINYGO_SOURCE_DIR)/llvm-project/llvm "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;RISCV;WebAssembly" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR" -DCMAKE_BUILD_TYPE=Release -DLIBCLANG_BUILD_STATIC=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF $(LLVM_OPTION)
+	mkdir -p $(LLVM_BUILDDIR); cd $(LLVM_BUILDDIR); cmake -G Ninja $(TINYGO_SOURCE_DIR)/$(LLVM_PROJECTDIR)/llvm "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;RISCV;WebAssembly" "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=AVR" -DCMAKE_BUILD_TYPE=Release -DLIBCLANG_BUILD_STATIC=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_TOOL_CLANG_TOOLS_EXTRA_BUILD=OFF $(LLVM_OPTION)
 
 # Build LLVM.
 $(LLVM_BUILDDIR): $(LLVM_BUILDDIR)/build.ninja


### PR DESCRIPTION
This allows setting a different directory for experimental changes. For example, I also have a llvm-project.master directory that tracks the master branch. It is very useful to be able to temporarily use that directory:

    make llvm-build.master LLVM_BUILDDIR=llvm-build.master LLVM_PROJECT=llvm-project.master