### PR TITLE
machine/arduino-nano33: use USB flag and remove debug flag for bossac flasher

### DIFF
--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "arduino_nano33"],
-    "flash-command": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
+    "flash-command": "bossac -d -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "arduino_nano33"],
-    "flash-command": "bossac -d -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
+    "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }


### PR DESCRIPTION
This PR uses the `-U` flag to ensure that device can be found by `bossac` flashing tool when the Arduino Nano33 IoT is not connected to the default port.
