### PR TITLE
main: extend test timeout from 1s to 10s

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -161,7 +161,7 @@ func runTest(path, target string, t *testing.T) {
 	}
 	go func() {
 		// Terminate the process if it runs too long.
-		timer := time.NewTimer(1 * time.Second)
+		timer := time.NewTimer(10 * time.Second)
 		select {
 		case <-runComplete:
 			timer.Stop()


### PR DESCRIPTION
This should avoid the rather frequent "test ran too long, terminating..." error message that often occurs in CI and when running `go test` manually. Apparently I was too optimistic: some tests take longer than 1 second to run.