### PR TITLE
call scheduler from resume

### DIFF
--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -58,6 +58,7 @@ func resume() {
 	go func() {
 		handleEvent()
 	}()
+	scheduler()
 }
 
 //export go_scheduler


### PR DESCRIPTION
Adding scheduler call per discussion with @jaddr2line here https://github.com/tinygo-org/tinygo/issues/1091 resolves the issue where JS event handlers are not executing anything.  I tested this on two examples which were exhibiting the bug and both are working now.