### PR TITLE
interp: show error line in first line of the traceback

### DIFF
--- a/interp/errors.go
+++ b/interp/errors.go
@@ -47,10 +47,12 @@ func (e *Error) Error() string {
 // location of the instruction. The location information may not be complete as
 // it depends on debug information in the IR.
 func (e *evalPackage) errorAt(inst llvm.Value, err error) *Error {
+	pos := getPosition(inst)
 	return &Error{
 		ImportPath: e.packagePath,
-		Pos:        getPosition(inst),
+		Pos:        pos,
 		Err:        err,
+		Traceback:  []ErrorLine{{pos, inst}},
 	}
 }
 


### PR DESCRIPTION
The first line of the traceback wasn't shown, which is the line that shows the actual error.

Before:

```
# image/png
/usr/local/go/src/sync/atomic/value.go:30:20: interp: load from a bitcast

traceback:
/usr/local/go/src/image/format.go:39:34:
  %8 = call %runtime._interface @"(*sync/atomic.Value).Load"(%"sync/atomic.Value"* @image.atomicFormats, i8* undef, i8* undef), !dbg !1910
/usr/local/go/src/image/png/reader.go:1031:22:
  call void @image.RegisterFormat(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"image/png.init#1$string", i32 0, i32 0), i64 3, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"image/png.init#1$string.773", i32 0, i32 0), i64 8, i8* undef, i64 ptrtoint (%runtime.funcValueWithSignature* @"image/png.Decode$withSignature" to i64), i8* undef, i64 ptrtoint (%runtime.funcValueWithSignature* @"image/png.DecodeConfig$withSignature" to i64), i8* undef, i8* undef), !dbg !1890
image/png/<init>:
  call void @"image/png.init#1"(i8* undef, i8* undef), !dbg !1892
```

after:

```
# image/png
/usr/local/go/src/sync/atomic/value.go:30:20: interp: load from a bitcast

traceback:
/usr/local/go/src/sync/atomic/value.go:30:20:
  %6 = load atomic i8*, i8** %5 seq_cst, align 8, !dbg !1915
/usr/local/go/src/image/format.go:39:34:
  %8 = call %runtime._interface @"(*sync/atomic.Value).Load"(%"sync/atomic.Value"* @image.atomicFormats, i8* undef, i8* undef), !dbg !1910
/usr/local/go/src/image/png/reader.go:1031:22:
  call void @image.RegisterFormat(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"image/png.init#1$string", i32 0, i32 0), i64 3, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"image/png.init#1$string.773", i32 0, i32 0), i64 8, i8* undef, i64 ptrtoint (%runtime.funcValueWithSignature* @"image/png.Decode$withSignature" to i64), i8* undef, i64 ptrtoint (%runtime.funcValueWithSignature* @"image/png.DecodeConfig$withSignature" to i64), i8* undef, i8* undef), !dbg !1890
image/png/<init>:
  call void @"image/png.init#1"(i8* undef, i8* undef), !dbg !1892
```

The `load atomic` line in sync/atomic/value.go is new in the traceback.

While this kind of error is hard to read for users, it is extremely useful for debugging these kinds of errors.