### PR TITLE
ci: build .deb files along with .tar.gz files for Debian

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,12 +205,20 @@ commands:
           name: "Test TinyGo"
           command: make test
       - run:
+          name: "Install fpm"
+          command: |
+            sudo apt-get install ruby ruby-dev
+            sudo gem install --no-document fpm
+      - run:
           name: "Build TinyGo release"
           command: |
-            make release -j3
+            make release deb -j3
             cp -p build/release.tar.gz /tmp/tinygo.linux-amd64.tar.gz
+            cp -p build/release.deb    /tmp/tinygo_amd64.deb
       - store_artifacts:
           path: /tmp/tinygo.linux-amd64.tar.gz
+      - store_artifacts:
+          path: /tmp/tinygo_amd64.deb
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ endif
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/export
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/main
 
-release: tinygo gen-device wasi-libc
+build/release: tinygo gen-device wasi-libc
 	@mkdir -p build/release/tinygo/bin
 	@mkdir -p build/release/tinygo/lib/clang/include
 	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
@@ -345,4 +345,13 @@ release: tinygo gen-device wasi-libc
 	./build/tinygo build-library -target=armv6m-none-eabi  -o build/release/tinygo/pkg/armv6m-none-eabi/picolibc.a picolibc
 	./build/tinygo build-library -target=armv7m-none-eabi  -o build/release/tinygo/pkg/armv7m-none-eabi/picolibc.a picolibc
 	./build/tinygo build-library -target=armv7em-none-eabi -o build/release/tinygo/pkg/armv7em-none-eabi/picolibc.a picolibc
+
+release: build/release
 	tar -czf build/release.tar.gz -C build/release tinygo
+
+deb: build/release
+	@mkdir -p build/release-deb/usr/local/bin
+	@mkdir -p build/release-deb/usr/local/lib
+	cp -ar build/release/tinygo build/release-deb/usr/local/lib/tinygo
+	ln -sf ../lib/tinygo/bin/tinygo build/release-deb/usr/local/bin/tinygo
+	fpm -f -s dir -t deb -n tinygo -v $(shell grep "version = " version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
         script: |
           export PATH="$PATH:./llvm-build/bin:/c/Program Files/qemu"
           unset GOROOT
-          make release -j4
+          make build/release -j4
     - publish: $(System.DefaultWorkingDirectory)/build/release/tinygo
       displayName: Publish zip as artifact
       artifact: tinygo


### PR DESCRIPTION
This should make installing TinyGo easier on Debian based systems by automatically creating a symlink in `/usr/local/bin`. For example, see #1103 and #725. It also makes the release process a little bit more robust and reproducible as the Debian package is built in CI instead of on my laptop.

fixes #725