### PR TITLE
riscv: allow interrupts to wake the scheduler

### DIFF
--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -127,12 +127,17 @@ func sleepTicks(d timeUnit) {
 	sifive.CLINT.MTIMECMP.Set(uint32(target))
 	riscv.MIE.SetBits(1 << 7) // MTIE
 	for {
+		riscv.Asm("wfi")
 		if timerWakeup.Get() != 0 {
 			timerWakeup.Set(0)
 			// Disable timer.
 			break
 		}
-		riscv.Asm("wfi")
+		if hasScheduler {
+			// Disable timer and return to scheduler.
+			riscv.MIE.ClearBits(1 << 7) // MTIE bit
+			break
+		}
 	}
 }
 

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -133,12 +133,17 @@ func sleepTicks(d timeUnit) {
 	kendryte.CLINT.MTIMECMP[0].Set(target)
 	riscv.MIE.SetBits(1 << 7) // MTIE
 	for {
+		riscv.Asm("wfi")
 		if timerWakeup.Get() != 0 {
 			timerWakeup.Set(0)
 			// Disable timer.
 			break
 		}
-		riscv.Asm("wfi")
+		if hasScheduler {
+			// Disable timer and return to scheduler.
+			riscv.MIE.ClearBits(1 << 7) // MTIE bit
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
This PR allows interrupts to wake the scheduler for the FE310 and the K210 RISC-V chips.

Depends on #1220 