### PR TITLE
machine/samd21: basic implementation for DAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,10 @@ smoketest:
 	$(TINYGO) build -size short -o test.hex -target=wioterminal         examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pygamer             examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=xiao                examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/dac
 	@$(MD5SUM) test.hex
 ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=atmega1284p         examples/serial

--- a/src/examples/dac/dac.go
+++ b/src/examples/dac/dac.go
@@ -1,0 +1,38 @@
+// Example using the DAC
+//
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+func main() {
+	enable := machine.PA30
+	enable.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	enable.Set(true)
+
+	speaker := machine.A0
+	speaker.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	machine.DAC0.Configure(machine.DACConfig{})
+
+	data := []uint16{4096, 2058, 1024, 512, 256, 128}
+
+	for {
+		for _, val := range data {
+			play(val)
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+}
+
+func play(val uint16) {
+	for i := 0; i < 100; i++ {
+		machine.DAC0.WriteData(val)
+		time.Sleep(2 * time.Millisecond)
+
+		machine.DAC0.WriteData(0)
+		time.Sleep(2 * time.Millisecond)
+	}
+}

--- a/src/examples/dac/dac.go
+++ b/src/examples/dac/dac.go
@@ -1,5 +1,7 @@
-// Example using the DAC
+// Simplistic example using the DAC on the Circuit Playground Express.
 //
+// To actually use the DAC for producing complex waveforms or samples requires a DMA
+// timer-based playback mechanism which is beyond the scope of this example.
 package main
 
 import (

--- a/src/examples/dac/dac.go
+++ b/src/examples/dac/dac.go
@@ -19,7 +19,7 @@ func main() {
 
 	machine.DAC0.Configure(machine.DACConfig{})
 
-	data := []uint16{4096, 2058, 1024, 512, 256, 128}
+	data := []uint16{32768, 8192, 2048, 512, 0}
 
 	for {
 		for _, val := range data {
@@ -31,10 +31,10 @@ func main() {
 
 func play(val uint16) {
 	for i := 0; i < 100; i++ {
-		machine.DAC0.WriteData(val)
+		machine.DAC0.Set(val)
 		time.Sleep(2 * time.Millisecond)
 
-		machine.DAC0.WriteData(0)
+		machine.DAC0.Set(0)
 		time.Sleep(2 * time.Millisecond)
 	}
 }

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2251,8 +2251,6 @@ func (dac DAC) Configure(config DACConfig) {
 func (dac DAC) WriteData(value uint16) error {
 	sam.DAC.DATA.Set(value & 0x3FF)
 	syncDAC()
-	sam.DAC.CTRLA.SetBits(sam.DAC_CTRLA_ENABLE)
-	syncDAC()
 	return nil
 }
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2249,25 +2249,10 @@ func (dac DAC) Configure(config DACConfig) {
 
 // WriteData writes a single value to the DAC.
 func (dac DAC) WriteData(value uint16) error {
-	syncDAC()
 	sam.DAC.DATA.Set(value & 0x3FF)
 	syncDAC()
 	sam.DAC.CTRLA.SetBits(sam.DAC_CTRLA_ENABLE)
 	syncDAC()
-	return nil
-}
-
-// Write is intended to satisfy the Writer interface.
-// This current implementation is probably not very useful.
-func (dac DAC) Write(p []uint16) (n int, err error) {
-	for _, val := range p {
-		dac.WriteData(val)
-	}
-	return len(p), nil
-}
-
-// Close the DAC.
-func (dac DAC) Close() error {
 	return nil
 }
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2218,13 +2218,13 @@ var (
 	DAC0 = DAC{}
 )
 
+// DACConfig placeholder for future expansion.
 type DACConfig struct {
-	// TBD
 }
 
+// Configure the DAC.
+// output pin must already be configured.
 func (dac DAC) Configure(config DACConfig) {
-	// output pin must already be configured
-
 	// Turn on clock for DAC
 	sam.PM.APBCMASK.SetBits(sam.PM_APBCMASK_DAC_)
 
@@ -2247,6 +2247,7 @@ func (dac DAC) Configure(config DACConfig) {
 	sam.DAC.CTRLA.Set(sam.DAC_CTRLA_ENABLE)
 }
 
+// WriteData writes a single value to the DAC.
 func (dac DAC) WriteData(value uint16) error {
 	syncDAC()
 	sam.DAC.DATA.Set(value & 0x3FF)
@@ -2256,6 +2257,8 @@ func (dac DAC) WriteData(value uint16) error {
 	return nil
 }
 
+// Write is intended to satisfy the Writer interface.
+// This current implementation is probably not very useful.
 func (dac DAC) Write(p []uint16) (n int, err error) {
 	for _, val := range p {
 		dac.WriteData(val)
@@ -2263,6 +2266,7 @@ func (dac DAC) Write(p []uint16) (n int, err error) {
 	return len(p), nil
 }
 
+// Close the DAC.
 func (dac DAC) Close() error {
 	return nil
 }

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2247,9 +2247,10 @@ func (dac DAC) Configure(config DACConfig) {
 	sam.DAC.CTRLA.Set(sam.DAC_CTRLA_ENABLE)
 }
 
-// WriteData writes a single value to the DAC.
-func (dac DAC) WriteData(value uint16) error {
-	sam.DAC.DATA.Set(value & 0x3FF)
+// Set writes a single 16-bit value to the DAC.
+// Since the ATSAMD21 only has a 10-bit DAC, the passed-in value will be scaled down.
+func (dac DAC) Set(value uint16) error {
+	sam.DAC.DATA.Set(value >> 6)
 	syncDAC()
 	return nil
 }


### PR DESCRIPTION
This PR adds a very basic DAC implementation for the SAMD21. It does not address any timer/DMA functionality needed to create a complex waveform, that will be for future PRs.