### PR TITLE
runtime: do not put scheduler and GC code in the same section

### DIFF
--- a/src/runtime/scheduler_avr.S
+++ b/src/runtime/scheduler_avr.S
@@ -188,6 +188,7 @@ tinygo_switchToScheduler:
     // Return into the scheduler, as if tinygo_switchToTask was a regular call.
     ret
 
+.section .text.tinygo_scanCurrentStack
 .global tinygo_scanCurrentStack
 .type tinygo_scanCurrentStack, %function
 tinygo_scanCurrentStack:

--- a/src/runtime/scheduler_cortexm.S
+++ b/src/runtime/scheduler_cortexm.S
@@ -112,6 +112,7 @@ tinygo_swapTask:
     pop {pc}
     #endif
 
+.section .text.tinygo_scanCurrentStack
 .global  tinygo_scanCurrentStack
 .type    tinygo_scanCurrentStack, %function
 tinygo_scanCurrentStack:


### PR DESCRIPTION
This allows dead code elimination and avoids linker errors with `-scheduler=leaking`.