### PR TITLE
internal/task,transform: fix coroutines scheduling order

### DIFF
--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -23,8 +23,8 @@ func TestChan(t *testing.T) {
 		chromedp.Navigate("http://localhost:8826/run?file=chan.wasm"),
 		waitLog(`1
 2
-4
 3
+4
 true`),
 	)
 	if err != nil {

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -207,6 +207,7 @@ var coroFunctionsUsedInTransforms = []string{
 	"internal/task.fake",
 	"internal/task.Current",
 	"internal/task.createTask",
+	"(*internal/task.Task).finish",
 	"(*internal/task.Task).setState",
 	"(*internal/task.Task).returnTo",
 	"(*internal/task.Task).returnCurrent",

--- a/transform/testdata/coroutines.ll
+++ b/transform/testdata/coroutines.ll
@@ -14,6 +14,7 @@ declare void @runtime.free(i8*, i8*, i8*)
 
 declare %"internal/task.Task"* @"internal/task.Current"(i8*, i8*)
 
+declare void @"(*internal/task.Task).finish"(%"internal/task.Task"*, i8*, i8*)
 declare i8* @"(*internal/task.Task).setState"(%"internal/task.Task"*, i8*, i8*, i8*)
 declare void @"(*internal/task.Task).setReturnPtr"(%"internal/task.Task"*, i8*, i8*, i8*)
 declare i8* @"(*internal/task.Task).getReturnPtr"(%"internal/task.Task"*, i8*, i8*)

--- a/transform/testdata/coroutines.out.ll
+++ b/transform/testdata/coroutines.out.ll
@@ -16,6 +16,8 @@ declare void @runtime.free(i8*, i8*, i8*)
 
 declare %"internal/task.Task"* @"internal/task.Current"(i8*, i8*)
 
+declare void @"(*internal/task.Task).finish"(%"internal/task.Task"*, i8*, i8*)
+
 declare i8* @"(*internal/task.Task).setState"(%"internal/task.Task"*, i8*, i8*, i8*)
 
 declare void @"(*internal/task.Task).setReturnPtr"(%"internal/task.Task"*, i8*, i8*, i8*)
@@ -151,6 +153,7 @@ entry:
   %start.task = call %"internal/task.Task"* @"internal/task.createTask"(i8* undef, i8* undef)
   %start.task.bitcast = bitcast %"internal/task.Task"* %start.task to i8*
   call void @sleepGoroutine(i8* undef, i8* %start.task.bitcast)
+  call void @"(*internal/task.Task).finish"(%"internal/task.Task"* %start.task, i8* undef, i8* undef)
   call void @sleep(i64 2000000, i8* undef, i8* %parentHandle)
   ret void
 }
@@ -160,6 +163,7 @@ entry:
   %start.task = call %"internal/task.Task"* @"internal/task.createTask"(i8* undef, i8* undef)
   %start.task.bitcast = bitcast %"internal/task.Task"* %start.task to i8*
   call void @progMain(i8* undef, i8* %start.task.bitcast)
+  call void @"(*internal/task.Task).finish"(%"internal/task.Task"* %start.task, i8* undef, i8* undef)
   call void @runtime.scheduler(i8* undef, i8* null)
   ret void
 }


### PR DESCRIPTION
This change applies a loop around resuming a task.
This means that a task will not suspend implicitly when returning from a function.