### PR TITLE
Gameboy Advance multiboot target

### DIFF
--- a/targets/gameboy-advance-mb.json
+++ b/targets/gameboy-advance-mb.json
@@ -1,0 +1,33 @@
+{
+	"llvm-target": "arm4-none-eabi",
+	"cpu": "arm7tdmi",
+	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
+	"goos": "linux",
+	"goarch": "arm",
+	"compiler": "clang",
+	"linker": "ld.lld",
+	"rtlib": "compiler-rt",
+	"libc": "picolibc",
+	"cflags": [
+		"-g",
+		"--target=arm4-none-eabi",
+		"-mcpu=arm7tdmi",
+		"-Oz",
+		"-Werror",
+		"-fshort-enums",
+		"-fomit-frame-pointer",
+		"-Qunused-arguments",
+		"-fno-exceptions", "-fno-unwind-tables",
+		"-ffunction-sections", "-fdata-sections"
+	],
+	"ldflags": [
+		"--gc-sections"
+	],
+	"linkerscript": "targets/gameboy-advance-mb.ld",
+	"extra-files": [
+		"targets/gameboy-advance-mb.s",
+		"src/runtime/scheduler_gba.S"
+	],
+	"gdb": "gdb-multiarch",
+	"emulator": ["mgba", "-2"]
+}

--- a/targets/gameboy-advance-mb.ld
+++ b/targets/gameboy-advance-mb.ld
@@ -1,0 +1,84 @@
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+/* Note: iwram is reduced by 96 bytes because the last part of that RAM
+ * (starting at 0x03007FA0) is used for interrupt handling.
+ */
+MEMORY {
+    ewram   : ORIGIN = 0x02000000, LENGTH = 256K   /* on-board work RAM (2 wait states) */
+    iwram   : ORIGIN = 0x03000000, LENGTH = 32K-96 /* in-chip work RAM (faster) */
+}
+
+__stack_size_irq = 1K;
+__stack_size_usr = 2K;
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP (*(.init))
+        *(.text)
+        . = ALIGN(4);
+    } >ewram
+
+    .rodata :
+    {
+        . = ALIGN(4);
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } >ewram
+
+    /* Put the stack at the bottom of RAM, so that the application will
+     * crash on stack overflow instead of silently corrupting memory.
+     * See: http://blog.japaric.io/stack-overflow-protection/ */
+    .stack (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _stack_top_irq = .;
+        . += __stack_size_irq;
+        _stack_top = .;
+        . += __stack_size_usr;
+    } >iwram
+
+    /* Start address (in flash) of .data, used by startup code. */
+    _sidata = LOADADDR(.data);
+
+    /* Globals with initial value */
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;        /* used by startup code */
+        *(.data)
+        *(.data*)
+        *(.iwram .iwram.*)
+        . = ALIGN(4);
+        _edata = .;        /* used by startup code */
+    } >iwram AT>ewram
+
+    /* Zero-initialized globals  */
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;         /* used by startup code */
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;         /* used by startup code */
+    } >iwram
+
+    /* TODO: find ewram ABSOLUTE for _heap_start */
+
+    /DISCARD/ :
+    {
+        *(.ARM.exidx)      /* causes 'no memory region specified' error in lld */
+        *(.ARM.exidx.*)    /* causes spurious 'undefined reference' errors */
+    }
+}
+
+/* For the memory allocator. */
+_heap_start = 0x2020000;
+_heap_end = ORIGIN(ewram) + LENGTH(ewram);
+_globals_start = _sdata;
+_globals_end = _ebss;

--- a/targets/gameboy-advance-mb.s
+++ b/targets/gameboy-advance-mb.s
@@ -1,0 +1,65 @@
+.section    .init
+.global     _start
+.align
+.arm
+
+_start:
+    b       start_vector
+    .fill   156,1,0                // Nintendo Logo Character Data (8000004h)
+    .fill   16,1,0                 // Game Title
+    .byte   0x30,0x31              // Maker Code (80000B0h)
+    .byte   0x96                   // Fixed Value (80000B2h)
+    .byte   0x00                   // Main Unit Code (80000B3h)
+    .byte   0x00                   // Device Type (80000B4h)
+    .fill   7,1,0                  // unused
+    .byte   0x00                   // Software Version No (80000BCh)
+    .byte   0xf0                   // Complement Check (80000BDh)
+    .byte   0x00,0x00              // Checksum (80000BEh)
+
+_rom_header_end:
+	b       start_vector
+
+_boot_method:
+	.byte   0   // boot method (0=ROM boot, 3=Multiplay boot)
+
+_slave_number:
+	.byte   0   // slave # (1=slave#1, 2=slave#2, 3=slave#3)
+
+	.byte   0   // reserved
+	.byte   0   // reserved
+	.word   0   // reserved
+	.word   0   // reserved
+	.word   0   // reserved
+	.word   0   // reserved
+	.word   0   // reserved
+	.word   0   // reserved
+
+.align
+
+start_vector:
+    // Configure stacks
+    mov     r0, #0x12                      // Switch to IRQ Mode
+    msr     cpsr, r0
+    ldr     sp, =_stack_top_irq            // Set IRQ stack
+    mov     r0, #0x1f                      // Switch to System Mode
+    msr     cpsr, r0
+    ldr     sp, =_stack_top                // Set user stack
+
+    // Configure interrupt handler
+    mov     r0, #0x4000000                 // REG_BASE
+    ldr     r1, =handleInterruptARM
+    str     r1, [r0, #-4]                  // actually storing to 0x03007FFC due to mirroring
+
+    // Enable interrupts
+    mov     r1, #1
+    str     r1, [r0, #0x208]               // 0x04000208 Interrupt Master Enable
+
+    // Jump to user code (switching to Thumb mode)
+    ldr     r3, =main
+    bx      r3
+
+// Small interrupt handler that immediately jumps to a function defined in the
+// program (in Thumb) for further processing.
+handleInterruptARM:
+    ldr     r0, =handleInterrupt
+    bx      r0


### PR DESCRIPTION
There is a feature on the GBA called multiboot. The bios uses the EXT1 port on the GBA to initiate a multiboot protocol over SIO (a custom protocol that is similar to SPI) to load a game directly into EWRAM and boot it by executing a branch instruction.

This PR adds the `gameboy-advance-mb` target which changes the linker script to support EWRAM loading.

I also updated the crt0 assembly to include some missing header info that is required on GBA for multiboot. It is important to include the multiboot header for all GBA roms as the bios will clobber some bytes while loading the rom. 

NOTE: this code is not functional likely due to an issue in the garbage collector which treats _sbss as part of heap. 
I am able to step through the main loop but as soon as the gc get's called, the program starts executing nop memory. 