### PR TITLE
reelboard: add SoftDevice target reelboard-s140v7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10056-s140v7     examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=reelboard-s140v7    examples/blinky1
+	@$(MD5SUM) test.hex
 ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=atmega1284p         examples/serial
 	@$(MD5SUM) test.hex

--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -6,7 +6,8 @@
 		"--target=armv6m-none-eabi",
 		"-Qunused-arguments",
 		"-DNRF51",
-		"-I{root}/lib/CMSIS/CMSIS/Include"
+		"-I{root}/lib/CMSIS/CMSIS/Include",
+		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf51.ld",
 	"extra-files": [

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -7,7 +7,8 @@
 		"-mfloat-abi=soft",
 		"-Qunused-arguments",
 		"-DNRF52840_XXAA",
-		"-I{root}/lib/CMSIS/CMSIS/Include"
+		"-I{root}/lib/CMSIS/CMSIS/Include",
+		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf52840.ld",
 	"extra-files": [

--- a/targets/reelboard-s140v7.json
+++ b/targets/reelboard-s140v7.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["reelboard", "nrf52840-s140v7"]
+}


### PR DESCRIPTION
Unfortunately, `tinygo flash` doesn't work. You have to merge the SoftDevice and the application hex with a mergehex tool and flash that to the board.

Replaces #970.