### PR TITLE
Copy picolibc header into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN cd /tinygo/ && \
     git submodule sync && \
     git submodule update --init --recursive --force
 
+COPY ./lib/picolibc-include/* /tinygo/lib/picolibc-include/
+
 RUN cd /tinygo/ && \
     go install /tinygo/
 


### PR DESCRIPTION
The headerfile for picolibc gets copied into the Dockerfile early on during its build, but then removed immediately afterwards when pulling in the subprojects, causing a compilation error when trying to build `.hex` files using hte Docker image.