### PR TITLE
building: add links to tinygo.org

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,6 +10,14 @@ This guide describes how to statically link TinyGo against LLVM, libclang and
 lld so that the binary can be easily moved between systems. It also shows how to
 build a release tarball that includes this binary and all necessary extra files.
 
+**Note**: this documentation describes how to build a statically linked release
+tarball. If you want to develop TinyGo, you will probably want to follow a
+different guide:
+
+  * [Linux](https://tinygo.org/getting-started/linux/#source-install)
+  * [macOS](https://tinygo.org/getting-started/macos/#source-install)
+  * [Windows](https://tinygo.org/getting-started/windows/#source-install)
+
 ## Dependencies
 
 LLVM, Clang and LLD are quite light on dependencies, requiring only standard


### PR DESCRIPTION
The BUILDING.md file is not intended for developer builds but for
release builds. The website contains more specific and more complete
information on how to build TinyGo, so provide links to these pages.

The Windows link doesn't work yet, but should work with the next
release when we update the website.