### PR TITLE
machine/hifive1b: remove extra println left in by mistake

### DIFF
--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -48,7 +48,6 @@ func (p Pin) Set(high bool) {
 // Get returns the current value of a GPIO pin.
 func (p Pin) Get() bool {
 	val := sifive.GPIO0.VALUE.Get() & (1 << uint8(p))
-	println(sifive.GPIO0.VALUE.Get())
 	return (val > 0)
 }
 


### PR DESCRIPTION
Just removes a println that was left in by mistake on the hifive1b implementation.