### PR TITLE
flash: add openocd settings to atsamd21 / atsamd51

### DIFF
--- a/targets/atsamd21e18a.json
+++ b/targets/atsamd21e18a.json
@@ -9,5 +9,7 @@
 	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21e18a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "at91samdXX"
 }

--- a/targets/atsamd21g18a.json
+++ b/targets/atsamd21g18a.json
@@ -9,5 +9,7 @@
 	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21g18a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "at91samdXX"
 }

--- a/targets/atsamd51g19a.json
+++ b/targets/atsamd51g19a.json
@@ -7,5 +7,7 @@
 	"linkerscript": "targets/atsamd51.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51g19a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "atsame5x"
 }

--- a/targets/atsamd51j19a.json
+++ b/targets/atsamd51j19a.json
@@ -7,5 +7,7 @@
 	"linkerscript": "targets/atsamd51.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51j19a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "atsame5x"
 }

--- a/targets/atsamd51j20a.json
+++ b/targets/atsamd51j20a.json
@@ -7,5 +7,7 @@
 	"linkerscript": "targets/atsamd51j20a.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51j20a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "atsame5x"
 }

--- a/targets/atsamd51p19a.json
+++ b/targets/atsamd51p19a.json
@@ -7,5 +7,7 @@
 	"linkerscript": "targets/atsamd51.ld",
 	"extra-files": [
 		"src/device/sam/atsamd51p19a.s"
-	]
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "atsame5x"
 }


### PR DESCRIPTION
Added a configuration for openocd.
This PR covers atsamd51 and atsamd21.

Once the PR has been merged, you can flash / debug it as follows.

### feather-m4 + cmsis-dap

```
# without programmer
$ tinygo flash --target feather-m4 --size short ./src/examples/blinky1

# with programmer
$ tinygo flash --target feather-m4 --programmer cmsis-dap --size short ./src/examples/blinky1

# with programmer / gdb
$ tinygo gdb --target feather-m4 --programmer cmsis-dap --size short ./src/examples/blinky1
```

### xiao + cmsis-dap

```
# without programmer
$ tinygo flash --target xiao --size short ./src/examples/blinky1

# with programmer
$ tinygo flash --target xiao --programmer cmsis-dap --size short ./src/examples/blinky1

# with programmer / gdb
$ tinygo gdb --target xiao --programmer cmsis-dap --size short ./src/examples/blinky1
```