### PR TITLE
compiler: add support for custom code model

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -272,6 +272,15 @@ func (c *Config) OpenOCDConfiguration() (args []string, err error) {
 	return args, nil
 }
 
+// CodeModel returns the code model used on this platform.
+func (c *Config) CodeModel() string {
+	if c.Target.CodeModel != "" {
+		return c.Target.CodeModel
+	}
+
+	return "default"
+}
+
 type TestConfig struct {
 	CompileTestBinary bool
 	// TODO: Filter the test functions to run, include verbose flag, etc

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -49,6 +49,7 @@ type TargetSpec struct {
 	OpenOCDTarget    string   `json:"openocd-target"`
 	OpenOCDTransport string   `json:"openocd-transport"`
 	JLinkDevice      string   `json:"jlink-device"`
+	CodeModel        string   `json:"code-model"`
 }
 
 // copyProperties copies all properties that are set in spec2 into itself.
@@ -129,6 +130,9 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	}
 	if spec2.JLinkDevice != "" {
 		spec.JLinkDevice = spec2.JLinkDevice
+	}
+	if spec2.CodeModel != "" {
+		spec.CodeModel = spec2.CodeModel
 	}
 }
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -91,7 +91,25 @@ func NewTargetMachine(config *compileopts.Config) (llvm.TargetMachine, error) {
 		return llvm.TargetMachine{}, err
 	}
 	features := strings.Join(config.Features(), ",")
-	machine := target.CreateTargetMachine(config.Triple(), config.CPU(), features, llvm.CodeGenLevelDefault, llvm.RelocStatic, llvm.CodeModelDefault)
+
+	var codeModel llvm.CodeModel
+
+	switch config.CodeModel() {
+	case "default":
+		codeModel = llvm.CodeModelDefault
+	case "tiny":
+		codeModel = llvm.CodeModelTiny
+	case "small":
+		codeModel = llvm.CodeModelSmall
+	case "kernel":
+		codeModel = llvm.CodeModelKernel
+	case "medium":
+		codeModel = llvm.CodeModelMedium
+	case "large":
+		codeModel = llvm.CodeModelLarge
+	}
+
+	machine := target.CreateTargetMachine(config.Triple(), config.CPU(), features, llvm.CodeGenLevelDefault, llvm.RelocStatic, codeModel)
 	return machine, nil
 }
 


### PR DESCRIPTION
This PR adds a new compiler option to change the code model used by LLVM. This is needed to support the 64-bit RISC-V architecture.

https://github.com/tinygo-org/tinygo/pull/1149