### PR TITLE
nrf: expose the RAM base address

### DIFF
--- a/targets/nrf52-s132v6.ld
+++ b/targets/nrf52-s132v6.ld
@@ -7,4 +7,7 @@ MEMORY
 
 _stack_size = 4K;
 
+/* This value is needed by the Nordic SoftDevice. */
+__app_ram_base = ORIGIN(RAM);
+
 INCLUDE "targets/arm.ld"

--- a/targets/nrf52840-s140v7.ld
+++ b/targets/nrf52840-s140v7.ld
@@ -7,4 +7,7 @@ MEMORY
 
 _stack_size = 4K;
 
+/* This value is needed by the Nordic SoftDevice. */
+__app_ram_base = ORIGIN(RAM);
+
 INCLUDE "targets/arm.ld"


### PR DESCRIPTION
The RAM base address is needed during SoftDevice initialization. So far, the same magic value has been used in aykevl/go-bluetooth and in TinyGo, but this should be configured in only one place.

This will have additional benefits in the future:

  * It is currently set to 0x39c0, which is around 14.5kB. Most nrf51822 chips have only 16kB of RAM, so this is way too much for those chips. Configuring this on the TinyGo side makes it easy to customize per chip.
  * LLD in LLVM 11 allows expressions in the MEMORY part of linker scripts, which will allow overriding the SoftDevice RAM area with a linker flag (using `#cgo LDFLAGS` for example), which might come in handy.