### PR TITLE
ci: fix Windows QEMU version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       displayName: Install QEMU
       inputs:
         targetType: inline
-        script: choco install qemu
+        script: choco install qemu --version=2020.06.12
     - task: CacheBeta@0
       displayName: Cache wasi-libc sysroot
       inputs:


### PR DESCRIPTION
It appears that version 2020.07.22 or 2020.07.23 introduced a breaking
change in RISC-V. We will have to fix this eventually, but for now it's
easiest to just pin the QEMU version. Once this new QEMU version
(version 5?) is more widely available, it becomes easier to debug and
fix the underlying cause.