### PR TITLE
LLVM memory builtins

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1325,6 +1325,8 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 		switch {
 		case name == "runtime.memcpy" || name == "runtime.memmove" || name == "reflect.memcpy":
 			return b.createMemoryCopyCall(fn, instr.Args)
+		case name == "runtime.memzero":
+			return b.createMemoryZeroCall(instr.Args)
 		case name == "device/arm.ReadRegister" || name == "device/riscv.ReadRegister":
 			return b.createReadRegister(name, instr.Args)
 		case name == "device/arm.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":

--- a/compiler/intrinsics.go
+++ b/compiler/intrinsics.go
@@ -28,3 +28,23 @@ func (b *builder) createMemoryCopyCall(fn *ssa.Function, args []ssa.Value) (llvm
 	b.CreateCall(llvmFn, params, "")
 	return llvm.Value{}, nil
 }
+
+// createMemoryZeroCall creates calls to llvm.memset.* to zero a block of
+// memory, declaring the function if needed. These calls will be lowered to
+// regular libc memset calls if they aren't optimized out in a different way.
+func (b *builder) createMemoryZeroCall(args []ssa.Value) (llvm.Value, error) {
+	fnName := "llvm.memset.p0i8.i" + strconv.Itoa(b.uintptrType.IntTypeWidth())
+	llvmFn := b.mod.NamedFunction(fnName)
+	if llvmFn.IsNil() {
+		fnType := llvm.FunctionType(b.ctx.VoidType(), []llvm.Type{b.i8ptrType, b.ctx.Int8Type(), b.uintptrType, b.ctx.Int1Type()}, false)
+		llvmFn = llvm.AddFunction(b.mod, fnName, fnType)
+	}
+	params := []llvm.Value{
+		b.getValue(args[0]),
+		llvm.ConstInt(b.ctx.Int8Type(), 0, false),
+		b.getValue(args[1]),
+		llvm.ConstInt(b.ctx.Int1Type(), 0, false),
+	}
+	b.CreateCall(llvmFn, params, "")
+	return llvm.Value{}, nil
+}

--- a/compiler/intrinsics.go
+++ b/compiler/intrinsics.go
@@ -1,0 +1,30 @@
+package compiler
+
+// This file contains helper functions to create calls to LLVM intrinsics.
+
+import (
+	"strconv"
+
+	"golang.org/x/tools/go/ssa"
+	"tinygo.org/x/go-llvm"
+)
+
+// createMemoryCopyCall creates a call to a builtin LLVM memcpy or memmove
+// function, declaring this function if needed. These calls are treated
+// specially by optimization passes possibly resulting in better generated code,
+// and will otherwise be lowered to regular libc memcpy/memmove calls.
+func (b *builder) createMemoryCopyCall(fn *ssa.Function, args []ssa.Value) (llvm.Value, error) {
+	fnName := "llvm." + fn.Name() + ".p0i8.p0i8.i" + strconv.Itoa(b.uintptrType.IntTypeWidth())
+	llvmFn := b.mod.NamedFunction(fnName)
+	if llvmFn.IsNil() {
+		fnType := llvm.FunctionType(b.ctx.VoidType(), []llvm.Type{b.i8ptrType, b.i8ptrType, b.uintptrType, b.ctx.Int1Type()}, false)
+		llvmFn = llvm.AddFunction(b.mod, fnName, fnType)
+	}
+	var params []llvm.Value
+	for _, param := range args {
+		params = append(params, b.getValue(param))
+	}
+	params = append(params, llvm.ConstInt(b.ctx.Int1Type(), 0, false))
+	b.CreateCall(llvmFn, params, "")
+	return llvm.Value{}, nil
+}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -678,5 +678,6 @@ func (e *ValueError) Error() string {
 	return "reflect: call of reflect.Value." + e.Method + " on invalid type"
 }
 
-//go:linkname memcpy runtime.memcpy
+// Calls to this function are converted to LLVM intrinsic calls such as
+// llvm.memcpy.p0i8.p0i8.i32().
 func memcpy(dst, src unsafe.Pointer, size uintptr)

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -41,11 +41,9 @@ func memcpy(dst, src unsafe.Pointer, size uintptr)
 func memmove(dst, src unsafe.Pointer, size uintptr)
 
 // Set the given number of bytes to zero.
-func memzero(ptr unsafe.Pointer, size uintptr) {
-	for i := uintptr(0); i < size; i++ {
-		*(*byte)(unsafe.Pointer(uintptr(ptr) + i)) = 0
-	}
-}
+// Calls to this function are converted to LLVM intrinsic calls such as
+// llvm.memset.p0i8.i32(ptr, 0, size, false).
+func memzero(ptr unsafe.Pointer, size uintptr)
 
 // Compare two same-size buffers for equality.
 func memequal(x, y unsafe.Pointer, n uintptr) bool {

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -30,26 +30,15 @@ func os_runtime_args() []string {
 }
 
 // Copy size bytes from src to dst. The memory areas must not overlap.
-func memcpy(dst, src unsafe.Pointer, size uintptr) {
-	for i := uintptr(0); i < size; i++ {
-		*(*uint8)(unsafe.Pointer(uintptr(dst) + i)) = *(*uint8)(unsafe.Pointer(uintptr(src) + i))
-	}
-}
+// Calls to this function are converted to LLVM intrinsic calls such as
+// llvm.memcpy.p0i8.p0i8.i32(dst, src, size, false).
+func memcpy(dst, src unsafe.Pointer, size uintptr)
 
 // Copy size bytes from src to dst. The memory areas may overlap and will do the
 // correct thing.
-func memmove(dst, src unsafe.Pointer, size uintptr) {
-	if uintptr(dst) < uintptr(src) {
-		// Copy forwards.
-		memcpy(dst, src, size)
-		return
-	}
-	// Copy backwards.
-	for i := size; i != 0; {
-		i--
-		*(*uint8)(unsafe.Pointer(uintptr(dst) + i)) = *(*uint8)(unsafe.Pointer(uintptr(src) + i))
-	}
-}
+// Calls to this function are converted to LLVM intrinsic calls such as
+// llvm.memmove.p0i8.p0i8.i32(dst, src, size, false).
+func memmove(dst, src unsafe.Pointer, size uintptr)
 
 // Set the given number of bytes to zero.
 func memzero(ptr unsafe.Pointer, size uintptr) {


### PR DESCRIPTION
Use LLVM intrinsics for memory operations (`memset`, `memcpy`, `memmove`). This gives more information to the optimizer and in the end lowers to libc functions instead of a custom TinyGo implementation. This is possible since #871 and #845.

Another motivation for this PR is to reduce the amount of code at the end of the `compiler.Compile` function, which should help with eventually breaking it down further into per-package compiles (#285).