### PR TITLE
fix for invoking the tools when target is arm64

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -170,7 +170,11 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		for i, path := range config.ExtraFiles() {
 			abspath := filepath.Join(root, path)
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, abspath)...)
+			targ:=config.Target.Triple
+			if targ!="" {
+				targ="--target="+config.Target.Triple
+			}
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", targ,"-o", outpath, abspath)...)
 			if err != nil {
 				return &commandError{"failed to build", path, err}
 			}

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -12,7 +12,10 @@ var Picolibc = Library{
 	name: "picolibc",
 	cflags: func() []string {
 		picolibcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc")
-		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
+		//note: different targets seems to imply different behavior from llvm so it's necessary
+		//note: to add this additional "-I"+picolibcDir+"/include" when compiling for arm64.
+		//note: it ends being ignored by other targets, so no harm, no foul.
+		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB","-I"+picolibcDir+"/include", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
 	},
 	sourceDir: "lib/picolibc/newlib/libc",
 	sources: func(target string) []string {


### PR DESCRIPTION
@aykevl I added the change for the problem we observed with picolibc.

This fix is necessary or you cannot compile picolibc due to a difference in the -I CFLAGS.  Weirdly, that seems to depend on the _target_.

This fix also passes the target, if supplied, to the extra assembly files when building.

It passes smoketests for me locally, with AVR=0.

