### PR TITLE
cgo: Add LDFlags support and float types

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -32,7 +32,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	if err != nil {
 		return err
 	}
-	mod, extraFiles, errs := compiler.Compile(pkgName, machine, config)
+	mod, extraFiles, extraLDFlags, errs := compiler.Compile(pkgName, machine, config)
 	if errs != nil {
 		return newMultiError(errs)
 	}
@@ -185,6 +185,10 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 				return &commandError{"failed to build", file, err}
 			}
 			ldflags = append(ldflags, outpath)
+		}
+
+		if len(extraLDFlags) > 0 {
+			ldflags = append(ldflags, extraLDFlags...)
 		}
 
 		// Link the object files together.

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -50,7 +50,7 @@ func TestCGo(t *testing.T) {
 			}
 
 			// Process the AST with CGo.
-			cgoAST, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
+			cgoAST, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
 
 			// Check the AST for type errors.
 			var typecheckErrors []error

--- a/cgo/testdata/flags.go
+++ b/cgo/testdata/flags.go
@@ -21,6 +21,13 @@ package main
 #if defined(NOTDEFINED)
 #warning flag must not be defined
 #endif
+
+// Check Compiler flags
+#cgo LDFLAGS: -lc
+
+// This flag is not valid ldflags
+#cgo LDFLAGS: -does-not-exists
+
 */
 import "C"
 

--- a/cgo/testdata/flags.out.go
+++ b/cgo/testdata/flags.out.go
@@ -1,6 +1,7 @@
 // CGo errors:
 //     testdata/flags.go:5:7: invalid #cgo line: NOFLAGS
 //     testdata/flags.go:8:13: invalid flag: -fdoes-not-exist
+//     testdata/flags.go:29:14: invalid flag: -does-not-exists
 
 package main
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -31,6 +31,7 @@ type Program struct {
 	Dir          string // current working directory (for error reporting)
 	TINYGOROOT   string // root of the TinyGo installation or root of the source code
 	CFlags       []string
+	LDFlags      []string
 	ClangHeaders string
 }
 
@@ -425,11 +426,12 @@ func (p *Package) parseFiles(includeTests bool) ([]*ast.File, error) {
 		if p.ClangHeaders != "" {
 			cflags = append(cflags, "-Xclang", "-internal-isystem", "-Xclang", p.ClangHeaders)
 		}
-		generated, errs := cgo.Process(files, p.Program.Dir, p.fset, cflags)
+		generated, ldflags, errs := cgo.Process(files, p.Program.Dir, p.fset, cflags)
 		if errs != nil {
 			fileErrs = append(fileErrs, errs...)
 		}
 		files = append(files, generated)
+		p.LDFlags = append(p.LDFlags, ldflags...)
 	}
 	if len(fileErrs) != 0 {
 		return nil, Errors{p, fileErrs}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -20,10 +20,10 @@ import (
 type common struct {
 	output io.Writer
 
-	failed     bool   // Test or benchmark has failed.
-	skipped    bool   // Test of benchmark has been skipped.
-	finished   bool   // Test function has completed.
-	name       string // Name of test or benchmark.
+	failed   bool   // Test or benchmark has failed.
+	skipped  bool   // Test of benchmark has been skipped.
+	finished bool   // Test function has completed.
+	name     string // Name of test or benchmark.
 }
 
 // TB is the interface common to T and B.


### PR DESCRIPTION
I added LDFlags support to CGO. It just parses the `#cgo LDFLAGS` statements and pass to the linker.

WIth this, I'm able to compile that:

```go
package main

/*
#cgo LDFLAGS: -lm

#include <math.h>
#include <stdio.h>
*/
import "C"

import "fmt"

func main() {
    f := float64(0.4)
    f2 := float64(0.5)

    res := C.fmax(f, f2)
    fmt.Println("FLOAT: ", float64(res))
}
```

Which uses libm function `fmax`

This should also help in #1108 for [gonx](https://github.com/racerxdl/gonx) link the libnx externally and not internally on tinygo.