### PR TITLE
main: use ToSlash() to specify pkgName

### DIFF
--- a/main.go
+++ b/main.go
@@ -901,7 +901,7 @@ func main() {
 			os.Exit(1)
 		}
 		var lib *builder.Library
-		switch name := filepath.ToSlash(flag.Arg(0)); name {
+		switch name := flag.Arg(0); name {
 		case "compiler-rt":
 			lib = &builder.CompilerRT
 		case "picolibc":
@@ -954,8 +954,7 @@ func main() {
 		handleCompilerError(err)
 	case "info":
 		if flag.NArg() == 1 {
-			pkgName := filepath.ToSlash(flag.Arg(0))
-			options.Target = pkgName
+			options.Target = flag.Arg(0)
 		} else if flag.NArg() > 1 {
 			fmt.Fprintln(os.Stderr, "only one target name is accepted")
 			usage()

--- a/main.go
+++ b/main.go
@@ -873,7 +873,7 @@ func main() {
 		}
 		pkgName := "."
 		if flag.NArg() == 1 {
-			pkgName = flag.Arg(0)
+			pkgName = filepath.ToSlash(flag.Arg(0))
 		} else if flag.NArg() > 1 {
 			fmt.Fprintln(os.Stderr, "build only accepts a single positional argument: package name, but multiple were specified")
 			usage()
@@ -901,7 +901,7 @@ func main() {
 			os.Exit(1)
 		}
 		var lib *builder.Library
-		switch name := flag.Arg(0); name {
+		switch name := filepath.ToSlash(flag.Arg(0)); name {
 		case "compiler-rt":
 			lib = &builder.CompilerRT
 		case "picolibc":
@@ -919,8 +919,9 @@ func main() {
 			usage()
 			os.Exit(1)
 		}
+		pkgName := filepath.ToSlash(flag.Arg(0))
 		if command == "flash" {
-			err := Flash(flag.Arg(0), *port, options)
+			err := Flash(pkgName, *port, options)
 			handleCompilerError(err)
 		} else {
 			if !options.Debug {
@@ -928,7 +929,7 @@ func main() {
 				usage()
 				os.Exit(1)
 			}
-			err := FlashGDB(flag.Arg(0), *ocdOutput, options)
+			err := FlashGDB(pkgName, *ocdOutput, options)
 			handleCompilerError(err)
 		}
 	case "run":
@@ -937,12 +938,13 @@ func main() {
 			usage()
 			os.Exit(1)
 		}
-		err := Run(flag.Arg(0), options)
+		pkgName := filepath.ToSlash(flag.Arg(0))
+		err := Run(pkgName, options)
 		handleCompilerError(err)
 	case "test":
 		pkgName := "."
 		if flag.NArg() == 1 {
-			pkgName = flag.Arg(0)
+			pkgName = filepath.ToSlash(flag.Arg(0))
 		} else if flag.NArg() > 1 {
 			fmt.Fprintln(os.Stderr, "test only accepts a single positional argument: package name, but multiple were specified")
 			usage()
@@ -952,7 +954,8 @@ func main() {
 		handleCompilerError(err)
 	case "info":
 		if flag.NArg() == 1 {
-			options.Target = flag.Arg(0)
+			pkgName := filepath.ToSlash(flag.Arg(0))
+			options.Target = pkgName
 		} else if flag.NArg() > 1 {
 			fmt.Fprintln(os.Stderr, "only one target name is accepted")
 			usage()


### PR DESCRIPTION
This change allows windows users to specify the package with backslash as a path separator.
You can also use slash.

This behavior is identical to that of `go build`.

![tinygo-toslash](https://user-images.githubusercontent.com/9251039/83931189-4f177a00-a7d6-11ea-9d79-35e97c85c985.gif)
