### PR TITLE
Standardize SAMD51 UART settings

### DIFF
--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -1,11 +1,6 @@
-// +build sam,atsamd51,feather_m4
+// +build feather_m4
 
 package machine
-
-import (
-	"device/sam"
-	"runtime/interrupt"
-)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -60,37 +55,10 @@ const (
 	UART2_RX_PIN = A5
 )
 
-var (
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM5_USART_INT,
-		SERCOM: 5,
-	}
-
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		SERCOM: 0,
-	}
-)
-
-func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
-}
-
 // I2C pins
 const (
 	SDA_PIN = D22 // SDA: SERCOM2/PAD[0]
 	SCL_PIN = D21 // SCL: SERCOM2/PAD[1]
-)
-
-// I2C on the Feather M4.
-var (
-	I2C0 = I2C{
-		Bus:    sam.SERCOM2_I2CM,
-		SERCOM: 2,
-	}
 )
 
 // SPI pins
@@ -98,14 +66,6 @@ const (
 	SPI0_SCK_PIN  = D25 // SCK: SERCOM1/PAD[1]
 	SPI0_MOSI_PIN = D24 // MOSI: SERCOM1/PAD[3]
 	SPI0_MISO_PIN = D23 // MISO: SERCOM1/PAD[2]
-)
-
-// SPI on the Feather M4.
-var (
-	SPI0 = SPI{
-		Bus:    sam.SERCOM1_SPIM,
-		SERCOM: 1,
-	}
 )
 
 // USB CDC identifiers

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -2,7 +2,10 @@
 
 package machine
 
-import "device/sam"
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -47,17 +50,34 @@ const (
 	USBCDC_DP_PIN = PA25
 )
 
-// UART1 pins
 const (
 	UART_TX_PIN = D1
 	UART_RX_PIN = D0
 )
 
-// UART2 pins
 const (
 	UART2_TX_PIN = A4
 	UART2_RX_PIN = A5
 )
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM5_USART_INT,
+		SERCOM: 5,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
 
 // I2C pins
 const (

--- a/src/machine/board_feather-m4_baremetal.go
+++ b/src/machine/board_feather-m4_baremetal.go
@@ -1,0 +1,43 @@
+// +build sam,atsamd51,feather_m4
+
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM5_USART_INT,
+		SERCOM: 5,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
+
+// I2C on the Feather M4.
+var (
+	I2C0 = I2C{
+		Bus:    sam.SERCOM2_I2CM,
+		SERCOM: 2,
+	}
+)
+
+// SPI on the Feather M4.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
+	}
+)

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -1,11 +1,6 @@
-// +build sam,atsamd51,itsybitsy_m4
+// +build itsybitsy_m4
 
 package machine
-
-import (
-	"device/sam"
-	"runtime/interrupt"
-)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -59,37 +54,10 @@ const (
 	UART2_RX_PIN = D2
 )
 
-var (
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM3_USART_INT,
-		SERCOM: 3,
-	}
-
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		SERCOM: 0,
-	}
-)
-
-func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
-}
-
 // I2C pins
 const (
 	SDA_PIN = PA12 // SDA: SERCOM2/PAD[0]
 	SCL_PIN = PA13 // SCL: SERCOM2/PAD[1]
-)
-
-// I2C on the ItsyBitsy M4.
-var (
-	I2C0 = I2C{
-		Bus:    sam.SERCOM2_I2CM,
-		SERCOM: 2,
-	}
 )
 
 // SPI pins
@@ -97,14 +65,6 @@ const (
 	SPI0_SCK_PIN  = PA01 // SCK: SERCOM1/PAD[1]
 	SPI0_MOSI_PIN = PA00 // MOSI: SERCOM1/PAD[0]
 	SPI0_MISO_PIN = PB23 // MISO: SERCOM1/PAD[3]
-)
-
-// SPI on the ItsyBitsy M4.
-var (
-	SPI0 = SPI{
-		Bus:    sam.SERCOM1_SPIM,
-		SERCOM: 1,
-	}
 )
 
 // USB CDC identifiers

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -2,7 +2,10 @@
 
 package machine
 
