### PR TITLE
build: add webhook notifier orb for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  webhook: eddiewebb/webhook@0.0.4
 
 commands:
   submodules:
@@ -219,6 +221,8 @@ commands:
           path: /tmp/tinygo.linux-amd64.tar.gz
       - store_artifacts:
           path: /tmp/tinygo_amd64.deb
+      - webhook/notify:
+          endpoint: "${WEBHOOK_ENDPOINT}"
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:


### PR DESCRIPTION
This PR adds the CircleCI orb with the hook needed to integrate the HCI server.