### PR TITLE
Compiler option for selecting output implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,11 +269,19 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0 -tags no_default_usb examples/serial
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m0          examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-m0 -tags no_default_usb examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=trinket-m0          examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=trinket-m0 -tags no_default_usb examples/serial
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=circuitplay-express -tags no_default_usb examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=stm32f4disco        examples/blinky1
 	@$(MD5SUM) test.hex
@@ -291,11 +299,17 @@ smoketest:
 	@$(MD5SUM) test.gba
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m4        examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m4 -tags no_default_usb examples/serial
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m4          examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-m4 -tags no_default_usb examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pybadge             examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=metro-m4-airlift    examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=metro-m4-airlift -tags no_default_usb examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pyportal            examples/blinky1
 	@$(MD5SUM) test.hex
@@ -320,6 +334,8 @@ smoketest:
 	$(TINYGO) build -size short -o test.hex -target=pygamer             examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=xiao                examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=xiao -tags no_default_usb examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/dac
 	@$(MD5SUM) test.hex

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -79,7 +79,12 @@ func (c *Config) GOARCH() string {
 
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
-	tags := append(c.Target.BuildTags, []string{"tinygo", "gc." + c.GC(), "scheduler." + c.Scheduler()}...)
+	tags := append(c.Target.BuildTags, []string{
+		"tinygo",
+		"gc." + c.GC(),
+		"output." + c.Output(),
+		"scheduler." + c.Scheduler(),
+	}...)
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}
@@ -155,6 +160,18 @@ func (c *Config) FuncImplementation() FuncValueImplementation {
 	default:
 		panic("unknown scheduler type")
 	}
