### PR TITLE
arduino-mega2560: fix flashing on Windows

### DIFF
--- a/targets/arduino-mega2560.json
+++ b/targets/arduino-mega2560.json
@@ -4,5 +4,5 @@
     "ldflags": [
         "-Wl,--defsym=_bootloader_size=8192"
     ],
-    "flash-command":"avrdude -c wiring -b 115200 -p atmega2560 -P {port} -U flash:w:{hex} -v -D"
+    "flash-command":"avrdude -c wiring -b 115200 -p atmega2560 -P {port} -U flash:w:{hex}:i -v -D"
 }


### PR DESCRIPTION
Without the extra `:i` at the end, avrdude will misinterpret the colon in Windows paths. **Untested**.

Also see https://github.com/tinygo-org/tinygo/pull/857.