### PR TITLE
machine: fix atmega2560 mapping for pins D2 and D5

### DIFF
--- a/src/machine/board_arduino_mega2560.go
+++ b/src/machine/board_arduino_mega2560.go
@@ -49,7 +49,7 @@ const (
 	// Digital pins
 	D0  Pin = PE0
 	D1  Pin = PE1
-	D2  Pin = PE6
+	D2  Pin = PE4
 	D3  Pin = PE5
 	D4  Pin = PG5
 	D5  Pin = PE3

--- a/src/machine/machine_atmega2560.go
+++ b/src/machine/machine_atmega2560.go
@@ -55,7 +55,8 @@ const (
 	PD7 = portD + 7
 	PE0 = portE + 0
 	PE1 = portE + 1
-	PE3 = portE + 2
+	PE3 = portE + 3
+	PE4 = portE + 4
 	PE5 = portE + 5
 	PE6 = portE + 6
 	PF0 = portF + 0


### PR DESCRIPTION
This PR corrects the port mappings for pins D2 and D5 on atmega2560.  Tested working on my board (elegoo mega2560 R3).