### PR TITLE
sam: fix register access for interrupts pins in samd51

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -335,7 +335,7 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 	pinCallbacks[extint] = callback
 	interruptPins[extint] = p
 
-	if (sam.EIC.CTRLA.Get() & sam.EIC_CTRLA_ENABLE) == 0 {
+	if !sam.EIC.CTRLA.HasBits(sam.EIC_CTRLA_ENABLE) {
 		// EIC peripheral has not yet been initialized. Initialize it now.
 
 		// The EIC needs two clocks: CLK_EIC_APB and GCLK_EIC. CLK_EIC_APB is

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -335,7 +335,7 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 	pinCallbacks[extint] = callback
 	interruptPins[extint] = p
 
-	if (sam.EIC.CTRLA.Get() & 0x02) == 0 {
+	if (sam.EIC.CTRLA.Get() & sam.EIC_CTRLA_ENABLE) == 0 {
 		// EIC peripheral has not yet been initialized. Initialize it now.
 
 		// The EIC needs two clocks: CLK_EIC_APB and GCLK_EIC. CLK_EIC_APB is
@@ -349,7 +349,7 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 	}
 
 	// CONFIG register is enable-protected, so disable EIC.
-	sam.EIC.CTRLA.Set(0)
+	sam.EIC.CTRLA.ClearBits(sam.EIC_CTRLA_ENABLE)
 
 	// Configure this pin. Set the 4 bits of the EIC.CONFIGx register to the
 	// sense value (filter bit set to 0, sense bits set to the change value).


### PR DESCRIPTION
#1139

@deadprogram 
This PR modifies the register access for interrupts pins on samd51.

Since only the EIC.CTRLA.ENABLE bit is required, only the EIC.CTRLA.ENABLE bit should be accessed and changed.

I tested it with feather-m4 and confirmed that it works.