### PR TITLE
main (test): remove global build lock in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -91,18 +90,6 @@ func runPlatTests(target string, matches []string, t *testing.T) {
 	}
 }
 
-// Due to some problems with LLD, we cannot run links in parallel, or in parallel with compiles.
-// Therefore, we put a lock around builds and run everything else in parallel.
-var buildLock sync.Mutex
-
-// runBuild is a thread-safe wrapper around Build.
-func runBuild(src, out string, opts *compileopts.Options) error {
-	buildLock.Lock()
-	defer buildLock.Unlock()
-
-	return Build(src, out, opts)
-}
-
 func runTest(path, target string, t *testing.T) {
 	// Get the expected output for this test.
 	txtpath := path[:len(path)-3] + ".txt"
@@ -138,7 +125,7 @@ func runTest(path, target string, t *testing.T) {
 		WasmAbi:    "js",
 	}
 	binary := filepath.Join(tmpdir, "test")
-	err = runBuild("./"+path, binary, config)
+	err = Build("./"+path, binary, config)
 	if err != nil {
 		printCompilerError(t.Log, err)
 		t.Fail()


### PR DESCRIPTION
Previously, due to bugs in LLD, we were forced to put a global lock around builds. Now that LLD and clang are being run in seperate processes, this is no longer necessary. This change allows tests to be run concurrently.