### PR TITLE
targets/maixbit: cleanup output from kflash command

### DIFF
--- a/targets/maixbit.json
+++ b/targets/maixbit.json
@@ -2,5 +2,5 @@
 	"inherits": ["k210"],
 	"build-tags": ["maixbit"],
 	"linkerscript": "targets/maixbit.ld",
-	"flash-command": "kflash -p {port} {bin}"
+	"flash-command": "kflash -p {port} --noansi --verbose {bin}"
 }


### PR DESCRIPTION
This PR cleans up the output from the kflash command by removing ansi colors that were cluttering the markdown use by TinyHCI.

I also turned on the "verbose" output, which is still rather compact.