### PR TITLE
machine: avoid binary size regression after LLVM memory intrinsics

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1736,6 +1736,7 @@ func cdcSetup(setup usbSetup) bool {
 	return false
 }
 
+//go:noinline
 func sendUSBPacket(ep uint32, data []byte) {
 	copy(udd_ep_in_cache_buffer[ep][:], data)
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1907,6 +1907,7 @@ func cdcSetup(setup usbSetup) bool {
 	return false
 }
 
+//go:noinline
 func sendUSBPacket(ep uint32, data []byte) {
 	copy(udd_ep_in_cache_buffer[ep][:], data)
 

--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -384,6 +384,7 @@ func cdcSetup(setup usbSetup) bool {
 	return false
 }
 
+//go:noinline
 func sendUSBPacket(ep uint32, data []byte) {
 	count := len(data)
 	copy(udd_ep_in_cache_buffer[ep][:], data)


### PR DESCRIPTION
Somehow moving to LLVM memory intrinsics for calls like memcpy made the
machine.sendUSBPacket get inlined. This is a problem because it is
called in many different functions and it is just big enough to cause a
significant file size increase.

Adding //go:noinline solves this problem and gets the examples/blinky1
program below the file size it was before this change (tested:
itsybitsy-m0, itsybitsy-m4, circuitplay-bluefruit).

This PR fixes the binary size regression seen in #995.