### PR TITLE
compiler: unexport some exported symbols

### DIFF
--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -11,7 +11,7 @@ import (
 
 // The maximum number of arguments that can be expanded from a single struct. If
 // a struct contains more fields, it is passed as a struct without expanding.
-const MaxFieldsPerParam = 3
+const maxFieldsPerParam = 3
 
 // paramFlags identifies parameter attributes for flags. Most importantly, it
 // determines which parameters are dereferenceable_or_null and which aren't.
@@ -52,7 +52,7 @@ func expandFormalParamType(t llvm.Type, goType types.Type) ([]llvm.Type, []param
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
 		fields, fieldFlags := flattenAggregateType(t, goType)
-		if len(fields) <= MaxFieldsPerParam {
+		if len(fields) <= maxFieldsPerParam {
 			return fields, fieldFlags
 		} else {
 			// failed to lower
@@ -72,7 +72,7 @@ func (b *builder) expandFormalParamOffsets(t llvm.Type) []uint64 {
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
 		fields := b.flattenAggregateTypeOffsets(t)
-		if len(fields) <= MaxFieldsPerParam {
+		if len(fields) <= maxFieldsPerParam {
 			return fields
 		} else {
 			// failed to lower
@@ -92,7 +92,7 @@ func (b *builder) expandFormalParam(v llvm.Value) []llvm.Value {
 	switch v.Type().TypeKind() {
 	case llvm.StructTypeKind:
 		fieldTypes, _ := flattenAggregateType(v.Type(), nil)
-		if len(fieldTypes) <= MaxFieldsPerParam {
+		if len(fieldTypes) <= maxFieldsPerParam {
 			fields := b.flattenAggregate(v)
 			if len(fields) != len(fieldTypes) {
 				panic("type and value param lowering don't match")
@@ -227,7 +227,7 @@ func (b *builder) collapseFormalParamInternal(t llvm.Type, fields []llvm.Value) 
 	switch t.TypeKind() {
 	case llvm.StructTypeKind:
 		flattened, _ := flattenAggregateType(t, nil)
-		if len(flattened) <= MaxFieldsPerParam {
+		if len(flattened) <= maxFieldsPerParam {
 			value := llvm.ConstNull(t)
 			for i, subtyp := range t.StructElementTypes() {
 				structField, remaining := b.collapseFormalParamInternal(subtyp, fields)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -65,7 +65,7 @@ type builder struct {
 	blockEntries      map[*ssa.BasicBlock]llvm.BasicBlock // a *ssa.BasicBlock may be split up
 	blockExits        map[*ssa.BasicBlock]llvm.BasicBlock // these are the exit blocks
 	currentBlock      *ssa.BasicBlock
-	phis              []Phi
+	phis              []phiNode
 	taskHandle        llvm.Value
 	deferPtr          llvm.Value
 	difunc            llvm.Metadata
@@ -77,7 +77,7 @@ type builder struct {
 	selectRecvBuf     map[*ssa.Select]llvm.Value
 }
 
-type Phi struct {
+type phiNode struct {
 	ssa  *ssa.Phi
 	llvm llvm.Value
 }
@@ -196,7 +196,7 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 			return ""
 		},
 		TypeChecker: types.Config{
-			Sizes: &StdSizes{
+			Sizes: &stdSizes{
 				IntSize:  int64(c.targetData.TypeAllocSize(c.intType)),
 				PtrSize:  int64(c.targetData.PointerSize()),
 				MaxAlign: int64(c.targetData.PrefTypeAlignment(c.i8ptrType)),
@@ -1740,7 +1740,7 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 		}
 	case *ssa.Phi:
 		phi := b.CreatePHI(b.getLLVMType(expr.Type()), "")
-		b.phis = append(b.phis, Phi{expr, phi})
+		b.phis = append(b.phis, phiNode{expr, phi})
 		return phi, nil
 	case *ssa.Range:
 		var iteratorType llvm.Type

--- a/compiler/sizes.go
+++ b/compiler/sizes.go
@@ -10,13 +10,13 @@ import (
 // The original license can be found here:
 //     https://golang.org/LICENSE
 
-type StdSizes struct {
+type stdSizes struct {
 	IntSize  int64
 	PtrSize  int64
 	MaxAlign int64
 }
 
-func (s *StdSizes) Alignof(T types.Type) int64 {
+func (s *stdSizes) Alignof(T types.Type) int64 {
 	// For arrays and structs, alignment is defined in terms
 	// of alignment of the elements and fields, respectively.
 	switch t := T.Underlying().(type) {
@@ -61,7 +61,7 @@ func (s *StdSizes) Alignof(T types.Type) int64 {
 	return a
 }
 
-func (s *StdSizes) Offsetsof(fields []*types.Var) []int64 {
+func (s *stdSizes) Offsetsof(fields []*types.Var) []int64 {
 	offsets := make([]int64, len(fields))
 	var o int64
 	for i, f := range fields {
@@ -89,7 +89,7 @@ var basicSizes = [...]byte{
 	types.Complex128: 16,
 }
 
-func (s *StdSizes) Sizeof(T types.Type) int64 {
+func (s *stdSizes) Sizeof(T types.Type) int64 {
 	switch t := T.Underlying().(type) {
 	case *types.Basic:
 		k := t.Kind()


### PR DESCRIPTION
Some symbols (constants/types/methods) were exported while they are an implementation detail. To keep the public API clean, unexport them.

The public API of the compiler package now consists of just the `Compile` and the `NewTargetMachine` functions.