### PR TITLE
machine/itsybitsy-nrf52840: add support for Adafruit Itsybitsy nrf52840

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-nrf52840  	examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=itsybitsy-nrf52840  examples/blinky1
+	@$(MD5SUM) test.hex
 ifneq ($(AVR), 0)
 	$(TINYGO) build -size short -o test.hex -target=atmega1284p         examples/serial
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following 40 microcontroller boards are currently supported:
 * [Adafruit Feather nRF52840 Express](https://www.adafruit.com/product/4062)
 * [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727)
 * [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800)
-* [Adafruit ItsyBitsy nrf52840](https://www.adafruit.com/product/4481)
+* [Adafruit ItsyBitsy nRF52840](https://www.adafruit.com/product/4481)
 * [Adafruit Metro M4 Express Airlift](https://www.adafruit.com/product/4000)
 * [Adafruit PyBadge](https://www.adafruit.com/product/4200)
 * [Adafruit PyGamer](https://www.adafruit.com/product/4242)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 39 microcontroller boards/devices are currently supported:
+The following 40 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -53,6 +53,7 @@ The following 39 microcontroller boards/devices are currently supported:
 * [Adafruit Feather nRF52840 Express](https://www.adafruit.com/product/4062)
 * [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727)
 * [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800)
+* [Adafruit ItsyBitsy nrf52840](https://www.adafruit.com/product/4481)
 * [Adafruit Metro M4 Express Airlift](https://www.adafruit.com/product/4000)
 * [Adafruit PyBadge](https://www.adafruit.com/product/4200)
 * [Adafruit PyGamer](https://www.adafruit.com/product/4242)

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -1,0 +1,100 @@
+// +build itsybitsy_nrf52840
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// GPIO Pins
+const (
+	D0  = P0_25 // UART TX
+	D1  = P0_24 // UART RX
+	D2  = P1_02
+	D3  = P0_06 // LED1
+	D4  = P0_20 // Button
+	D5  = P0_27
+	D6  = P1_09 // DotStar Clock
+	D7  = P1_08
+	D8  = P0_08 // DotStar Data
+	D9  = P0_07
+	D10 = P0_05
+	D11 = P0_26
+	D12 = P0_11
+	D13 = P0_12
+	D14 = P0_04 // A0
+	D15 = P0_30 // A1
+	D16 = P0_28 // A2
+	D17 = P0_31 // A3
+	D18 = P0_02 // A4
+	D19 = P0_03 // A5
+	D20 = P0_05 // A6
+	D21 = P0_16 // I2C SDA
+	D22 = P0_14 // I2C SCL
+	D23 = P0_20 // SPI SDI
+	D24 = P0_15 // SPI SDO
+	D25 = P0_13 // SPI SCK
+	D26 = P0_19 // QSPI SCK
+	D27 = P0_23 // QSPI CS
+	D28 = P0_21 // QSPI Data 0
+	D29 = P0_22 // QSPI Data 1
+	D30 = P1_00 // QSPI Data 2
+	D31 = P0_17 // QSPI Data 3
+)
+
+// Analog Pins
+const (
+	A0 = D14
+	A1 = D15
+	A2 = D16
+	A3 = D17
+	A4 = D18
+	A5 = D19
+	A6 = D20
+)
+
+const (
+	LED    = D3
+	LED1   = LED
+	BUTTON = D4
+
+	QSPI_SCK   = D26
+	QSPI_CS    = D27
+	QSPI_DATA0 = D28
+	QSPI_DATA1 = D29
+	QSPI_DATA2 = D30
+	QSPI_DATA3 = D31
+)
+
+// UART0 pins (logical UART1)
+const (
+	UART_RX_PIN = D0
+	UART_TX_PIN = D1
+)
+
+// UART0 is the USB device
+var (
+	UART0 = USB
+)
+
+// I2C pins
+const (
+	SDA_PIN = D21 // I2C0 external
+	SCL_PIN = D22 // I2C0 external
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN  = D25
+	SPI0_MOSI_PIN = D24
+	SPI0_MISO_PIN = D23
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Adafruit ItsyBitsy nRF52840 Express"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x0052
+)

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -10,7 +10,7 @@ const (
 	D1  = P0_24 // UART RX
 	D2  = P1_02
 	D3  = P0_06 // LED1
-	D4  = P0_20 // Button
+	D4  = P0_29 // Button
 	D5  = P0_27
 	D6  = P1_09 // DotStar Clock
 	D7  = P1_08
@@ -83,9 +83,9 @@ const (
 
 // SPI pins
 const (
-	SPI0_SCK_PIN  = D25
-	SPI0_MOSI_PIN = D24
-	SPI0_MISO_PIN = D23
+	SPI0_SCK_PIN = D25
+	SPI0_SDO_PIN = D24
+	SPI0_SDI_PIN = D23
 )
 
 // USB CDC identifiers
@@ -96,5 +96,5 @@ const (
 
 var (
 	usb_VID uint16 = 0x239A
-	usb_PID uint16 = 0x0052
+	usb_PID uint16 = 0x8051
 )

--- a/targets/itsybitsy-nrf52840.json
+++ b/targets/itsybitsy-nrf52840.json
@@ -1,0 +1,10 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["itsybitsy_nrf52840","nrf52840_reset_uf2"],
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "msd-volume-name": "ITSY840BOOT",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
This PR adds support for Adafruit Itsybitsy nrf52840 Express board.