### PR TITLE
docker: use git submodule sync to fix broken docker dev build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY . /tinygo
 # after copying the tinygo directory in the previous step.
 RUN cd /tinygo/ && \
     rm -rf ./lib/* && \
+    git submodule sync && \
     git submodule update --init --recursive --force
 
 RUN cd /tinygo/ && \


### PR DESCRIPTION
This PR adds the use of the `git submodule sync` command in the docker dev build to handle case where repo url changes, which fixes the broken dockerhub builds:

https://hub.docker.com/repository/registry-1.docker.io/tinygo/tinygo-dev/builds/2c37af2e-b3c7-4718-bb87-fe145312ad44 