### PR TITLE
builder: remove optimization level 0

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -76,8 +76,15 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(stri
 	// exactly.
 	errs = nil
 	switch config.Options.Opt {
-	case "none", "0":
-		errs = transform.Optimize(mod, config, 0, 0, 0) // -O0
+	/*
+		Currently, turning optimizations off causes compile failures.
+		We rely on the optimizer removing some dead symbols.
+		Avoid providing an option that does not work right now.
+		In the future once everything has been fixed we can re-enable this.
+
+		case "none", "0":
+			errs = transform.Optimize(mod, config, 0, 0, 0) // -O0
+	*/
 	case "1":
 		errs = transform.Optimize(mod, config, 1, 0, 0) // -O1
 	case "2":


### PR DESCRIPTION
Currently, turning optimizations off causes compile failures.
We rely on the optimizer removing some dead symbols.
Avoid providing an option that does not work right now.
In the future once everything has been fixed we can re-enable this.