### PR TITLE
avr: work around codegen bug in LLVM 10

### DIFF
--- a/src/runtime/print.go
+++ b/src/runtime/print.go
@@ -48,6 +48,16 @@ func printint16(n int16) {
 }
 
 func printuint32(n uint32) {
+	if TargetBits == 8 {
+		// AVR-specific workaround on LLVM 10. Should be removed when we switch
+		// to LLVM 11.
+		prevdigits := n / 10
+		if prevdigits != 0 {
+			printuint32(prevdigits)
+		}
+		putchar(byte((n % 10) + '0'))
+		return
+	}
 	printuint64(uint64(n))
 }
 


### PR DESCRIPTION
Commit fc4857e98c (runtime: avoid recursion in printuint64 function)
caused a regression for AVR. I have tried locally with LLVM 11 (which
contains a number of codegen bugs) and the issue is no longer present,
so I'm assuming it's a codegen bug that is now fixed. However, LLVM 11
is not yet released so it seems best to me to work around this
temporarily (for the next few months).

This commit can easily be reverted when we start using LLVM 11.