### PR TITLE
machine: move errors.New calls to globals

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -35,6 +35,8 @@ import (
 	"unsafe"
 )
 
+var errCycleCountTooLarge = errors.New("requested cycle count is too large, overflows 24 bit counter")
+
 // Run the given assembly code. The code will be marked as having side effects,
 // as it doesn't produce output and thus would normally be eliminated by the
 // optimizer.
@@ -232,7 +234,7 @@ func SetupSystemTimer(cyclecount uint32) error {
 	}
 	if cyclecount&SYST_RVR_RELOAD_Msk != cyclecount {
 		// The cycle refresh register is only 24 bits wide.  The user-specified value will overflow.
-		return errors.New("requested cycle count is too large, overflows 24 bit counter")
+		return errCycleCountTooLarge
 	}
 
 	// set refresh count

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -2,10 +2,25 @@
 
 package machine
 
+import (
+	"errors"
+)
+
 // TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
 const (
 	TWI_FREQ_100KHZ = 100000
 	TWI_FREQ_400KHZ = 400000
+)
+
+var (
+	errI2CWriteTimeout       = errors.New("I2C timeout during write")
+	errI2CReadTimeout        = errors.New("I2C timeout during read")
+	errI2CBusReadyTimeout    = errors.New("I2C timeout on bus ready")
+	errI2CSignalStartTimeout = errors.New("I2C timeout on signal start")
+	errI2CSignalReadTimeout  = errors.New("I2C timeout on signal read")
+	errI2CSignalStopTimeout  = errors.New("I2C timeout on signal stop")
+	errI2CAckExpected        = errors.New("I2C error: expected ACK not NACK")
+	errI2CBusError           = errors.New("I2C bus error")
 )
 
 // WriteRegister transmits first the register and then the data to the

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -10,7 +10,6 @@ package machine
 import (
 	"device/arm"
 	"device/sam"
-	"errors"
 	"runtime/interrupt"
 	"unsafe"
 )
@@ -925,13 +924,13 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 		for !i2c.Bus.INTFLAG.HasBits(sam.SERCOM_I2CM_INTFLAG_MB) {
 			timeout--
 			if timeout == 0 {
-				return errors.New("I2C timeout on ready to write data")
+				return errI2CWriteTimeout
 			}
 		}
 
 		// ACK received (0: ACK, 1: NACK)
 		if i2c.Bus.STATUS.HasBits(sam.SERCOM_I2CM_STATUS_RXNACK) {
-			return errors.New("I2C write error: expected ACK not NACK")
+			return errI2CAckExpected
 		}
 
 		// write data
@@ -957,13 +956,13 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			// In that case, send a stop condition and return error.
 			if i2c.Bus.INTFLAG.HasBits(sam.SERCOM_I2CM_INTFLAG_MB) {
 				i2c.Bus.CTRLB.SetBits(wireCmdStop << sam.SERCOM_I2CM_CTRLB_CMD_Pos) // Stop condition
-				return errors.New("I2C read error: expected ACK not NACK")
+				return errI2CAckExpected
 			}
 		}
 
 		// ACK received (0: ACK, 1: NACK)
 		if i2c.Bus.STATUS.HasBits(sam.SERCOM_I2CM_STATUS_RXNACK) {
-			return errors.New("I2C read error: expected ACK not NACK")
+			return errI2CAckExpected
 		}
 
 		// read first byte
@@ -1000,16 +999,16 @@ func (i2c I2C) WriteByte(data byte) error {
 	for !i2c.Bus.INTFLAG.HasBits(sam.SERCOM_I2CM_INTFLAG_MB) {
 		// check for bus error
 		if i2c.Bus.STATUS.HasBits(sam.SERCOM_I2CM_STATUS_BUSERR) {
-			return errors.New("I2C bus error")
+			return errI2CBusError
 		}
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on write data")
+			return errI2CWriteTimeout
 		}
 	}
 
 	if i2c.Bus.STATUS.HasBits(sam.SERCOM_I2CM_STATUS_RXNACK) {
-		return errors.New("I2C write error: expected ACK not NACK")
+		return errI2CAckExpected
 	}
 
 	return nil
