### PR TITLE
avr: clean up ATtiny definitions

### DIFF
--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -8,12 +8,12 @@ func CPUFrequency() uint32 {
 }
 
 const (
-	P0 Pin = 0
-	P1 Pin = 1
-	P2 Pin = 2
-	P3 Pin = 3
-	P4 Pin = 4
-	P5 Pin = 5
+	P0 Pin = PB0
+	P1 Pin = PB1
+	P2 Pin = PB2
+	P3 Pin = PB3
+	P4 Pin = PB4
+	P5 Pin = PB5
 
 	LED = P1
 )

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -2,30 +2,6 @@
 
 package machine
 
-import (
-	"device/avr"
-	"runtime/volatile"
-)
-
-// Configure sets the pin to input or output.
-func (p Pin) Configure(config PinConfig) {
-	if config.Mode == PinOutput { // set output bit
-		avr.DDRB.SetBits(1 << uint8(p))
-	} else { // configure input: clear output bit
-		avr.DDRB.ClearBits(1 << uint8(p))
-	}
-}
-
-func (p Pin) getPortMask() (*volatile.Register8, uint8) {
-	return avr.PORTB, 1 << uint8(p)
-}
-
-// Get returns the current value of a GPIO pin.
-func (p Pin) Get() bool {
-	val := avr.PINB.Get() & (1 << uint8(p))
-	return (val > 0)
-}
-
 // UART on the AVR is a dummy implementation. UART has not been implemented for ATtiny
 // devices.
 type UART struct {

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -1,0 +1,36 @@
+// +build attiny85
+
+package machine
+
+import (
+	"device/avr"
+	"runtime/volatile"
+)
+
+const (
+	PB0 Pin = iota
+	PB1
+	PB2
+	PB3
+	PB4
+	PB5
+)
+
+// Configure sets the pin to input or output.
+func (p Pin) Configure(config PinConfig) {
+	if config.Mode == PinOutput { // set output bit
+		avr.DDRB.SetBits(1 << uint8(p))
+	} else { // configure input: clear output bit
+		avr.DDRB.ClearBits(1 << uint8(p))
+	}
+}
+
+func (p Pin) getPortMask() (*volatile.Register8, uint8) {
+	return avr.PORTB, 1 << uint8(p)
+}
+
+// Get returns the current value of a GPIO pin.
+func (p Pin) Get() bool {
+	val := avr.PINB.Get() & (1 << uint8(p))
+	return (val > 0)
+}


### PR DESCRIPTION
Add definitions for constants like PB0.

This was originally based on #957 but as long as I can't get that chip to work, I'll post the cleanup here anyway.

Note: I've started pin numbers (like `PB0`) from 0 instead of 8 because there is only one port on the attiny85. It saves 14 bytes of code for blinky1.