### PR TITLE
Use a jump table instead of if-then-else for Teensy 3.6 pin decoding

### DIFF
--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -187,17 +187,18 @@ func (p Pin) reg() (*nxp.GPIO_Type, *volatile.Register32, uint8) {
 	var gpio *nxp.GPIO_Type
 	var pcr *nxp.PORT_Type
 
-	if p < 32 {
+	switch p / 32 {
+	case 0:
 		gpio, pcr = nxp.GPIOA, nxp.PORTA
-	} else if p < 64 {
+	case 1:
 		gpio, pcr = nxp.GPIOB, nxp.PORTB
-	} else if p < 96 {
+	case 2:
 		gpio, pcr = nxp.GPIOC, nxp.PORTC
-	} else if p < 128 {
+	case 3:
 		gpio, pcr = nxp.GPIOD, nxp.PORTD
-	} else if p < 160 {
+	case 5:
 		gpio, pcr = nxp.GPIOE, nxp.PORTE
-	} else {
+	default:
 		panic("invalid pin number")
 	}
 


### PR DESCRIPTION
Changes `machine.Pin.reg` for the NXP MK66F18 to use a switch statement instead of an if/else-if block. The previous version compiles to a sequence of branches, whereas the switch statement compiles to a jump table. This will improve performance and may slightly reduce code size. The example below uses `machine.Pin.Control` because `reg` is inlined and does not appear itself.

### Current Version

```asm
(machine.Pin).Control:
    movw    r1, #0x9000
    movt    r1, #0x4004
    uxtb    r2, r0
    cmp     r2, #32
    bcc.n   done
    cmp     r2, #0x40
    bcs.n   next1
    add.w   r1, r1, #0x1000
    b.n     done
next1:
    cmp     r2, #0x60
    bcs.n   next2
    add.w   r1, r1, #0x2000
    b.n     done
next2:
    sxtb    r3, r0
    cmp.w   r3, #0xffffffff
    ble.n   next3
    add.w   r1, r1, #0x3000
    b.n     done
next3:
    cmp     r2, #0xa0
    bcs.n   panic
    add.w   r1, r1, #0x4000
done:
    and.w   r0, r0, #31
    add.w   r0, r1, r0, lsl #2
    bx      lr
panic:
    push    {r7, lr}
    movw    r1, #0x8fd4
    movt    r1, #0
    movs    r0, #0x22
    bl      <runtime._panic>
```

### Switch / Jump Table

```asm
(machine.Pin).Control:
    ubfx    r2, r0, #5, #3
    cmp     r2, #5
    bhi.n   panic
    movw    r1, #0x9000
    movt    r1, #0x4004
    tbb     [pc, r2]
    .byte  0x06
    .byte  0x09
    .byte  0x03
    .byte  0x0e
    .byte  0x0c
    .byte  0x13
    add.w   r1, r1, #0x1000
    b.n     done
    add.w   r1, r1, #0x3000
    b.n     done
    add.w   r1, r1, #0x2000
    b.n     done
    add.w   r1, r1, #0x4000
done:
    and.w   r0, r0, #31
    add.w   r0, r1, r0, lsl #2
    bx      lr
panic:
    push    {r7, lr}
    movw    r1, #0x8fc4
    movt    r1, #0
    movs    r0, #0x22
    bl      <runtime._panic>
```