### PR TITLE
refactor stm32 UART code

### DIFF
--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -2,6 +2,11 @@
 
 package machine
 
+import (
+	"device/stm32"
+	"runtime/interrupt"
+)
+
 const (
 	PA0  = portA + 0
 	PA1  = portA + 1
@@ -110,3 +115,17 @@ const (
 	UART_TX_PIN = PA2
 	UART_RX_PIN = PA3
 )
+
+var (
+	UART0 = UART{
+		Buffer:          NewRingBuffer(),
+		Bus:             stm32.USART2,
+		AltFuncSelector: stm32.AF7_USART1_2_3,
+	}
+	UART1 = &UART0
+)
+
+// set up RX IRQ handler. Follow similar pattern for other UARTx instances
+func init() {
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+}

--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -82,7 +82,7 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc stm32.AltFunc) {
 		port.PUPDR.ReplaceBits(stm32.GPIOPUPDRFloating, 0x3, pos)
 		p.SetAltFunc(altFunc)
 
-	// I2C)
+	// I2C
 	case PinModeI2CSCL:
 		port.MODER.ReplaceBits(stm32.GPIOModeOutputAltFunc, 0x3, pos)
 		port.OTYPER.ReplaceBits(stm32.GPIOOutputTypeOpenDrain, 0x1, pos)

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -1,0 +1,62 @@
+// +build stm32
+
+package machine
+
+// Peripheral abstraction layer for UARTs on the stm32 family.
+
+import (
+	"device/stm32"
+	"runtime/interrupt"
+	"unsafe"
+)
+
+// Configure the UART.
+func (uart UART) Configure(config UARTConfig) {
+	// Default baud rate to 115200.
+	if config.BaudRate == 0 {
+		config.BaudRate = 115200
+	}
+
+	// Set the GPIO pins to defaults if they're not set
+	if config.TX == 0 && config.RX == 0 {
+		config.TX = UART_TX_PIN
+		config.RX = UART_RX_PIN
+	}
+
+	// Enable USART clock
+	enableAltFuncClock(unsafe.Pointer(uart.Bus))
+
+	uart.configurePins(config)
+
+	// Set baud rate
+	uart.SetBaudRate(config.BaudRate)
+
+	// Enable USART port, tx, rx and rx interrupts
+	uart.Bus.CR1.Set(stm32.USART_CR1_TE | stm32.USART_CR1_RE | stm32.USART_CR1_RXNEIE | stm32.USART_CR1_UE)
+
+	// Enable RX IRQ
+	uart.Interrupt.SetPriority(0xc0)
+	uart.Interrupt.Enable()
+}
+
+// handleInterrupt should be called from the appropriate interrupt handler for
+// this UART instance.
+func (uart *UART) handleInterrupt(interrupt.Interrupt) {
+	uart.Receive(byte((uart.Bus.DR.Get() & 0xFF)))
+}
+
+// SetBaudRate sets the communication speed for the UART. Defer to chip-specific
+// routines for calculation
+func (uart UART) SetBaudRate(br uint32) {
+	divider := uart.getBaudRateDivisor(br)
+	uart.Bus.BRR.Set(divider)
+}
+
+// WriteByte writes a byte of data to the UART.
+func (uart UART) WriteByte(c byte) error {
+	uart.Bus.DR.Set(uint32(c))
+
+	for !uart.Bus.SR.HasBits(stm32.USART_SR_TXE) {
+	}
+	return nil
+}


### PR DESCRIPTION
Step 2 of #777 : UART code cleanup

Moving the common parts of the STM32F1xx and STM32F4xx UART setup into a separate file, and simplifying the chip-specific pieces.