### PR TITLE
all: fix -gc=none

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,11 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/export
 	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/main
+	# test various compiler flags
+	$(TINYGO) build -size short -o test.hex -target=pca10040 -gc=none -scheduler=none examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=1     examples/blinky1
+	@$(MD5SUM) test.hex
 
 wasmtest:
 	$(GO) test ./tests/wasm

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -122,6 +122,8 @@ func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, *Error) 
 					// External function call. Assume only limited side effects
 					// (no affected globals, etc.).
 					switch child.Name() {
+					case "runtime.alloc":
+						continue
 					case "runtime.typeAssert":
 						continue // implemented in interp
 					case "runtime.interfaceImplements":

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -158,7 +158,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 	// After TinyGo-specific transforms have finished, undo exporting these functions.
 	for _, name := range getFunctionsUsedInTransforms(config) {
 		fn := mod.NamedFunction(name)
-		if fn.IsNil() {
+		if fn.IsNil() || fn.IsDeclaration() {
 			continue
 		}
 		fn.SetLinkage(llvm.InternalLinkage)


### PR DESCRIPTION
This option was broken for a long time, in part because we didn't test for it. This commit fixes that and adds a test to make sure it won't break again unnoticed.