### PR TITLE
gen-device-svd: fix lowercase in register spaced array

### DIFF
--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -571,7 +571,7 @@ func parseRegister(groupName string, regEl *SVDRegister, baseAddress uint64, bit
 			for i := uint64(0); i < uint64(reg.dim()); i++ {
 				regAddress := reg.address() + (i * dimIncrement)
 				results = append(results, &PeripheralField{
-					name:        strings.Replace(reg.name(), "%s", strconv.FormatUint(i, 10), -1),
+					name:        strings.ToUpper(strings.Replace(reg.name(), "%s", strconv.FormatUint(i, 10), -1)),
 					address:     regAddress,
 					description: reg.description(),
 					array:       -1,


### PR DESCRIPTION
Similar issue as in #1163.

<details><summary>Before:</summary>
<p>

```go
// Serial Peripheral Interface 0 (master)
type SPI_Type struct {
	CTRLR0           volatile.Register32
	CTRLR1           volatile.Register32
	SSIENR           volatile.Register32
	MWCR             volatile.Register32
	SER              volatile.Register32
	BAUDR            volatile.Register32
	TXFTLR           volatile.Register32
	RXFTLR           volatile.Register32
	TXFLR            volatile.Register32
	RXFLR            volatile.Register32
	SR               volatile.Register32
	IMR              volatile.Register32
	ISR              volatile.Register32
	RISR             volatile.Register32
	TXOICR           volatile.Register32
	RXOICR           volatile.Register32
	RXUICR           volatile.Register32
	MSTICR           volatile.Register32
	ICR              volatile.Register32
	DMACR            volatile.Register32
	DMATDLR          volatile.Register32
	DMARDLR          volatile.Register32
	IDR              volatile.Register32
	SSIC_VERSION_ID  volatile.Register32
	dr0              volatile.Register32
	dr1              volatile.Register32
	dr2              volatile.Register32
	dr3              volatile.Register32
	dr4              volatile.Register32
	dr5              volatile.Register32
	dr6              volatile.Register32
	dr7              volatile.Register32
	dr8              volatile.Register32
	dr9              volatile.Register32
	dr10             volatile.Register32
	dr11             volatile.Register32
	dr12             volatile.Register32
	dr13             volatile.Register32
	dr14             volatile.Register32
	dr15             volatile.Register32
	dr16             volatile.Register32
	dr17             volatile.Register32
	dr18             volatile.Register32
	dr19             volatile.Register32
	dr20             volatile.Register32
	dr21             volatile.Register32
	dr22             volatile.Register32
	dr23             volatile.Register32
	dr24             volatile.Register32
	dr25             volatile.Register32
	dr26             volatile.Register32
	dr27             volatile.Register32
	dr28             volatile.Register32
	dr29             volatile.Register32
	dr30             volatile.Register32
	dr31             volatile.Register32
	dr32             volatile.Register32
	dr33             volatile.Register32
	dr34             volatile.Register32
	dr35             volatile.Register32
	RX_SAMPLE_DELAY  volatile.Register32
	SPI_CTRLR0       volatile.Register32
	_                [4]byte
	XIP_MODE_BITS    volatile.Register32
	XIP_INCR_INST    volatile.Register32
	XIP_WRAP_INST    volatile.Register32
	XIP_CTRL         volatile.Register32
	XIP_SER          volatile.Register32
	XRXOICR          volatile.Register32
	XIP_CNT_TIME_OUT volatile.Register32
	ENDIAN           volatile.Register32
}
```

</p>
</details>

<details><summary>After:</summary>
<p>

```go
// Serial Peripheral Interface 0 (master)
type SPI_Type struct {
	CTRLR0           volatile.Register32
	CTRLR1           volatile.Register32
	SSIENR           volatile.Register32
	MWCR             volatile.Register32
	SER              volatile.Register32
	BAUDR            volatile.Register32
	TXFTLR           volatile.Register32
	RXFTLR           volatile.Register32
	TXFLR            volatile.Register32
	RXFLR            volatile.Register32
	SR               volatile.Register32
	IMR              volatile.Register32
	ISR              volatile.Register32
	RISR             volatile.Register32
	TXOICR           volatile.Register32
	RXOICR           volatile.Register32
	RXUICR           volatile.Register32
	MSTICR           volatile.Register32
	ICR              volatile.Register32
	DMACR            volatile.Register32
	DMATDLR          volatile.Register32
	DMARDLR          volatile.Register32
	IDR              volatile.Register32
	SSIC_VERSION_ID  volatile.Register32
	DR0              volatile.Register32
	DR1              volatile.Register32
	DR2              volatile.Register32
	DR3              volatile.Register32
	DR4              volatile.Register32
	DR5              volatile.Register32
	DR6              volatile.Register32
	DR7              volatile.Register32
	DR8              volatile.Register32
	DR9              volatile.Register32
	DR10             volatile.Register32
	DR11             volatile.Register32
	DR12             volatile.Register32
	DR13             volatile.Register32
	DR14             volatile.Register32
	DR15             volatile.Register32
	DR16             volatile.Register32
	DR17             volatile.Register32
	DR18             volatile.Register32
	DR19             volatile.Register32
	DR20             volatile.Register32
	DR21             volatile.Register32
	DR22             volatile.Register32
	DR23             volatile.Register32
	DR24             volatile.Register32
	DR25             volatile.Register32
	DR26             volatile.Register32
	DR27             volatile.Register32
	DR28             volatile.Register32
	DR29             volatile.Register32
	DR30             volatile.Register32
	DR31             volatile.Register32
	DR32             volatile.Register32
	DR33             volatile.Register32
	DR34             volatile.Register32
	DR35             volatile.Register32
	RX_SAMPLE_DELAY  volatile.Register32
	SPI_CTRLR0       volatile.Register32
	_                [4]byte
	XIP_MODE_BITS    volatile.Register32
	XIP_INCR_INST    volatile.Register32
	XIP_WRAP_INST    volatile.Register32
	XIP_CTRL         volatile.Register32
	XIP_SER          volatile.Register32
	XRXOICR          volatile.Register32
	XIP_CNT_TIME_OUT volatile.Register32
	ENDIAN           volatile.Register32
}
```

</p>
</details>
