### PR TITLE
Set USB CDC identifiers to Particle ones

### DIFF
--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -97,11 +97,11 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Particle Argon"
+	usb_STRING_PRODUCT      = "Argon"
 	usb_STRING_MANUFACTURER = "Particle"
 )
 
 var (
-	usb_VID uint16 = 0x239A
-	usb_PID uint16 = 0x8029
+	usb_VID uint16 = 0x2B04
+	usb_PID uint16 = 0xD00C
 )

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -100,11 +100,11 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Particle Boron"
+	usb_STRING_PRODUCT      = "Boron"
 	usb_STRING_MANUFACTURER = "Particle"
 )
 
 var (
-	usb_VID uint16 = 0x239A
-	usb_PID uint16 = 0x8029
+	usb_VID uint16 = 0x2B04
+	usb_PID uint16 = 0xD00D
 )

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -86,11 +86,11 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Particle Xenon"
+	usb_STRING_PRODUCT      = "Xenon"
 	usb_STRING_MANUFACTURER = "Particle"
 )
 
 var (
-	usb_VID uint16 = 0x239A
-	usb_PID uint16 = 0x8029
+	usb_VID uint16 = 0x2B04
+	usb_PID uint16 = 0xD00E
 )


### PR DESCRIPTION
Set the USB VID, PID and product names to the same ones as used by Particle.