### PR TITLE
Fix ROM / RAM size on atsamd51j20

### DIFF
--- a/targets/atsamd51j20a.json
+++ b/targets/atsamd51j20a.json
@@ -6,7 +6,7 @@
 		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
-	"linkerscript": "targets/atsamd51.ld",
+	"linkerscript": "targets/atsamd51j20a.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51j20a.s"
 	]

--- a/targets/atsamd51j20a.ld
+++ b/targets/atsamd51j20a.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x00000000+0x4000, LENGTH = 0x00100000-0x4000  /* First 16KB used by bootloader */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 0x00040000
+}
+
+_stack_size = 4K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
In this PR, I'll correct the linker script.

ROM size of the atsamd51j20a is 1024KB, not 512KB.
RAM size is 256KB, not 192KB.