### PR TITLE
runtime: refactor time handling

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -61,7 +61,7 @@ func memequal(x, y unsafe.Pointer, n uintptr) bool {
 }
 
 func nanotime() int64 {
-	return int64(ticks()) * tickMicros
+	return ticksToNanoseconds(ticks())
 }
 
 // timeOffset is how long the monotonic clock started after the Unix epoch. It

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -9,8 +9,6 @@ import (
 
 type timeUnit int64
 
-const tickMicros = 1
-
 func putchar(c byte) {
 	// dummy, TODO
 }
@@ -58,6 +56,14 @@ func preinit() {
 		dst = unsafe.Pointer(uintptr(dst) + 4)
 		src = unsafe.Pointer(uintptr(src) + 4)
 	}
+}
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns)
 }
 
 func ticks() timeUnit {

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -14,8 +14,6 @@ type timeUnit uint32
 
 var currentTime timeUnit
 
-const tickMicros = 1024 * 16384
-
 // Watchdog timer periods. These can be off by a large margin (hence the jump
 // between 64ms and 125ms which is not an exact double), so don't rely on this
 // for accurate time keeping.
@@ -70,6 +68,16 @@ func putchar(c byte) {
 }
 
 const asyncScheduler = false
+
+const tickNanos = 1024 * 16384 // roughly 16ms in nanoseconds
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks) * tickNanos
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns / tickNanos)
+}
 
 // Sleep this number of ticks of 16ms.
 //

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -13,8 +13,6 @@ import (
 
 type timeUnit int64
 
-const tickMicros = 1
-
 var timestamp timeUnit
 
 func postinit() {}
@@ -28,6 +26,14 @@ func main() {
 }
 
 const asyncScheduler = false
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns)
+}
 
 func sleepTicks(d timeUnit) {
 	// TODO: actually sleep here for the given time.

--- a/src/runtime/runtime_fe310_baremetal.go
+++ b/src/runtime/runtime_fe310_baremetal.go
@@ -6,7 +6,21 @@ import (
 	"device/riscv"
 )
 
-const tickMicros = 32768 // RTC clock runs at 32.768kHz
+// ticksToNanoseconds converts RTC ticks (at 32768Hz) to nanoseconds.
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	// The following calculation is actually the following, but with both sides
+	// reduced to reduce the risk of overflow:
+	//     ticks * 1e9 / 32768
+	return int64(ticks) * 1953125 / 64
+}
+
+// nanosecondsToTicks converts nanoseconds to RTC ticks (running at 32768Hz).
+func nanosecondsToTicks(ns int64) timeUnit {
+	// The following calculation is actually the following, but with both sides
+	// reduced to reduce the risk of overflow:
+	//     ns * 32768 / 1e9
+	return timeUnit(ns * 64 / 1953125)
+}
 
 func abort() {
 	// lock up forever

--- a/src/runtime/runtime_fe310_qemu.go
+++ b/src/runtime/runtime_fe310_qemu.go
@@ -7,12 +7,18 @@ import (
 	"unsafe"
 )
 
-const tickMicros = 100 // CLINT.MTIME increments every 100ns
-
 // Special memory-mapped device to exit tests, created by SiFive.
 var testExit = (*volatile.Register32)(unsafe.Pointer(uintptr(0x100000)))
 
-var timestamp timeUnit
+// ticksToNanoseconds converts CLINT ticks (at 100ns per tick) to nanoseconds.
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks) * 100
+}
+
+// nanosecondsToTicks converts nanoseconds to CLINT ticks (at 100ns per tick).
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns / 100)
+}
 
 func abort() {
 	// Signal a successful exit.

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -53,8 +53,6 @@ func initCLK() {
 	}
 }
 
