### PR TITLE
ci: run `tinygo test` for known-working packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ commands:
       - run: go test -v -tags=llvm<<parameters.llvm>> ./cgo ./compileopts ./interp ./transform .
       - run: make gen-device -j4
       - run: make smoketest XTENSA=0
+      - run: make tinygo-test
       - run: make wasmtest
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,14 @@ tinygo:
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -buildmode exe -tags byollvm ./cgo ./compileopts ./interp ./transform .
 
+# Test known-working standard library packages.
+# TODO: do this in one command, parallelize, and only show failing tests (no
+# implied -v flag).
+.PHONY: tinygo-test
 tinygo-test:
-	cd tests/tinygotest && tinygo test
+	$(TINYGO) test container/list
+	$(TINYGO) test container/ring
+	$(TINYGO) test text/scanner
 
 .PHONY: smoketest
 smoketest:


### PR DESCRIPTION
These packages are known to pass tests with `tinygo test`. It's still a very short list, but hopefully this list can be expanded to eventually cover most or all of the standard library.