### PR TITLE
os: add Args stub

### DIFF
--- a/src/os/proc.go
+++ b/src/os/proc.go
@@ -9,6 +9,15 @@ import (
 	"syscall"
 )
 
+// Args hold the command-line arguments, starting with the program name.
+var Args []string
+
+func init() {
+	Args = runtime_args()
+}
+
+func runtime_args() []string // in package runtime
+
 // Exit causes the current program to exit with the given status code.
 // Conventionally, code zero indicates success, non-zero an error.
 // The program terminates immediately; deferred functions are not run.

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -24,9 +24,12 @@ func GOROOT() string {
 	return "/usr/local/go"
 }
 
+// TODO: fill with real args.
+var args = []string{"/proc/self/exe"}
+
 //go:linkname os_runtime_args os.runtime_args
 func os_runtime_args() []string {
-	return nil
+	return args
 }
 
 // Copy size bytes from src to dst. The memory areas must not overlap.


### PR DESCRIPTION
Tnis allows code that relies on it to compile, the `flags` package compiles now. No real parameters are passed but Args[0] contains a static mock string.

Setting Args as recommended https://github.com/tinygo-org/tinygo/issues/541#issuecomment-531483733 did not work tho:

`tinygo/src/runtime/runtime_unix.go`
```
func main() int {
	args = []string{"/proc/self/exe2"}
	preinit()
	run()
```

has no effect, os.Args will still hold the old value
