### PR TITLE
machine/stm32f4disco: add target file for updated board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=stm32f4disco        examples/blinky2
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=stm32f4disco-1       examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-bluefruit examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/i2s

--- a/targets/stm32f4disco-1.json
+++ b/targets/stm32f4disco-1.json
@@ -1,0 +1,4 @@
+{
+    "inherits": ["stm32f4disco"],
+    "openocd-interface": "stlink-v2-1"
+}


### PR DESCRIPTION
This PR adds an additional target file for updated versions of the STM32F4 Discovery boards that have the updated ST-Link-2-1 onboard.