### PR TITLE
interp: show backtrace with error

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -884,7 +884,8 @@ func (b *builder) createFunctionDefinition() {
 		if b.fn.Synthetic == "package initializer" {
 			// Package initializers have no debug info. Create some fake debug
 			// info to at least have *something*.
-			b.difunc = b.attachDebugInfoRaw(b.fn, b.fn.LLVMFn, "", "", 0)
+			filename := b.fn.Package().Pkg.Path() + "/<init>"
+			b.difunc = b.attachDebugInfoRaw(b.fn, b.fn.LLVMFn, "", filename, 0)
 		} else if b.fn.Syntax() != nil {
 			// Create debug info file if needed.
 			b.difunc = b.attachDebugInfo(b.fn)

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -97,7 +97,7 @@ func Run(mod llvm.Module, debug bool) error {
 // function interprets the given function. The params are the function params
 // and the indent is the string indentation to use when dumping all interpreted
 // instructions.
-func (e *evalPackage) function(fn llvm.Value, params []Value, indent string) (Value, error) {
+func (e *evalPackage) function(fn llvm.Value, params []Value, indent string) (Value, *Error) {
 	fr := frame{
 		evalPackage: e,
 		fn:          fn,

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"errors"
 	"strings"
 
 	"tinygo.org/x/go-llvm"
@@ -40,7 +41,7 @@ type sideEffectResult struct {
 // hasSideEffects scans this function and all descendants, recursively. It
 // returns whether this function has side effects and if it does, which globals
 // it mentions anywhere in this function or any called functions.
-func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, error) {
+func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, *Error) {
 	name := fn.Name()
 	switch {
 	case name == "runtime.alloc":
@@ -99,7 +100,7 @@ func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, error) {
 			switch inst.InstructionOpcode() {
 			case llvm.IndirectBr, llvm.Invoke:
 				// Not emitted by the compiler.
-				return nil, e.errorAt(inst, "unknown instructions")
+				return nil, e.errorAt(inst, errors.New("unknown instructions"))
 			case llvm.Call:
 				child := inst.CalledValue()
 				if !child.IsAInlineAsm().IsNil() {

--- a/main.go
+++ b/main.go
@@ -658,22 +658,22 @@ func usage() {
 // to limitations in the LLVM bindings.
 func printCompilerError(logln func(...interface{}), err error) {
 	switch err := err.(type) {
-	case *interp.Unsupported:
-		// hit an unknown/unsupported instruction
-		logln("#", err.ImportPath)
-		msg := "unsupported instruction during init evaluation:"
-		if err.Pos.String() != "" {
-			msg = err.Pos.String() + " " + msg
-		}
-		logln(msg)
-		err.Inst.Dump()
-		logln()
 	case types.Error, scanner.Error:
 		logln(err)
-	case interp.Error:
+	case *interp.Error:
 		logln("#", err.ImportPath)
-		for _, err := range err.Errs {
-			logln(err)
+		logln(err.Error())
+		if !err.Inst.IsNil() {
+			err.Inst.Dump()
+			logln()
+		}
+		if len(err.Traceback) > 0 {
+			logln("\ntraceback:")
+			for _, line := range err.Traceback {
+				logln(line.Pos.String() + ":")
+				line.Inst.Dump()
+				logln()
+			}
 		}
 	case loader.Errors:
 		logln("#", err.Pkg.ImportPath)


### PR DESCRIPTION
This should make it much easier to figure out why and where an error happens at package initialization time.

Example error:

```
# github.com/marianogappa/cheesse/api
../../../../../../usr/local/go/src/regexp/syntax/parse.go:1535:5: interp: branch on a non-constant

traceback:
../../../../../../usr/local/go/src/regexp/syntax/parse.go:774:28:
  %107 = call { %runtime._string, %runtime._interface } @"(*regexp/syntax.parser).parseClass"(%"regexp/syntax.parser"* %23, i8* %105, i32 %106, i8* undef, i8* undef), !dbg !2008
../../../../../../usr/local/go/src/regexp/regexp.go:170:25:
  %8 = call { %"regexp/syntax.Regexp"*, %runtime._interface } @"regexp/syntax.Parse"(i8* %6, i32 %7, i16 %2, i8* undef, i8* undef), !dbg !1916
../../../../../../usr/local/go/src/regexp/regexp.go:133:16:
  %6 = call { %regexp.Regexp*, %runtime._interface } @regexp.compile(i8* %4, i32 %5, i16 212, i1 false, i8* undef, i8* undef), !dbg !1873
../../../../../../usr/local/go/src/regexp/regexp.go:309:24:
  %6 = call { %regexp.Regexp*, %runtime._interface } @regexp.Compile(i8* %4, i32 %5, i8* undef, i8* undef), !dbg !1875
github.com/marianogappa/cheesse/api/<init>:26:59:
  %550 = call %regexp.Regexp* @regexp.MustCompile(i8* getelementptr inbounds ([271 x i8], [271 x i8]* @"github.com/marianogappa/cheesse/api.init$string.966", i32 0, i32 0), i32 271, i8* undef, i8* undef), !dbg !2082
```

Previously, it would show this error:

```
# github.com/marianogappa/cheesse/api
../../../../../../usr/local/go/src/regexp/syntax/parse.go:1535:5: interp: branch on a non-constant
```

I've also taken the opportunity to merge `interp.Unsupported` into the generic interp error message (with traceback).