### PR TITLE
transform: replace panics with source locations

### DIFF
--- a/transform/interface-lowering_test.go
+++ b/transform/interface-lowering_test.go
@@ -2,9 +2,16 @@ package transform
 
 import (
 	"testing"
+
+	"tinygo.org/x/go-llvm"
 )
 
 func TestInterfaceLowering(t *testing.T) {
 	t.Parallel()
-	testTransform(t, "testdata/interface", LowerInterfaces)
+	testTransform(t, "testdata/interface", func(mod llvm.Module) {
+		err := LowerInterfaces(mod)
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -75,7 +75,10 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		OptimizeMaps(mod)
 		OptimizeStringToBytes(mod)
 		OptimizeAllocs(mod)
-		LowerInterfaces(mod)
+		err := LowerInterfaces(mod)
+		if err != nil {
+			return []error{err}
+		}
 
 		errs := LowerInterrupts(mod)
 		if len(errs) > 0 {
@@ -115,7 +118,10 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 
 	} else {
 		// Must be run at any optimization level.
-		LowerInterfaces(mod)
+		err := LowerInterfaces(mod)
+		if err != nil {
+			return []error{err}
+		}
 		if config.FuncImplementation() == compileopts.FuncValueSwitch {
 			LowerFuncValues(mod)
 		}


### PR DESCRIPTION
Panics are bad for usability: whenever something breaks, the user is shown a (not very informative) backtrace. Replace it with real error messages instead, that even try to display the Go source location.

(This PR is only for the interface lowering pass, other passes can be done later as needed).