-import "device/sam"
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -51,15 +54,29 @@ const (
 	UART_RX_PIN = D0
 )
 
-// UART1 var is on SERCOM3, defined in atsamd51.go
-
-// UART2 pins
 const (
 	UART2_TX_PIN = A4
 	UART2_RX_PIN = D2
 )
 
-// UART2 var is on SERCOM0, defined in atsamd51.go
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM3_USART_INT,
+		SERCOM: 3,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
 
 // I2C pins
 const (

--- a/src/machine/board_itsybitsy-m4_baremetal.go
+++ b/src/machine/board_itsybitsy-m4_baremetal.go
@@ -1,0 +1,43 @@
+// +build sam,atsamd51,itsybitsy_m4
+
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM3_USART_INT,
+		SERCOM: 3,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
+
+// I2C on the ItsyBitsy M4.
+var (
+	I2C0 = I2C{
+		Bus:    sam.SERCOM2_I2CM,
+		SERCOM: 2,
+	}
+)
+
+// SPI on the ItsyBitsy M4.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
+	}
+)

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -1,11 +1,6 @@
-// +build sam,atsamd51,metro_m4_airlift
+// +build metro_m4_airlift
 
 package machine
-
-import (
-	"device/sam"
-	"runtime/interrupt"
-)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -61,25 +56,6 @@ const (
 	UART2_RX_PIN = PA07
 )
 
