### PR TITLE
compiler: track the result of string concatenation

### DIFF
--- a/compiler/gc.go
+++ b/compiler/gc.go
@@ -41,6 +41,12 @@ func (b *builder) trackExpr(expr ssa.Value, value llvm.Value) {
 			// pointer in there (if there is one).
 			b.trackValue(value)
 		}
+	case *ssa.BinOp:
+		switch expr.Op {
+		case token.ADD:
+			// String concatenation.
+			b.trackValue(value)
+		}
 	}
 }
 


### PR DESCRIPTION
Before this commit, the garbage collector was able to collect string values while they were still in use.