### PR TITLE
nrf: add microbit-s110v8 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=microbit            examples/echo
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=microbit-s110v8     examples/echo
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10031            examples/blinky1

--- a/targets/microbit-s110v8.json
+++ b/targets/microbit-s110v8.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["microbit", "nrf51-s110v8"]
+}

--- a/targets/nrf51-s110v8.json
+++ b/targets/nrf51-s110v8.json
@@ -1,0 +1,4 @@
+{
+	"build-tags": ["softdevice", "s110v8"],
+	"linkerscript": "targets/nrf51-s110v8.ld"
+}

--- a/targets/nrf51-s110v8.ld
+++ b/targets/nrf51-s110v8.ld
@@ -1,0 +1,12 @@
+
+MEMORY
+{
+    /* This SoftDevice requires 96K flash and 8K RAM according to the release
+     * notes of version 8.0.0 */
+    FLASH_TEXT (rw) : ORIGIN = 0x00000000 + 96K, LENGTH = 256K - 96K
+    RAM (xrw)       : ORIGIN = 0x20000000 + 8K,  LENGTH = 16K  - 8K
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
This makes it possible to use Bluetooth on the BBC micro:bit.

You can't use the regular flasher, you need to use `-programmer=cmsis-dap`. I've made a PR to add this to the documentation: https://github.com/tinygo-org/tinygo-site/pull/88

Bluetooth support is in a PR here: https://github.com/aykevl/go-bluetooth/pull/4