### PR TITLE
gba: always use ARM mode instead of Thumb mode

### DIFF
--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,5 +1,5 @@
 {
-	"llvm-target": "thumb4-none-eabi",
+	"llvm-target": "arm4-none-eabi",
 	"cpu": "arm7tdmi",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
@@ -10,7 +10,7 @@
 	"libc": "picolibc",
 	"cflags": [
 		"-g",
-		"--target=thumb4-none-eabi",
+		"--target=arm4-none-eabi",
 		"-mcpu=arm7tdmi",
 		"-Oz",
 		"-Werror",


### PR DESCRIPTION
This results in bigger code size, but it works around a bug in the linker.

The issue starts with the problem that libraries (picolibc, compiler-rt) were compiled as ARM and the rest as Thumb. This causes some blx instructions to be inserted by the linker to call into these libraries.

Ideally we should fix the libraries to use Thumb mode instead, but that requires some more extensive changes (including fixes to compiler-rt) and it's just way easier to use ARM mode everywhere.

fixes #894 