### PR TITLE
runtime: fix compilation errors when using gc.extalloc

### DIFF
--- a/src/runtime/gc_extalloc.go
+++ b/src/runtime/gc_extalloc.go
@@ -602,3 +602,11 @@ func alloc(size uintptr) unsafe.Pointer {
 func free(ptr unsafe.Pointer) {
 	// Currently unimplemented due to bugs in coroutine lowering.
 }
+
+func KeepAlive(x interface{}) {
+	// Unimplemented. Only required with SetFinalizer().
+}
+
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// Unimplemented.
+}


### PR DESCRIPTION
When using `-gc extalloc` and an import of `golang.org/x/sys/unix` the compile failed due to:

```
../../vendor/golang.org/x/sys/unix/ioctl.go:30:10: KeepAlive not declared by package runtime
../../vendor/golang.org/x/sys/unix/ioctl.go:40:10: KeepAlive not declared by package runtime
../../vendor/golang.org/x/sys/unix/syscall_linux.go:96:10: KeepAlive not declared by package runtime
```
