### PR TITLE
avr: move data address space to 0x800000

### DIFF
--- a/targets/avr.ld
+++ b/targets/avr.ld
@@ -1,8 +1,8 @@
 
 MEMORY
 {
-    FLASH_TEXT (rw) : ORIGIN = 0,           LENGTH = __flash_size - _bootloader_size
-    RAM (xrw)       : ORIGIN = __ram_start, LENGTH = __ram_size
+    FLASH_TEXT (rw) : ORIGIN = 0,                      LENGTH = __flash_size - _bootloader_size
+    RAM (xrw)       : ORIGIN = 0x800000 + __ram_start, LENGTH = __ram_size
 }
 
 SECTIONS


### PR DESCRIPTION
This convention is followed by most of the avr-gcc toolchain but older versions of binutils don't mind overlapping program/data spaces. However, newer versions start complaining about an overlap in address space:

    avr-ld: section .stack VMA [0000000000000100,00000000000002ff] overlaps section .text VMA [0000000000000000,0000000000000225]

This commit moves the data space in the linker script to 0x800000, like the rest of the AVR toolchain assumes.

Tested:

* examples/serial and examples/echo on the Arduino Uno
* examples/blinky1 on the Digispark