### PR TITLE
avr: fix target triple

### DIFF
--- a/targets/atmega1284p.json
+++ b/targets/atmega1284p.json
@@ -1,6 +1,5 @@
 {
     "inherits": ["avr"],
-    "llvm-target": "avr-atmel-none",
     "cpu": "atmega1284p",
     "build-tags": ["atmega1284p", "atmega"],
     "cflags": [

--- a/targets/atmega2560.json
+++ b/targets/atmega2560.json
@@ -1,6 +1,5 @@
 {
     "inherits": ["avr"],
-    "llvm-target": "avr-atmel-none",
     "cpu": "atmega2560",
     "build-tags": ["atmega2560", "atmega"],
     "cflags": [

--- a/targets/atmega328p.json
+++ b/targets/atmega328p.json
@@ -1,6 +1,5 @@
 {
 	"inherits": ["avr"],
-	"llvm-target": "avr-atmel-none",
 	"cpu": "atmega328p",
 	"build-tags": ["atmega328p", "atmega", "avr5"],
 	"cflags": [

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -1,4 +1,5 @@
 {
+	"llvm-target": "avr-unknown-unknown",
 	"build-tags": ["avr", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -1,6 +1,5 @@
 {
 	"inherits": ["avr"],
-	"llvm-target": "avr-atmel-none",
 	"cpu": "attiny85",
 	"build-tags": ["digispark", "attiny85", "attiny", "avr2", "avr25"],
 	"cflags": [

--- a/transform/testdata/interrupt-avr.ll
+++ b/transform/testdata/interrupt-avr.ll
@@ -1,5 +1,5 @@
 target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
-target triple = "avr-atmel-none"
+target triple = "avr-unknown-unknown"
 
 %"runtime/interrupt.handle" = type { %runtime.funcValue, %"runtime/interrupt.Interrupt" } %runtime.funcValue = type { i8*, i16 }
 %runtime.typecodeID = type { %runtime.typecodeID*, i16 }

--- a/transform/testdata/interrupt-avr.out.ll
+++ b/transform/testdata/interrupt-avr.out.ll
@@ -1,5 +1,5 @@
 target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
-target triple = "avr-atmel-none"
+target triple = "avr-unknown-unknown"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i16 }
 %runtime.funcValueWithSignature = type { i16, %runtime.typecodeID* }


### PR DESCRIPTION
It was `avr-atmel-none`, which is incorrect. It must be `avr-unknown-unknown`.

Additionally, there is no reason to specify the target triple per chip, it can be done for all AVR chips at once as it doesn't vary like Cortex-M chips.

---

Comment that triggered this PR: https://github.com/rust-lang/rust/issues/44052#issuecomment-649807495