### PR TITLE
Stm32 refactor spi to add to stm32f4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN cd /tinygo/ && \
     git submodule sync && \
     git submodule update --init --recursive --force
 
-COPY ./lib/picolibc-include/* /tinygo/lib/picolibc-include/
-
 RUN cd /tinygo/ && \
     go install /tinygo/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN cd /tinygo/ && \
     git submodule sync && \
     git submodule update --init --recursive --force
 
+COPY ./lib/picolibc-include/* /tinygo/lib/picolibc-include/
+
 RUN cd /tinygo/ && \
     go install /tinygo/
 

--- a/src/device/stm32/stm32-moder-bitfields.go
+++ b/src/device/stm32/stm32-moder-bitfields.go
@@ -43,3 +43,15 @@ const (
 	GPIOPUPDRPullUp   = 1
 	GPIOPUPDRPullDown = 2
 )
+
+// SPI prescaler values fPCLK / X
+const (
+	SPI_PCLK_2   = 0
+	SPI_PCLK_4   = 1
+	SPI_PCLK_8   = 2
+	SPI_PCLK_16  = 3
+	SPI_PCLK_32  = 4
+	SPI_PCLK_64  = 5
+	SPI_PCLK_128 = 6
+	SPI_PCLK_256 = 7
+)

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -129,3 +129,30 @@ var (
 func init() {
 	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
 }
+
+// SPI pins
+const (
+	SPI1_SCK_PIN  = PA5
+	SPI1_MISO_PIN = PA6
+	SPI1_MOSI_PIN = PA7
+	SPI0_SCK_PIN  = SPI1_SCK_PIN
+	SPI0_MISO_PIN = SPI1_MISO_PIN
+	SPI0_MOSI_PIN = SPI1_MOSI_PIN
+)
+
+// MEMs accelerometer
+const (
+	MEMS_ACCEL_CS   = PE3
+	MEMS_ACCEL_INT1 = PE0
+	MEMS_ACCEL_INT2 = PE1
+)
+
+// Since the first interface is named SPI1, both SPI0 and SPI1 refer to SPI1.
+// TODO: implement SPI2 and SPI3.
+var (
+	SPI0 = SPI{
+		Bus:             stm32.SPI1,
+		AltFuncSelector: stm32.AF5_SPI1_SPI2,
+	}
+	SPI1 = &SPI0
+)

--- a/src/machine/machine_stm32_spi.go
+++ b/src/machine/machine_stm32_spi.go
@@ -1,0 +1,99 @@
+// +build stm32
+
+package machine
+
+// Peripheral abstraction layer for SPI on the stm32 family
+
+import (
+	"device/stm32"
+	"unsafe"
+)
+
+// SPIConfig is used to store config info for SPI.
+type SPIConfig struct {
+	Frequency uint32
+	SCK       Pin
+	MOSI      Pin
+	MISO      Pin
+	LSBFirst  bool
+	Mode      uint8
+}
+
+// Configure is intended to setup the STM32 SPI1 interface.
+// Features still TODO:
+// - support SPI2 and SPI3
+// - allow setting data size to 16 bits?
+// - allow setting direction in HW for additional optimization?
+// - hardware SS pin?
+func (spi SPI) Configure(config SPIConfig) {
+	// enable clock for SPI
+	enableAltFuncClock(unsafe.Pointer(spi.Bus))
+
+	// Get SPI baud rate based on the bus speed it's attached to
+	var conf uint32 = spi.getBaudRate(config)
+
+	// set bit transfer order
+	if config.LSBFirst {
+		conf |= stm32.SPI_CR1_LSBFIRST
+	}
+
+	// set polarity and phase on the SPI interface
+	switch config.Mode {
+	case Mode0:
+		conf &^= (1 << stm32.SPI_CR1_CPOL_Pos)
+		conf &^= (1 << stm32.SPI_CR1_CPHA_Pos)
+	case Mode1:
+		conf &^= (1 << stm32.SPI_CR1_CPOL_Pos)
+		conf |= (1 << stm32.SPI_CR1_CPHA_Pos)
+	case Mode2:
+		conf |= (1 << stm32.SPI_CR1_CPOL_Pos)
+		conf &^= (1 << stm32.SPI_CR1_CPHA_Pos)
+	case Mode3:
+		conf |= (1 << stm32.SPI_CR1_CPOL_Pos)
+		conf |= (1 << stm32.SPI_CR1_CPHA_Pos)
+	default: // to mode 0
+		conf &^= (1 << stm32.SPI_CR1_CPOL_Pos)
+		conf &^= (1 << stm32.SPI_CR1_CPHA_Pos)
+	}
+
+	// set to SPI master
+	conf |= stm32.SPI_CR1_MSTR
+
+	// disable MCU acting as SPI slave
+	conf |= stm32.SPI_CR1_SSM | stm32.SPI_CR1_SSI
+
+	// now set the configuration
+	spi.Bus.CR1.Set(conf)
+
+	// init pins
+	if config.SCK == 0 && config.MOSI == 0 && config.MISO == 0 {
+		config.SCK = SPI0_SCK_PIN
+		config.MOSI = SPI0_MOSI_PIN
+		config.MISO = SPI0_MISO_PIN
+	}
+	spi.configurePins(config)
+
+	// enable SPI interface
+	spi.Bus.CR1.SetBits(stm32.SPI_CR1_SPE)
+}
+
+// Transfer writes/reads a single byte using the SPI interface.
+func (spi SPI) Transfer(w byte) (byte, error) {
+	// Write data to be transmitted to the SPI data register
+	spi.Bus.DR.Set(uint32(w))
+
+	// Wait until transmit complete
+	for !spi.Bus.SR.HasBits(stm32.SPI_SR_TXE) {
+	}
+
+	// Wait until receive complete
+	for !spi.Bus.SR.HasBits(stm32.SPI_SR_RXNE) {
+	}
+
+	// Wait until SPI is not busy
+	for spi.Bus.SR.HasBits(stm32.SPI_SR_BSY) {
+	}
+
+	// Return received data from SPI data register
+	return byte(spi.Bus.DR.Get()), nil
+}

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,8 +1,16 @@
-// +build !baremetal sam stm32,!stm32f407 fe310
+// +build !baremetal sam stm32 fe310
 
 package machine
 
 import "errors"
+
+// SPI phase and polarity configs CPOL and CPHA
+const (
+	Mode0 = 0
+	Mode1 = 1
+	Mode2 = 2
+	Mode3 = 3
+)
 
 var (
 	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")


### PR DESCRIPTION
Extending #777, part 3 : Leverage the stm32f103 SPI implementation across more stm32 families.

Some of the constants might need renaming, not sure.

Also, @deadprogram or @aykevl if you're able to verify the SPI behavior on your f103-based boards, that would be awesome.