### PR TITLE
gen-device-svd: fix lowercase cluster name

### DIFF
--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -342,6 +342,11 @@ func readSVD(path, sourceURL string) (*Device, error) {
 				firstAddress := clusterRegisters[0].address
 				dimIncrement = int(lastAddress - firstAddress)
 			}
+
+			if !unicode.IsUpper(rune(clusterName[0])) && !unicode.IsDigit(rune(clusterName[0])) {
+				clusterName = strings.ToUpper(clusterName)
+			}
+
 			p.registers = append(p.registers, &PeripheralField{
 				name:        clusterName,
 				address:     baseAddress + clusterOffset,


### PR DESCRIPTION
Not sure if this is the right way to do this but this produces the expected output in issue  #1163:
```go
// Platform-Level Interrupt Controller
type PLIC_Type struct {
	PRIORITY       [1024]volatile.Register32
	PENDING        [32]volatile.Register32
	_              [3968]byte
	TARGET_ENABLES [4]struct {
		ENABLE [32]volatile.Register32
	}
	_       [2088448]byte
	TARGETS [4]struct {
		THRESHOLD volatile.Register32
		CLAIM     volatile.Register32
		_         [4084]byte
		_RESERVED volatile.Register32
	}
}
```