### PR TITLE
machine/hifive1b: add definitions for UART0 pins

### DIFF
--- a/src/machine/board_hifive1b.go
+++ b/src/machine/board_hifive1b.go
@@ -37,8 +37,8 @@ const (
 
 const (
 	// TODO: figure out the pin numbers for these.
-	UART_TX_PIN = NoPin
-	UART_RX_PIN = NoPin
+	UART_TX_PIN = D1
+	UART_RX_PIN = D0
 )
 
 // SPI pins


### PR DESCRIPTION
This PR add definitions for UART0 pins. It is a lot more reliable to use them vs. trying to use the UART connection via the SEGGER interface.