### PR TITLE
wasm_exec: Port over safe features

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -306,6 +306,13 @@
 						Reflect.set(v, p, x);
 					},
 
+					// func valueDelete(v ref, p string)
+					"syscall/js.valueDelete": (v_addr, p_ptr, p_len) => {
+						const v = loadValue(v_addr);
+						const p = loadString(p_ptr, p_len);
+						Reflect.deleteProperty(v, p);
+					},
+
 					// func valueIndex(v ref, i int) ref
 					"syscall/js.valueIndex": (ret_addr, v_addr, i) => {
 						storeValue(ret_addr, Reflect.get(loadValue(v_addr), i));

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -381,6 +381,23 @@
 					//	mem().setUint8(sp + 24, loadValue(sp + 8) instanceof loadValue(sp + 16));
 					//},
 
+					// func copyBytesToGo(dst []byte, src ref) (int, bool)
+					"syscall/js.copyBytesToGo": (ret_addr, dest_addr, dest_len, dest_cap, source_addr) => {
+						let num_bytes_copied_addr = ret_addr;
+						let returned_status_addr = ret_addr + 4; // Address of returned boolean status variable
+
+						const dst = loadSlice(dest_addr, dest_len);
+						const src = loadValue(source_addr);
+						if (!(src instanceof Uint8Array)) {
+							mem().setUint8(returned_status_addr, 0); // Return "not ok" status
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(num_bytes_copied_addr, toCopy.length);
+						mem().setUint8(returned_status_addr, 1); // Return "ok" status
+					},
+
 					// copyBytesToJS(dst ref, src []byte) (int, bool)
 					// Originally copied from upstream Go project, then modified:
 					//   https://github.com/golang/go/blob/3f995c3f3b43033013013e6c7ccc93a9b1411ca9/misc/wasm/wasm_exec.js#L404-L416

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -466,7 +466,7 @@
 		!global.process.versions.electron
 	) {
 		if (process.argv.length != 3) {
-			process.stderr.write("usage: go_js_wasm_exec [wasm binary] [arguments]\n");
+			console.error("usage: go_js_wasm_exec [wasm binary] [arguments]");
 			process.exit(1);
 		}
 
@@ -480,7 +480,8 @@
 			});
 			return go.run(result.instance);
 		}).catch((err) => {
-			throw err;
+			console.error(err);
+			process.exit(1);
 		});
 	}
 })();


### PR DESCRIPTION
These are only new things on the wasm side, so they should do nothing until the Go side starts calling them, which should only be in Go 1.14.