### PR TITLE
machine: change machine.Pin type to uint8

### DIFF
--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -17,11 +17,11 @@ type PinConfig struct {
 // Pin is a single pin on a chip, which may be connected to other hardware
 // devices. It can either be used directly as GPIO pin or it can be used in
 // other peripherals like ADC, I2C, etc.
-type Pin int8
+type Pin uint8
 
 // NoPin explicitly indicates "not a pin". Use this pin if you want to leave one
 // of the pins in a peripheral unconfigured (if supported by the hardware).
-const NoPin = Pin(-1)
+const NoPin = Pin(0xff)
 
 // High sets this GPIO pin to high, assuming it has been configured as an output
 // pin. It is hardware dependent (and often undefined) what happens if you set a


### PR DESCRIPTION
The `machine.Pin` type was a int8, which works fine but limits the
number of pin numbers to 127. This patch changes the type to uint8 and
changes NoPin to 0xff, which allows more pins to be used.

Some boards might not have that many pins but their internal
organization requires more pin numbers to be used (because it is
organized in pin ports and not all pins in a port have a physical
connection). Therefore the range of a int8 is too low to address these
higher pins.

This patch also has the surprising side effect of reducing binary size
in a number of cases. If there is a reduction it's usually just a few
bytes, with one outlier: the driver example amg88xx when compiled for
the pybadge board. I have not seen any increases in binary size.

---

Note: I need to test this more thoroughly as many boards are potentially affected.