### PR TITLE
arm: make FPU configuration consistent

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -69,7 +69,7 @@ func (l *Library) Load(target string) (path string, err error) {
 	// Precalculate the flags to the compiler invocation.
 	args := append(l.cflags(), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
-		args = append(args, "-fshort-enums", "-fomit-frame-pointer")
+		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft")
 	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")

--- a/targets/atsamd51g19a.json
+++ b/targets/atsamd51g19a.json
@@ -1,9 +1,7 @@
 {
-	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"inherits": ["cortex-m4"],
 	"build-tags": ["atsamd51g19", "atsamd51", "sam"],
 	"cflags": [
-		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
 	"linkerscript": "targets/atsamd51.ld",

--- a/targets/atsamd51j19a.json
+++ b/targets/atsamd51j19a.json
@@ -1,9 +1,7 @@
 {
-	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"inherits": ["cortex-m4"],
 	"build-tags": ["atsamd51j19", "atsamd51", "sam"],
 	"cflags": [
-		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
 	"linkerscript": "targets/atsamd51.ld",

--- a/targets/atsamd51j20a.json
+++ b/targets/atsamd51j20a.json
@@ -1,9 +1,7 @@
 {
-	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"inherits": ["cortex-m4"],
 	"build-tags": ["sam", "atsamd51", "atsamd51j20", "atsamd51j20a"],
 	"cflags": [
-		"--target=armv7em-none-eabi",
 		"-Qunused-arguments"
 	],
 	"linkerscript": "targets/atsamd51j20a.ld",

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -1,0 +1,8 @@
+{
+	"inherits": ["cortex-m"],
+	"llvm-target": "armv7em-none-eabi",
+	"cflags": [
+		"--target=armv7em-none-eabi",
+		"-mfloat-abi=soft"
+	]
+}

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -1,10 +1,7 @@
 {
-	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"inherits": ["cortex-m4"],
 	"build-tags": ["nrf52", "nrf"],
 	"cflags": [
-		"--target=armv7em-none-eabi",
-		"-mfloat-abi=soft",
 		"-Qunused-arguments",
 		"-DNRF52832_XXAA",
 		"-I{root}/lib/CMSIS/CMSIS/Include",

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -1,10 +1,7 @@
 {
-	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"inherits": ["cortex-m4"],
 	"build-tags": ["nrf52840", "nrf"],
 	"cflags": [
-		"--target=armv7em-none-eabi",
-		"-mfloat-abi=soft",
 		"-Qunused-arguments",
 		"-DNRF52840_XXAA",
 		"-I{root}/lib/CMSIS/CMSIS/Include",

--- a/targets/stm32f4disco.json
+++ b/targets/stm32f4disco.json
@@ -1,9 +1,7 @@
 {
-  "inherits": ["cortex-m"],
-  "llvm-target": "armv7em-none-eabi",
+  "inherits": ["cortex-m4"],
   "build-tags": ["stm32f4disco", "stm32f407", "stm32"],
   "cflags": [
-    "--target=armv7em-none-eabi",
     "-Qunused-arguments"
   ],
   "linkerscript": "targets/stm32f407.ld",


### PR DESCRIPTION
Eventually we might want to start using the FPU, but the easy option right now is to simply disable it everywhere. Previously, it depended on whether Clang was built as part of TinyGo or it was an external binary (but Go code compiled with TinyGo never used the FPU). By setting the floating point mode explicitly, such inconsistencies are avoided.

This commit creates a new cortex-m4 target which can be the central place for setting FPU-related settings across all Cortex-M4 chips.

Tested on the pca10040 and the ItsyBitsy-m4.