### PR TITLE
riscv: switch to tasks-based scheduler

### DIFF
--- a/src/internal/task/task_stack_tinygoriscv.go
+++ b/src/internal/task/task_stack_tinygoriscv.go
@@ -1,0 +1,88 @@
+// +build scheduler.tasks,tinygo.riscv
+
+package task
+
+import "unsafe"
+
+const stackSize = 1024
+
+// calleeSavedRegs is the list of registers that must be saved and restored when
+// switching between tasks. Also see scheduler_riscv.S that relies on the
+// exact layout of this struct.
+type calleeSavedRegs struct {
+	s0  uintptr // x8 (fp)
+	s1  uintptr // x9
+	s2  uintptr // x18
+	s3  uintptr // x19
+	s4  uintptr // x20
+	s5  uintptr // x21
+	s6  uintptr // x22
+	s7  uintptr // x23
+	s8  uintptr // x24
+	s9  uintptr // x25
+	s10 uintptr // x26
+	s11 uintptr // x27
+
+	pc uintptr
+}
+
+// registers gets a pointer to the registers stored at the top of the stack.
+func (s *state) registers() *calleeSavedRegs {
+	return (*calleeSavedRegs)(unsafe.Pointer(s.sp))
+}
+
+// startTask is a small wrapper function that sets up the first (and only)
+// argument to the new goroutine and makes sure it is exited when the goroutine
+// finishes.
+//go:extern tinygo_startTask
+var startTask [0]uint8
+
+// archInit runs architecture-specific setup for the goroutine startup.
+func (s *state) archInit(stack []uintptr, fn uintptr, args unsafe.Pointer) {
+	// Set up the stack canary, a random number that should be checked when
+	// switching from the task back to the scheduler. The stack canary pointer
+	// points to the first word of the stack. If it has changed between now and
+	// the next stack switch, there was a stack overflow.
+	s.canaryPtr = &stack[0]
+	*s.canaryPtr = stackCanary
+
+	// Store the initial sp for the startTask function (implemented in assembly).
+	s.sp = uintptr(unsafe.Pointer(&stack[uintptr(len(stack))-(unsafe.Sizeof(calleeSavedRegs{})/unsafe.Sizeof(uintptr(0)))]))
+
+	// Initialize the registers.
+	// These will be popped off of the stack on the first resume of the goroutine.
+	r := s.registers()
+
+	// Start the function at tinygo_startTask (defined in scheduler_riscv.S).
+	// This assembly code calls a function (passed in s0) with a single argument
+	// (passed in s1). After the function returns, it calls Pause().
+	r.pc = uintptr(unsafe.Pointer(&startTask))
+
+	// Pass the function to call in s0.
+	// This function is a compiler-generated wrapper which loads arguments out
+	// of a struct pointer. See createGoroutineStartWrapper (defined in
+	// compiler/goroutine.go) for more information.
+	r.s0 = fn
+
+	// Pass the pointer to the arguments struct in s1.
+	r.s1 = uintptr(args)
+}
+
+func (s *state) resume() {
+	switchToTask(s.sp)
+}
+
+//export tinygo_switchToTask
+func switchToTask(uintptr)
+
+//export tinygo_switchToScheduler
+func switchToScheduler(*uintptr)
+
+func (s *state) pause() {
+	switchToScheduler(&s.sp)
+}
+
+//export tinygo_pause
+func pause() {
+	Pause()
+}

