### PR TITLE
docker: fix the problem with the wasm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ COPY --from=tinygo-base /tinygo/targets /tinygo/targets
 
 RUN apt-get install -y libllvm10 lld-10
 
+RUN cd /tinygo/ && \
+    apt-get update && \
+    apt-get install -y make clang-10 && \
+    make wasi-libc
+
 # tinygo-avr stage installs the needed dependencies to compile TinyGo programs for AVR microcontrollers.
 FROM tinygo-base AS tinygo-avr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,9 @@ COPY --from=tinygo-base /go/bin/tinygo /go/bin/tinygo
 COPY --from=tinygo-base /tinygo/src /tinygo/src
 COPY --from=tinygo-base /tinygo/targets /tinygo/targets
 
-RUN apt-get install -y libllvm10 lld-10
-
 RUN cd /tinygo/ && \
     apt-get update && \
-    apt-get install -y make clang-10 && \
+    apt-get install -y make clang-10 libllvm10 lld-10 && \
     make wasi-libc
 
 # tinygo-avr stage installs the needed dependencies to compile TinyGo programs for AVR microcontrollers.


### PR DESCRIPTION
This PR fixes #1303 .

As a docker newbie, there may be a better way to fix this.
However, the following does work now.

```
$ docker run --rm -v $(pwd):/src -w /src 61d76abc1edf tinygo build -o app.wasm -target=wasm ./src/examples/wasm/main
```