### PR TITLE
track phi nodes in stack slots

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1025,6 +1025,18 @@ func (b *builder) createFunctionDefinition() {
 			phi.llvm.AddIncoming([]llvm.Value{llvmVal}, []llvm.BasicBlock{llvmBlock})
 		}
 	}
+
+	if b.NeedsStackObjects() {
+		// Track phi nodes.
+		for _, phi := range b.phis {
+			insertPoint := llvm.NextInstruction(phi.llvm)
+			for !insertPoint.IsAPHINode().IsNil() {
+				insertPoint = llvm.NextInstruction(insertPoint)
+			}
+			b.SetInsertPointBefore(insertPoint)
+			b.trackValue(phi.llvm)
+		}
+	}
 }
 
 // createInstruction builds the LLVM IR equivalent instructions for the

--- a/transform/testdata/gc-stackslots.out.ll
+++ b/transform/testdata/gc-stackslots.out.ll
@@ -56,3 +56,59 @@ define i8* @noAllocatingFunction() {
   %ptr = call i8* @getPointer()
   ret i8* %ptr
 }
+
+define i8* @fibNext(i8* %x, i8* %y) {
+  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8* }
+  store { %runtime.stackChainObject*, i32, i8* } { %runtime.stackChainObject* null, i32 1, i8* null }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject
+  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart
+  %2 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 0
+  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2
+  %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
+  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart
+  %x.val = load i8, i8* %x
+  %y.val = load i8, i8* %y
+  %out.val = add i8 %x.val, %y.val
+  %out.alloc = call i8* @runtime.alloc(i32 1)
+  %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
+  store i8* %out.alloc, i8** %4
+  store i8 %out.val, i8* %out.alloc
+  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart
+  ret i8* %out.alloc
+}
+
+define i8* @allocLoop() {
+entry:
+  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }
+  store { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* } { %runtime.stackChainObject* null, i32 5, i8* null, i8* null, i8* null, i8* null, i8* null }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject
+  %0 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart
+  %1 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 0
+  store %runtime.stackChainObject* %0, %runtime.stackChainObject** %1
+  %2 = bitcast { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject to %runtime.stackChainObject*
+  store %runtime.stackChainObject* %2, %runtime.stackChainObject** @runtime.stackChainStart
+  %entry.x = call i8* @runtime.alloc(i32 1)
+  %3 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 2
+  store i8* %entry.x, i8** %3
+  %entry.y = call i8* @runtime.alloc(i32 1)
+  %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 3
+  store i8* %entry.y, i8** %4
+  store i8 1, i8* %entry.y
+  br label %loop
+
+loop:
+  %prev.y = phi i8* [ %entry.y, %entry ], [ %prev.x, %loop ]
+  %prev.x = phi i8* [ %entry.x, %entry ], [ %next.x, %loop ]
+  %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 5
+  store i8* %prev.y, i8** %5
+  %6 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 4
+  store i8* %prev.x, i8** %6
+  %next.x = call i8* @fibNext(i8* %prev.x, i8* %prev.y)
+  %7 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 6
+  store i8* %next.x, i8** %7
+  %next.x.val = load i8, i8* %next.x
+  %loop.done = icmp ult i8 40, %next.x.val
+  br i1 %loop.done, label %end, label %loop
+
+end:
+  store %runtime.stackChainObject* %0, %runtime.stackChainObject** @runtime.stackChainStart
+  ret i8* %next.x
+}


### PR DESCRIPTION
As demonstrated in #1009, allocations are sometimes released too early because the stack slot is hit multiple times. This PR attempts to fix this by generating separate stack slots for PHI nodes.