### PR TITLE
ir: add descriptive error messages to SimpleDCE pass

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -237,7 +237,10 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 	c.ir = ir.NewProgram(lprogram, pkgName)
 
 	// Run a simple dead code elimination pass.
-	c.ir.SimpleDCE()
+	err = c.ir.SimpleDCE()
+	if err != nil {
+		return c.mod, nil, []error{err}
+	}
 
 	// Initialize debug information.
 	if c.Debug() {


### PR DESCRIPTION
This commit modifies the SimpleDCE pass to emit errors similar to those emitted by gc when the main function is missing.

gc's output:
```
# command-line-arguments
runtime.main_main·f: function main is undeclared in the main package
```

our output (after this commit):
```
error: function main is undeclared in the main package
```