@@ -1028,7 +1027,7 @@ func (i2c I2C) sendAddress(address uint16, write bool) error {
 		!i2c.Bus.STATUS.HasBits(wireOwnerState<<sam.SERCOM_I2CM_STATUS_BUSSTATE_Pos) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on bus ready")
+			return errI2CBusReadyTimeout
 		}
 	}
 	i2c.Bus.ADDR.Set(uint32(data))
@@ -1042,7 +1041,7 @@ func (i2c I2C) signalStop() error {
 	for i2c.Bus.SYNCBUSY.HasBits(sam.SERCOM_I2CM_SYNCBUSY_SYSOP) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on signal stop")
+			return errI2CSignalStopTimeout
 		}
 	}
 	return nil
@@ -1054,7 +1053,7 @@ func (i2c I2C) signalRead() error {
 	for i2c.Bus.SYNCBUSY.HasBits(sam.SERCOM_I2CM_SYNCBUSY_SYSOP) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on signal read")
+			return errI2CSignalReadTimeout
 		}
 	}
 	return nil
@@ -1455,7 +1454,7 @@ func (usbcdc USBCDC) WriteByte(c byte) error {
 		for (getEPINTFLAG(usb_CDC_ENDPOINT_IN) & sam.USB_DEVICE_ENDPOINT_EPINTFLAG_TRCPT1) == 0 {
 			timeout--
 			if timeout == 0 {
-				return errors.New("USBCDC write byte timeout")
+				return errUSBCDCWriteByteTimeout
 			}
 		}
 	}

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -4,7 +4,6 @@ package machine
 
 import (
 	"device/sifive"
-	"errors"
 	"runtime/interrupt"
 )
 
@@ -195,8 +194,6 @@ type I2CConfig struct {
 	SDA       Pin
 }
 
-var i2cAckExpectedError error = errors.New("I2C write error: expected ACK not NACK")
-
 // Configure is intended to setup the I2C interface.
 func (i2c I2C) Configure(config I2CConfig) error {
 	var i2cClockFrequency uint32 = 32000000
@@ -238,7 +235,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 		// ACK received (0: ACK, 1: NACK)
 		if i2c.Bus.CR_SR.HasBits(sifive.I2C_SR_RX_ACK) {
-			return i2cAckExpectedError
+			return errI2CAckExpected
 		}
 
 		// write data
@@ -255,7 +252,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 
 		// ACK received (0: ACK, 1: NACK)
 		if i2c.Bus.CR_SR.HasBits(sifive.I2C_SR_RX_ACK) {
-			return i2cAckExpectedError
+			return errI2CAckExpected
 		}
 
 		// read first byte
@@ -290,7 +287,7 @@ func (i2c I2C) writeByte(data byte) error {
 
 	// ACK received (0: ACK, 1: NACK)
 	if i2c.Bus.CR_SR.HasBits(sifive.I2C_SR_RX_ACK) {
-		return i2cAckExpectedError
+		return errI2CAckExpected
 	}
 
 	return nil

--- a/src/machine/machine_stm32f103xx.go
+++ b/src/machine/machine_stm32f103xx.go
@@ -6,7 +6,6 @@ package machine
 
 import (
 	"device/stm32"
-	"errors"
 	"runtime/interrupt"
 	"unsafe"
 )
@@ -343,7 +342,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read clear address")
+					return errI2CWriteTimeout
 				}
 			}
 
@@ -354,7 +353,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read 1 byte")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -382,7 +381,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read clear address")
+					return errI2CWriteTimeout
 				}
 			}
 
@@ -394,7 +393,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read 2 bytes")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -428,7 +427,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read clear address")
+					return errI2CWriteTimeout
 				}
 			}
 
@@ -440,8 +439,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
-					println("I2C timeout on read 3 bytes")
-					return errors.New("I2C timeout on read 3 bytes")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -455,7 +453,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read 3 bytes")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -483,7 +481,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read clear address")
+					return errI2CWriteTimeout
 				}
 			}
 
