### PR TITLE
interp: improve support for load/store instructions

### DIFF
--- a/interp/frame.go
+++ b/interp/frame.go
@@ -92,7 +92,8 @@ func (fr *frame) evalBasicBlock(bb, incoming llvm.BasicBlock, indent string) (re
 		case !inst.IsALoadInst().IsNil():
 			operand := fr.getLocal(inst.Operand(0)).(*LocalValue)
 			var value llvm.Value
-			if !operand.IsConstant() || inst.IsVolatile() || (!operand.Underlying.IsAConstantExpr().IsNil() && operand.Underlying.Opcode() == llvm.BitCast) {
+			if inst.IsVolatile() || fr.Eval.isDirty(operand.Value()) {
+				fr.Eval.markDirty(operand.Value())
 				value = fr.builder.CreateLoad(operand.Value(), inst.Name())
 			} else {
 				var err error
@@ -108,7 +109,8 @@ func (fr *frame) evalBasicBlock(bb, incoming llvm.BasicBlock, indent string) (re
 		case !inst.IsAStoreInst().IsNil():
 			value := fr.getLocal(inst.Operand(0))
 			ptr := fr.getLocal(inst.Operand(1))
-			if inst.IsVolatile() {
+			if inst.IsVolatile() || fr.Eval.isDirty(ptr.Value()) {
+				fr.Eval.markDirty(ptr.Value())
 				fr.builder.CreateStore(value.Value(), ptr.Value())
 			} else {
 				err := ptr.Store(value.Value())


### PR DESCRIPTION
This is a combination of two commits that allows a significant number of packages to compile (perhaps most importantly `math/big`):

  * crypto/dsa
  * crypto/ed25519
  * crypto/elliptic
  * crypto/rand
  * go/constant
  * math/big

However, it also breaks the image/color/palette package. I am hopeful that this will be fixed with the removal of the `runtime.isnil` mechanism which appears to cause this problem.