### PR TITLE
compileopts: automatically add -g flag when including debug symbols

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -176,6 +176,9 @@ func (c *Config) CFlags() []string {
 		cflags = append(cflags, "-nostdlibinc", "-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "picolibc", "newlib", "libc", "include"))
 		cflags = append(cflags, "-I"+filepath.Join(root, "lib/picolibc-include"))
 	}
+	if c.Debug() {
+		cflags = append(cflags, "-g")
+	}
 	return cflags
 }
 

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -9,7 +9,6 @@
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"cflags": [
-		"-g",
 		"--target=arm4-none-eabi",
 		"-mcpu=arm7tdmi",
 		"-Oz",


### PR DESCRIPTION
Debug information is often useful and there is no reason to include it
for Go code but not for C code. Also, disabling debug information should
disable it entirely, not just for Go code.

---

This will also be useful for automatically determining stack sizes, as such support (in my attempts) relies on DWARF stack frame information.