### PR TITLE
nrf: add lib/nrfx/mdk to include dirs

### DIFF
--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -6,7 +6,8 @@
 		"--target=armv6m-none-eabi",
 		"-Qunused-arguments",
 		"-DNRF51",
-		"-I{root}/lib/CMSIS/CMSIS/Include"
+		"-I{root}/lib/CMSIS/CMSIS/Include",
+		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf51.ld",
 	"extra-files": [

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -7,7 +7,8 @@
 		"-mfloat-abi=soft",
 		"-Qunused-arguments",
 		"-DNRF52840_XXAA",
-		"-I{root}/lib/CMSIS/CMSIS/Include"
+		"-I{root}/lib/CMSIS/CMSIS/Include",
+		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf52840.ld",
 	"extra-files": [


### PR DESCRIPTION
This directory is needed for nrf.h and other headers that are used by
the SoftDevice. It is definitely needed for nrf52840 for example, but
I've also added it to the nrf51 as it will likely also require adding
this directory.