### PR TITLE
Fix portL mappings for atmega2560

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -82,8 +82,11 @@ The result should not contain libclang or libLLVM.
 
 Now that we have a working static build, it's time to make a release tarball:
 
-    git submodule update --init
     make release
+
+If you did not clone the repository with the `--recursive` option, you will get errors until you initialize the project submodules:
+
+    git submodule update --init
 
 The release tarball is stored in build/release.tar.gz, and can be extracted with
 the following command (for example in ~/lib):

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -82,6 +82,7 @@ The result should not contain libclang or libLLVM.
 
 Now that we have a working static build, it's time to make a release tarball:
 
+    git submodule update --init
     make release
 
 The release tarball is stored in build/release.tar.gz, and can be extracted with

--- a/src/machine/machine_atmega2560.go
+++ b/src/machine/machine_atmega2560.go
@@ -94,7 +94,7 @@ const (
 	PL4 = portL + 4
 	PL5 = portL + 5
 	PL6 = portL + 6
-	PL7 = portL + 7
+	PL7 = portE + 7
 )
 
 // getPortMask returns the PORTx register and mask for the pin.

--- a/src/machine/machine_atmega2560.go
+++ b/src/machine/machine_atmega2560.go
@@ -94,7 +94,7 @@ const (
 	PL4 = portL + 4
 	PL5 = portL + 5
 	PL6 = portL + 6
-	PL7 = portE + 7
+	PL7 = portL + 7
 )
 
 // getPortMask returns the PORTx register and mask for the pin.


### PR DESCRIPTION
Due to a typo in the machine package, port L pins were not mapped correctly on atmega2560.  This fixes the package so they are correctly mapped, tested working on my atmega2560.