--- a/src/runtime/scheduler_tinygoriscv.S
+++ b/src/runtime/scheduler_tinygoriscv.S
@@ -1,0 +1,137 @@
+.section .text.tinygo_startTask
+.global  tinygo_startTask
+.type    tinygo_startTask, %function
+tinygo_startTask:
+    // Small assembly stub for starting a goroutine. This is already run on the
+    // new stack, with the callee-saved registers already loaded.
+    // Most importantly, s0 contains the pc of the to-be-started function and s1
+    // contains the only argument it is given. Multiple arguments are packed
+    // into one by storing them in a new allocation.
+
+    // Set the first argument of the goroutine start wrapper, which contains all
+    // the arguments.
+    mv    a0, s1
+
+    // Branch to the "goroutine start" function. Use jalr to write the return
+    // address to ra so we'll return here after the goroutine exits.
+    jalr  s0
+
+    // After return, exit this goroutine. This is a tail call.
+    tail  tinygo_pause
+
+.section .text.tinygo_getSystemStackPointer
+.global  tinygo_getSystemStackPointer
+.type    tinygo_getSystemStackPointer, %function
+tinygo_getSystemStackPointer:
+    // The thread pointer (tp) is reserved by the ABI but is otherwise unused in
+    // TinyGo. Use it here to store the system stack pointer (equivalent of MSP
+    // in ARM). When it's zero we're already on the main stack pointer,
+    // otherwise return the main stack pointer from tp.
+    // Pseudocode:
+    //     if tp:
+    //         return tp
+    //     return sp
+    mv a0, sp
+    beq tp, zero, 1f
+    mv a0, tp
+1:
+    ret
+
+.section .text.tinygo_switchToTask
+.global  tinygo_switchToTask
+.type    tinygo_switchToTask, %function
+tinygo_switchToTask:
+    // a0 = sp uintptr
+
+    // Push all the registers.
+    addi sp, sp, -64
+    sw ra,  60(sp)
+    sw s11, 56(sp)
+    sw s10, 52(sp)
+    sw s9,  48(sp)
+    sw s8,  44(sp)
+    sw s7,  40(sp)
+    sw s6,  36(sp)
+    sw s5,  32(sp)
+    sw s4,  28(sp)
+    sw s3,  24(sp)
+    sw s2,  20(sp)
+    sw s1,  16(sp)
+    sw s0,  12(sp)
+
+    // Store the old stack pointer in tp (thread pointer, otherwise unused in
+    // TinyGo).
+    mv tp,  sp
+
+    // Load the new stack pointer from a0 (newTask) and switch to it.
+    mv sp,  a0
+
+    // Pop all saved registers from this new stack.
+    lw ra,  48(sp)
+    lw s11, 44(sp)
+    lw s10, 40(sp)
+    lw s9,  36(sp)
+    lw s8,  32(sp)
+    lw s7,  28(sp)
+    lw s6,  24(sp)
+    lw s5,  20(sp)
+    lw s4,  16(sp)
+    lw s3,  12(sp)
+    lw s2,   8(sp)
+    lw s1,   4(sp)
+    lw s0,    (sp)
+    addi sp, sp, 48
+
+    // Return into the task.
+    ret
+
+.section .text.tinygo_switchToScheduler
+.global  tinygo_switchToScheduler
+.type    tinygo_switchToScheduler, %function
+tinygo_switchToScheduler:
+    // a0 = sp *uintptr
+
+    // Currently on the task stack. Push all callee-saved registers on this
+    // stack.
+    addi sp, sp, -48
+    sw ra,  48(sp)
+    sw s11, 44(sp)
+    sw s10, 40(sp)
+    sw s9,  36(sp)
+    sw s8,  32(sp)
+    sw s7,  28(sp)
+    sw s6,  24(sp)
+    sw s5,  20(sp)
+    sw s4,  16(sp)
+    sw s3,  12(sp)
+    sw s2,   8(sp)
+    sw s1,   4(sp)
+    sw s0,    (sp)
+
+    // Store the current stack pointer into a0 (&task.sp).
+    sw sp,    (a0)
+
+    // Switch to the system stack pointer, which was saved in tp.
+    // Also, clear the tp to make sure tinygo_getSystemStackPointer will work
+    // correctly.
+    mv sp, tp
+    mv tp, zero
+
+    // Pop all registers from the system stack.
+    lw ra,  60(sp)
+    lw s11, 56(sp)
+    lw s10, 52(sp)
+    lw s9,  48(sp)
+    lw s8,  44(sp)
+    lw s7,  40(sp)
+    lw s6,  36(sp)
+    lw s5,  32(sp)
+    lw s4,  28(sp)
+    lw s3,  24(sp)
+    lw s2,  20(sp)
+    lw s1,  16(sp)
+    lw s0,  12(sp)
+    addi sp, sp, 64
+
+    // Return into the scheduler.
+    ret

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -4,6 +4,7 @@
 	"goarch": "arm",
 	"build-tags": ["tinygo.riscv", "baremetal", "linux", "arm"],
 	"gc": "conservative",
+	"scheduler": "tasks",
 	"compiler": "clang",
 	"linker": "ld.lld",
 	"rtlib": "compiler-rt",
@@ -22,7 +23,8 @@
 		"--gc-sections"
 	],
 	"extra-files": [
-		"src/device/riscv/start.S"
+		"src/device/riscv/start.S",
+		"src/runtime/scheduler_tinygoriscv.S"
 	],
 	"gdb": "riscv64-unknown-elf-gdb"
 }


### PR DESCRIPTION
This means RISC-V will use a very similar scheduler as is used on Cortex-M.

WIP: there is some sort of crash when running testdata/math.go and testdata/reflect.go (apparently somewhere in `tinygo_pause` after exiting a goroutine).