### PR TITLE
main: support gdb debugging with AVR

### DIFF
--- a/main.go
+++ b/main.go
@@ -348,12 +348,14 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 		switch gdbInterface {
 		case "msd", "command", "":
 			if len(config.Target.Emulator) != 0 {
-				// Assume QEMU as an emulator.
 				if config.Target.Emulator[0] == "mgba" {
 					gdbInterface = "mgba"
+				} else if config.Target.Emulator[0] == "simavr" {
+					gdbInterface = "simavr"
 				} else if strings.HasPrefix(config.Target.Emulator[0], "qemu-system-") {
 					gdbInterface = "qemu"
 				} else {
+					// Assume QEMU as an emulator.
 					gdbInterface = "qemu-user"
 				}
 			} else if openocdInterface != "" && config.Target.OpenOCDTarget != "" {
@@ -426,6 +428,14 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 
 			// Run in an emulator.
 			args := append(config.Target.Emulator[1:], result.Binary, "-g")
+			daemon = exec.Command(config.Target.Emulator[0], args...)
+			daemon.Stdout = os.Stdout
+			daemon.Stderr = os.Stderr
+		case "simavr":
+			gdbCommands = append(gdbCommands, "target remote :1234")
+
+			// Run in an emulator.
+			args := append(config.Target.Emulator[1:], "-g", result.Binary)
 			daemon = exec.Command(config.Target.Emulator[0], args...)
 			daemon.Stdout = os.Stdout
 			daemon.Stderr = os.Stderr

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -15,5 +15,6 @@
 	"extra-files": [
 		"src/internal/task/task_stack_avr.S",
 		"src/runtime/gc_avr.S"
-	]
+	],
+	"gdb": "avr-gdb"
 }


### PR DESCRIPTION
Be able to run `tinygo gdb -target=arduino ./testdata/alias.go` and debug a program with the power of a real debugger.

Note that this only works on LLVM 11 (see #1056) because older versions have a bug in the AVR backend that cause it to produce invalid debug information: https://reviews.llvm.org/D74213.

![Screenshot from 2020-04-14 23-20-29](https://user-images.githubusercontent.com/729697/79275485-8fc5d780-7ea6-11ea-9604-5569f113340e.png)