+}
+
+// Output returns the selected output destination for putchar
+func (c *Config) Output() string {
+	if c.Options.Output != "" {
+		return c.Options.Output
+	}
+	if c.Target.Output != "" {
+		return c.Target.Output
+	}
+	// Fall back to 'default', which at the moment doesn't really mean anything
+	return "default"
 }
 
 // PanicStrategy returns the panic strategy selected for this target. Valid

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -10,6 +10,7 @@ var (
 	validSchedulerOptions     = []string{"none", "tasks", "coroutines"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
+	validOutputOptions        = []string{"none", "default", "custom", "usbcdc", "uart"}
 )
 
 // Options contains extra options to give to the compiler. These options are
@@ -33,6 +34,7 @@ type Options struct {
 	HeapSize      int64
 	TestConfig    TestConfig
 	Programmer    string
+	Output        string
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.
@@ -70,6 +72,15 @@ func (o *Options) Verify() error {
 			return fmt.Errorf(`invalid panic option '%s': valid values are %s`,
 				o.PanicStrategy,
 				strings.Join(validPanicStrategyOptions, ", "))
+		}
+	}
+
+	if o.Output != "" {
+		valid := isInArray(validOutputOptions, o.Output)
+		if !valid {
+			return fmt.Errorf(`invalid output option '%s': valid values are %s`,
+				o.Output,
+				strings.Join(validOutputOptions, ", "))
 		}
 	}
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -28,6 +28,7 @@ type TargetSpec struct {
 	GOARCH           string   `json:"goarch"`
 	BuildTags        []string `json:"build-tags"`
 	GC               string   `json:"gc"`
+	Output           string   `json:"output"`
 	Scheduler        string   `json:"scheduler"`
 	Compiler         string   `json:"compiler"`
 	Linker           string   `json:"linker"`
@@ -77,6 +78,9 @@ func (spec *TargetSpec) copyProperties(spec2 *TargetSpec) {
 	spec.BuildTags = append(spec.BuildTags, spec2.BuildTags...)
 	if spec2.GC != "" {
 		spec.GC = spec2.GC
+	}
+	if spec2.Output != "" {
+		spec.Output = spec2.Output
 	}
 	if spec2.Scheduler != "" {
 		spec.Scheduler = spec2.Scheduler

--- a/main.go
+++ b/main.go
@@ -767,6 +767,7 @@ func main() {
 	printStacks := flag.Bool("print-stacks", false, "print stack sizes of goroutines")
 	nodebug := flag.Bool("no-debug", false, "disable DWARF debug symbol generation")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
+	output := flag.String("output", "", "default output destination for putchar (none, default, custom, usbcdc, uart)")
 	port := flag.String("port", "", "flash port")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	cFlags := flag.String("cflags", "", "additional cflags for compiler")
@@ -808,6 +809,7 @@ func main() {
 		Tags:          *tags,
 		WasmAbi:       *wasmAbi,
 		Programmer:    *programmer,
+		Output:        *output,
 	}
 
 	if *cFlags != "" {
@@ -981,6 +983,7 @@ func main() {
 		fmt.Printf("build tags:        %s\n", strings.Join(config.BuildTags(), " "))
 		fmt.Printf("garbage collector: %s\n", config.GC())
 		fmt.Printf("scheduler:         %s\n", config.Scheduler())
+		fmt.Printf("output:            %s\n", config.Output())
 		fmt.Printf("cached GOROOT:     %s\n", cachedGOROOT)
 	case "list":
 		config, err := builder.NewConfig(options)

--- a/src/machine/board_arduino_nano33_baremetal.go
+++ b/src/machine/board_arduino_nano33_baremetal.go
@@ -23,6 +23,7 @@ var (
 		Bus:    sam.SERCOM5_USART,
 		SERCOM: 5,
 	}
+	UART_DEFAULT = UART2
 )
 
 func init() {

--- a/src/machine/board_circuitplay_express_baremetal.go
+++ b/src/machine/board_circuitplay_express_baremetal.go
@@ -14,6 +14,7 @@ var (
 		Bus:    sam.SERCOM4_USART,
 		SERCOM: 4,
 	}
+	UART_DEFAULT = UART1
 )
 
 func init() {

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -61,6 +61,7 @@ var (
 		Bus:    sam.SERCOM1_USART,
 		SERCOM: 1,
 	}
+	UART_DEFAULT = UART1
 )
 
 func init() {

--- a/src/machine/board_feather-m4_baremetal.go
+++ b/src/machine/board_feather-m4_baremetal.go
@@ -13,6 +13,7 @@ var (
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,
 	}
+	UART_DEFAULT = UART1
 
 	UART2 = UART{
 		Buffer: NewRingBuffer(),

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -61,6 +61,7 @@ var (
 		Bus:    sam.SERCOM1_USART,
 		SERCOM: 1,
 	}
+	UART_DEFAULT = UART1
 )
 
 func init() {

--- a/src/machine/board_itsybitsy-m4_baremetal.go
+++ b/src/machine/board_itsybitsy-m4_baremetal.go
@@ -13,6 +13,7 @@ var (
 		Bus:    sam.SERCOM3_USART_INT,
 		SERCOM: 3,
 	}
+	UART_DEFAULT = UART1
 
 	UART2 = UART{
 		Buffer: NewRingBuffer(),

--- a/src/machine/board_metro-m4-airlift_baremetal.go
+++ b/src/machine/board_metro-m4-airlift_baremetal.go
@@ -8,12 +8,15 @@ import (
 )
 
 var (
+	// UART on the TX/RX pins
 	UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM3_USART_INT,
 		SERCOM: 3,
 	}
+	UART_DEFAULT = UART1
 
+	// UART to ESP chip
 	UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -52,6 +52,7 @@ var (
 		Bus:    sam.SERCOM0_USART,
 		SERCOM: 0,
 	}
+	UART_DEFAULT = UART1
 )
 
 func init() {

--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -67,6 +67,7 @@ var (
 		Bus:    sam.SERCOM4_USART,
 		SERCOM: 4,
 	}
+	UART_DEFAULT = UART1
 )
 
 func init() {

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -444,11 +444,6 @@ type UART struct {
 	Interrupt interrupt.Interrupt
 }
 
-var (
-	// UART0 is actually a USB CDC interface.
-	UART0 = USBCDC{Buffer: NewRingBuffer()}
-)
-
 const (
 	sampleRate16X = 16
 	lsbFirst      = 1

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -900,11 +900,6 @@ type UART struct {
 	Interrupt interrupt.Interrupt // RXC interrupt
 }
 
-var (
-	// UART0 is actually a USB CDC interface.
-	UART0 = USBCDC{Buffer: NewRingBuffer()}
-)
-
 const (
 	sampleRate16X = 16
 	lsbFirst      = 1

--- a/src/machine/machine_atsamd_default_uart.go
+++ b/src/machine/machine_atsamd_default_uart.go
@@ -1,0 +1,8 @@
+// +build atsamd21,no_default_usb atsamd51,no_default_usb
+
+package machine
+
+var (
+	// UART0 is actually a USB CDC interface.
+	UART0 = UART_DEFAULT
+)

--- a/src/machine/machine_atsamd_default_usb.go
+++ b/src/machine/machine_atsamd_default_usb.go
@@ -1,0 +1,8 @@
+// +build atsamd21,!no_default_usb atsamd51,!no_default_usb
+
+package machine
+
+var (
+	// UART0 is actually a USB CDC interface.
+	UART0 = USBCDC{Buffer: NewRingBuffer()}
+)

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j20a"],
     "build-tags": ["pyportal"],
+    "output": "usbcdc",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PORTALBOOT",


### PR DESCRIPTION
I would like feedback on this as a possible mechanism for allowing to disable the USB CDC implementation on boards where it is the default output for `print()`

This is useful for devices/applications that need more control over the USB interface.  Such a capability is probably a necessity in order to be able to implement other USB interface classes such as HID, MSD, etc.

This draft implementation utilizes a build tag named `no_default_usb` which causes `UART0`  (used as the destination for putchar) to be a UART implementation instead of configuring/using USB CDC.  Right now I've only implemented this for samd targets, but if it looks good it will be easy to do the same for nrf52840 (which I believe is only other chipset with USB CDC support at the moment)