### PR TITLE
device/arm: do not mask fault handlers in critical sections

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -196,7 +196,7 @@ func SetPriority(irq uint32, priority uint32) {
 func DisableInterrupts() uintptr {
 	return AsmFull(`
 		mrs {}, PRIMASK
-		cpsid if
+		cpsid i
 	`, nil)
 }
 


### PR DESCRIPTION
It appears that we were incorrectly leaving faults masked permanently. On Cortex-M4 systems, this led to the microcontroller becoming non-responsive and passing garbage to the debugger. As far as I can tell, we aren't actually faulting anywhere, so this is probably a hardware bug. We should figure out what is going wrong, but until we do we should probably stop bricking microcontrollers.