### PR TITLE
runtime: copy stack scan assembly for GBA 

### DIFF
--- a/src/runtime/scheduler_gba.S
+++ b/src/runtime/scheduler_gba.S
@@ -1,0 +1,19 @@
+.section .text.tinygo_scanCurrentStack
+.global  tinygo_scanCurrentStack
+.type    tinygo_scanCurrentStack, %function
+tinygo_scanCurrentStack:
+    // Save callee-saved registers onto the stack.
+    mov r0, r8
+    mov r1, r9
+    mov r2, r10
+    mov r3, r11
+    push {r0-r3, lr}
+    push {r4-r7}
+
+    // Scan the stack.
+    mov r0, sp
+    bl tinygo_scanstack
+
+    // Restore stack state and return.
+    add sp, #32
+    pop {pc}

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -25,7 +25,8 @@
 	],
 	"linkerscript": "targets/gameboy-advance.ld",
 	"extra-files": [
-		"targets/gameboy-advance.s"
+		"targets/gameboy-advance.s",
+		"src/runtime/scheduler_gba.S"
 	],
 	"gdb": "gdb-multiarch",
 	"emulator": ["mgba", "-3"]


### PR DESCRIPTION
This is a continuation of #1058 that attempts to fix the issue on GBA. It now appears to link, but the display example does not appear to run right now:

![image](https://user-images.githubusercontent.com/16477604/79676746-3667ec00-81b7-11ea-84ad-446f5975e186.png)
