### PR TITLE
Omit frame pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,8 @@ smoketest:
 	# test simulated boards on play.tinygo.org
 	$(TINYGO) build             -o test.wasm -tags=arduino              examples/blinky1
 	@$(MD5SUM) test.wasm
+	$(TINYGO) build             -o test.wasm -tags=hifive1-qemu         examples/serial
+	@$(MD5SUM) test.wasm
 	$(TINYGO) build             -o test.wasm -tags=hifive1b             examples/blinky1
 	@$(MD5SUM) test.wasm
 	$(TINYGO) build             -o test.wasm -tags=reelboard            examples/blinky1

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -158,7 +158,7 @@ var aeabiBuiltins = []string{
 // For more information, see: https://compiler-rt.llvm.org/
 var CompilerRT = Library{
 	name:      "compiler-rt",
-	cflags:    func() []string { return []string{"-Werror", "-Wall", "-std=c11", "-fshort-enums", "-nostdlibinc"} },
+	cflags:    func() []string { return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"} },
 	sourceDir: "lib/compiler-rt/lib/builtins",
 	sources: func(target string) []string {
 		builtins := append([]string{}, genericBuiltins...) // copy genericBuiltins

--- a/builder/library.go
+++ b/builder/library.go
@@ -69,7 +69,7 @@ func (l *Library) Load(target string) (path string, err error) {
 	// Precalculate the flags to the compiler invocation.
 	args := append(l.cflags(), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
-		args = append(args, "-fshort-enums")
+		args = append(args, "-fshort-enums", "-fomit-frame-pointer")
 	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")

--- a/builder/library.go
+++ b/builder/library.go
@@ -68,6 +68,9 @@ func (l *Library) Load(target string) (path string, err error) {
 
 	// Precalculate the flags to the compiler invocation.
 	args := append(l.cflags(), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
+	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
+		args = append(args, "-fshort-enums")
+	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")
 	}

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -12,7 +12,7 @@ var Picolibc = Library{
 	name: "picolibc",
 	cflags: func() []string {
 		picolibcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc")
-		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "-fshort-enums", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
+		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
 	},
 	sourceDir: "lib/picolibc/newlib/libc",
 	sources: func(target string) []string {

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -1,4 +1,4 @@
-// +build tinygo.riscv,qemu
+// +build tinygo.riscv,virt,qemu
 
 package runtime
 

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -13,6 +13,7 @@
 		"-mthumb",
 		"-Werror",
 		"-fshort-enums",
+		"-fomit-frame-pointer",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -15,6 +15,7 @@
 		"-Oz",
 		"-Werror",
 		"-fshort-enums",
+		"-fomit-frame-pointer",
 		"-Qunused-arguments",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -20,6 +20,8 @@ int globalUnionSize = sizeof(globalUnion);
 option_t globalOption = optionG;
 bitfield_t globalBitfield = {244, 15, 1, 2, 47, 5};
 
+int smallEnumWidth = sizeof(option2_t);
+
 int fortytwo() {
 	return 42;
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -111,6 +111,9 @@ func main() {
 	println("option 2A:", C.option2A)
 	println("option 3A:", C.option3A)
 
+	// Check that enums are considered the same width in C and CGo.
+	println("enum width matches:", unsafe.Sizeof(C.option2_t(0)) == uintptr(C.smallEnumWidth))
+
 	// libc: test whether C functions work at all.
 	buf1 := []byte("foobar\x00")
 	buf2 := make([]byte, len(buf1))

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -134,6 +134,8 @@ extern int globalUnionSize;
 extern option_t globalOption;
 extern bitfield_t globalBitfield;
 
+extern int smallEnumWidth;
+
 // test duplicate definitions
 int add(int a, int b);
 extern int global;

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -55,4 +55,5 @@ option F: 11
 option G: 12
 option 2A: 20
 option 3A: 21
+enum width matches: true
 copied string: foobar


### PR DESCRIPTION
A collection of somewhat related changes.

1. A fix to get hifive1-qemu to compile again (oops!).
2. Use `-fshort-enums` consistently.
3. Omit frame pointers on ARM.

The main reason to omit frame pointers is that it makes it easier for me to recover stack usage from DWARF call frame information.