### PR TITLE
builder: fix picolibc include path

### DIFF
--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -12,7 +12,7 @@ var Picolibc = Library{
 	name: "picolibc",
 	cflags: func() []string {
 		picolibcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc")
-		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "--sysroot=" + picolibcDir, "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
+		return []string{"-Werror", "-Wall", "-std=gnu11", "-D_COMPILING_NEWLIB", "-nostdlibinc", "-Xclang", "-internal-isystem", "-Xclang", picolibcDir + "/include", "-I" + picolibcDir + "/tinystdio", "-I" + goenv.Get("TINYGOROOT") + "/lib/picolibc-include"}
 	},
 	sourceDir: "lib/picolibc/newlib/libc",
 	sources: func(target string) []string {

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -173,7 +173,7 @@ func (c *Config) CFlags() []string {
 	}
 	if c.Target.Libc == "picolibc" {
 		root := goenv.Get("TINYGOROOT")
-		cflags = append(cflags, "--sysroot="+filepath.Join(root, "lib", "picolibc", "newlib", "libc"))
+		cflags = append(cflags, "-nostdlibinc", "-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "picolibc", "newlib", "libc", "include"))
 		cflags = append(cflags, "-I"+filepath.Join(root, "lib/picolibc-include"))
 	}
 	return cflags


### PR DESCRIPTION
Previously we used `--sysroot` to set the sysroot explicitly. Unfortunately, this flag is not used directly by Clang to set the include path (`<sysroot>/include`) but is instead interpreted by the toolchain code. This means that even when the toolchain is explicitly set (using the `--sysroot` parameter), it may still decide to use a different include path such as `<sysroot>/usr/include` (such as on baremetal aarch64).

This commit uses the Clang-internal `-internal-isystem` flag which sets the include directory directly (as a system include path). This should be more robust.

The reason the `--sysroot` parameter has so far worked is that all existing targets happened to add `<sysroot>/include` as an include path.

The relevant Clang code is here:
https://github.com/llvm/llvm-project/blob/release/9.x/clang/lib/Driver/Driver.cpp#L4693-L4739
So far, RISC-V is handled by `RISCVToolchain`, Cortex-M targets by `BareMetal` (which seems to be specific to ARM unlike what the name says) and aarch64 fell back to `Generic_ELF`.