### PR TITLE
feather-nrf52840: corrected USB identifier constants

### DIFF
--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -95,11 +95,11 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Adafruit Feather nRF52840 Express"
-	usb_STRING_MANUFACTURER = "Adafruit"
+	usb_STRING_PRODUCT      = "Feather nRF52840 Express"
+	usb_STRING_MANUFACTURER = "Adafruit Industries LLC"
 )
 
 var (
 	usb_VID uint16 = 0x239A
-	usb_PID uint16 = 0x0029
+	usb_PID uint16 = 0x802A
 )


### PR DESCRIPTION
It was discovered in https://github.com/tinygo-org/tinygo/pull/1243#discussion_r456862654 that I used the incorrect USB identifier for feather-nrf52840.

This change updates the values to match the CircuitPython firmware that comes from the factory:

```
[1816963.399302] usb 1-1.2: new full-speed USB device number 63 using ehci-pci                                     
[1816963.527053] usb 1-1.2: New USB device found, idVendor=239a, idProduct=802a                                    
[1816963.527058] usb 1-1.2: New USB device strings: Mfr=2, Product=3, SerialNumber=1                               
[1816963.527060] usb 1-1.2: Product: Feather nRF52840 Express                                                      
[1816963.527062] usb 1-1.2: Manufacturer: Adafruit Industries LLC                                                  
[1816963.527064] usb 1-1.2: SerialNumber: DD7354737FB50733                                                         
[1816963.530062] cdc_acm 1-1.2:1.0: ttyACM0: USB ACM device                                                        
[1816963.536185] usb-storage 1-1.2:1.2: USB Mass Storage device detected                                           
[1816963.536913] scsi host6: usb-storage 1-1.2:1.2
[1816963.556310] input: Adafruit Industries LLC Feather nRF52840 Express as /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.2/1-1.2:1.3/0003:239A:802A.004B/input/input23
[1816963.616532] hid-generic 0003:239A:802A.004B: input,hidraw0: USB HID v1.11 Keyboard [Adafruit Industries LLC Feather nRF52840 Express] on usb-0000:00:1a.0-1.2/input3
[1816964.555091] scsi host6: scsi scan: INQUIRY result too short (5), using 36                                     
[1816964.555099] scsi 6:0:0:0: Direct-Access     Adafruit Feather nRF52840 1.0  PQ: 0 ANSI: 2                      
[1816964.556117] sd 6:0:0:0: Attached scsi generic sg2 type 0                                                      
[1816964.560033] sd 6:0:0:0: [sdb] 4089 512-byte logical blocks: (2.09 MB/2.00 MiB)                                
[1816964.563011] sd 6:0:0:0: [sdb] Write Protect is off
[1816964.563025] sd 6:0:0:0: [sdb] Mode Sense: 03 00 00 00                                                         
[1816964.566151] sd 6:0:0:0: [sdb] No Caching mode page found                                                      
[1816964.566159] sd 6:0:0:0: [sdb] Assuming drive cache: write through                                             
[1816964.605092]  sdb: sdb1
[1816964.624191] sd 6:0:0:0: [sdb] Attached SCSI removable disk                                                    
```