### PR TITLE
transform: fix debug information in func lowering pass

### DIFF
--- a/transform/func-lowering.go
+++ b/transform/func-lowering.go
@@ -225,6 +225,10 @@ func addFuncLoweringSwitch(mod llvm.Module, builder llvm.Builder, funcID, call l
 	// in this gap.
 	nextBlock := llvmutil.SplitBasicBlock(builder, sw, llvm.NextBasicBlock(sw.InstructionParent()), "func.next")
 
+	// Temporarily set the insert point to set the correct debug insert location
+	// for the builder. It got destroyed by the SplitBasicBlock call.
+	builder.SetInsertPointBefore(call)
+
 	// The 0 case, which is actually a nil check.
 	nilBlock := ctx.InsertBasicBlock(nextBlock, "func.nil")
 	builder.SetInsertPointAtEnd(nilBlock)


### PR DESCRIPTION
This commit fixes errors like the following:

    inlinable function call in a function with debug info must have a !dbg location
      call void @runtime.nilPanic(i8* undef, i8* null)
    inlinable function call in a function with debug info must have a !dbg location
      %24 = call fastcc %runtime._interface @"(*github.com/vugu/vugu/domrender.JSRenderer).render$1"(%"github.com/vugu/vugu.VGNode"** %19, i32 %22, i32 %23, i8* %15, i8* undef)
    error: optimizations caused a verification failure

Not all instructions had a debug location, which apparently caused issues for the inliner.

This was a problem when trying to compile Vugu.