### PR TITLE
sam: return an error when an incorrect PWM pin is used

### DIFF
--- a/src/examples/pwm/pwm.go
+++ b/src/examples/pwm/pwm.go
@@ -28,13 +28,16 @@ func main() {
 	machine.InitPWM()
 
 	red := machine.PWM{redPin}
-	red.Configure()
+	err := red.Configure()
+	checkError(err, "failed to configure red pin")
 
 	green := machine.PWM{greenPin}
-	green.Configure()
+	err = green.Configure()
+	checkError(err, "failed to configure green pin")
 
 	blue := machine.PWM{bluePin}
-	blue.Configure()
+	err = blue.Configure()
+	checkError(err, "failed to configure blue pin")
 
 	var rc uint8
 	var gc uint8 = 20
@@ -50,5 +53,12 @@ func main() {
 		blue.Set(uint16(bc) << 8)
 
 		time.Sleep(time.Millisecond * 500)
+	}
+}
+
+func checkError(err error, msg string) {
+	if err != nil {
+		print(msg, ": ", err.Error())
+		println()
 	}
 }

--- a/src/machine/machine_atmega328p.go
+++ b/src/machine/machine_atmega328p.go
@@ -79,13 +79,14 @@ func InitPWM() {
 }
 
 // Configure configures a PWM pin for output.
-func (pwm PWM) Configure() {
+func (pwm PWM) Configure() error {
 	switch pwm.Pin / 8 {
 	case 0: // port B
 		avr.DDRB.SetBits(1 << uint8(pwm.Pin))
 	case 2: // port D
 		avr.DDRD.SetBits(1 << uint8(pwm.Pin-16))
 	}
+	return nil
 }
 
 // Set turns on the duty cycle for a PWM pin using the provided value. On the AVR this is normally a

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -90,7 +90,8 @@ func InitPWM() {
 }
 
 // Configure configures a PWM pin for output.
-func (pwm PWM) Configure() {
+func (pwm PWM) Configure() error {
+	return nil
 }
 
 // Set turns on the duty cycle for a PWM pin using the provided value.

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -159,7 +159,8 @@ func InitPWM() {
 }
 
 // Configure configures a PWM pin for output.
-func (pwm PWM) Configure() {
+func (pwm PWM) Configure() error {
+	return nil
 }
 
 // Set turns on the duty cycle for a PWM pin using the provided value.

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -104,8 +104,8 @@ func InitADC() {
 }
 
 // Configure configures an ADC pin to be able to read analog data.
-func (a ADC) Configure() {
-	return // no pin specific setup on nrf52840 machine.
+func (a ADC) Configure() error {
+	return nil // no pin specific setup on nrf52840 machine.
 }
 
 // Get returns the current value of a ADC pin in the range 0..0xffff.


### PR DESCRIPTION
Previously it would trigger a nil pointer panic.

fixes #1038 