### PR TITLE
runtime (chan): fix blocking select on a nil channel

### DIFF
--- a/testdata/channel.go
+++ b/testdata/channel.go
@@ -134,6 +134,8 @@ func main() {
 	select {
 	case make(chan int) <- 3:
 		println("unreachable")
+	case <-(chan int)(nil):
+		println("unreachable")
 	case n := <-ch:
 		println("select n from chan:", n)
 	case n := <-make(chan int):


### PR DESCRIPTION
Previously, a blocking select on a nil channel would result in a nil panic inside the channel runtime code. This change fixes the nil checks so that the select works as intended.

Fixes: #1047 