### PR TITLE
flash: call PortReset only on other than openocd

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 
 	return builder.Build(pkgName, fileExt, config, func(tmppath string) error {
 		// do we need port reset to put MCU into bootloader mode?
-		if config.Target.PortReset == "true" {
+		if config.Target.PortReset == "true" && flashMethod != "openocd" {
 			if port == "" {
 				var err error
 				port, err = getDefaultPort()


### PR DESCRIPTION
Before this fix, PortReset == true is judged and portReset is executed first.
If your microcontroller is crashing, portReset will fail.

 We don't need the portReset when we write from openocd.
