### PR TITLE
main: use ToSlash() to specify program path

### DIFF
--- a/main.go
+++ b/main.go
@@ -273,7 +273,7 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 			if err != nil {
 				return err
 			}
-			args = append(args, "-c", "program "+tmppath+" reset exit")
+			args = append(args, "-c", "program "+filepath.ToSlash(tmppath)+" reset exit")
 			cmd := exec.Command("openocd", args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr


### PR DESCRIPTION
This PR fixes the problem with #1273.

> I think the problems is (quote) "OpenOCD uses Tcl and a backslash is an escape char", so you'll need to use double backslash in the path.

before: `C:UsersTAKASA~1.MASAppDataLocalTemp        inygo987121619main.hex`
after : `C:/Users/TAKASA~1.MAS/AppData/Local/Temp/tinygo987121619/main.hex`
