### PR TITLE
Allow Go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,12 @@ jobs:
     steps:
       - test-linux:
           llvm: "10"
+  test-llvm10-go115:
+    docker:
+      - image: circleci/golang:1.15-rc-buster
+    steps:
+      - test-linux:
+          llvm: "10"
   assert-test-linux:
     docker:
       - image: circleci/golang:1.14-stretch
@@ -418,6 +424,7 @@ workflows:
       - test-llvm10-go112
       - test-llvm10-go113
       - test-llvm10-go114
+      - test-llvm10-go115
       - build-linux
       - build-macos
       - assert-test-linux

--- a/builder/config.go
+++ b/builder/config.go
@@ -25,8 +25,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 11 || minor > 14 {
-		return nil, fmt.Errorf("requires go version 1.11, 1.12, 1.13, or 1.14, got go%d.%d", major, minor)
+	if major != 1 || minor < 11 || minor > 15 {
+		return nil, fmt.Errorf("requires go version 1.11, 1.12, 1.13, 1.14, or 1.15, got go%d.%d", major, minor)
 	}
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
 	return &compileopts.Config{


### PR DESCRIPTION
This all seemed to magically work (`go test` and smoketests), but let's see how CI feels about it.