### PR TITLE
flash: fix touchSerialPortAt1200bps on windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -479,6 +479,13 @@ func touchSerialPortAt1200bps(port string) (err error) {
 		// Open port
 		p, e := serial.Open(port, &serial.Mode{BaudRate: 1200})
 		if e != nil {
+			if runtime.GOOS == `windows` {
+				se, ok := e.(*serial.PortError)
+				if ok && se.Code() == serial.InvalidSerialPort {
+					// InvalidSerialPort error occurs when transitioning to boot
+					return nil
+				}
+			}
 			time.Sleep(1 * time.Second)
 			err = e
 			continue


### PR DESCRIPTION
#1077 

This PR solves a problem that causes tinygo flash to fail in a windows environment.
The fix isn't the right one, but it's a step forward because until now it wasn't possible to `tinygo flash` the `flash-method == msd target` on windows.

I use runtime.GOOS to affect only windows.
Also, even if you get the judgement wrong, it should fail on subsequent msd-volume-name checks.



BEFORE: We couldn't tinygo flash in windows + msd
AFTER: We can do tinygo flash with windows + msd too!

I'd like to see it merged, as it would be more convenient for windows users (who don't have jlink, etc.).