-var (
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM3_USART_INT,
-		SERCOM: 3,
-	}
-
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		SERCOM: 0,
-	}
-)
-
-func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
-}
-
 const (
 	NINA_CS     = PA15
 	NINA_ACK    = PB04
@@ -97,14 +73,6 @@ const (
 	SCL_PIN = PB03 // SCL: SERCOM5/PAD[1]
 )
 
-// I2C on the Metro M4.
-var (
-	I2C0 = I2C{
-		Bus:    sam.SERCOM5_I2CM,
-		SERCOM: 5,
-	}
-)
-
 // SPI pins
 const (
 	SPI0_SCK_PIN  = PA13 // SCK:  SERCOM2/PAD[1]
@@ -116,27 +84,10 @@ const (
 	NINA_SCK  = SPI0_SCK_PIN
 )
 
-// SPI on the Metro M4.
-var (
-	SPI0 = SPI{
-		Bus:    sam.SERCOM2_SPIM,
-		SERCOM: 2,
-	}
-	NINA_SPI = SPI0
-)
-
 const (
 	SPI1_SCK_PIN  = D12 // MISO: SERCOM1/PAD[1]
 	SPI1_MOSI_PIN = D11 // MOSI: SERCOM1/PAD[3]
 	SPI1_MISO_PIN = D13 // SCK:  SERCOM1/PAD[0]
-)
-
-// SPI1 on the Metro M4 on pins 11,12,13
-var (
-	SPI1 = SPI{
-		Bus:    sam.SERCOM1_SPIM,
-		SERCOM: 1,
-	}
 )
 
 // USB CDC identifiers

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -2,7 +2,10 @@
 
 package machine
 
-import "device/sam"
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -53,7 +56,29 @@ const (
 	UART_RX_PIN = D0
 )
 
-// Note: UART1 is on SERCOM3, defined in machine_atsamd51.go
+const (
+	UART2_TX_PIN = PA04
+	UART2_RX_PIN = PA07
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM3_USART_INT,
+		SERCOM: 3,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
 
 const (
 	NINA_CS     = PA15
@@ -65,9 +90,6 @@ const (
 	NINA_RX  = PA07
 	NINA_RTS = PB23
 )
-
-// UART2 is on SERCOM0,  defined in machine_atsamd51.go, and connects to the
-// onboard ESP32-WROOM chip.
 
 // I2C pins
 const (

--- a/src/machine/board_metro-m4-airlift_baremetal.go
+++ b/src/machine/board_metro-m4-airlift_baremetal.go
@@ -1,0 +1,52 @@
+// +build sam,atsamd51,metro_m4_airlift
+
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM3_USART_INT,
+		SERCOM: 3,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
+
+// I2C on the Metro M4.
+var (
+	I2C0 = I2C{
+		Bus:    sam.SERCOM5_I2CM,
+		SERCOM: 5,
+	}
+)
+
+// SPI on the Metro M4.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM2_SPIM,
+		SERCOM: 2,
+	}
+	NINA_SPI = SPI0
+)
+
+// SPI1 on the Metro M4 on pins 11,12,13
+var (
+	SPI1 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
+	}
+)

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -2,7 +2,10 @@
 
 package machine
 
-import "device/sam"
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -80,15 +83,29 @@ const (
 	UART_RX_PIN = D0
 )
 
-// UART1 var is on SERCOM3, defined in atsamd51.go
-
-// UART2 pins
 const (
 	UART2_TX_PIN = A4
 	UART2_RX_PIN = A5
 )
 
-// UART2 var is on SERCOM0, defined in atsamd51.go
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM5_USART_INT,
+		SERCOM: 5,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
 
 // I2C pins
 const (

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -1,11 +1,6 @@
-// +build sam,atsamd51,pybadge
+// +build pybadge
 
 package machine
-
-import (
-	"device/sam"
-	"runtime/interrupt"
-)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -88,37 +83,10 @@ const (
 	UART2_RX_PIN = A5
 )
 
-var (
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM5_USART_INT,
-		SERCOM: 5,
-	}
-
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		SERCOM: 0,
-	}
-)
-
-func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
-}
-
 // I2C pins
 const (
 	SDA_PIN = PA12 // SDA: SERCOM2/PAD[0]
 	SCL_PIN = PA13 // SCL: SERCOM2/PAD[1]
-)
-
-// I2C on the ItsyBitsy M4.
-var (
-	I2C0 = I2C{
-		Bus:    sam.SERCOM2_I2CM,
-		SERCOM: 2,
-	}
 )
 
 // SPI pins
@@ -128,27 +96,11 @@ const (
 	SPI0_MISO_PIN = PB22 // MISO: SERCOM1/PAD[2]
 )
 
-// SPI on the PyBadge.
-var (
-	SPI0 = SPI{
-		Bus:    sam.SERCOM1_SPIM,
-		SERCOM: 1,
-	}
-)
-
 // TFT SPI pins
 const (
 	SPI1_SCK_PIN  = PB13 // SCK: SERCOM4/PAD[1]
 	SPI1_MOSI_PIN = PB15 // MOSI: SERCOM4/PAD[3]
 	SPI1_MISO_PIN = NoPin
-)
-
-// TFT SPI on the PyBadge.
-var (
-	SPI1 = SPI{
-		Bus:    sam.SERCOM4_SPIM,
-		SERCOM: 4,
-	}
 )
 
 // USB CDC identifiers

--- a/src/machine/board_pybadge_baremetal.go
+++ b/src/machine/board_pybadge_baremetal.go
@@ -1,0 +1,51 @@
+// +build sam,atsamd51,pybadge
+
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM5_USART_INT,
+		SERCOM: 5,
+	}
+
+	UART2 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM0_USART_INT,
+		SERCOM: 0,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+}
+
+// I2C on the ItsyBitsy M4.
+var (
+	I2C0 = I2C{
+		Bus:    sam.SERCOM2_I2CM,
+		SERCOM: 2,
+	}
+)
+
+// SPI on the PyBadge.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPIM,
+		SERCOM: 1,
+	}
+)
+
+// TFT SPI on the PyBadge.
+var (
+	SPI1 = SPI{
+		Bus:    sam.SERCOM4_SPIM,
+		SERCOM: 4,
+	}
+)

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -1,11 +1,6 @@
-// +build sam,atsamd51,pyportal
+// +build pyportal
 
 package machine
