### PR TITLE
flash: add openocd settings to nrf5

### DIFF
--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -14,5 +14,6 @@
 		"lib/nrfx/mdk/system_nrf51.c",
 		"src/device/nrf/nrf51.s"
 	],
+	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -12,5 +12,6 @@
 		"lib/nrfx/mdk/system_nrf52.c",
 		"src/device/nrf/nrf52.s"
 	],
+	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -12,5 +12,6 @@
 		"lib/nrfx/mdk/system_nrf52840.c",
 		"src/device/nrf/nrf52840.s"
 	],
+	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }


### PR DESCRIPTION
This is the nrf5 version of #1310 .

I'm only testing with feather-nrf52840.
I can't test nrf51 or nRF52832 as I don't have them.
I have chosen swd for my environment, but please let me know if you are having problems.


before:

```
$ ./build/tinygo flash --target feather-nrf52840 --size short --programmer jlink ./src/examples/b1
   code    data     bss |   flash     ram
   6264      12    4064 |    6276    4076
Open On-Chip Debugger 0.10.0+dev-g5c9350d2 (2020-08-07-12:56)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
/usr/local/bin/../share/openocd/scripts/target/swj-dp.tcl:30: Error: newtap: nrf51.cpu missing IR length
in procedure 'script' 
at file "embedded:startup.tcl", line 26
in procedure 'swj_newdap' called at file "/usr/local/bin/../share/openocd/scripts/target/nrf51.cfg", line 33
at file "/usr/local/bin/../share/openocd/scripts/target/swj-dp.tcl", line 30
error: failed to flash /tmp/tinygo617108177/main.hex: exit status 1
```

after:

```
$ ./build/tinygo flash --target feather-nrf52840 --size short --programmer jlink ./src/examples/b1
   code    data     bss |   flash     ram
   6264      12    4064 |    6276    4076
Open On-Chip Debugger 0.10.0+dev-g5c9350d2 (2020-08-07-12:56)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
swd
Info : J-Link EDU Mini V1 compiled Jun  9 2020 13:36:46
Info : Hardware version: 1.00
Info : VTarget = 3.299 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf51.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf51.cpu on 3333
Info : Listening on port 3333 for gdb connections
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000a80 msp: 0x20000400
** Programming Started **
Info : nRF52840-xxAA(build code: D0) 1024kB Flash, 256kB RAM
Warn : Flash protection of this nRF device is not supported
Warn : Adding extra erase range, 0x00027884 .. 0x00027fff
** Programming Finished **
** Resetting Target **
shutdown command invoked
```