### PR TITLE
hifive1b: zero PLIC threshold value at startup

### DIFF
--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -24,6 +24,9 @@ func main() {
 	sifive.PLIC.ENABLE[0].Set(0)
 	sifive.PLIC.ENABLE[1].Set(0)
 
+	// Zero the threshold value to allow all priorities of interrupts.
+	sifive.PLIC.THRESHOLD.Set(0)
+
 	// Set the interrupt address.
 	// Note that this address must be aligned specially, otherwise the MODE bits
 	// of MTVEC won't be zero.


### PR DESCRIPTION
The PLIC threshold value must be zeroed at startup to permit all interrupt priorities. Fixes #1128.