### PR TITLE
Remove runtime.isnil

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -339,9 +339,6 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 		c.mod.NamedFunction("runtime.alloc").AddAttributeAtIndex(0, getAttr(attrName))
 	}
 
-	// See createNilCheck in asserts.go.
-	c.mod.NamedFunction("runtime.isnil").AddAttributeAtIndex(1, nocapture)
-
 	// On *nix systems, the "abort" functuion in libc is used to handle fatal panics.
 	// Mark it as noreturn so LLVM can optimize away code.
 	if abort := c.mod.NamedFunction("abort"); !abort.IsNil() && abort.IsDeclaration() {

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -125,11 +125,13 @@ func (c *compilerContext) getRawFuncType(typ *types.Signature) llvm.Type {
 			// The receiver is not an interface, but a i8* type.
 			recv = c.i8ptrType
 		}
-		paramTypes = append(paramTypes, expandFormalParamType(recv)...)
+		recvFragments, _ := expandFormalParamType(recv, nil)
+		paramTypes = append(paramTypes, recvFragments...)
 	}
 	for i := 0; i < typ.Params().Len(); i++ {
 		subType := c.getLLVMType(typ.Params().At(i).Type())
-		paramTypes = append(paramTypes, expandFormalParamType(subType)...)
+		paramTypeFragments, _ := expandFormalParamType(subType, nil)
+		paramTypes = append(paramTypes, paramTypeFragments...)
 	}
 	// All functions take these parameters at the end.
 	paramTypes = append(paramTypes, c.i8ptrType) // context

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -437,7 +437,7 @@ func (c *compilerContext) getInterfaceInvokeWrapper(f *ir.Function) llvm.Value {
 
 	// Get the expanded receiver type.
 	receiverType := c.getLLVMType(f.Params[0].Type())
-	expandedReceiverType := expandFormalParamType(receiverType)
+	expandedReceiverType, _ := expandFormalParamType(receiverType, nil)
 
 	// Does this method even need any wrapping?
 	if len(expandedReceiverType) == 1 && receiverType.TypeKind() == llvm.PointerTypeKind {

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -12,7 +12,7 @@ import (
 // runtime/volatile.LoadT().
 func (b *builder) createVolatileLoad(instr *ssa.CallCommon) (llvm.Value, error) {
 	addr := b.getValue(instr.Args[0])
-	b.createNilCheck(addr, "deref")
+	b.createNilCheck(instr.Args[0], addr, "deref")
 	val := b.CreateLoad(addr, "")
 	val.SetVolatile(true)
 	return val, nil
@@ -23,7 +23,7 @@ func (b *builder) createVolatileLoad(instr *ssa.CallCommon) (llvm.Value, error) 
 func (b *builder) createVolatileStore(instr *ssa.CallCommon) (llvm.Value, error) {
 	addr := b.getValue(instr.Args[0])
 	val := b.getValue(instr.Args[1])
-	b.createNilCheck(addr, "deref")
+	b.createNilCheck(instr.Args[0], addr, "deref")
 	store := b.CreateStore(val, addr)
 	store.SetVolatile(true)
 	return llvm.Value{}, nil

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -27,14 +27,6 @@ func _recover() interface{} {
 	return nil
 }
 
-// See emitNilCheck in compiler/asserts.go.
-// This function is a dummy function that has its first and only parameter
-// marked 'nocapture' to work around a limitation in LLVM: a regular pointer
-// comparison captures the pointer.
-func isnil(ptr *uint8) bool {
-	return ptr == nil
-}
-
 // Panic when trying to dereference a nil pointer.
 func nilPanic() {
 	runtimePanic("nil pointer dereference")

--- a/transform/func-lowering.go
+++ b/transform/func-lowering.go
@@ -197,19 +197,8 @@ func LowerFuncValues(mod llvm.Module) {
 						panic("expected inttoptr")
 					}
 					for _, ptrUse := range getUses(callIntPtr) {
-						if !ptrUse.IsABitCastInst().IsNil() {
-							for _, bitcastUse := range getUses(ptrUse) {
-								if bitcastUse.IsACallInst().IsNil() || bitcastUse.CalledValue().IsAFunction().IsNil() {
-									panic("expected a call instruction")
-								}
-								switch bitcastUse.CalledValue().Name() {
-								case "runtime.isnil":
-									bitcastUse.ReplaceAllUsesWith(llvm.ConstInt(ctx.Int1Type(), 0, false))
-									bitcastUse.EraseFromParentAsInstruction()
-								default:
-									panic("expected a call to runtime.isnil")
-								}
-							}
+						if !ptrUse.IsAICmpInst().IsNil() {
+							ptrUse.ReplaceAllUsesWith(llvm.ConstInt(ctx.Int1Type(), 0, false))
 						} else if !ptrUse.IsACallInst().IsNil() && ptrUse.CalledValue() == callIntPtr {
 							addFuncLoweringSwitch(mod, builder, funcID, ptrUse, func(funcPtr llvm.Value, params []llvm.Value) llvm.Value {
 								return builder.CreateCall(funcPtr, params, "")

--- a/transform/testdata/func-lowering.ll
+++ b/transform/testdata/func-lowering.ll
@@ -19,8 +19,6 @@ declare void @"internal/task.start"(i32, i8*, i8*, i8*)
 
 declare void @runtime.nilPanic(i8*, i8*)
 
-declare i1 @runtime.isnil(i8*, i8*, i8*)
-
 declare void @"main$1"(i32, i8*, i8*)
 
 declare void @"main$2"(i32, i8*, i8*)
@@ -38,9 +36,8 @@ define void @runFunc1(i8*, i32, i8, i8* %context, i8* %parentHandle) {
 entry:
   %3 = call i32 @runtime.getFuncPtr(i8* %0, i32 %1, %runtime.typecodeID* @"reflect/types.type:func:{basic:int8}{}", i8* undef, i8* null)
   %4 = inttoptr i32 %3 to void (i8, i8*, i8*)*
-  %5 = bitcast void (i8, i8*, i8*)* %4 to i8*
-  %6 = call i1 @runtime.isnil(i8* %5, i8* undef, i8* null)
-  br i1 %6, label %fpcall.nil, label %fpcall.next
+  %5 = icmp eq void (i8, i8*, i8*)* %4, null
+  br i1 %5, label %fpcall.nil, label %fpcall.next
 
 fpcall.nil:
   call void @runtime.nilPanic(i8* undef, i8* null)
@@ -58,9 +55,8 @@ define void @runFunc2(i8*, i32, i8, i8* %context, i8* %parentHandle) {
 entry:
   %3 = call i32 @runtime.getFuncPtr(i8* %0, i32 %1, %runtime.typecodeID* @"reflect/types.type:func:{basic:uint8}{}", i8* undef, i8* null)
   %4 = inttoptr i32 %3 to void (i8, i8*, i8*)*
-  %5 = bitcast void (i8, i8*, i8*)* %4 to i8*
-  %6 = call i1 @runtime.isnil(i8* %5, i8* undef, i8* null)
-  br i1 %6, label %fpcall.nil, label %fpcall.next
+  %5 = icmp eq void (i8, i8*, i8*)* %4, null
+  br i1 %5, label %fpcall.nil, label %fpcall.next
 
 fpcall.nil:
   call void @runtime.nilPanic(i8* undef, i8* null)

--- a/transform/testdata/func-lowering.out.ll
+++ b/transform/testdata/func-lowering.out.ll
@@ -19,8 +19,6 @@ declare void @"internal/task.start"(i32, i8*, i8*, i8*)
 
 declare void @runtime.nilPanic(i8*, i8*)
 
-declare i1 @runtime.isnil(i8*, i8*, i8*)
-
 declare void @"main$1"(i32, i8*, i8*)
 
 declare void @"main$2"(i32, i8*, i8*)
@@ -38,9 +36,8 @@ define void @runFunc1(i8*, i32, i8, i8* %context, i8* %parentHandle) {
 entry:
   %3 = icmp eq i32 %1, 0
   %4 = select i1 %3, void (i8, i8*, i8*)* null, void (i8, i8*, i8*)* @funcInt8
-  %5 = bitcast void (i8, i8*, i8*)* %4 to i8*
-  %6 = call i1 @runtime.isnil(i8* %5, i8* undef, i8* null)
-  br i1 %6, label %fpcall.nil, label %fpcall.next
+  %5 = icmp eq void (i8, i8*, i8*)* %4, null
+  br i1 %5, label %fpcall.nil, label %fpcall.next
 
 fpcall.nil:
   call void @runtime.nilPanic(i8* undef, i8* null)


### PR DESCRIPTION
Finally, I think this branch is ready.

The first three commits are commits to prepare for the change in the fourth commit, which is what this PR is about. They make sure escape analysis won't regress after `runtime.isnil` has been removed.

I found exactly one regression in escape analysis: in testdata/calls.go, but only on a host OS and on WebAssembly. Further investigation revealed that it has something to do with function pointers or closures.
Most tests I've done (including smoke tests) result in a reduction of code size however some get bigger (perhaps because the inliner made different choices somewhere). None of the baremetal tests resulted in an escape analysis regression. Overall I think this is an improvement.

(Note that the GitHub ordering of commits is wrong, they're sorted by date and not by actual commit order).