### PR TITLE
ci: set git-fetch-depth to 1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
       inputs:
         version: '1.15'
     - checkout: self
+      fetchDepth: 1
     - task: Cache@2
       displayName: Cache LLVM source
       inputs:


### PR DESCRIPTION
I think this PR will make windows CI a little faster.

> steps:
> - checkout: self | none | repository name # self represents the repo where the initial Pipelines YAML file was found
>   fetchDepth: number  # the depth of commits to ask Git to fetch; defaults to no limit

https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#checkout
