### PR TITLE
test: support non-host tests 

### DIFF
--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -39,4 +39,9 @@ func libc_free(ptr unsafe.Pointer) {
 	free(ptr)
 }
 
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	abort()
+}
+
 const baremetal = true

--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -1,4 +1,4 @@
-// +build cortexm,!nxp
+// +build cortexm,!nxp,!qemu
 
 package runtime
 

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -21,6 +21,8 @@ func postinit() {}
 func main() {
 	preinit()
 	run()
+
+	// Signal successful exit.
 	arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingApplicationExit)
 	abort()
 }
@@ -53,4 +55,14 @@ func putchar(c byte) {
 
 func waitForEvents() {
 	arm.Asm("wfe")
+}
+
+func abort() {
+	// Signal an abnormal exit.
+	arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingRunTimeErrorUnknown)
+
+	// Lock up forever (should be unreachable).
+	for {
+		arm.Asm("wfi")
+	}
 }

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -195,6 +195,8 @@ func (m *M) Run() int {
 	if failures > 0 {
 		fmt.Printf("exit status %d\n", failures)
 		fmt.Println("FAIL")
+	} else {
+		fmt.Println("PASS")
 	}
 	return failures
 }

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -289,6 +289,17 @@
 						setTimeout(this._inst.exports.go_scheduler, timeout);
 					},
 
+					// func Exit(code int)
+					"syscall.Exit": (code) => {
+						if (global.process) {
+							// Node.js
+							process.exit(code);
+						} else {
+							// Can't exit in a browser.
+							throw 'trying to exit with code ' + code;
+						}
+					},
+
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (sp) => {
 						// Note: TinyGo does not support finalizers so this should never be


### PR DESCRIPTION
For example, for running tests with `-target=wasm` or `-target=cortex-m-qemu`. It looks at the output to determine whether tests were successful in the absence of a status code.

~~Depends on #1346 because they would otherwise conflict.~~