### PR TITLE
compiler: add debug info to goroutine start wrappers

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1078,7 +1078,7 @@ func (b *builder) createInstruction(instr ssa.Instruction) {
 				panic("StaticCallee returned an unexpected value")
 			}
 			params = append(params, context) // context parameter
-			b.createGoInstruction(calleeFn.LLVMFn, params)
+			b.createGoInstruction(calleeFn.LLVMFn, params, "", callee.Pos())
 		} else if !instr.Call.IsInvoke() {
 			// This is a function pointer.
 			// At the moment, two extra params are passed to the newly started
@@ -1096,7 +1096,7 @@ func (b *builder) createInstruction(instr ssa.Instruction) {
 			default:
 				panic("unknown scheduler type")
 			}
-			b.createGoInstruction(funcPtr, params)
+			b.createGoInstruction(funcPtr, params, b.fn.RelString(nil), instr.Pos())
 		} else {
 			b.addError(instr.Pos(), "todo: go on interface call")
 		}


### PR DESCRIPTION
In an effort to add debug info to _all_ functions, this PR adds debug information to goroutine start wrappers.