### PR TITLE
riscv: fix infinite loop in garbage collector

### DIFF
--- a/src/runtime/scheduler_tinygoriscv.S
+++ b/src/runtime/scheduler_tinygoriscv.S
@@ -22,6 +22,9 @@ tinygo_scanCurrentStack:
    mv a0, sp
    call tinygo_scanstack
 
+   // Restore return address.
+   lw ra, 60(sp)
+
    // Restore stack state.
    addi sp, sp, 64
 


### PR DESCRIPTION
This fixes an infinite loop in the riscv scheduler caused by the `ra` register which gets overwritten.

The bug occures when `runtime.GC()` is called.