### PR TITLE
risc-v: disable linker relaxations during gp initialization

### DIFF
--- a/src/device/riscv/start.S
+++ b/src/device/riscv/start.S
@@ -9,7 +9,12 @@ _start:
     // Load the globals pointer. The program will load pointers relative to this
     // register, so it must be set to the right value on startup.
     // See: https://gnu-mcu-eclipse.github.io/arch/riscv/programmer/#the-gp-global-pointer-register
+    // Linker relaxations must be disabled to avoid the initialization beign
+    // relaxed with an uninitialized global pointer: mv gp, gp
+    .option push
+    .option norelax
     la gp,      __global_pointer$
+    .option pop
 
     // Jump to runtime.main
     call main


### PR DESCRIPTION
Linker relaxations should be disabled when initializing the global pointer to avoid ending up with 
```asm
mv gp, gp
```
LLVM does not seem to use linker relaxations at the moment but this could change in the future leading to unexpected results.