### PR TITLE
ci: add archlinux release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,53 @@ commands:
             - ~/.cache/go-build
             - ~/.cache/tinygo
             - /go/pkg/mod
-
+  arch-release:
+    steps:
+      - run:
+          name: Install dependencies
+          command: pacman -Sy --noconfirm openssh git pacman-contrib binutils
+      - run:
+          name: Create TinyGo user
+          command: useradd -m tinygo
+      - run:
+          name: Become TinyGo user
+          command: su tinygo
+      - run:
+          name: Start SSH Agent
+          command: eval $(ssh-agent -s)
+      - run:
+          name: Add ARCH_RELEASE_SSH_PRIVATE_KEY identity
+          command: echo "${ARCH_RELEASE_SSH_PRIVATE_KEY}" | tr -d '\r' | ssh-add -
+      - run:
+          name: Create SSH directory
+          command: mkdir -p ~/.ssh && chmod 700 ~/.ssh
+      - run:
+          name: Add aur.archlinux.org to known hosts
+          command: ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+      - run:
+          name: Clone tinygo-bin repo
+          command: git clone ssh://aur@aur.archlinux.org/tinygo-bin.git ~/tinygo-bin
+      - run:
+          name: Update package version
+          command: sed -i -E "s/(pkgver=)(.*)$/\1${CIRCLE_TAG}/" ~/tinygo-bin/PKGBUILD
+      - run:
+          name: Update file checksums
+          command: cd ~/tinygo-bin && updpkgsums
+      - run:
+          name: Update .SRCINFO
+          command: cd ~/tinygo-bin && makepkg --printsrcinfo > .SRCINFO
+      # Commit the update
+      - run:
+          name: Set git commit config
+          command: |
+            git config --global user.email "tinygo-bot@tinygo.org" &&
+            git config --global user.name "TinyGo Release Bot"
+      - run:
+          name: Commit and push changes
+          command: |
+            cd ~/tinygo-bin &&
+            git commit -a -m "Update tinygo-bin to v${CIRCLE_TAG}" &&
+            git push origin master
 
 jobs:
   test-llvm9-go111:
@@ -361,6 +407,11 @@ jobs:
       xcode: "10.1.0"
     steps:
       - build-macos
+  arch-release:
+    docker:
+      - image: archlinux:latest
+    steps:
+      - arch-release
 
 
 
@@ -375,3 +426,12 @@ workflows:
       - build-linux
       - build-macos
       - assert-test-linux
+  release:
+    jobs:
+      - arch-release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # Runs on every semver release
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/


### PR DESCRIPTION
Adds the arch-release job, which automatically updates
the tinygo-bin AUR package on every new git tag with
a semver version.

This will require setting the `$ARCH_RELEASE_SSH_PRIVATE_KEY` secret CI variable to a value that I have transferred to @deadprogram.