### PR TITLE
transform (func-lowering): remove specializations from function value lowering and fix lowering of a function value of an unimplemented type

### DIFF
--- a/transform/testdata/func-lowering.out.ll
+++ b/transform/testdata/func-lowering.out.ll
@@ -4,10 +4,9 @@ target triple = "wasm32-unknown-unknown-wasm"
 %runtime.typecodeID = type { %runtime.typecodeID*, i32 }
 %runtime.funcValueWithSignature = type { i32, %runtime.typecodeID* }
 
-@"reflect/types.type:func:{basic:int8}{}" = external constant %runtime.typecodeID
 @"reflect/types.type:func:{basic:uint8}{}" = external constant %runtime.typecodeID
 @"reflect/types.type:func:{basic:int}{}" = external constant %runtime.typecodeID
-@"funcInt8$withSignature" = constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i8, i8*, i8*)* @funcInt8 to i32), %runtime.typecodeID* @"reflect/types.type:func:{basic:int8}{}" }
+@"reflect/types.type:func:{}{basic:uint32}" = external constant %runtime.typecodeID
 @"func1Uint8$withSignature" = constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i8, i8*, i8*)* @func1Uint8 to i32), %runtime.typecodeID* @"reflect/types.type:func:{basic:uint8}{}" }
 @"func2Uint8$withSignature" = constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i8, i8*, i8*)* @func2Uint8 to i32), %runtime.typecodeID* @"reflect/types.type:func:{basic:uint8}{}" }
 @"main$withSignature" = constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i32, i8*, i8*)* @"main$1" to i32), %runtime.typecodeID* @"reflect/types.type:func:{basic:int}{}" }
@@ -23,26 +22,32 @@ declare void @"main$1"(i32, i8*, i8*)
 
 declare void @"main$2"(i32, i8*, i8*)
 
-declare void @funcInt8(i8, i8*, i8*)
-
 declare void @func1Uint8(i8, i8*, i8*)
 
 declare void @func2Uint8(i8, i8*, i8*)
 
-define void @runFunc1(i8* %0, i32 %1, i8 %2, i8* %context, i8* %parentHandle) {
+define i32 @runFuncNone(i8* %0, i32 %1, i8* %context, i8* %parentHandle) {
 entry:
-  %3 = icmp eq i32 %1, 0
-  %4 = select i1 %3, void (i8, i8*, i8*)* null, void (i8, i8*, i8*)* @funcInt8
-  %5 = icmp eq void (i8, i8*, i8*)* %4, null
-  br i1 %5, label %fpcall.nil, label %fpcall.next
+  br i1 false, label %fpcall.nil, label %fpcall.next
 
 fpcall.nil:                                       ; preds = %entry
   call void @runtime.nilPanic(i8* undef, i8* null)
   unreachable
 
 fpcall.next:                                      ; preds = %entry
-  call void %4(i8 %2, i8* %0, i8* undef)
-  ret void
+  switch i32 %1, label %func.default [
+    i32 0, label %func.nil
+  ]
+
+func.nil:                                         ; preds = %fpcall.next
+  call void @runtime.nilPanic(i8* undef, i8* null)
+  unreachable
+
+func.next:                                        ; No predecessors!
+  ret i32 undef
+
+func.default:                                     ; preds = %fpcall.next
+  unreachable
 }
 
 define void @runFunc2(i8* %0, i32 %1, i8 %2, i8* %context, i8* %parentHandle) {


### PR DESCRIPTION
Previously, the function value lowering pass had special cases for when there were 0 or 1 function implementations. However, the results of the pass were incorrect in both of these cases. This change removes the specializations and fixes the transformation.

In the case that there was a single function implementation, the compiler emitted a select instruction to obtain the function pointer. This selected between null and the implementing function pointer.
While this was technically correct, it failed to eliminate indirect function calls. This prevented discovery of these calls by the coroutine lowering pass, and caused async function calls to be passed through unlowered. As a result, the generated code had undefined behavior (usually resulting in a segfault).

In the case of no function implementations, the lowering code was correct. However, the lowering code was not run. The discovery of function signatures was accomplished by scanning implementations, and when there were no implementations nothing was discovered or lowered.

For maintainability reasons, I have removed both specializations rather than fixing them. This substantially simplifies the code, and reduces the amount of variation that we need to worry about for testing purposes. The IR now generated in the cases of 0 or 1 function implementations can be efficiently simplified by LLVM's optimization passes. Therefore, there should not be a substantial regression in terms of performance or machine code size.

I have also inspected some final output IR, and it seems that LLVM optimizes it to something similar to what we had wanted for a single function implementation:
```
  %switch = icmp eq i64 %.unpack2, 0
  br i1 %switch, label %func.nil, label %func.call1
```