### PR TITLE
Cleanup Teensy 3.6 linker script

### DIFF
--- a/targets/nxpmk66f18.ld
+++ b/targets/nxpmk66f18.ld
@@ -33,54 +33,6 @@ SECTIONS
         . = ALIGN(4);
 
     } >FLASH_TEXT = 0xFF
-
-    /* Put the stack at the bottom of RAM, so that the application will
-     * crash on stack overflow instead of silently corrupting memory.
-     * See: http://blog.japaric.io/stack-overflow-protection/ */
-    .stack (NOLOAD) :
-    {
-        . = ALIGN(4);
-        . += _stack_size;
-        _stack_top = .;
-    } >RAM
-
-    /* Start address (in flash) of .data, used by startup code. */
-    _sidata = LOADADDR(.data);
-
-    /* this is where Teensy's LD script places .usbdescriptortable .dmabuffers .usbbuffers */
-
-    /* Globals with initial value */
-    .data :
-    {
-        . = ALIGN(4);
-        _sdata = .;        /* used by startup code */
-        *(.data)
-        *(.data.*)
-        . = ALIGN(4);
-        _edata = .;        /* used by startup code */
-    } >RAM AT>FLASH_TEXT
-
-    /* Zero-initialized globals  */
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;         /* used by startup code */
-        *(.bss)
-        *(.bss.*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;         /* used by startup code */
-    } >RAM
-
-    /DISCARD/ :
-    {
-        *(.ARM.exidx)      /* causes 'no memory region specified' error in lld */
-        *(.ARM.exidx.*)    /* causes spurious 'undefined reference' errors */
-    }
 }
 
-/* For the memory allocator. */
-_heap_start = _ebss;
-_heap_end = ORIGIN(RAM) + LENGTH(RAM);
-_globals_start = _sdata;
-_globals_end = _ebss;
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
I replaced most of `nxpmk66f18.ld` with `INCLUDE "targets/arm.ld"`. I left the `.text` section, since the K66 needs that arranged specially, but I verified (with `objdump`) that the linker script change does not change the binaries produced.