### PR TITLE
interp: add support for constant type asserts

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -15,6 +15,7 @@ func TestInterp(t *testing.T) {
 		"slice-copy",
 		"consteval",
 		"map",
+		"interface",
 	} {
 		name := name // make tc local to this closure
 		t.Run(name, func(t *testing.T) {

--- a/interp/testdata/interface.ll
+++ b/interp/testdata/interface.ll
@@ -1,0 +1,28 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+%runtime.typecodeID = type { %runtime.typecodeID*, i64 }
+%runtime.interfaceMethodInfo = type { i8*, i64 }
+%runtime.typeInInterface = type { %runtime.typecodeID*, %runtime.interfaceMethodInfo* }
+
+@main.v1 = global i1 0
+@"reflect/types.type:named:main.foo" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i64 0 }
+@"reflect/types.type:basic:int" = external constant %runtime.typecodeID
+@"typeInInterface:reflect/types.type:named:main.foo" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:named:main.foo", %runtime.interfaceMethodInfo* null }
+
+
+declare i1 @runtime.typeAssert(i64, %runtime.typecodeID*, i8*, i8*)
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  call void @main.init()
+  ret void
+}
+
+define internal void @main.init() unnamed_addr {
+entry:
+  ; Test type asserts.
+  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:named:main.foo" to i64), %runtime.typecodeID* @"reflect/types.type:named:main.foo", i8* undef, i8* null)
+  store i1 %typecode, i1* @main.v1
+  ret void
+}

--- a/interp/testdata/interface.out.ll
+++ b/interp/testdata/interface.out.ll
@@ -1,0 +1,9 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64--linux"
+
+@main.v1 = local_unnamed_addr global i1 true
+
+define void @runtime.initAll() unnamed_addr {
+entry:
+  ret void
+}

--- a/testdata/interface.go
+++ b/testdata/interface.go
@@ -137,6 +137,12 @@ func printItf(val interface{}) {
 	}
 }
 
+var (
+	// Test for type assert support in the interp package.
+	globalThing interface{} = Foo(3)
+	_                       = globalThing.(Foo)
+)
+
 func nestedSwitch(verb rune, arg interface{}) bool {
 	switch verb {
 	case 'v', 's':


### PR DESCRIPTION
This is needed for compiling math/rand on Go 1.14 (but it is not a complete solution).

Non-constant type asserts are not yet implemented, but should be relatively easy to add at a later time. They should result in a clear error message for now.