### PR TITLE
machine/samd51: add DAC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/dac
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pyportal            examples/dac
+	@$(MD5SUM) test.hex
 ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=atmega1284p         examples/serial
 	@$(MD5SUM) test.hex

--- a/src/examples/dac/circuitplay_express.go
+++ b/src/examples/dac/circuitplay_express.go
@@ -1,0 +1,13 @@
+// +build circuitplay_express
+
+package main
+
+import (
+	"machine"
+)
+
+func init() {
+	enable := machine.PA30
+	enable.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	enable.Set(true)
+}

--- a/src/examples/dac/dac.go
+++ b/src/examples/dac/dac.go
@@ -15,7 +15,7 @@ func main() {
 
 	machine.DAC0.Configure(machine.DACConfig{})
 
-	data := []uint16{32768, 8192, 2048, 512, 0}
+	data := []uint16{0xFFFF, 0x8000, 0x4000, 0x2000, 0x1000, 0x0000}
 
 	for {
 		for _, val := range data {

--- a/src/examples/dac/dac.go
+++ b/src/examples/dac/dac.go
@@ -10,10 +10,6 @@ import (
 )
 
 func main() {
-	enable := machine.PA30
-	enable.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	enable.Set(true)
-
 	speaker := machine.A0
 	speaker.Configure(machine.PinConfig{Mode: machine.PinOutput})
 

--- a/src/examples/dac/pyportal.go
+++ b/src/examples/dac/pyportal.go
@@ -1,0 +1,13 @@
+// +build pyportal
+
+package main
+
+import (
+	"machine"
+)
+
+func init() {
+	enable := machine.SPK_SD
+	enable.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	enable.Set(true)
+}

--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -132,9 +132,6 @@ const (
 	PIN_DAC0 = PA02
 	PIN_DAC1 = PA05
 
-	DAC0 = PIN_DAC0
-	DAC1 = PIN_DAC1
-
 	// FPO Analog RPIs
 	//FPC_A7  = FPC_D7
 	//FPC_A8  = FPC_D8

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -2331,7 +2331,7 @@ func (dac DAC) Configure(config DACConfig) {
 	}
 
 	// enable
-	sam.DAC.CTRLB.Set(sam.DAC_CTRLB_REFSEL_VREFPU)
+	sam.DAC.CTRLB.Set(sam.DAC_CTRLB_REFSEL_VREFPU << sam.DAC_CTRLB_REFSEL_Pos)
 	sam.DAC.DACCTRL[0].SetBits((sam.DAC_DACCTRL_CCTRL_CC12M << sam.DAC_DACCTRL_CCTRL_Pos) | sam.DAC_DACCTRL_ENABLE)
 	sam.DAC.CTRLA.Set(sam.DAC_CTRLA_ENABLE)
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -2341,9 +2341,10 @@ func (dac DAC) Configure(config DACConfig) {
 	}
 }
 
-// WriteData writes a single value to the DAC.
-func (dac DAC) WriteData(value uint16) error {
-	sam.DAC.DATA[0].Set(value & 0xFFF)
+// Set writes a single 16-bit value to the DAC.
+// Since the ATSAMD51 only has a 12-bit DAC, the passed-in value will be scaled down.
+func (dac DAC) Set(value uint16) error {
+	sam.DAC.DATA[0].Set(value >> 4)
 	syncDAC()
 	return nil
 }


### PR DESCRIPTION
This PR adds a very basic DAC implementation for the SAMD51.
It is the SAMD51 version of the implementation created in #1183.

There are two DACs in the SAMD51, but so far I've only implemented one.