-
-import (
-	"device/sam"
-	"runtime/interrupt"
-)
 
 // used to reset into bootloader
 const RESET_MAGIC_VALUE = 0xf01669ef
@@ -111,30 +106,10 @@ const (
 	UART_RX_PIN = D0
 )
 
-var (
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM4_USART_INT,
-		SERCOM: 4,
-	}
-)
-
-func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, UART1.handleInterrupt)
-}
-
 // I2C pins
 const (
 	SDA_PIN = PB02 // SDA: SERCOM2/PAD[0]
 	SCL_PIN = PB03 // SCL: SERCOM2/PAD[1]
-)
-
-// I2C on the PyPortal.
-var (
-	I2C0 = I2C{
-		Bus:    sam.SERCOM5_I2CM,
-		SERCOM: 5,
-	}
 )
 
 // SPI pins
@@ -146,15 +121,6 @@ const (
 	NINA_MOSI = SPI0_MOSI_PIN
 	NINA_MISO = SPI0_MISO_PIN
 	NINA_SCK  = SPI0_SCK_PIN
-)
-
-// SPI on the PyPortal.
-var (
-	SPI0 = SPI{
-		Bus:    sam.SERCOM2_SPIM,
-		SERCOM: 2,
-	}
-	NINA_SPI = SPI0
 )
 
 // USB CDC identifiers

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -4,6 +4,7 @@ package machine
 
 import (
 	"device/sam"
+	"runtime/interrupt"
 )
 
 // used to reset into bootloader
@@ -104,11 +105,23 @@ const (
 	USBCDC_DP_PIN = PA25
 )
 
-// TODO: add configuration for UART on SERCOM4 that is connected to TX/RX of ESP32
+// UART1 aka NINA_TX/NINA_RX
 const (
-	UART_TX_PIN = NoPin
-	UART_RX_PIN = NoPin
+	UART_TX_PIN = D1
+	UART_RX_PIN = D0
 )
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM4_USART_INT,
+		SERCOM: 4,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, UART1.handleInterrupt)
+}
 
 // I2C pins
 const (

--- a/src/machine/board_pyportal_baremetal.go
+++ b/src/machine/board_pyportal_baremetal.go
@@ -1,0 +1,37 @@
+// +build sam,atsamd51,pyportal
+
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+var (
+	UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM4_USART_INT,
+		SERCOM: 4,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, UART1.handleInterrupt)
+}
+
+// I2C on the PyPortal.
+var (
+	I2C0 = I2C{
+		Bus:    sam.SERCOM5_I2CM,
+		SERCOM: 5,
+	}
+)
+
+// SPI on the PyPortal.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM2_SPIM,
+		SERCOM: 2,
+	}
+	NINA_SPI = SPI0
+)

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -903,27 +903,7 @@ type UART struct {
 var (
 	// UART0 is actually a USB CDC interface.
 	UART0 = USBCDC{Buffer: NewRingBuffer()}
-
-	// The first hardware serial port on the SAMD51. Uses the SERCOM3 interface.
-	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM3_USART_INT,
-		SERCOM: 3,
-	}
-
-	// The second hardware serial port on the SAMD51. Uses the SERCOM0 interface.
-	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    sam.SERCOM0_USART_INT,
-		SERCOM: 0,
-	}
 )
-
-func init() {
-	// Register RXC interrupts.
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
-}
 
 const (
 	sampleRate16X = 16


### PR DESCRIPTION
Because SERCOM used by UART is different in each board, I divided the file by this PR.

I've written about which SERCOM to use in the comments below.
https://github.com/tinygo-org/tinygo/pull/1124#issuecomment-633205440