-const tickMicros = 1000
-
 var (
 	timestamp        timeUnit // microseconds since boottime
 	timerLastCounter uint64
@@ -108,6 +106,14 @@ func initTIM() {
 }
 
 const asyncScheduler = false
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks) * 1000
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns / 1000)
+}
 
 // sleepTicks should sleep for specific number of microseconds.
 func sleepTicks(d timeUnit) {

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -109,14 +109,20 @@ func initCLK() {
 
 }
 
-const tickMicros = 1000
-
 var (
 	// tick in milliseconds
 	tickCount timeUnit
 )
 
 var timerWakeup volatile.Register8
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks) * 1000
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns / 1000)
+}
 
 // Enable the TIM3 clock.(sleep count)
 func initTIM3() {

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -13,8 +13,6 @@ import (
 
 type timeUnit int64
 
-const tickMicros = 1
-
 var timestamp timeUnit
 
 func postinit() {}
@@ -27,6 +25,14 @@ func main() {
 }
 
 const asyncScheduler = false
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns)
+}
 
 func sleepTicks(d timeUnit) {
 	// TODO: actually sleep here for the given time.

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -26,8 +26,6 @@ func clock_gettime(clk_id int32, ts *timespec)
 
 type timeUnit int64
 
-const tickMicros = 1
-
 // Note: tv_sec and tv_nsec vary in size by platform. They are 32-bit on 32-bit
 // systems and 64-bit on 64-bit systems (at least on macOS/Linux), so we can
 // simply use the 'int' type which does the same.
@@ -57,7 +55,18 @@ func putchar(c byte) {
 
 const asyncScheduler = false
 
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	// The OS API works in nanoseconds so no conversion necessary.
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	// The OS API works in nanoseconds so no conversion necessary.
+	return timeUnit(ns)
+}
+
 func sleepTicks(d timeUnit) {
+	// timeUnit is in nanoseconds, so need to convert to microseconds here.
 	usleep(uint(d) / 1000)
 }
 

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -6,8 +6,6 @@ import "unsafe"
 
 type timeUnit float64 // time in milliseconds, just like Date.now() in JavaScript
 
-const tickMicros = 1000000
-
 // Implements __wasi_ciovec_t and __wasi_iovec_t.
 type wasiIOVec struct {
 	buf    unsafe.Pointer
@@ -67,6 +65,19 @@ func go_scheduler() {
 }
 
 const asyncScheduler = true
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	// The JavaScript API works in float64 milliseconds, so convert to
+	// nanoseconds first before converting to a timeUnit (which is a float64),
+	// to avoid precision loss.
+	return int64(ticks * 1e6)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	// The JavaScript API works in float64 milliseconds, so convert to timeUnit
+	// (which is a float64) first before dividing, to avoid precision loss.
+	return timeUnit(ns) / 1e6
+}
 
 // This function is called by the scheduler.
 // Schedule a call to runtime.scheduler, do not actually sleep.

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -75,14 +75,14 @@ func runqueuePushBack(t *task.Task) {
 }
 
 // Add this task to the sleep queue, assuming its state is set to sleeping.
-func addSleepTask(t *task.Task, duration int64) {
+func addSleepTask(t *task.Task, duration timeUnit) {
 	if schedulerDebug {
-		println("  set sleep:", t, uint(duration/tickMicros))
+		println("  set sleep:", t, duration)
 		if t.Next != nil {
 			panic("runtime: addSleepTask: expected next task to be nil")
 		}
 	}
-	t.Data = uint(duration / tickMicros) // TODO: longer durations
+	t.Data = uint(duration) // TODO: longer durations
 	now := ticks()
 	if sleepQueue == nil {
 		scheduleLog("  -> sleep new queue")

--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -7,7 +7,7 @@ import "internal/task"
 // Pause the current task for a given time.
 //go:linkname sleep time.Sleep
 func sleep(duration int64) {
-	addSleepTask(task.Current(), duration)
+	addSleepTask(task.Current(), nanosecondsToTicks(duration))
 	task.Pause()
 }
 

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -4,7 +4,7 @@ package runtime
 
 //go:linkname sleep time.Sleep
 func sleep(duration int64) {
-	sleepTicks(timeUnit(duration / tickMicros))
+	sleepTicks(nanosecondsToTicks(duration))
 }
 
 // getSystemStackPointer returns the current stack pointer of the system stack.


### PR DESCRIPTION
This commit refactors both determining the current time and sleeping for
a given time. It also improves precision for many chips.

  * The nrf chips had a long-standing TODO comment about a slightly
    inaccurate clock. This should now be fixed.
  * The SAM D2x/D5x chips may have a slightly more accurate clock,
    although probably within the error margin of the RTC. Also, by
    working with RTC ticks and converting in the least number of places,
    code size is often slightly reduced (usually just a few bytes, up to
    around 1kB in some cases).
  * I believe the HiFive1 rev B timer was slightly wrong (32768Hz vs
    30517.6Hz). Because the datasheet says the clock runs at 32768Hz,
    I've used the same conversion code here as in the nrf and sam cases.
  * I couldn't test both stm32 timers, so I kept them as they currently
    are. It may be possible to make them more efficient by using the
    native tick frequency instead of using microseconds everywhere.

This commit also replaces the incorrectly-named `tickMicros`.

Note that this may increase code size on nrf chips, probably because a simple shift (the power-of-two divide) got replaced with a 64-bit divide. But I think it's needed, as it fixes a real issue.

As indicated, I had trouble flashing my Blue Pill board, so if anyone can test whether it didn't break that would be great. The change is actually very small so I don't expect any breakage.

@mickey-happygolucky can you test the STM32F4 Discovery maybe? You can test examples/blinky1.