### PR TITLE
cgo: add support for negative numeric constants in tokenizer

### DIFF
--- a/cgo/const.go
+++ b/cgo/const.go
@@ -131,7 +131,7 @@ func (t *tokenizer) Next() {
 			t.value = t.buf[:1]
 			t.buf = t.buf[1:]
 			return
-		case c >= '0' && c <= '9':
+		case (c >= '0' && c <= '9') || c == '-':
 			// Numeric constant (int, float, etc.).
 			// Find the last non-numeric character.
 			tokenLen := len(t.buf)
@@ -140,7 +140,7 @@ func (t *tokenizer) Next() {
 				if c == '.' {
 					hasDot = true
 				}
-				if c >= '0' && c <= '9' || c == '.' || c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' {
+				if c >= '0' && c <= '9' || c == '-' || c == '.' || c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' {
 					tokenLen = i + 1
 				} else {
 					break

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -15,6 +15,7 @@ func TestParseConst(t *testing.T) {
 		Go string
 	}{
 		{`5`, `5`},
+		{`-5`, `-5`},
 		{`(5)`, `(5)`},
 		{`(((5)))`, `(5)`},
 		{`)`, `error: 1:1: unexpected token )`},


### PR DESCRIPTION
Closes #770

before:

```
# net
/usr/include/netdb.h:617:23: unexpected token ILLEGAL
/usr/include/netdb.h:618:22: unexpected token ILLEGAL
/usr/include/netdb.h:624:23: unexpected token ILLEGAL
```

failing lines were like:
`# define EAI_NONAME   -2    /* NAME or SERVICE is unknown.  */`
