### PR TITLE
Interface nil check

### DIFF
--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -24,6 +24,7 @@ declare void @runtime.printuint8(i8)
 declare void @runtime.printint32(i32)
 declare void @runtime.printptr(i32)
 declare void @runtime.printnl()
+declare void @runtime.nilPanic(i8*, i8*)
 
 define void @printInterfaces() {
   call void @printInterface(i32 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:basic:int" to i32), i8* inttoptr (i32 5 to i8*))

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -47,8 +47,8 @@ typeswitch.notUnmatched:                          ; preds = %0
   br i1 %typeassert.ok, label %typeswitch.Doubler, label %typeswitch.notDoubler
 
 typeswitch.Doubler:                               ; preds = %typeswitch.notUnmatched
-  %doubler.result = call i32 @"(Number).Double$invoke"(i8* %value, i8* null)
-  call void @runtime.printint32(i32 %doubler.result)
+  %1 = call i32 @"(Doubler).Double"(i8* %value, i8* null, i32 %typecode, i8* null)
+  call void @runtime.printint32(i32 %1)
   ret void
 
 typeswitch.notDoubler:                            ; preds = %typeswitch.notUnmatched
@@ -74,6 +74,20 @@ define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %parentHandle) {
   %receiver = ptrtoint i8* %receiverPtr to i32
   %ret = call i32 @"(Number).Double"(i32 %receiver, i8* null)
   ret i32 %ret
+}
+
+define internal i32 @"(Doubler).Double"(i8* %0, i8* %1, i32 %actualType, i8* %parentHandle) unnamed_addr {
+entry:
+  switch i32 %actualType, label %default [
+    i32 68, label %"reflect/types.type:named:Number"
+  ]
+
+default:                                          ; preds = %entry
+  unreachable
+
+"reflect/types.type:named:Number":                ; preds = %entry
+  %2 = call i32 @"(Number).Double$invoke"(i8* %0, i8* %1)
+  ret i32 %2
 }
 
 define internal i1 @"Doubler$typeassert"(i32 %actualType) unnamed_addr {

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -25,6 +25,8 @@ declare void @runtime.printptr(i32)
 
 declare void @runtime.printnl()
 
+declare void @runtime.nilPanic(i8*, i8*)
+
 define void @printInterfaces() {
   call void @printInterface(i32 4, i8* inttoptr (i32 5 to i8*))
   call void @printInterface(i32 16, i8* inttoptr (i8 120 to i8*))
@@ -83,6 +85,7 @@ entry:
   ]
 
 default:                                          ; preds = %entry
+  call void @runtime.nilPanic(i8* undef, i8* undef)
   unreachable
 
 "reflect/types.type:named:Number":                ; preds = %entry


### PR DESCRIPTION


I ran into an issue where I did a method call on a nil interface and it
resulted in a HardFault. Luckily I quickly realized what was going on so
I could fix it, but I think undefined behavior is definitely the wrong
behavior in this case. This commit therefore changes such calls to cause
a nil panic instead of introducing undefined behavior.

This does have a code size impact. It's relatively minor, much lower
than I expected. When comparing the before and after of the drivers
smoke tests (probably the most representative sample available), I found
that most did not change at all and those that did change, normally not
more than 100 bytes (16 or 32 byte changes are typical).

Right now the pattern is the following:

    switch typecode {
    case 1:
        call method 1
    case 2:
        call method 2
    default:
        nil panic
    }

I also tried the following (in the hope that it would be easier to
optimize), but it didn't really result in a code size reduction:

    switch typecode {
    case 1:
        call method 1
    case 2:
        call method 2
    case 0:
        nil panic
    default:
        unreachable
    }

Some code got smaller, while other code (the majority) got bigger. Maybe
this can be improved once [range](https://llvm.org/docs/LangRef.html#range-metadata) is finally [allowed](https://github.com/rust-lang/rust/issues/50156) on function
parameters, but it'll probably take a while before that is implemented.

---

The first commit refactors some code that makes the second commit easier to implement. It also has a (very small) code size impact.