### PR TITLE
Go 1.14 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,8 +232,8 @@ commands:
       - run:
           name: "Install dependencies"
           command: |
-            curl https://dl.google.com/go/go1.13.darwin-amd64.tar.gz -o go1.13.darwin-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.13.darwin-amd64.tar.gz
+            curl https://dl.google.com/go/go1.14.darwin-amd64.tar.gz -o go1.14.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.14.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
             HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
       - restore_cache:
@@ -327,14 +327,20 @@ jobs:
     steps:
       - test-linux:
           llvm: "10"
+  test-llvm10-go114:
+    docker:
+      - image: circleci/golang:1.14-buster
+    steps:
+      - test-linux:
+          llvm: "10"
   assert-test-linux:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     steps:
       - assert-test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.14-stretch
     steps:
       - build-linux
   build-macos:
@@ -352,6 +358,7 @@ workflows:
       - test-llvm9-go111
       - test-llvm10-go112
       - test-llvm10-go113
+      - test-llvm10-go114
       - build-linux
       - build-macos
       - assert-test-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# TinyGo base stage installs Go 1.13, LLVM 10 and the TinyGo compiler itself.
-FROM golang:1.13 AS tinygo-base
+# TinyGo base stage installs Go 1.14, LLVM 10 and the TinyGo compiler itself.
+FROM golang:1.14 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" >> /etc/apt/sources.list && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
     - task: GoTool@0
       inputs:
-        version: '1.13.8'
+        version: '1.14.1'
     - checkout: self
     - task: CacheBeta@0
       displayName: Cache LLVM source

--- a/builder/config.go
+++ b/builder/config.go
@@ -25,8 +25,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || (minor != 11 && minor != 12 && minor != 13) {
-		return nil, fmt.Errorf("requires go version 1.11, 1.12, or 1.13, got go%d.%d", major, minor)
+	if major != 1 || minor < 11 || minor > 14 {
+		return nil, fmt.Errorf("requires go version 1.11, 1.12, 1.13, or 1.14, got go%d.%d", major, minor)
 	}
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
 	return &compileopts.Config{

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -62,12 +62,18 @@ type C.union3_t = C.union_1
 type C.union_nested_t = C.union_3
 type C.unionarray_t = struct{ arr [10]C.uchar }
 
-func (s *C.struct_4) bitfield_a() C.uchar          { return s.__bitfield_1 & 0x1f }
-func (s *C.struct_4) set_bitfield_a(value C.uchar) { s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0 }
+func (s *C.struct_4) bitfield_a() C.uchar {
+	return s.__bitfield_1 & 0x1f
+}
+func (s *C.struct_4) set_bitfield_a(value C.uchar) {
+	s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0
+}
 func (s *C.struct_4) bitfield_b() C.uchar {
 	return s.__bitfield_1 >> 5 & 0x1
 }
-func (s *C.struct_4) set_bitfield_b(value C.uchar) { s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5 }
+func (s *C.struct_4) set_bitfield_b(value C.uchar) {
+	s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5
+}
 func (s *C.struct_4) bitfield_c() C.uchar {
 	return s.__bitfield_1 >> 6
 }
@@ -94,25 +100,45 @@ type C.struct_type1 struct {
 }
 type C.struct_type2 struct{ _type C.int }
 
-func (union *C.union_1) unionfield_i() *C.int   { return (*C.int)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_1) unionfield_d() *float64 { return (*float64)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_1) unionfield_s() *C.short { return (*C.short)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_1) unionfield_i() *C.int {
+	return (*C.int)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_1) unionfield_d() *float64 {
+	return (*float64)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_1) unionfield_s() *C.short {
+	return (*C.short)(unsafe.Pointer(&union.$union))
+}
 
 type C.union_1 struct{ $union uint64 }
 
-func (union *C.union_2) unionfield_area() *C.point2d_t  { return (*C.point2d_t)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_2) unionfield_solid() *C.point3d_t { return (*C.point3d_t)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_2) unionfield_area() *C.point2d_t {
+	return (*C.point2d_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_2) unionfield_solid() *C.point3d_t {
+	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
+}
 
 type C.union_2 struct{ $union [3]uint32 }
 
-func (union *C.union_3) unionfield_point() *C.point3d_t    { return (*C.point3d_t)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_3) unionfield_array() *C.unionarray_t { return (*C.unionarray_t)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_3) unionfield_thing() *C.union3_t     { return (*C.union3_t)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_3) unionfield_point() *C.point3d_t {
+	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_3) unionfield_array() *C.unionarray_t {
+	return (*C.unionarray_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_3) unionfield_thing() *C.union3_t {
+	return (*C.union3_t)(unsafe.Pointer(&union.$union))
+}
 
 type C.union_3 struct{ $union [2]uint64 }
 
-func (union *C.union_union2d) unionfield_i() *C.int      { return (*C.int)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_union2d) unionfield_d() *[2]float64 { return (*[2]float64)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_union2d) unionfield_i() *C.int {
+	return (*C.int)(unsafe.Pointer(&union.$union))
+}
+func (union *C.union_union2d) unionfield_d() *[2]float64 {
+	return (*[2]float64)(unsafe.Pointer(&union.$union))
+}
 
 type C.union_union2d struct{ $union [2]uint64 }
 type C.enum_option C.int

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -415,7 +415,6 @@
 				this,
 			];
 			this._refs = new Map();
-			this._callbackShutdown = false;
 			this.exited = false;
 
 			const mem = new DataView(this._inst.exports.memory.buffer)
@@ -472,12 +471,6 @@
 
 		const go = new Go();
 		WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then((result) => {
-			process.on("exit", (code) => { // Node.js exits if no callback is pending
-				if (code === 0 && !go.exited) {
-					// deadlock, make Go print error and stack traces
-					go._callbackShutdown = true;
-				}
-			});
 			return go.run(result.instance);
 		}).catch((err) => {
 			throw err;


### PR DESCRIPTION
This is a continuation of #901. I have modified the PR of @QuLogic to include the bits needed to get all tests to run on Go 1.14 and extended it a bit to switch to Go 1.14 entirely.

Note that this PR drops support for WebAssembly on Go 1.13 (at least when you import the syscall/js package) but I think working around that would be difficult. It should definitely be possible to create a workaround (for example, by exporting a function that when called returns the Go minor version) but I'd like to avoid such hacks if possible. Therefore I would propose keeping it as-is for now and only adding a workaround if there is enough demand (which I don't expect).

This will probably conflict with #1014 but the conflicts should be easy to resolve.