### PR TITLE
main: update go-llvm to fix macOS build problem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	go.bug.st/serial v1.0.0
 	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2
 	google.golang.org/appengine v1.4.0 // indirect
-	tinygo.org/x/go-llvm v0.0.0-20200401165421-8d120882fc7a
+	tinygo.org/x/go-llvm v0.0.0-20200503225853-345b2947b59d
 )

--- a/go.sum
+++ b/go.sum
@@ -57,3 +57,5 @@ tinygo.org/x/go-llvm v0.0.0-20200226165415-53522ab6713d h1:mtgZh/e8a3wxneQFuLXoQ
 tinygo.org/x/go-llvm v0.0.0-20200226165415-53522ab6713d/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
 tinygo.org/x/go-llvm v0.0.0-20200401165421-8d120882fc7a h1:Ugje2Lxuv8CFncHzs5W+hWfJvPsM+W4K0zRvzFbLvoE=
 tinygo.org/x/go-llvm v0.0.0-20200401165421-8d120882fc7a/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
+tinygo.org/x/go-llvm v0.0.0-20200503225853-345b2947b59d h1:hcX7vpB067GWM/EH4sGGOti0PMgIx+0bbZwUXctOIvE=
+tinygo.org/x/go-llvm v0.0.0-20200503225853-345b2947b59d/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=


### PR DESCRIPTION
The go-llvm package was still trying to use LLVM version 9 on MacOS.