### PR TITLE
Remove --no-threads from wasm-ld calls.

### DIFF
--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -12,7 +12,6 @@
 	],
 	"ldflags": [
 		"--allow-undefined",
-		"--no-threads",
 		"--stack-first",
 		"--export-all",
 		"--no-demangle",


### PR DESCRIPTION
The bugs linked from the original addition of this flag are fixed:
https://bugs.llvm.org/show_bug.cgi?id=41508
or 'possibly fixed':
https://bugs.llvm.org/show_bug.cgi?id=37064#c8
since LLVM 8.0.1. TinyGo only support LLVM 9+, and as noted in the
original PR (#377), this can be removed when switching to 9.

Additionally, this flag was dropped from LLVM 11.