@@ -496,8 +494,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 				for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 					timeout--
 					if timeout == 0 {
-						println("I2C timeout on read 3 bytes")
-						return errors.New("I2C timeout on read 3 bytes")
+						return errI2CReadTimeout
 					}
 				}
 
@@ -510,7 +507,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read more than 3 bytes")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -530,7 +527,7 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
 				timeout--
 				if timeout == 0 {
-					return errors.New("I2C timeout on read last byte of more than 3")
+					return errI2CReadTimeout
 				}
 			}
 
@@ -554,7 +551,7 @@ func (i2c I2C) signalStart() error {
 	for i2c.Bus.SR2.HasBits(stm32.I2C_SR2_BUSY) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C busy on start")
+			return errI2CSignalStartTimeout
 		}
 	}
 
@@ -569,7 +566,7 @@ func (i2c I2C) signalStart() error {
 	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_SB) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on start")
+			return errI2CSignalStartTimeout
 		}
 	}
 
@@ -592,8 +589,7 @@ func (i2c I2C) waitForStop() error {
 	for i2c.Bus.SR1.HasBits(stm32.I2C_SR1_STOPF) {
 		timeout--
 		if timeout == 0 {
-			println("I2C timeout on wait for stop signal")
-			return errors.New("I2C timeout on wait for stop signal")
+			return errI2CSignalStopTimeout
 		}
 	}
 
@@ -617,7 +613,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
 			timeout--
 			if timeout == 0 {
-				return errors.New("I2C timeout on send write address")
+				return errI2CWriteTimeout
 			}
 		}
 
@@ -625,7 +621,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY | stm32.I2C_SR2_TRA) {
 			timeout--
 			if timeout == 0 {
-				return errors.New("I2C timeout on send write address")
+				return errI2CWriteTimeout
 			}
 		}
 	} else {
@@ -633,7 +629,7 @@ func (i2c I2C) sendAddress(address uint8, write bool) error {
 		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
 			timeout--
 			if timeout == 0 {
-				return errors.New("I2C timeout on send read address")
+				return errI2CWriteTimeout
 			}
 		}
 	}
@@ -653,7 +649,7 @@ func (i2c I2C) WriteByte(data byte) error {
 	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_TxE) {
 		timeout--
 		if timeout == 0 {
-			return errors.New("I2C timeout on write")
+			return errI2CWriteTimeout
 		}
 	}
 

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -4,6 +4,8 @@ package machine
 
 import "errors"
 
+var errUARTBufferEmpty = errors.New("UART buffer empty")
+
 type UARTConfig struct {
 	BaudRate uint32
 	TX       Pin
@@ -60,7 +62,7 @@ func (uart UART) ReadByte() (byte, error) {
 	// check if RX buffer is empty
 	buf, ok := uart.Buffer.Get()
 	if !ok {
-		return 0, errors.New("Buffer empty")
+		return 0, errUARTBufferEmpty
 	}
 	return buf, nil
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -9,6 +9,11 @@ import (
 
 const deviceDescriptorSize = 18
 
+var (
+	errUSBCDCBufferEmpty      = errors.New("USB-CDC buffer empty")
+	errUSBCDCWriteByteTimeout = errors.New("USB-CDC write byte timeout")
+)
+
 // DeviceDescriptor implements the USB standard device descriptor.
 //
 // Table 9-8. Standard Device Descriptor
@@ -598,7 +603,7 @@ func (usbcdc USBCDC) ReadByte() (byte, error) {
 	// check if RX buffer is empty
 	buf, ok := usbcdc.Buffer.Get()
 	if !ok {
-		return 0, errors.New("Buffer empty")
+		return 0, errUSBCDCBufferEmpty
 	}
 	return buf, nil
 }


### PR DESCRIPTION
Calling `errors.New` in an error path causes a heap allocation at an already unfortunate moment. It is more efficient to create these error values in globals and return these constant globals. If these errors are not used (because the related code was optimized out), the globals will also be optimized out.

Feel free to suggest more (or less) precise error messages, I haven't put much thought in which errors should be merged and which shouldn't.

---

This commit also helps avoid a possible recursive code path: `runtime.alloc` may print an error message when the heap is full but the USB-CDC code to print it may also cause an allocation to happen.