### PR TITLE
machine/atsamd21,atsamd51,nrf52840: correct USB CDC

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1648,6 +1648,8 @@ func handleUSBIRQ(interrupt.Interrupt) {
 			// clear stall request
 			setEPINTENCLR(0, sam.USB_DEVICE_ENDPOINT_EPINTENCLR_STALL1)
 		}
+	} else {
+		sendZlp(0)
 	}
 
 	// Now the actual transfer handlers, ignore endpoint number 0 (setup)
@@ -1967,53 +1969,29 @@ func sendDescriptor(setup usbSetup) {
 		sendConfiguration(setup)
 		return
 	case usb_DEVICE_DESCRIPTOR_TYPE:
-		if setup.wLength == 8 {
-			// composite descriptor requested, so only send 8 bytes
-			dd := NewDeviceDescriptor(0xEF, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-			sendUSBPacket(0, dd.Bytes()[:8])
-		} else {
-			// complete descriptor requested so send entire packet
-			dd := NewDeviceDescriptor(0x02, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-			sendUSBPacket(0, dd.Bytes())
+		// composite descriptor
+		dd := NewDeviceDescriptor(0xef, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
+		l := deviceDescriptorSize
+		if setup.wLength < deviceDescriptorSize {
+			l = int(setup.wLength)
 		}
+		sendUSBPacket(0, dd.Bytes()[:l])
 		return
 
 	case usb_STRING_DESCRIPTOR_TYPE:
 		switch setup.wValueL {
 		case 0:
-			b := make([]byte, 4)
-			b[0] = 0x04
-			b[1] = 0x03
-			b[2] = 0x09
-			b[3] = 0x04
+			b := []byte{0x04, 0x03, 0x09, 0x04}
 			sendUSBPacket(0, b)
 			return
 
 		case usb_IPRODUCT:
-			prod := []byte(usb_STRING_PRODUCT)
-			b := make([]byte, len(prod)*2+2)
-			b[0] = byte(len(prod)*2 + 2)
-			b[1] = 0x03
-
-			for i, val := range prod {
-				b[i*2+2] = val
-				b[i*2+3] = 0
-			}
-
+			b := strToUTF16LEDescriptor(usb_STRING_PRODUCT)
 			sendUSBPacket(0, b)
 			return
 
 		case usb_IMANUFACTURER:
-			prod := []byte(usb_STRING_MANUFACTURER)
-			b := make([]byte, len(prod)*2+2)
-			b[0] = byte(len(prod)*2 + 2)
-			b[1] = 0x03
-
-			for i, val := range prod {
-				b[i*2+2] = val
-				b[i*2+3] = 0
-			}
-
+			b := strToUTF16LEDescriptor(usb_STRING_MANUFACTURER)
 			sendUSBPacket(0, b)
 			return
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1649,7 +1649,7 @@ func handleUSBIRQ(interrupt.Interrupt) {
 			setEPINTENCLR(0, sam.USB_DEVICE_ENDPOINT_EPINTENCLR_STALL1)
 		}
 	} else {
-		sendZlp(0)
+		sendZlp()
 	}
 
 	// Now the actual transfer handlers, ignore endpoint number 0 (setup)
@@ -1772,7 +1772,7 @@ func handleStandardSetup(setup usbSetup) bool {
 		} else if setup.wValueL == 0 { // ENDPOINTHALT
 			isEndpointHalt = false
 		}
-		sendZlp(0)
+		sendZlp()
 		return true
 
 	case usb_SET_FEATURE:
@@ -1781,7 +1781,7 @@ func handleStandardSetup(setup usbSetup) bool {
 		} else if setup.wValueL == 0 { // ENDPOINTHALT
 			isEndpointHalt = true
 		}
-		sendZlp(0)
+		sendZlp()
 		return true
 
 	case usb_SET_ADDRESS:
@@ -1836,7 +1836,7 @@ func handleStandardSetup(setup usbSetup) bool {
 			// Enable interrupt for CDC data messages from host
 			setEPINTENSET(usb_CDC_ENDPOINT_OUT, sam.USB_DEVICE_ENDPOINT_EPINTENSET_TRCPT0)
 
-			sendZlp(0)
+			sendZlp()
 			return true
 		} else {
 			return false
@@ -1850,7 +1850,7 @@ func handleStandardSetup(setup usbSetup) bool {
 	case usb_SET_INTERFACE:
 		usbSetInterface = setup.wValueL
 
-		sendZlp(0)
+		sendZlp()
 		return true
 
 	default:
@@ -1895,14 +1895,14 @@ func cdcSetup(setup usbSetup) bool {
 			} else {
 				// TODO: cancel any reset
 			}
-			sendZlp(0)
+			sendZlp()
 		}
 
 		if setup.bRequest == usb_CDC_SEND_BREAK {
 			// TODO: something with this value?
 			// breakValue = ((uint16_t)setup.wValueH << 8) | setup.wValueL;
 			// return false;
-			sendZlp(0)
+			sendZlp()
 		}
 		return true
 	}
@@ -1961,104 +1961,6 @@ func receiveUSBControlPacket() []byte {
 	return data
 }
 
-// sendDescriptor creates and sends the various USB descriptor types that
-// can be requested by the host.
-func sendDescriptor(setup usbSetup) {
-	switch setup.wValueH {
-	case usb_CONFIGURATION_DESCRIPTOR_TYPE:
-		sendConfiguration(setup)
-		return
-	case usb_DEVICE_DESCRIPTOR_TYPE:
-		// composite descriptor
-		dd := NewDeviceDescriptor(0xef, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-		l := deviceDescriptorSize
-		if setup.wLength < deviceDescriptorSize {
-			l = int(setup.wLength)
-		}
-		sendUSBPacket(0, dd.Bytes()[:l])
-		return
-
-	case usb_STRING_DESCRIPTOR_TYPE:
-		switch setup.wValueL {
-		case 0:
-			b := []byte{0x04, 0x03, 0x09, 0x04}
-			sendUSBPacket(0, b)
-			return
-
-		case usb_IPRODUCT:
-			b := strToUTF16LEDescriptor(usb_STRING_PRODUCT)
-			sendUSBPacket(0, b)
-			return
-
-		case usb_IMANUFACTURER:
-			b := strToUTF16LEDescriptor(usb_STRING_MANUFACTURER)
-			sendUSBPacket(0, b)
-			return
-
-		case usb_ISERIAL:
-			// TODO: allow returning a product serial number
-			sendZlp(0)
-		}
-
-		// send final zero length packet and return
-		sendZlp(0)
-		return
-	}
-
-	// do not know how to handle this message, so return zero
-	sendZlp(0)
-	return
-}
-
-// sendConfiguration creates and sends the configuration packet to the host.
-func sendConfiguration(setup usbSetup) {
-	if setup.wLength == 9 {
-		sz := uint16(configDescriptorSize + cdcSize)
-		config := NewConfigDescriptor(sz, 2)
-		sendUSBPacket(0, config.Bytes())
-	} else {
-		iad := NewIADDescriptor(0, 2, usb_CDC_COMMUNICATION_INTERFACE_CLASS, usb_CDC_ABSTRACT_CONTROL_MODEL, 0)
-
-		cif := NewInterfaceDescriptor(usb_CDC_ACM_INTERFACE, 1, usb_CDC_COMMUNICATION_INTERFACE_CLASS, usb_CDC_ABSTRACT_CONTROL_MODEL, 0)
-
-		header := NewCDCCSInterfaceDescriptor(usb_CDC_HEADER, usb_CDC_V1_10&0xFF, (usb_CDC_V1_10>>8)&0x0FF)
-
-		controlManagement := NewACMFunctionalDescriptor(usb_CDC_ABSTRACT_CONTROL_MANAGEMENT, 6)
-
-		functionalDescriptor := NewCDCCSInterfaceDescriptor(usb_CDC_UNION, usb_CDC_ACM_INTERFACE, usb_CDC_DATA_INTERFACE)
-
-		callManagement := NewCMFunctionalDescriptor(usb_CDC_CALL_MANAGEMENT, 1, 1)
-
-		cifin := NewEndpointDescriptor((usb_CDC_ENDPOINT_ACM | usbEndpointIn), usb_ENDPOINT_TYPE_INTERRUPT, 0x10, 0x10)
-
-		dif := NewInterfaceDescriptor(usb_CDC_DATA_INTERFACE, 2, usb_CDC_DATA_INTERFACE_CLASS, 0, 0)
-
-		out := NewEndpointDescriptor((usb_CDC_ENDPOINT_OUT | usbEndpointOut), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
-
-		in := NewEndpointDescriptor((usb_CDC_ENDPOINT_IN | usbEndpointIn), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
-
-		cdc := NewCDCDescriptor(iad,
-			cif,
-			header,
-			controlManagement,
-			functionalDescriptor,
-			callManagement,
-			cifin,
-			dif,
-			out,
-			in)
-
-		sz := uint16(configDescriptorSize + cdcSize)
-		config := NewConfigDescriptor(sz, 2)
-
-		buf := make([]byte, 0)
-		buf = append(buf, config.Bytes()...)
-		buf = append(buf, cdc.Bytes()...)
-
-		sendUSBPacket(0, buf)
-	}
-}
-
 func handleEndpoint(ep uint32) {
 	// get data
 	count := int((usbEndpointDescriptors[ep].DeviceDescBank[0].PCKSIZE.Get() >>
@@ -2079,8 +1981,8 @@ func handleEndpoint(ep uint32) {
 	setEPSTATUSCLR(ep, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
 }
 
-func sendZlp(ep uint32) {
-	usbEndpointDescriptors[ep].DeviceDescBank[1].PCKSIZE.ClearBits(usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
+func sendZlp() {
+	usbEndpointDescriptors[0].DeviceDescBank[1].PCKSIZE.ClearBits(usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
 }
 
 func epPacketSize(size uint16) uint32 {

--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -400,110 +400,6 @@ func sendUSBPacket(ep uint32, data []byte) {
 	)
 }
 
-// sendDescriptor creates and sends the various USB descriptor types that
-// can be requested by the host.
-func sendDescriptor(setup usbSetup) {
-	switch setup.wValueH {
-	case usb_CONFIGURATION_DESCRIPTOR_TYPE:
-		sendConfiguration(setup)
-		return
-	case usb_DEVICE_DESCRIPTOR_TYPE:
-		// composite descriptor
-		dd := NewDeviceDescriptor(0xef, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-		l := deviceDescriptorSize
-		if setup.wLength < deviceDescriptorSize {
-			l = int(setup.wLength)
-		}
-		sendUSBPacket(0, dd.Bytes()[:l])
-		return
-
-	case usb_STRING_DESCRIPTOR_TYPE:
-		switch setup.wValueL {
-		case 0:
-			b := make([]byte, 4)
-			b[0] = 0x04
-			b[1] = 0x03
-			b[2] = 0x09
-			b[3] = 0x04
-			sendUSBPacket(0, b)
-
-		case usb_IPRODUCT:
-			b := strToUTF16LEDescriptor(usb_STRING_PRODUCT)
-			if setup.wLength == 2 {
-				sendUSBPacket(0, b[:2])
-			} else {
-				sendUSBPacket(0, b)
-			}
-
-		case usb_IMANUFACTURER:
-			b := strToUTF16LEDescriptor(usb_STRING_MANUFACTURER)
-			if setup.wLength == 2 {
-				sendUSBPacket(0, b[:2])
-			} else {
-				sendUSBPacket(0, b)
-			}
-
-		case usb_ISERIAL:
-			// TODO: allow returning a product serial number
-			nrf.USBD.TASKS_EP0STATUS.Set(1)
-		}
-		return
-	}
-
-	// do not know how to handle this message, so return zero
-	nrf.USBD.TASKS_EP0STATUS.Set(1)
-	return
-}
-
-// sendConfiguration creates and sends the configuration packet to the host.
-func sendConfiguration(setup usbSetup) {
-	if setup.wLength == 9 {
-		sz := uint16(configDescriptorSize + cdcSize)
-		config := NewConfigDescriptor(sz, 2)
-
-		sendUSBPacket(0, config.Bytes())
-	} else {
-		iad := NewIADDescriptor(0, 2, usb_CDC_COMMUNICATION_INTERFACE_CLASS, usb_CDC_ABSTRACT_CONTROL_MODEL, 0)
-
-		cif := NewInterfaceDescriptor(usb_CDC_ACM_INTERFACE, 1, usb_CDC_COMMUNICATION_INTERFACE_CLASS, usb_CDC_ABSTRACT_CONTROL_MODEL, 0)
-
-		header := NewCDCCSInterfaceDescriptor(usb_CDC_HEADER, usb_CDC_V1_10&0xFF, (usb_CDC_V1_10>>8)&0x0FF)
-
-		controlManagement := NewACMFunctionalDescriptor(usb_CDC_ABSTRACT_CONTROL_MANAGEMENT, 6)
-
-		functionalDescriptor := NewCDCCSInterfaceDescriptor(usb_CDC_UNION, usb_CDC_ACM_INTERFACE, usb_CDC_DATA_INTERFACE)
-
-		callManagement := NewCMFunctionalDescriptor(usb_CDC_CALL_MANAGEMENT, 1, 1)
-
-		cifin := NewEndpointDescriptor((usb_CDC_ENDPOINT_ACM | usbEndpointIn), usb_ENDPOINT_TYPE_INTERRUPT, 0x10, 0x10)
-
-		dif := NewInterfaceDescriptor(usb_CDC_DATA_INTERFACE, 2, usb_CDC_DATA_INTERFACE_CLASS, 0, 0)
-
-		out := NewEndpointDescriptor((usb_CDC_ENDPOINT_OUT | usbEndpointOut), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
-
-		in := NewEndpointDescriptor((usb_CDC_ENDPOINT_IN | usbEndpointIn), usb_ENDPOINT_TYPE_BULK, usbEndpointPacketSize, 0)
-
-		cdc := NewCDCDescriptor(iad,
-			cif,
-			header,
-			controlManagement,
-			functionalDescriptor,
-			callManagement,
-			cifin,
-			dif,
-			out,
-			in)
-
-		sz := uint16(configDescriptorSize + cdcSize)
-		config := NewConfigDescriptor(sz, 2)
-
-		buf := make([]byte, 0)
-		buf = append(buf, config.Bytes()...)
-		buf = append(buf, cdc.Bytes()...)
-		sendUSBPacket(0, buf)
-	}
-}
-
 func (usbcdc USBCDC) handleEndpoint(ep uint32) {
 	// get data
 	count := int(nrf.USBD.EPOUT[ep].AMOUNT.Get())
@@ -515,6 +411,10 @@ func (usbcdc USBCDC) handleEndpoint(ep uint32) {
 
 	// set ready for next data
 	nrf.USBD.SIZE.EPOUT[ep].Set(0)
+}
+
+func sendZlp() {
+	nrf.USBD.TASKS_EP0STATUS.Set(1)
 }
 
 func sendViaEPIn(ep uint32, ptr *byte, count int) {

--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -408,15 +408,13 @@ func sendDescriptor(setup usbSetup) {
 		sendConfiguration(setup)
 		return
 	case usb_DEVICE_DESCRIPTOR_TYPE:
-		if setup.wLength == 8 {
-			// composite descriptor requested, so only send 8 bytes
-			dd := NewDeviceDescriptor(0xEF, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-			sendUSBPacket(0, dd.Bytes()[:8])
-		} else {
-			// complete descriptor requested so send entire packet
-			dd := NewDeviceDescriptor(0x02, 0x00, 0x00, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
-			sendUSBPacket(0, dd.Bytes())
+		// composite descriptor
+		dd := NewDeviceDescriptor(0xef, 0x02, 0x01, 64, usb_VID, usb_PID, 0x100, usb_IMANUFACTURER, usb_IPRODUCT, usb_ISERIAL, 1)
+		l := deviceDescriptorSize
+		if setup.wLength < deviceDescriptorSize {
+			l = int(setup.wLength)
 		}
+		sendUSBPacket(0, dd.Bytes()[:l])
 		return
 
 	case usb_STRING_DESCRIPTOR_TYPE:


### PR DESCRIPTION
This PR corrects the USB CDC composite descriptors for the ATSAMD21, ATSAMD51, and NRF52840 processors.

Turns out that the clues provided by @sago35 were correct, the descriptor needed to be changed.

I tested the `example/echo` program with these boards: 

- Circuit Playground Express
- ItsyBitsy M4
- Circuit Playground Bluefruit

On these OS:

- Ubuntu
- macOS
- Windows 10.