### PR TITLE
compiler: fix named string to []byte slice conversion

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2536,7 +2536,7 @@ func (b *builder) createConvert(typeFrom, typeTo types.Type, value llvm.Value, p
 		return llvm.Value{}, b.makeError(pos, "todo: convert: basic non-integer type: "+typeFrom.String()+" -> "+typeTo.String())
 
 	case *types.Slice:
-		if basic, ok := typeFrom.(*types.Basic); !ok || basic.Info()&types.IsString == 0 {
+		if basic, ok := typeFrom.Underlying().(*types.Basic); !ok || basic.Info()&types.IsString == 0 {
 			panic("can only convert from a string to a slice")
 		}
 

--- a/testdata/string.go
+++ b/testdata/string.go
@@ -17,8 +17,11 @@ func testRunesToString(r []rune) {
 	println("string from runes:", string(r))
 }
 
+type myString string
+
 func main() {
 	testRangeString()
 	testStringToRunes()
 	testRunesToString([]rune{97, 98, 99, 252, 162, 8364, 66376, 176, 120})
+	var _ = len([]byte(myString("foobar"))) // issue 1246
 }


### PR DESCRIPTION
This was missing a `.Underlying()` call to avoid testing the named type (but instead test for the underlying type).

See #1246