### PR TITLE
main: embed git-hash in tinygo-dev executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
 # Build the Go compiler.
 tinygo:
 	@if [ ! -f "$(LLVM_BUILDDIR)/bin/llvm-config" ]; then echo "Fetch and build LLVM first by running:"; echo "  make llvm-source"; echo "  make $(LLVM_BUILDDIR)"; exit 1; fi
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm -ldflags="-X main.gitSha1=`git rev-parse --short HEAD`" .
 
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -buildmode exe -tags byollvm ./cgo ./compileopts ./interp ./transform .

--- a/main.go
+++ b/main.go
@@ -1001,11 +1001,11 @@ func main() {
 		if s, err := goenv.GorootVersionString(goenv.Get("GOROOT")); err == nil {
 			goversion = s
 		}
-		if !strings.HasSuffix(goenv.Version, "-dev") {
-			fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
-		} else {
-			fmt.Printf("tinygo version %s-%s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, gitSha1, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		version := goenv.Version
+		if strings.HasSuffix(goenv.Version, "-dev") && gitSha1 != "" {
+			version += "-" + gitSha1
 		}
+		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
 	case "env":
 		if flag.NArg() == 0 {
 			// Show all environment variables.

--- a/main.go
+++ b/main.go
@@ -28,6 +28,10 @@ import (
 	"go.bug.st/serial"
 )
 
+var (
+	gitSha1 string
+)
+
 // commandError is an error type to wrap os/exec.Command errors. This provides
 // some more information regarding what went wrong while running a command.
 type commandError struct {
@@ -995,7 +999,11 @@ func main() {
 		if s, err := goenv.GorootVersionString(goenv.Get("GOROOT")); err == nil {
 			goversion = s
 		}
-		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		if !strings.HasSuffix(goenv.Version, "-dev") {
+			fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		} else {
+			fmt.Printf("tinygo version %s-%s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version, gitSha1, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		}
 	case "env":
 		if flag.NArg() == 0 {
 			// Show all environment variables.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ import (
 )
 
 var (
+	// This variable is set at build time using -ldflags parameters.
+	// See: https://stackoverflow.com/a/11355611
 	gitSha1 string
 )
 


### PR DESCRIPTION
When reading issues and slack (tinygo channel), I'm finding it increasingly difficult to get the exact version of tinygo executable.
I think we should embed git-hash in it as well as go.
