### PR TITLE
avr: add emulator to atmega1284p

### DIFF
--- a/targets/atmega1284p.json
+++ b/targets/atmega1284p.json
@@ -15,5 +15,6 @@
     "extra-files": [
         "targets/avr.S",
         "src/device/avr/atmega1284p.s"
-    ]
+    ],
+    "emulator": ["simavr", "-m", "atmega1284p", "-f", "20000000"]
 }


### PR DESCRIPTION
Somehow I forgot to add this emulator. With this, you can easily emulate programs:

    $ tinygo run -target=atmega1284p examples/serial
    Loaded 698 .text at address 0x0
    Loaded 12 .data
    hello world!..
    hello world!..
    hello world!..