### PR TITLE
compiler: add support for anonymous type asserts

### DIFF
--- a/testdata/interface.go
+++ b/testdata/interface.go
@@ -26,6 +26,9 @@ func main() {
 	println("Stringer.String():", s.String())
 	var itf interface{} = s
 	println("Stringer.(*Thing).String():", itf.(Stringer).String())
+	if s, ok := s.(interface{ String() string }); ok {
+		println("s has String() method:", s.String())
+	}
 
 	println("nested switch:", nestedSwitch('v', 3))
 

--- a/testdata/interface.txt
+++ b/testdata/interface.txt
@@ -18,6 +18,7 @@ is Tuple: 0 8 16 24
 SmallPair.Print: 3 5
 Stringer.String(): foo
 Stringer.(*Thing).String(): foo
+s has String() method: foo
 nested switch: true
 non-blocking call on sometimes-blocking interface
 slept 1ms


### PR DESCRIPTION
This is used for example by the errors package, which contains:

    if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
        return true
    }

The interface here is not a named type.