### PR TITLE
esp32: add support for basic GPIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ ifneq ($(AVR), 0)
 	@$(MD5SUM) test.hex
 endif
 ifneq ($(XTENSA), 0)
-	$(TINYGO) build -size short -o test.bin -target=esp32               examples/serial
+	$(TINYGO) build -size short -o test.bin -target=esp32-wroom-32      examples/blinky1
 endif
 	$(TINYGO) build -size short -o test.hex -target=hifive1b            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/machine/board_esp32-wroom-32.go
+++ b/src/machine/board_esp32-wroom-32.go
@@ -1,0 +1,6 @@
+// +build esp32_wroom_32
+
+package machine
+
+// Blue LED on the ESP32-WROOM-32 module.
+const LED = Pin(2)

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -13,7 +13,52 @@ const (
 	PinInput
 )
 
-func (p Pin) Set(value bool)
+// Configure this pin with the given configuration.
+func (p Pin) Configure(config PinConfig) {
+	if config.Mode == PinOutput {
+		// Set the 'output enable' bit.
+		if p < 32 {
+			esp.GPIO.ENABLE_W1TS.Set(1 << p)
+		} else {
+			esp.GPIO.ENABLE1_W1TS.Set(1 << (p - 32))
+		}
+	} else {
+		// Clear the 'output enable' bit.
+		if p < 32 {
+			esp.GPIO.ENABLE_W1TC.Set(1 << p)
+		} else {
+			esp.GPIO.ENABLE1_W1TC.Set(1 << (p - 32))
+		}
+	}
+}
+
+// Set the pin to high or low.
+// Warning: only use this on an output pin!
+func (p Pin) Set(value bool) {
+	if value {
+		if p < 32 {
+			esp.GPIO.OUT_W1TS.Set(1 << p)
+		} else {
+			esp.GPIO.OUT1_W1TS.Set(1 << (p - 32))
+		}
+	} else {
+		if p < 32 {
+			esp.GPIO.OUT_W1TC.Set(1 << p)
+		} else {
+			esp.GPIO.OUT1_W1TC.Set(1 << (p - 32))
+		}
+	}
+}
+
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input.
+func (p Pin) Get() bool {
+	if p < 32 {
+		return esp.GPIO.IN.Get()&(1<<p) != 0
+	} else {
+		return esp.GPIO.IN1.Get()&(1<<(p-32)) != 0
+	}
+}
 
 var (
 	UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}

--- a/targets/esp32-wroom-32.json
+++ b/targets/esp32-wroom-32.json
@@ -1,0 +1,4 @@
+{
+	"inherits": ["esp32"],
+	"build-tags": ["esp32_wroom_32"]
+}


### PR DESCRIPTION
GPIO is much more advanced on the ESP32, but this is a starting point. It gets examples/blinky1 to work.

I chose to support the ESP32-WROOM-32 instead of an actual board as this is the module that is used on the vast majority of ESP32 boards. I also don't have a "standard" ESP32 board, just some random dev board from AliExpress that is really a breakout board with USB-to-serial chip for programming.