### PR TITLE
interp: fix sync/atomic.Value load/store methods

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -276,6 +276,8 @@ func Compile(pkgName string, machine llvm.TargetMachine, config *compileopts.Con
 		pos := c.ir.Program.Fset.Position(initFn.Pos())
 		irbuilder.SetCurrentDebugLocation(uint(pos.Line), uint(pos.Column), difunc, llvm.Metadata{})
 	}
+	initFn.LLVMFn.Param(0).SetName("context")
+	initFn.LLVMFn.Param(1).SetName("parentHandle")
 	block := c.ctx.AddBasicBlock(initFn.LLVMFn, "entry")
 	irbuilder.SetInsertPointAtEnd(block)
 	for _, fn := range initFuncs {

--- a/interp/scan.go
+++ b/interp/scan.go
@@ -62,6 +62,10 @@ func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, *Error) 
 		return &sideEffectResult{severity: sideEffectNone}, nil
 	case name == "llvm.dbg.value":
 		return &sideEffectResult{severity: sideEffectNone}, nil
+	case name == "(*sync/atomic.Value).Load" || name == "(*sync/atomic.Value).Store":
+		// These functions do some unsafe pointer loading/storing but are
+		// otherwise safe.
+		return &sideEffectResult{severity: sideEffectLimited}, nil
 	case strings.HasPrefix(name, "llvm.lifetime."):
 		return &sideEffectResult{severity: sideEffectNone}, nil
 	}


### PR DESCRIPTION
These methods do some unsafe pointer casting but can be assumed to not have significant side effects. Simply call these functions at runtime instead of compile time.

This is a partial fix for importing image/png, see #1262.