### PR TITLE
all: change //go:export to //export

### DIFF
--- a/src/examples/systick/systick.go
+++ b/src/examples/systick/systick.go
@@ -17,7 +17,7 @@ func main() {
 
 var led_state bool
 
-//go:export SysTick_Handler
+//export SysTick_Handler
 func timer_isr() {
 	if led_state {
 		machine.LED.Low()

--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -2,7 +2,7 @@
 
 The examples here show two different ways of using WebAssembly with TinyGo:
 
-1. Defining and exporting functions via the `//go:export <name>` directive. See
+1. Defining and exporting functions via the `//export <name>` directive. See
 [the export folder](./export) for an example of this.  Additionally, the Wasm
 module (which has a default value of `env`) can be specified using
 `//go:wasm-module <module>`.

--- a/src/examples/wasm/export/wasm.go
+++ b/src/examples/wasm/export/wasm.go
@@ -8,12 +8,12 @@ import (
 func main() {
 }
 
-//go:export add
+//export add
 func add(a, b int) int {
 	return a + b
 }
 
-//go:export update
+//export update
 func update() {
 	document := js.Global().Get("document")
 	aStr := document.Call("getElementById", "a").Get("value").String()

--- a/src/internal/task/task_coroutine.go
+++ b/src/internal/task/task_coroutine.go
@@ -10,12 +10,12 @@ import (
 // This matches *i8 in LLVM.
 type rawState uint8
 
-//go:export llvm.coro.resume
+//export llvm.coro.resume
 func (s *rawState) resume()
 
 type state struct{ *rawState }
 
-//go:export llvm.coro.noop
+//export llvm.coro.noop
 func noopState() *rawState
 
 // Resume the task until it pauses or completes.

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -31,13 +31,13 @@ func (p Pin) Get() bool {
 	return gpioGet(p)
 }
 
-//go:export __tinygo_gpio_configure
+//export __tinygo_gpio_configure
 func gpioConfigure(pin Pin, config PinConfig)
 
-//go:export __tinygo_gpio_set
+//export __tinygo_gpio_set
 func gpioSet(pin Pin, value bool)
 
-//go:export __tinygo_gpio_get
+//export __tinygo_gpio_get
 func gpioGet(pin Pin) bool
 
 type SPI struct {
@@ -61,10 +61,10 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 	return spiTransfer(spi.Bus, w), nil
 }
 
-//go:export __tinygo_spi_configure
+//export __tinygo_spi_configure
 func spiConfigure(bus uint8, sck Pin, mosi Pin, miso Pin)
 
-//go:export __tinygo_spi_transfer
+//export __tinygo_spi_transfer
 func spiTransfer(bus uint8, w uint8) uint8
 
 // InitADC enables support for ADC peripherals.
@@ -81,7 +81,7 @@ func (adc ADC) Get() uint16 {
 	return adcRead(adc.Pin)
 }
 
-//go:export __tinygo_adc_read
+//export __tinygo_adc_read
 func adcRead(pin Pin) uint16
 
 // InitPWM enables support for PWM peripherals.
@@ -98,7 +98,7 @@ func (pwm PWM) Set(value uint16) {
 	pwmSet(pwm.Pin, value)
 }
 
-//go:export __tinygo_pwm_set
+//export __tinygo_pwm_set
 func pwmSet(pin Pin, value uint16)
 
 // I2C is a generic implementation of the Inter-IC communication protocol.
@@ -125,10 +125,10 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 	return nil
 }
 
-//go:export __tinygo_i2c_configure
+//export __tinygo_i2c_configure
 func i2cConfigure(bus uint8, scl Pin, sda Pin)
 
-//go:export __tinygo_i2c_transfer
+//export __tinygo_i2c_transfer
 func i2cTransfer(bus uint8, w *byte, wlen int, r *byte, rlen int) int
 
 type UART struct {
@@ -174,11 +174,11 @@ func (uart UART) WriteByte(b byte) error {
 	return nil
 }
 
-//go:export __tinygo_uart_configure
+//export __tinygo_uart_configure
 func uartConfigure(bus uint8, tx Pin, rx Pin)
 
-//go:export __tinygo_uart_read
+//export __tinygo_uart_read
 func uartRead(bus uint8, buf *byte, bufLen int) int
 
-//go:export __tinygo_uart_write
+//export __tinygo_uart_write
 func uartWrite(bus uint8, buf *byte, bufLen int) int

--- a/src/runtime/arch_wasm.go
+++ b/src/runtime/arch_wasm.go
@@ -14,7 +14,7 @@ const TargetBits = 32
 //go:extern __heap_base
 var heapStartSymbol [0]byte
 
-//go:export llvm.wasm.memory.size.i32
+//export llvm.wasm.memory.size.i32
 func wasm_memory_size(index int32) int32
 
 var (

--- a/src/runtime/math.go
+++ b/src/runtime/math.go
@@ -63,7 +63,7 @@ func math_Ceil(x float64) float64 {
 	return math_ceil(x)
 }
 
-//go:export llvm.ceil.f64
+//export llvm.ceil.f64
 func llvm_ceil(x float64) float64
 
 //go:linkname math_ceil math.ceil
@@ -119,7 +119,7 @@ func math_Floor(x float64) float64 {
 	return math_floor(x)
 }
 
-//go:export llvm.floor.f64
+//export llvm.floor.f64
 func llvm_floor(x float64) float64
 
 //go:linkname math_floor math.floor
@@ -175,7 +175,7 @@ func math_Max(x, y float64) float64 {
 	return math_max(x, y)
 }
 
-//go:export llvm.maximum.f64
+//export llvm.maximum.f64
 func llvm_maximum(x, y float64) float64
 
 //go:linkname math_max math.max
@@ -189,7 +189,7 @@ func math_Min(x, y float64) float64 {
 	return math_min(x, y)
 }
 
-//go:export llvm.minimum.f64
+//export llvm.minimum.f64
 func llvm_minimum(x, y float64) float64
 
 //go:linkname math_min math.min
@@ -239,7 +239,7 @@ func math_Sqrt(x float64) float64 {
 	return math_sqrt(x)
 }
 
-//go:export llvm.sqrt.f64
+//export llvm.sqrt.f64
 func llvm_sqrt(x float64) float64
 
 //go:linkname math_sqrt math.sqrt
@@ -265,7 +265,7 @@ func math_Trunc(x float64) float64 {
 	return math_trunc(x)
 }
 
-//go:export llvm.trunc.f64
+//export llvm.trunc.f64
 func llvm_trunc(x float64) float64
 
 //go:linkname math_trunc math.trunc

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -2,7 +2,7 @@ package runtime
 
 // trap is a compiler hint that this function cannot be executed. It is
 // translated into either a trap instruction or a call to abort().
-//go:export llvm.trap
+//export llvm.trap
 func trap()
 
 // Builtin function panic(msg), used as a compiler intrinsic.

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -33,7 +33,7 @@ var _edata [0]byte
 func postinit() {}
 
 // Entry point for Go. Initialize all packages and call main.main().
-//go:export main
+//export main
 func main() {
 	// Initialize .data and .bss sections.
 	preinit()

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -15,7 +15,7 @@ type timeUnit int64
 
 func postinit() {}
 
-//go:export Reset_Handler
+//export Reset_Handler
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -14,7 +14,7 @@ type timeUnit int64
 
 func postinit() {}
 
-//go:export Reset_Handler
+//export Reset_Handler
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -36,7 +36,7 @@ var _sbss [0]byte
 //go:extern _ebss
 var _ebss [0]byte
 
-//go:export main
+//export main
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -74,7 +74,7 @@ type interruptStack struct {
 // For details, see:
 // https://community.arm.com/developer/ip-products/system/f/embedded-forum/3257/debugging-a-cortex-m0-hard-fault
 // https://blog.feabhas.com/2013/02/developing-a-generic-hard-fault-handler-for-arm-cortex-m3cortex-m4/
-//go:export handleHardFault
+//export handleHardFault
 func handleHardFault(sp *interruptStack) {
 	print("fatal error: ")
 	if uintptr(unsafe.Pointer(sp)) < 0x20000000 {

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -19,7 +19,7 @@ var timestamp timeUnit
 
 func postinit() {}
 
-//go:export Reset_Handler
+//export Reset_Handler
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -18,7 +18,7 @@ type timeUnit int64
 
 func postinit() {}
 
-//go:export main
+//export main
 func main() {
 	// Zero the PLIC enable bits on startup: they are not zeroed at reset.
 	sifive.PLIC.ENABLE[0].Set(0)

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -19,7 +19,7 @@ func systemInit()
 
 func postinit() {}
 
-//go:export Reset_Handler
+//export Reset_Handler
 func main() {
 	systemInit()
 	preinit()

--- a/src/runtime/runtime_stm32.go
+++ b/src/runtime/runtime_stm32.go
@@ -6,7 +6,7 @@ type timeUnit int64
 
 func postinit() {}
 
-//go:export Reset_Handler
+//export Reset_Handler
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -19,7 +19,7 @@ var timestamp timeUnit
 
 func postinit() {}
 
-//go:export main
+//export main
 func main() {
 	preinit()
 	run()

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -6,22 +6,22 @@ import (
 	"unsafe"
 )
 
-//go:export putchar
+//export putchar
 func _putchar(c int) int
 
-//go:export usleep
+//export usleep
 func usleep(usec uint) int
 
-//go:export malloc
+//export malloc
 func malloc(size uintptr) unsafe.Pointer
 
-//go:export abort
+//export abort
 func abort()
 
-//go:export exit
+//export exit
 func exit(code int)
 
-//go:export clock_gettime
+//export clock_gettime
 func clock_gettime(clk_id int32, ts *timespec)
 
 type timeUnit int64
@@ -41,7 +41,7 @@ const CLOCK_MONOTONIC_RAW = 4
 func postinit() {}
 
 // Entry point for Go. Initialize all packages and call main.main().
-//go:export main
+//export main
 func main() int {
 	preinit()
 
@@ -83,5 +83,5 @@ func extalloc(size uintptr) unsafe.Pointer {
 	return malloc(size)
 }
 
-//go:export free
+//export free
 func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -53,14 +53,14 @@ func setEventHandler(fn func()) {
 	handleEvent = fn
 }
 
-//go:export resume
+//export resume
 func resume() {
 	go func() {
 		handleEvent()
 	}()
 }
 
-//go:export go_scheduler
+//export go_scheduler
 func go_scheduler() {
 	scheduler()
 }
@@ -69,10 +69,10 @@ const asyncScheduler = true
 
 // This function is called by the scheduler.
 // Schedule a call to runtime.scheduler, do not actually sleep.
-//go:export runtime.sleepTicks
+//export runtime.sleepTicks
 func sleepTicks(d timeUnit)
 
-//go:export runtime.ticks
+//export runtime.ticks
 func ticks() timeUnit
 
 // Abort executes the wasm 'unreachable' instruction.

--- a/src/syscall/syscall_darwin.go
+++ b/src/syscall/syscall_darwin.go
@@ -12,7 +12,7 @@ package syscall
 //         return errno;
 //     }
 //
-//go:export __error
+//export __error
 func libc___error() *int32
 
 // getErrno returns the current C errno. It may not have been caused by the last

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -53,5 +53,5 @@ func splitSlice(p []byte) (buf *byte, len uintptr) {
 }
 
 // ssize_t write(int fd, const void *buf, size_t count)
-//go:export write
+//export write
 func libc_write(fd int32, buf *byte, count uint) int

--- a/testdata/calls.go
+++ b/testdata/calls.go
@@ -100,7 +100,7 @@ func deferred(msg string, i int) {
 	println(msg, i)
 }
 
-//go:export __exportedDefer
+//export __exportedDefer
 func exportedDefer() {
 	println("...exported defer")
 }


### PR DESCRIPTION
This is the kind that is used in Go (actually CGo) for exporting functions. I think it's best to use `//export` instead of our custom `//go:export` pragma, for consistency (they are equivalent in TinyGo). Therefore I've updated all instances to the standard format, except for two that are updated in https://github.com/tinygo-org/tinygo/pull/1024.

No smoke tests changed (when comparing the output hash), except for some wasm tests that include DWARF debug info and tend to be flaky anyway. Therefore this should be safe to apply.