### PR TITLE
rpi3 support with interrupts

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -170,7 +170,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		for i, path := range config.ExtraFiles() {
 			abspath := filepath.Join(root, path)
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, abspath)...)
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "--target="+config.Target.Triple,"-o", outpath, abspath)...)
 			if err != nil {
 				return &commandError{"failed to build", path, err}
 			}

--- a/builder/build.go
+++ b/builder/build.go
@@ -170,7 +170,11 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		for i, path := range config.ExtraFiles() {
 			abspath := filepath.Join(root, path)
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "--target="+config.Target.Triple,"-o", outpath, abspath)...)
+			targ:=config.Target.Triple
+			if targ!="" {
+				targ="--target="+config.Target.Triple
+			}
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", targ,"-o", outpath, abspath)...)
 			if err != nil {
 				return &commandError{"failed to build", path, err}
 			}

--- a/builder/build.go
+++ b/builder/build.go
@@ -170,11 +170,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 		for i, path := range config.ExtraFiles() {
 			abspath := filepath.Join(root, path)
 			outpath := filepath.Join(dir, "extra-"+strconv.Itoa(i)+"-"+filepath.Base(path)+".o")
-			targ:=config.Target.Triple
-			if targ!="" {
-				targ="--target="+config.Target.Triple
-			}
-			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", targ,"-o", outpath, abspath)...)
+			err := runCCompiler(config.Target.Compiler, append(config.CFlags(), "-c", "-o", outpath, abspath)...)
 			if err != nil {
 				return &commandError{"failed to build", path, err}
 			}

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -13,7 +13,10 @@ var Picolibc = Library{
 	//lib/picolibc/newlib/libc/include/
 	cflags: func() []string {
 		picolibcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc")
-		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "-I"+picolibcDir+"/include","--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
+		//note: different targets seems to imply different behavior from llvm so it's necessary
+		//note: to add this additional "-I"+picolibcDir+"/include" when compiling for arm64.
+		//note: it ends being ignored by other targets, so no harm, no foul.
+		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB","-I"+picolibcDir+"/include", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
 	},
 	sourceDir: "lib/picolibc/newlib/libc",
 	sources: func(target string) []string {

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -10,9 +10,10 @@ import (
 // based on newlib.
 var Picolibc = Library{
 	name: "picolibc",
+	//lib/picolibc/newlib/libc/include/
 	cflags: func() []string {
 		picolibcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc")
-		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
+		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "-I"+picolibcDir+"/include","--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
 	},
 	sourceDir: "lib/picolibc/newlib/libc",
 	sources: func(target string) []string {

--- a/src/device/arm/arm-cortex-a53.S
+++ b/src/device/arm/arm-cortex-a53.S
@@ -1,11 +1,13 @@
-.section ".text.boot","",@progbits
+.section ".exc_vector","ax",@progbits
+.align 7
+
+.extern raw_exception_handler
 
 /*
  * Interrupt vectors that are jumped to by the hardware when we get
  * an exception. There are 4 states and 4 types of exceptions so
  * we have 0x10 entries, and each entry cannot exceed 0x80
  */
-
 #define S_FRAME_SIZE			256 		// size of all saved registers
 
 #define SYNC_EL1t		0
@@ -33,15 +35,8 @@
 	mov	x0, #\type
 	mrs	x1, esr_el1
 	mrs	x2, elr_el1
-
-    mov x3,#\type
-    lsl x3,x3,#3 //multiply by 8
-    ldr x4,excptrs
-    add x4,x4,x3
-    ldr x5,[x4]
-
-    br x5
-	b	err_hang
+    bl raw_exception_handler
+    kernel_exit
 	.endm
 
 	.macro	ventry	label
@@ -90,8 +85,9 @@
 	eret
 	.endm
 
-.align 7
-//vectors:
+.align 11
+.globl vectors
+vectors:
 	ventry	sync_el1t			// Synchronous EL1t
 	ventry	irq_el1t			// IRQ EL1t
 	ventry	fiq_el1t			// FIQ EL1t
@@ -178,16 +174,7 @@ fiq_el0_32:
 error_el0_32:
 	interrupt_entry  ERROR_EL0_32
 
-.globl err_hang
-err_hang: b err_hang
-
-.globl excptrs
-excptrs:
-.space 0x8*16
-
-
-
-.section ".text"
+.section ".text.boot"
 .globl _start
 _start:
     mov x0, #0x760
@@ -199,7 +186,7 @@ _start:
 	b	proc_hang
 
 .align 3
-proc_hang: 
+proc_hang:
 	b 	proc_hang
 
 master:
@@ -266,3 +253,6 @@ get_el:
 	lsr x0, x0, #2
 	ret
 
+
+.globl err_hang
+err_hang: b err_hang

--- a/src/device/arm/arm-cortex-a53.S
+++ b/src/device/arm/arm-cortex-a53.S
@@ -1,0 +1,268 @@
+.section ".text.boot","",@progbits
+
+/*
+ * Interrupt vectors that are jumped to by the hardware when we get
+ * an exception. There are 4 states and 4 types of exceptions so
+ * we have 0x10 entries, and each entry cannot exceed 0x80
+ */
+
+#define S_FRAME_SIZE			256 		// size of all saved registers
+
+#define SYNC_EL1t		0
+#define IRQ_EL1t		1
+#define FIQ_EL1t		2
+#define ERROR_EL1t		3
+
+#define SYNC_EL1h		4
+#define IRQ_EL1h		5
+#define FIQ_EL1h		6
+#define ERROR_EL1h		7
+
+#define SYNC_EL0_64	    	8
+#define IRQ_EL0_64	    	9
+#define FIQ_EL0_64		10
+#define ERROR_EL0_64		11
+
+#define SYNC_EL0_32		12
+#define IRQ_EL0_32		13
+#define FIQ_EL0_32		14
+#define ERROR_EL0_32		15
+
+	.macro interrupt_entry type
+	kernel_entry
+	mov	x0, #\type
+	mrs	x1, esr_el1
+	mrs	x2, elr_el1
+
+    mov x3,#\type
+    lsl x3,x3,#3 //multiply by 8
+    ldr x4,excptrs
+    add x4,x4,x3
+    ldr x5,[x4]
+
+    br x5
+	b	err_hang
+	.endm
+
+	.macro	ventry	label
+	.align	7
+	b	\label
+	.endm
+
+	.macro	kernel_entry
+	sub	sp, sp, #S_FRAME_SIZE
+	stp	x0, x1, [sp, #16 * 0]
+	stp	x2, x3, [sp, #16 * 1]
+	stp	x4, x5, [sp, #16 * 2]
+	stp	x6, x7, [sp, #16 * 3]
+	stp	x8, x9, [sp, #16 * 4]
+	stp	x10, x11, [sp, #16 * 5]
+	stp	x12, x13, [sp, #16 * 6]
+	stp	x14, x15, [sp, #16 * 7]
+	stp	x16, x17, [sp, #16 * 8]
+	stp	x18, x19, [sp, #16 * 9]
+	stp	x20, x21, [sp, #16 * 10]
+	stp	x22, x23, [sp, #16 * 11]
+	stp	x24, x25, [sp, #16 * 12]
+	stp	x26, x27, [sp, #16 * 13]
+	stp	x28, x29, [sp, #16 * 14]
+	str	x30, [sp, #16 * 15]
+	.endm
+
+	.macro	kernel_exit
+	ldp	x0, x1, [sp, #16 * 0]
+	ldp	x2, x3, [sp, #16 * 1]
+	ldp	x4, x5, [sp, #16 * 2]
+	ldp	x6, x7, [sp, #16 * 3]
+	ldp	x8, x9, [sp, #16 * 4]
+	ldp	x10, x11, [sp, #16 * 5]
+	ldp	x12, x13, [sp, #16 * 6]
+	ldp	x14, x15, [sp, #16 * 7]
+	ldp	x16, x17, [sp, #16 * 8]
+	ldp	x18, x19, [sp, #16 * 9]
+	ldp	x20, x21, [sp, #16 * 10]
+	ldp	x22, x23, [sp, #16 * 11]
+	ldp	x24, x25, [sp, #16 * 12]
+	ldp	x26, x27, [sp, #16 * 13]
+	ldp	x28, x29, [sp, #16 * 14]
+	ldr	x30, [sp, #16 * 15]
+	add	sp, sp, #S_FRAME_SIZE
+	eret
+	.endm
+
+.align 7
+//vectors:
+	ventry	sync_el1t			// Synchronous EL1t
+	ventry	irq_el1t			// IRQ EL1t
+	ventry	fiq_el1t			// FIQ EL1t
+	ventry	error_el1t			// Error EL1t
+
+	ventry	sync_el1h			// Synchronous EL1h
+	ventry	irq_el1h		    // IRQ EL1h -- big dog
+	ventry	fiq_el1h			// FIQ EL1h
+	ventry	error_el1h			// Error EL1h
+
+	ventry	sync_el0_64			// Synchronous 64-bit EL0
+	ventry	irq_el0_64			// IRQ 64-bit EL0
+	ventry	fiq_el0_64			// FIQ 64-bit EL0
+	ventry	error_el0_64		// Error 64-bit EL0
+
+	ventry	sync_el0_32			// Synchronous 32-bit EL0
+	ventry	irq_el0_32			// IRQ 32-bit EL0
+	ventry	fiq_el0_32			// FIQ 32-bit EL0
+	ventry	error_el0_32		// Error 32-bit EL0
+
+
+// these functions need to be broken out so each macro instation can jump to a different point.
+.globl sync_el1t
+sync_el1t:
+	interrupt_entry  SYNC_EL1t
+
+.globl irq_el1t
+irq_el1t:
+	interrupt_entry  IRQ_EL1t
+
+.globl fiq_el1t
+fiq_el1t:
+	interrupt_entry  FIQ_EL1t
+
+.globl error_el1t
+error_el1t:
+	interrupt_entry  ERROR_EL1t
+
+.globl sync_el1h
+sync_el1h:
+	interrupt_entry  SYNC_EL1h
+
+.globl irq_el1h
+irq_el1h:
+    interrupt_entry IRQ_EL1h
+
+.globl fiq_el1h
+fiq_el1h:
+	interrupt_entry  FIQ_EL1h
+
+.globl error_el1h
+error_el1h:
+	interrupt_entry  ERROR_EL1h
+
+.globl sync_el0_64
+sync_el0_64:
+	interrupt_entry  SYNC_EL0_64
+
+.globl irq_el0_64
+irq_el0_64:
+	interrupt_entry  IRQ_EL0_64
+
+.globl fiq_el0_64
+fiq_el0_64:
+	interrupt_entry  FIQ_EL0_64
+
+.globl error_el0_64
+error_el0_64:
+	interrupt_entry  ERROR_EL0_64
+
+.globl sync_el0_32
+sync_el0_32:
+	interrupt_entry  SYNC_EL0_32
+
+.globl irq_el0_32
+irq_el0_32:
+	interrupt_entry  IRQ_EL0_32
+
+.globl fiq_el0_32
+fiq_el0_32:
+	interrupt_entry  FIQ_EL0_32
+
+.globl error_el0_32
+error_el0_32:
+	interrupt_entry  ERROR_EL0_32
+
+.globl err_hang
+err_hang: b err_hang
+
+.globl excptrs
+excptrs:
+.space 0x8*16
+
+
+
+.section ".text"
+.globl _start
+_start:
+    mov x0, #0x760
+    lsl x0,x0,#8
+    mov sp,x0 //safety if we fail during boot
+	mrs	x0, mpidr_el1		
+	and	x0, x0,#0xFF		// Check processor id
+	cbz	x0, master		// Hang for all non-primary CPU
+	b	proc_hang
+
+.align 3
+proc_hang: 
+	b 	proc_hang
+
+master:
+    bl get_el
+    sub x4,x0,#2 //store 0 if EL2 and 1 (assumed) if EL3 (hardware?)
+	//cant do this
+	//orr x0, xzr, #0x30D00800 // SystemControlRegisterValueMMUDisabled
+	//so forced to do this
+    orr x0,xzr, #3
+    lsl x0,x0,#28
+    orr x1,xzr, #3
+    lsl x1,x1,22
+    orr x2,xzr,#1
+    lsl x2,x2,20
+    orr x2,x2,#0x800
+    orr x1,x1,x2
+    orr x0,x0,x1
+    msr	sctlr_el1, x0
+
+	orr	x0,xzr, #0x80000000 // HypervisorConfigurationRegisterValue
+	msr	hcr_el2, x0
+
+    //do we need to do the drop from el2 because we are in qemu?
+    cbz x4,el2_drop_to_el1
+
+    //we are in el3
+	orr	x0,xzr, #0x400 // SecureConfigurationRegisterValue
+	orr x0,x0, #0x30
+	orr x0,x0,#1
+	msr	scr_el3, x0
+
+    //xxx seems like this should be C3 not C0? to go to EL1
+	and x0,x0, #0x1C0 // SavedProgramStatusRegisterValue, we use a const for el3
+	msr	spsr_el3, x0
+
+	adr	x0, el1_entry		
+	msr	elr_el3, x0
+	eret
+
+el2_drop_to_el1:
+	mrs x0, spsr_el2 // SavedProgramStatusRegisterValue but for EL2
+	orr x0,x0,#0x4 //bit 2, bit 0  (bit 2 => level 1 is desired EL, bit0 means use own stack for EL1), so EL1h
+	orr x0,x0,#0x1 //second step because #0x5 isn't a legal const
+	msr	spsr_el2, x0
+
+	adr	x0, el1_entry
+	msr	elr_el2, x0
+    eret
+
+el1_entry:
+    // retset stack before our code (we are now in el1)
+    mov     x1, #0x760
+    lsl     x1,x1,#0x8
+    mov     sp, x1
+    mov     x30,xzr
+
+    //can't branch and link here because the stack and link are in a bad state
+	b main
+	b err_hang		// nuke the site from orbit...
+
+.globl get_el
+get_el:
+	mrs x0, CurrentEL
+	lsr x0, x0, #2
+	ret
+

--- a/src/machine/board_rpi3.go
+++ b/src/machine/board_rpi3.go
@@ -1,0 +1,638 @@
+// +build rpi3
+
+package machine
+
+import (
+	"device/arm"
+	"runtime/volatile"
+	"unsafe"
+)
+
+//specific to raspberry pi 3
+const MemoryMappedIO = uintptr(0x3F000000)
+
+var Aux *AuxPeripheralsRegisterMap = (*AuxPeripheralsRegisterMap)(unsafe.Pointer(MemoryMappedIO + 0x00215000))
+var GPIO *GPIORegisterMap = (*GPIORegisterMap)(unsafe.Pointer(MemoryMappedIO + 0x00200000))
+var SysTimer *SysTimerRegisterMap = (*SysTimerRegisterMap)(unsafe.Pointer(MemoryMappedIO + 0x3000))
+var InterruptController *IRQRegisterMap = (*IRQRegisterMap)(unsafe.Pointer(MemoryMappedIO + 0xB200))
+
+//decls
+var MiniUART UART
+
+// for the interrupt numbers for use with interrupt controller
+const AuxInterrupt = 1 << 29
+
+type AuxPeripheralsRegisterMap struct {
+	InterruptStatus           volatile.Register32 //0x00
+	Enables                   volatile.Register32 //0x04
+	reserved00                [14]uint32
+	MiniUARTData              volatile.Register32 //0x40, 8 bits wide
+	MiniUARTInterruptEnable   volatile.Register32 //0x44
+	MiniUARTInterruptIdentify volatile.Register32 //0x48
+	MiniUARTLineControl       volatile.Register32 //0x4C
+	MiniUARTModemControl      volatile.Register32 //0x50
+	MiniUARTLineStatus        volatile.Register32 //0x54, readonly
+	MiniUARTModemStatus       volatile.Register32 //0x58, readonly
+	MiniUARTScratch           volatile.Register32 //0x5C
+	MiniUARTExtraControl      volatile.Register32 //0x60
+	MiniUARTExtraStatus       volatile.Register32 //0x64
+	MiniUARTBAUD              volatile.Register32 //0x68
+	reserved01                [5]uint32
+	SPI1ControlRegister0      volatile.Register32 //0x80
+	SPI1ControlRegister1      volatile.Register32 //0x84
+	SPI1Status                volatile.Register32 //0x88
+	reserved02                volatile.Register32 //0x8C
+	SPI1Data                  volatile.Register32 //0x90
+	SPI1Peek                  volatile.Register32 //0x94
+	reserved03                [10]uint32
+	SPI2ControlRegister0      volatile.Register32 //0xC0
+	SPI2ControlRegister1      volatile.Register32 //0xC4
+	SPI2Status                volatile.Register32 //0xC8
+	reserved04                volatile.Register32
+	SPI2Data                  volatile.Register32 //0xD0
+	SPI2Peek                  volatile.Register32 //0xD4
+}
+
+// mini uart: peripheral enable
+const PeripheralMiniUART = 1 << 0
+
+// mini uart: extra control bitfields
+const ReceiveEnable = 1 << 0
+const TransmitEnable = 1 << 1
+const EnableRTS = 1 << 2
+const EnableCTS = 1 << 3
+const RTSFlowLevelMask = 0x1F //use with register32.ReplaceBits
+const RTSFlowLevelFIFO3Spaces = 0 << 4
+const RTSFlowLevelFIFO2Spaces = 1 << 4
+const RTSFlowLevelFIFO1Space = 2 << 4
+const RTSFlowLevelFIFO4Spaces = 3 << 4
+const RTSAssertLevel = 1 << 6
+const CTSAssertLevel = 1 << 7
+
+// mini uart: line control register bitfields
+//https://elinux.org/BCM2835_datasheet_errata
+const DataLength8Bits = 3 << 0
+const Break = 1 << 6
+const DLab = 1 << 7
+
+// mini uart: line control register bitfields
+const ReadyToSend = 1 << 1
+
+// mini uart: interrupt identify register bitfields
+const Pending = 1 << 0
+const TransmitInterruptsPending = 1 << 1 //Read
+const ReceiveInterruptsPending = 2 << 1 //Read
+
+const ClearFIFOsMask = 0x6//use with register32.ReplaceBits
+const ClearReceiveFIFO = 1 << 1 //Write
+const ClearTransmitFIFO = 1 << 2 //Write
+
+// mini uart: line status register bitfields
+const ReceivedDataAvailable = 1 << 0
+const ReceivedDataOverrun = 1 << 1
+const TransmitFIFOSpaceAvailable = 1 << 5
+const TransmitterIdle = 1 << 6
+
+// mini uart: interrupt enable register bitfields
+//https://elinux.org/BCM2835_datasheet_errata#p12 (does not explain two magic bits 3:2)
+//https://github.com/LdB-ECM/Raspberry-Pi/blob/bc38ce183f731891d52a31df87df24904e466d0c/PlayGround/rpi-SmartStart.c#L255
+const ReceiveFIFOReady = 1 << 0
+const TransmitFIFOEmpty = 1 << 1
+const LineStatusError = 1 << 2 //overrun error, parity error, framing error
+const ModemStatusChange = 1 << 3 //changes to DSR/CTS
+
+type GPIORegisterMap struct {
+	FuncSelect               [6]volatile.Register32 //0x00,04,08,0C,10, and 14
+	reserved00               volatile.Register32 //0x18
+	OutputSet0               volatile.Register32 //0x1C
+	OutputSet1               volatile.Register32 //0x20
+	reserved01               volatile.Register32 //0x24
+	OutputClear0             volatile.Register32 //0x28
+	OutputClear1             volatile.Register32 //0x2C
+	reserved03               volatile.Register32 //0x30
+	Level0                   volatile.Register32 //0x34
+	Level1                   volatile.Register32 //0x38
+	reserved04               volatile.Register32 //0x3C
+	EventDetectStatus0       volatile.Register32 //0x40
+	EventDetectStatus1       volatile.Register32 //0x44
+	reserved05               volatile.Register32 //0x48
+	RisingEdgeDetectEnable0  volatile.Register32 //0x4C
+	RisingEdgeDetectEnable1  volatile.Register32 //0x50
+	reserved06               volatile.Register32 //0x54
+	FallingEdgeDetectEnable0 volatile.Register32 //0x58
+	FallingEdgeDetectEnable1 volatile.Register32 //0x5C
+	reserved07               volatile.Register32 //0x60
+	HighDetectEnable9        volatile.Register32 //0x64
+	HighDetectEnable1        volatile.Register32 //0x68
+	reserved08               volatile.Register32 //0x6C
+	LowDetectEnable0         volatile.Register32 //0x70
+	LowDetectEnable1         volatile.Register32 //0x74
+	reserved09               volatile.Register32 //0x78
+	AsyncRisingEdgeDetect0   volatile.Register32 //0x7C
+	AsyncRisingEdgeDetect1   volatile.Register32 //0x80
+	reserved0A               volatile.Register32 //0x84
+	AsyncFallingEdgeDetect0  volatile.Register32 //0x88
+	AsyncFallingEdgeDetect1  volatile.Register32 //0x8C
+	reserved0B               volatile.Register32 //0x90
+	PullUpDownEnable         volatile.Register32 // 0x94
+	PullUpDownEnableClock0   volatile.Register32 //0x98
+	PullUpDownEnableClock1   volatile.Register32 //0x9C
+	reserved0C               volatile.Register32 //0xA0
+	test                     volatile.Register32 //0xA4
+}
+
+type GPIOMode uint32 //3 bits wide
+const GPIOInput GPIOMode = 0
+const GPIOOutput GPIOMode = 1
+const GPIOAltFunc5 GPIOMode = 2
+const GPIOAltFunc4 GPIOMode = 3
+const GPIOAltFunc0 GPIOMode = 4
+const GPIOAltFunc1 GPIOMode = 5
+const GPIOAltFunc2 GPIOMode = 6
+const GPIOAltFunc3 GPIOMode = 7
+
+type SysTimerRegisterMap struct {
+	ControlStatus   volatile.Register32 //0x00
+	CounterLower32  volatile.Register32 //0x04
+	CounterHigher32 volatile.Register32 //0x08
+	reservedGPU0    volatile.Register32 //0x0C
+	Compare1        volatile.Register32 //0x10
+	reservedGPU2    volatile.Register32 //0x14
+	Compare3        volatile.Register32 //0x18
+}
+
+type IRQRegisterMap struct {
+	IRQBasicPending  volatile.Register32 //0x00
+	IRQPending1      volatile.Register32 //0x04
+	IRQPending2      volatile.Register32 //0x08
+	FIQControl       volatile.Register32 //0x0C
+	EnableIRQs1      volatile.Register32 //0x10
+	EnableIRQs2      volatile.Register32 //0x14
+	EnableBasicIRQs  volatile.Register32 //0x18
+	DisableIRQs1     volatile.Register32 //0x1C
+	DisableIRQs2     volatile.Register32 //0x20
+	DisableBasicIRQs volatile.Register32 //0x24
+}
+
+// ***************************************
+// SCTLR_EL1, System Control Register (EL1), Page 2654 of AArch64-Reference-Manual.
+// ***************************************
+
+const SystemControlRegisterEL1Reserved = (3 << 28) | (3 << 22) | (1 << 20) | (1 << 11)
+const SystemControlRegisterEELittleEndian = (0 << 25)
+const SystemControlRegisterEOELittleEndian = (0 << 24)
+const SystemControlRegisterICacheDisabled = (0 << 12)
+const SystemControlRegisterDCacheDisabled = (0 << 2)
+const SystemControlRegisterMMUDisabled = (0 << 0)
+const SystemControlRegisterMMUEnabled = (1 << 0)
+
+const SystemControlRegisterValueMMUDisabled = (SystemControlRegisterEL1Reserved | // 0x30000000 | 0xC00000 | 0x100000 | 0x800 => 0x30D00800
+	SystemControlRegisterEELittleEndian | //0x0
+	SystemControlRegisterICacheDisabled | //0x0
+	SystemControlRegisterDCacheDisabled | //0x0
+	SystemControlRegisterMMUDisabled) //0x0
+
+// ***************************************
+// HCR_EL2, Hypervisor Configuration Register (EL2), Page 2487 of AArch64-Reference-Manual.
+// ***************************************
+
+const HypervisorConfigurationRegisterRW = (1 << 31)
+const HypervisorConfigurationRegisterValue = HypervisorConfigurationRegisterRW //0x80000000
+
+// ***************************************
+// SCR_EL3, Secure Configuration Register (EL3), Page 2648 of AArch64-Reference-Manual.
+// ***************************************
+
+const SecureConfigurationRegisterReserved = (3 << 4)
+const SecureConfigurationRegisterRW = (1 << 10)
+const SecureConfigurationRegisterNS = (1 << 0)
+const SecureConfigurationRegisterValue = //0x30 | 0x400 | 0x1 => 0x431
+SecureConfigurationRegisterReserved |
+	SecureConfigurationRegisterRW |
+	SecureConfigurationRegisterNS
+
+// ***************************************
+// SPSR_EL3, Saved Program Status Register (EL3) Page 389 of AArch64-Reference-Manual.
+// ***************************************
+
+const SavedProgramStatusRegisterMaskAll = (7 << 6)
+const SavedProgramStatusRegisterEl1h = (5 << 0)                                                            //EL1 has own stack
+const SavedProgramStatusRegisterValue =
+	SavedProgramStatusRegisterMaskAll |
+		SavedProgramStatusRegisterEl1h //0x1C0
+
+func Abort() {
+	MiniUART.WriteString("Aborting...")
+	arm.Asm("wfe")
+}
+
+
+//
+// Wait MuSec waits for at least n musecs based on the system timer. This is a busy wait.
+//
+//go:export WaitMuSec
+func WaitMuSec(n uint64) {
+	var f, t, r uint64
+	arm.AsmFull(`mrs x28, cntfrq_el0
+		str x28,{f}
+		mrs x27, cntpct_el0
+		str x27,{t}`, map[string]interface{}{"f": &f, "t": &t})
+	//expires at t
+	t += ((f / 1000) * n) / 1000
+	for r < t {
+		arm.AsmFull(`mrs x27, cntpct_el0
+			str x27,{r}`, map[string]interface{}{"r": &r})
+	}
+}
+
+//
+// SysTimer gets the 64 bit timer's value.
+//
+//go:export SystemTime()
+func SystemTime() uint64 {
+	h := uint32(0xffffffff)
+	var l uint32
+
+	// the reads from system timer are two separate 32 bit reads
+	h = SysTimer.CounterHigher32.Get()
+	l = SysTimer.CounterLower32.Get()
+	//the read of hi can fail
+	again := SysTimer.CounterHigher32.Get()
+	if h != again {
+		h = SysTimer.CounterHigher32.Get()
+		l = SysTimer.CounterLower32.Get()
+	}
+	high := uint64(h << 32)
+	return high | uint64(l)
+}
+
+// XXX Unclear how to do the PIN mapping for a RPI3 because of function select
+type PinMode struct{}
+
+func (p Pin) Set(_ bool) {}
+
+//
+// RPI has many uarts, this is the "miniuart" which is the simplest to configure.
+//
+const RxBufMax = 0xfff
+
+type UART struct {
+	rxhead   *volatile.Register32
+	rxtail   *volatile.Register32
+	rxbuffer []uint8
+}
+
+func NewUART() UART {
+	return UART{
+		rxhead:   &volatile.Register32{},
+		rxtail:   &volatile.Register32{},
+		rxbuffer: make([]uint8, RxBufMax+1),
+	}
+}
+
+//
+// For now, zero value is a non-interrupt UART at 8bits, bidirectional.
+// If you set EnableRXInterrupt, you'll need to actually "turn on" the
+// interrupts when you are ready:
+// InterruptController.EnableIRQs1.SetBits(1<<AuxInterrupt)
+type UARTConfig struct {
+	RXInterrupt bool
+	Data7Bits         bool
+	DisableTx         bool
+	DisableRx         bool
+}
+
+func GPIOSetup(pinNumber uint8, mode GPIOMode) bool {
+	if (pinNumber > 54) { //54 pins on RPI
+		return false
+	}									// Check GPIO pin number valid, return false if invalid
+	var shift uint8
+	shift = ((pinNumber % 10) * 3);							// Create shift amount
+
+	value := uint32(mode)
+	mask:=uint32(7)
+
+	GPIO.FuncSelect[pinNumber % 10].ReplaceBits(value,mask,shift)
+	return true;													// Return true
+}
+
+
+// Configure accepts a config object to set some simple
+// properties of the UART.  It is not a fully featured 16550 UART,
+// rather it is the "mini" UART.   The zero value of conf
+// gives you 8 bits, no interrupts, and both tx and rx enabled.
+func (uart UART) Configure(conf UARTConfig) error {
+	var r uint32
+
+	Aux.Enables.SetBits(PeripheralMiniUART) //enable AUX Mini uart
+
+	//turn off the transmitter and receiver
+	Aux.MiniUARTExtraControl.ClearBits(ReceiveEnable|TransmitEnable)
+	Aux.MiniUARTExtraControl.Set(0)
+
+	//configure data bits
+	if conf.Data7Bits {
+		Aux.MiniUARTLineControl.ClearBits(DataLength8Bits) //7 bits
+	} else {
+		//see errata for why (bad docs!) uses excuse of compat with 16550
+		// https://elinux.org/BCM2835_datasheet_errata#p14
+		Aux.MiniUARTLineControl.SetBits(DataLength8Bits)
+	}
+
+	Aux.MiniUARTModemControl.ClearBits(ReadyToSend) // this asserts the line
+	Aux.MiniUARTInterruptIdentify.ReplaceBits(ClearTransmitFIFO|ClearReceiveFIFO, ClearFIFOsMask,0/*no shift*/)
+
+	// derived from clock speed: BCM2835 ARM Peripheral manual page 11
+	Aux.MiniUARTBAUD.Set(270)               // 115200 baud
+
+	//set the bits
+	if conf.RXInterrupt {
+		Aux.MiniUARTInterruptEnable.SetBits(ReceiveFIFOReady)
+	} else {
+		Aux.MiniUARTInterruptEnable.ClearBits(ReceiveFIFOReady|TransmitFIFOEmpty|LineStatusError|ModemStatusChange)
+	}
+
+	// map UART1 to GPIO pins
+	GPIOSetup(14,GPIOAltFunc5)
+	GPIOSetup(15,GPIOAltFunc5)
+
+	//sleep 150 cycles
+	r = 150
+	for r > 0 {
+		r--
+		arm.Asm("nop")
+	}
+
+	GPIO.PullUpDownEnableClock0.SetBits((1 << 14) | (1 << 15))
+
+	//sleep 150 cycles
+	r = 150
+	for r > 0 {
+		r--
+		arm.Asm("nop")
+	}
+
+	GPIO.PullUpDownEnableClock0.Set(0) //flush gpio setup
+
+	if !conf.DisableRx {
+		Aux.MiniUARTExtraControl.SetBits(ReceiveEnable)
+	} else {
+		Aux.MiniUARTExtraControl.ClearBits(ReceiveEnable)
+	}
+	if !conf.DisableTx {
+		Aux.MiniUARTExtraControl.SetBits(TransmitEnable)
+	} else {
+		Aux.MiniUARTExtraControl.ClearBits(TransmitEnable)
+	}
+
+	return nil
+}
+
+//
+// Writing a byte over serial.  Blocking.
+//
+func (uart UART) WriteByte(c byte) error {
+	// wait until we can send
+	for {
+		if Aux.MiniUARTLineStatus.HasBits(TransmitFIFOSpaceAvailable) {
+			break
+		}
+		arm.Asm("nop")
+	}
+
+	// write the character to the buffer
+	c32 := uint32(c)
+	Aux.MiniUARTData.Set(c32) //really 8 bit write
+	return nil
+}
+
+//
+// Write a CR (and secretly an LF) to serial.
+//
+func (uart UART) WriteCR() error {
+	if err:=uart.WriteByte(10); err!=nil {
+		return err
+	}
+	if err:=uart.WriteByte(13); err!=nil {
+		return err
+	}
+	return nil
+}
+//
+// Reading a byte from serial. Blocking.
+//
+func (uart UART) ReadByte() uint8 {
+	for {
+		if Aux.MiniUARTLineStatus.HasBits(ReceiveFIFOReady) {
+			break
+		}
+		arm.Asm("nop")
+	}
+	r := Aux.MiniUARTData.Get() //8 bit read
+	return uint8(r)
+}
+
+//
+// Put a whole string out to serial. Blocking.
+//
+func (uart UART) WriteString(s string) error {
+	for i := 0; i < len(s); i++ {
+		uart.WriteByte(s[i])
+	}
+	return nil
+}
+
+func (uart UART) Hex32string(d uint32) {
+	var rb uint32
+	var rc uint32
+
+	rb = 32
+	for {
+		rb -= 4
+		rc = (d >> rb) & 0xF
+		if rc > 9 {
+			rc += 0x37
+		} else {
+			rc += 0x30
+		}
+		uart.WriteByte(uint8(rc))
+		if rb == 0 {
+			break
+		}
+	}
+	uart.WriteByte(0x20)
+}
+
+func (uart UART) Hex64string(d uint64) {
+	var rb uint64
+	var rc uint64
+
+	rb = 64
+	for {
+		rb -= 4
+		rc = (d >> rb) & 0xF
+		if rc > 9 {
+			rc += 0x37
+		} else {
+			rc += 0x30
+		}
+		uart.WriteByte(uint8(rc))
+		if rb == 0 {
+			break
+		}
+	}
+	uart.WriteByte(0x20)
+}
+
+// DumpRxBuffer is for debugging. Returns the size of the buffer dumped.
+func (uart UART) DumpRxBuffer() uint32 {
+	moved := uint32(0)
+	for !uart.EmptyRx() {
+		index := uart.rxtail.Get()
+		uart.WriteByte(uart.rxbuffer[index])
+		tail := index + 1
+		tail &= RxBufMax
+		uart.rxtail.Set(tail)
+		moved++
+	}
+	return moved
+}
+
+// LoadRx puts a byte in the RxBuffer as if it came in from
+// the other side.  This is probably only interesting for callers
+// if they are doing testing.
+func (uart UART) LoadRx(b uint8) {
+	//receiver holds a valid byte
+	index := uart.rxhead.Get()
+	uart.rxbuffer[index] = b
+	head := index + 1
+	head &= RxBufMax
+	uart.rxhead.Set(head)
+}
+
+// EmptyRx is true if the receiver ring buffer is empty.
+func (uart UART) EmptyRx() bool {
+	return uart.rxtail.Get() == uart.rxhead.Get()
+}
+
+// Returns the next element from the read queue.  Note that
+// this busy waits on EmptyRx() so you should be sure
+// there is data there before you call this or it will block
+// and only an interrupt can save that...
+func (uart UART) NextRx() uint8 {
+	for {
+		if !uart.EmptyRx() {
+			break
+		}
+	}
+	result := uart.rxbuffer[uart.rxtail.Get()]
+	tail := uart.rxtail.Get() + 1
+	tail &= RxBufMax
+	uart.rxtail.Set(tail)
+	return result
+}
+
+// pullRXData is only called if you have enabled RX interrupts *and* you have
+// inserted functions address into the proper interrupt vector.
+func (uart UART) pullRXData() {
+	//an interrupt has occurred, find out why
+	for { //resolve all interrupts to uart
+		//weird, clear means we DO have interrupt
+		if Aux.MiniUARTInterruptIdentify.HasBits(1) {
+			break //no more interrupts
+		}
+		//this ignores the possibility that HasBits(6) because docs (!)
+		//say that bits 2 and 1 cannot both be set, so we just check bit 2
+		if Aux.MiniUARTInterruptIdentify.HasBits(4) {
+			//receiver holds a valid byte
+			rc := Aux.MiniUARTData.Get() //read byte from rx fifo
+			uart.LoadRx(uint8(rc))
+		}
+	}
+}
+//////////////////////////////////////////////////////////////////
+// ARM64 Exception Handlers
+//////////////////////////////////////////////////////////////////
+type interruptHandler func(uint64,uint64, uint64)
+
+//go:export excptrs
+var excptrs [16]interruptHandler
+
+func handleIRQ(t uint64, esr uint64, addr uint64) {
+	MiniUART.WriteString("woot! ")
+	MiniUART.WriteString(", ESR 0x")
+	MiniUART.Hex64string(esr)
+	MiniUART.WriteString(", ADDR 0x")
+	MiniUART.Hex64string(addr)
+	MiniUART.WriteCR()
+
+	for { //resolve all interrupts to uart
+		//weird, clear means we DO have interrupt
+		if Aux.MiniUARTInterruptIdentify.HasBits(1) {
+			break //no more interrupts
+		}
+		//this ignores the possibility that HasBits(6) because docs (!)
+		//say that bits 2 and 1 cannot both be set, so we just check bit 2
+		if Aux.MiniUARTInterruptIdentify.HasBits(4) {
+			MiniUART.pullRXData()
+		}
+	}
+}
+
+
+// MaskDAIF sets the value of the four D-A-I-F interupt masking on the ARM
+func MaskDAIF() {
+	arm.Asm("msr    daifset, #0xf")
+
+}
+// UnmaskDAIF sets the value of the four D-A-I-F interupt masking on the ARM
+func UnmaskDAIF() {
+	arm.Asm("msr    daifclr, #0xf")
+}
+
+// see rpi3.ld
+const exceptionBase = 0x2000
+
+//go:extern single_exception_code_ptr
+var singleExceptionCodePtr uint64
+
+// InitInterrupts is called by postinit (before main) to make sure all the interrupt
+// machinery is in the right startup state.
+func InitInterrupts() {
+	arm.Asm("adr	x0, #0x76000")		// load VBAR_EL1 with exc vector
+	arm.Asm("msr	vbar_el1, x0")
+	MaskDAIF()
+	InterruptController.DisableIRQs1.SetBits(AuxInterrupt)
+}
+
+// when an interrupt falls in the woods and nobody is around to hear it
+func showInvalidEntryMessage(t uint64, esr uint64, addr uint64 ) {
+	MiniUART.WriteString(entryErrorMessages[t])
+	MiniUART.WriteString(", ESR 0x")
+	MiniUART.Hex64string(esr)
+	MiniUART.WriteString(", ADDR 0x")
+	MiniUART.Hex64string(addr)
+	MiniUART.WriteCR()
+}
+
+var entryErrorMessages = []string {
+	"SYNC_INVALID_EL1t",
+	"IRQ_INVALID_EL1t",
+	"FIQ_INVALID_EL1t",
+	"ERROR_INVALID_EL1T",
+
+	"SYNC_INVALID_EL1h",
+	"IRQ_INVALID_EL1h",
+	"FIQ_INVALID_EL1h",
+	"ERROR_INVALID_EL1h",
+
+	"SYNC_INVALID_EL0_64",
+	"IRQ_INVALID_EL0_64",
+	"FIQ_INVALID_EL0_64",
+	"ERROR_INVALID_EL0_64",
+
+	"SYNC_INVALID_EL0_32",
+	"IRQ_INVALID_EL0_32",
+	"FIQ_INVALID_EL0_32",
+	"ERROR_INVALID_EL0_32",
+}

--- a/src/runtime/runtime_rpi3.go
+++ b/src/runtime/runtime_rpi3.go
@@ -1,0 +1,58 @@
+// +build rpi3
+
+package runtime
+
+import (
+	"machine"
+	"unsafe"
+)
+
+const tickMicros = int64(1)
+
+type timeUnit int64
+
+//go:export sleepticks sleepticks
+func sleepTicks(n timeUnit) {
+	machine.WaitMuSec(uint64(n))
+}
+
+func ticks() timeUnit {
+	return timeUnit(machine.SystemTime())
+}
+
+//go:export main
+func main() {
+	run()
+	machine.Abort()
+}
+
+func putchar(c byte) {
+	machine.MiniUART.WriteByte(c)
+}
+
+
+// abort is called by panic().
+func abort() {
+	machine.Abort()
+}
+
+
+// called once the memory allocator is ready and heap initialized
+// this turns off the AuxInterrupt so we can configure the UART
+func postinit() {
+	// Initialize .bss: zero-initialized global variables.
+	//ptr := unsafe.Pointer(&_sbss)
+	//for ptr != unsafe.Pointer(&_ebss) {
+	//	*(*uint32)(ptr) = 0
+	//	ptr = unsafe.Pointer(uintptr(ptr) + 4)
+	//}
+}
+
+//wasm workaround -- we will get coroutines
+const asyncScheduler = false
+
+//go:extern _sbss
+var _sbss unsafe.Pointer
+
+//go:extern _ebss
+var _ebss unsafe.Pointer

--- a/targets/arm64.json
+++ b/targets/arm64.json
@@ -1,0 +1,25 @@
+{
+	"build-tags":["arm64"],
+	"goos": "linux",
+	"goarch": "arm64",
+	"compiler": "clang",
+	"gc": "leaking",
+	"scheduler": "none",
+	"linker": "ld.lld",
+	"rtlib": "compiler-rt",
+	"libc": "picolibc",
+	"tags": "arm64",
+	"llvm-target": "aarch64-none-elf",
+	"cflags": [
+		"-Oz",
+		"-Werror",
+		"-fshort-enums",
+		"-fomit-frame-pointer",
+		"-fno-exceptions", "-fno-unwind-tables",
+		"-ffunction-sections", "-fdata-sections"
+	],
+	"ldflags": [
+		"--gc-sections"
+	],
+	"gdb": "gdb"
+}

--- a/targets/rpi3.json
+++ b/targets/rpi3.json
@@ -3,6 +3,7 @@
 	"build-tags": ["rpi3", "rpi", "baremetal"],
 	"scheduler": "none",
 	"gc": "leaking",
+	"cflags": ["--target=aarch64-elf"],
 	"ldflags": [
 		"-T", "targets/rpi3.ld"
 	],

--- a/targets/rpi3.json
+++ b/targets/rpi3.json
@@ -1,0 +1,12 @@
+{
+	"inherits": ["arm64"],
+	"build-tags": ["rpi3", "rpi", "baremetal"],
+	"scheduler": "none",
+	"gc": "leaking",
+	"ldflags": [
+		"-T", "targets/rpi3.ld"
+	],
+	"extra-files": [
+		"src/device/arm/arm-cortex-a53.S"
+	]
+}

--- a/targets/rpi3.ld
+++ b/targets/rpi3.ld
@@ -10,9 +10,11 @@ SECTIONS
 {
     . = 0x80000;
     .text : {
+                KEEP(*(.text.boot))
                 KEEP(*(.text))
-                *(.text.*)
-                *(.gnu.linkonce.t*) }
+                KEEP(*(.text.*))
+                *(.gnu.linkonce.t*)
+    }
 
     .rodata : {
         *(.rodata .rodata.* .gnu.linkonce.r*)
@@ -32,11 +34,10 @@ SECTIONS
         _ebss = .;
     }
 
-    . = 0x96000; /* interrupt vectors must be 2k aligned */
+    . = 0x96000;
    .exc  : {
-                KEEP(*(.text.boot))
+        KEEP(*(.exc_vector))
      }
-
    /DISCARD/ : { *(.comment) *(.gnu*) *(.note*) *(.eh_frame*)  }
 }
 

--- a/targets/rpi3.ld
+++ b/targets/rpi3.ld
@@ -1,0 +1,44 @@
+/*
+ * This file assumes that you are running with the Raspberry PI 3/4 firmware
+ * that expects bare metal to be linked for a boot address of 0x80000.
+ *
+ * You may want to consult https://www.raspberrypi.org/documentation/configuration/config-txt/boot.md
+ * if you want to see how to force this boot address in your config.txt.
+ */
+
+SECTIONS
+{
+    . = 0x80000;
+    .text : {
+                KEEP(*(.text))
+                *(.text.*)
+                *(.gnu.linkonce.t*) }
+
+    .rodata : {
+        *(.rodata .rodata.* .gnu.linkonce.r*)
+    }
+
+	/* Globals with initial value */
+    .data : {
+        *(.data)
+        *(.data*)
+    }
+
+	/* zero initialized data is initialized by preinit */
+    .bss (NOLOAD) : {
+        _sbss = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        _ebss = .;
+    }
+
+    . = 0x96000; /* interrupt vectors must be 2k aligned */
+   .exc  : {
+                KEEP(*(.text.boot))
+     }
+
+   /DISCARD/ : { *(.comment) *(.gnu*) *(.note*) *(.eh_frame*)  }
+}
+
+_heap_start = 0x400000;
+_heap_end = 0x1000000;


### PR DESCRIPTION
* Allows you to set interrupts, although in a very simple way 
* Removed hack in builder that pushed triple to the assembler (now using rpi3.json)
* Included the change to builder/picolibc.go to make that deal with arm64 targets

@aykevl Please take a look.