### PR TITLE
runtime: add cheap atomic condition variable

### DIFF
--- a/src/runtime/cond.go
+++ b/src/runtime/cond.go
@@ -1,0 +1,90 @@
+// +build !scheduler.none
+
+package runtime
+
+import (
+	"internal/task"
+	"sync/atomic"
+	"unsafe"
+)
+
+// notifiedPlaceholder is a placeholder task which is used to indicate that the condition variable has been notified.
+var notifiedPlaceholder task.Task
+
+// Cond is a simplified condition variable, useful for notifying goroutines of interrupts.
+type Cond struct {
+	t *task.Task
+}
+
+// Notify sends a notification.
+// If the condition variable already has a pending notification, this returns false.
+func (c *Cond) Notify() bool {
+	for {
+		t := (*task.Task)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t))))
+		switch t {
+		case nil:
+			// Nothing is waiting yet.
+			// Apply the notification placeholder.
+			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t)), unsafe.Pointer(t), unsafe.Pointer(&notifiedPlaceholder)) {
+				return true
+			}
+		case &notifiedPlaceholder:
+			// The condition variable has already been notified.
+			return false
+		default:
+			// Unblock the waiting task.
+			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t)), unsafe.Pointer(t), nil) {
+				runqueuePushBack(t)
+				return true
+			}
+		}
+	}
+}
+
+// Poll checks for a notification.
+// If a notification is found, it is cleared and this returns true.
+func (c *Cond) Poll() bool {
+	for {
+		t := (*task.Task)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t))))
+		switch t {
+		case nil:
+			// No notifications are present.
+			return false
+		case &notifiedPlaceholder:
+			// A notification arrived and there is no waiting goroutine.
+			// Clear the notification and return.
+			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t)), unsafe.Pointer(t), nil) {
+				return true
+			}
+		default:
+			// A task is blocked on the condition variable, which means it has not been notified.
+			return false
+		}
+	}
+}
+
+// Wait for a notification.
+// If the condition variable was previously notified, this returns immediately.
+func (c *Cond) Wait() {
+	cur := task.Current()
+	for {
+		t := (*task.Task)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t))))
+		switch t {
+		case nil:
+			// Condition variable has not been notified.
+			// Block the current task on the condition variable.
+			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t)), nil, unsafe.Pointer(cur)) {
+				task.Pause()
+				return
+			}
+		case &notifiedPlaceholder:
+			// A notification arrived and there is no waiting goroutine.
+			// Clear the notification and return.
+			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&c.t)), unsafe.Pointer(t), nil) {
+				return
+			}
+		default:
+			panic("interrupt.Cond: condition variable in use by another goroutine")
+		}
+	}
+}

--- a/src/runtime/cond_nosched.go
+++ b/src/runtime/cond_nosched.go
@@ -1,0 +1,38 @@
+// +build scheduler.none
+
+package runtime
+
+import "runtime/interrupt"
+
+// Cond is a simplified condition variable, useful for notifying goroutines of interrupts.
+type Cond struct {
+	notified bool
+}
+
+// Notify sends a notification.
+// If the condition variable already has a pending notification, this returns false.
+func (c *Cond) Notify() bool {
+	i := interrupt.Disable()
+	prev := c.notified
+	c.notified = true
+	interrupt.Restore(i)
+	return !prev
+}
+
+// Poll checks for a notification.
+// If a notification is found, it is cleared and this returns true.
+func (c *Cond) Poll() bool {
+	i := interrupt.Disable()
+	notified := c.notified
+	c.notified = false
+	interrupt.Restore(i)
+	return notified
+}
+
+// Wait for a notification.
+// If the condition variable was previously notified, this returns immediately.
+func (c *Cond) Wait() {
+	for !c.Poll() {
+		waitForEvents()
+	}
+}

--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"runtime"
 	"sync"
 	"time"
 )
@@ -71,6 +72,8 @@ func main() {
 	startSimpleFunc(emptyFunc)
 
 	time.Sleep(2 * time.Millisecond)
+
+	testCond()
 }
 
 func acquire(m *sync.Mutex) {
@@ -126,4 +129,45 @@ func (i *myPrinter) Print() {
 type simpleFunc func()
 
 func emptyFunc() {
+}
+
+func testCond() {
+	var cond runtime.Cond
+	go func() {
+		// Wait for the caller to wait on the cond.
+		time.Sleep(time.Millisecond)
+
+		// Notify the caller.
+		ok := cond.Notify()
+		if !ok {
+			panic("notification not sent")
+		}
+
+		// This notification will be buffered inside the cond.
+		ok = cond.Notify()
+		if !ok {
+			panic("notification not queued")
+		}
+
+		// This notification should fail, since there is already one buffered.
+		ok = cond.Notify()
+		if ok {
+			panic("notification double-sent")
+		}
+	}()
+
+	// Verify that the cond has no pending notifications.
+	ok := cond.Poll()
+	if ok {
+		panic("unexpected early notification")
+	}
+
+	// Wait for the goroutine spawned earlier to send a notification.
+	cond.Wait()
+
+	// The goroutine should have also queued a notification in the cond.
+	ok = cond.Poll()
+	if !ok {
+		panic("missing queued notification")
+	}
 }


### PR DESCRIPTION
Earlier on slack @aykevl suggested that something like this would be needed.

Usage example with systick:
```Go
package main

import (
	"device/arm"
	"machine"
	"runtime"
)

var cond runtime.Cond

func main() {
	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})

	// timer fires 10 times per second
	arm.SetupSystemTimer(machine.CPUFrequency() / 10)

	for {
		machine.LED.Low()
		cond.Wait()
		machine.LED.High()
		cond.Wait()
	}
}

//export SysTick_Handler
func timer_isr() {
	cond.Notify()
}
```

Current issues making this WIP/not ready:
1. #1142 needs to be merged
2. Where should this go? It was originally in `runtime/interrupt`, but that caused an import cycle.
3. The no-scheduler implementation is still suboptimal (it should wait instead of using a polling loop).