### PR TITLE
 runtime/interrupt: add cross-chip disable/restore interrupt support

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1327,9 +1327,9 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.createMemoryCopyCall(fn, instr.Args)
 		case name == "runtime.memzero":
 			return b.createMemoryZeroCall(instr.Args)
-		case name == "device/arm.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
+		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
 			return b.createInlineAsm(instr.Args)
-		case name == "device/arm.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull":
+		case name == "device.AsmFull" || name == "device/arm.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull":
 			return b.createInlineAsmFull(instr)
 		case strings.HasPrefix(name, "device/arm.SVCall"):
 			return b.emitSVCall(instr.Args)

--- a/src/device/asm.go
+++ b/src/device/asm.go
@@ -1,0 +1,21 @@
+package device
+
+// Run the given assembly code. The code will be marked as having side effects,
+// as it doesn't produce output and thus would normally be eliminated by the
+// optimizer.
+func Asm(asm string)
+
+// Run the given inline assembly. The code will be marked as having side
+// effects, as it would otherwise be optimized away. The inline assembly string
+// recognizes template values in the form {name}, like so:
+//
+//     arm.AsmFull(
+//         "str {value}, {result}",
+//         map[string]interface{}{
+//             "value":  1
+//             "result": &dest,
+//         })
+//
+// You can use {} in the asm string (which expands to a register) to set the
+// return value.
+func AsmFull(asm string, regs map[string]interface{}) uintptr

--- a/src/runtime/interrupt/interrupt_gameboyadvance.go
+++ b/src/runtime/interrupt/interrupt_gameboyadvance.go
@@ -34,3 +34,32 @@ func handleInterrupt() {
 // appropriate interrupt handler for the given interrupt ID.
 //go:linkname callInterruptHandler runtime.callInterruptHandler
 func callInterruptHandler(id int)
+
+// State represents the previous global interrupt state.
+type State uint8
+
+// Disable disables all interrupts and returns the previous interrupt state. It
+// can be used in a critical section like this:
+//
+//     state := interrupt.Disable()
+//     // critical section
+//     interrupt.Restore(state)
+//
+// Critical sections can be nested. Make sure to call Restore in the same order
+// as you called Disable (this happens naturally with the pattern above).
+func Disable() (state State) {
+	// Save the previous interrupt state.
+	state = State(regInterruptMasterEnable.Get())
+	// Disable all interrupts.
+	regInterruptMasterEnable.Set(0)
+	return
+}
+
+// Restore restores interrupts to what they were before. Give the previous state
+// returned by Disable as a parameter. If interrupts were disabled before
+// calling Disable, this will not re-enable interrupts, allowing for nested
+// cricital sections.
+func Restore(state State) {
+	// Restore interrupts to the previous state.
+	regInterruptMasterEnable.Set(uint16(state))
+}

--- a/src/runtime/interrupt/interrupt_tinygoriscv.go
+++ b/src/runtime/interrupt/interrupt_tinygoriscv.go
@@ -1,26 +1,8 @@
-// +build cortexm
+// +build tinygo.riscv
 
 package interrupt
 
-import (
-	"device/arm"
-)
-
-// Enable enables this interrupt. Right after calling this function, the
-// interrupt may be invoked if it was already pending.
-func (irq Interrupt) Enable() {
-	arm.EnableIRQ(uint32(irq.num))
-}
-
-// SetPriority sets the interrupt priority for this interrupt. A lower number
-// means a higher priority. Additionally, most hardware doesn't implement all
-// priority bits (only the uppoer bits).
-//
-// Examples: 0xff (lowest priority), 0xc0 (low priority), 0x00 (highest possible
-// priority).
-func (irq Interrupt) SetPriority(priority uint8) {
-	arm.SetPriority(uint32(irq.num), uint32(priority))
-}
+import "device/riscv"
 
 // State represents the previous global interrupt state.
 type State uintptr
@@ -35,7 +17,7 @@ type State uintptr
 // Critical sections can be nested. Make sure to call Restore in the same order
 // as you called Disable (this happens naturally with the pattern above).
 func Disable() (state State) {
-	return State(arm.DisableInterrupts())
+	return State(riscv.DisableInterrupts())
 }
 
 // Restore restores interrupts to what they were before. Give the previous state
@@ -43,5 +25,5 @@ func Disable() (state State) {
 // calling Disable, this will not re-enable interrupts, allowing for nested
 // cricital sections.
 func Restore(state State) {
-	arm.EnableInterrupts(uintptr(state))
+	riscv.EnableInterrupts(uintptr(state))
 }


### PR DESCRIPTION
This should cover all supported baremetal targets.