### PR TITLE
compiler: implement spec-compliant shifts

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -186,6 +186,19 @@ func (b *builder) createNilCheck(inst ssa.Value, ptr llvm.Value, blockPrefix str
 	b.createRuntimeAssert(isnil, blockPrefix, "nilPanic")
 }
 
+// createNegativeShiftCheck creates an assertion that panics if the given shift value is negative.
+// This function assumes that the shift value is signed.
+func (b *builder) createNegativeShiftCheck(shift llvm.Value) {
+	if b.fn.IsNoBounds() {
+		// Function disabled bounds checking - skip shift check.
+		return
+	}
+
+	// isNegative = shift < 0
+	isNegative := b.CreateICmp(llvm.IntSLT, shift, llvm.ConstInt(shift.Type(), 0, false), "")
+	b.createRuntimeAssert(isNegative, "shift", "negativeShiftPanic")
+}
+
 // createRuntimeAssert is a common function to create a new branch on an assert
 // bool, calling an assert func if the assert value is true (1).
 func (b *builder) createRuntimeAssert(assert llvm.Value, blockPrefix, assertFunc string) {

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -47,6 +47,11 @@ func chanMakePanic() {
 	runtimePanic("new channel is too big")
 }
 
+// Panic when a shift value is negative.
+func negativeShiftPanic() {
+	runtimePanic("negative shift")
+}
+
 func blockingPanic() {
 	runtimePanic("trying to do blocking operation in exported function")
 }

--- a/testdata/binop.go
+++ b/testdata/binop.go
@@ -61,6 +61,15 @@ func main() {
 	println(c128 != 3+2i)
 	println(c128 != 4+2i)
 	println(c128 != 3+3i)
+
+	println("shifts")
+	println(shlSimple == 4)
+	println(shlOverflow == 0)
+	println(shrSimple == 1)
+	println(shrOverflow == 0)
+	println(ashrNeg == -1)
+	println(ashrOverflow == 0)
+	println(ashrNegOverflow == -1)
 }
 
 var x = true
@@ -87,3 +96,23 @@ type Struct2 struct {
 	_ float64
 	i int
 }
+
+func shl(x uint, y int) uint {
+	return x << y
+}
+
+func shr(x uint, y int) uint {
+	return x >> y
+}
+
+func ashr(x int, y int) int {
+	return x >> y
+}
+
+var shlSimple = shl(2, 1)
+var shlOverflow = shl(2, 1000)
+var shrSimple = shr(2, 1)
+var shrOverflow = shr(2, 1000000)
+var ashrNeg = ashr(-1, 1)
+var ashrOverflow = ashr(1, 1000000)
+var ashrNegOverflow = ashr(-1, 1000000)

--- a/testdata/binop.go
+++ b/testdata/binop.go
@@ -97,15 +97,15 @@ type Struct2 struct {
 	i int
 }
 
-func shl(x uint, y int) uint {
+func shl(x uint, y uint) uint {
 	return x << y
 }
 
-func shr(x uint, y int) uint {
+func shr(x uint, y uint) uint {
 	return x >> y
 }
 
-func ashr(x int, y int) int {
+func ashr(x int, y uint) int {
 	return x >> y
 }
 

--- a/testdata/binop.txt
+++ b/testdata/binop.txt
@@ -54,3 +54,11 @@ false
 true
 true
 true
+shifts
+true
+true
+true
+true
+true
+true
+true


### PR DESCRIPTION
Previously, the compiler used LLVM's shift instructions directly, which have UB whenever the shifts are large or negative. This commit adds runtime checks for negative shifts, and handles oversized shifts.