### PR TITLE
all: add go.mod for ide integration

### DIFF
--- a/src/device/arm/go.mod
+++ b/src/device/arm/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/arm
+
+go 1.14

--- a/src/device/avr/go.mod
+++ b/src/device/avr/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/avr
+
+go 1.14

--- a/src/device/esp/go.mod
+++ b/src/device/esp/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/esp
+
+go 1.14

--- a/src/device/go.mod
+++ b/src/device/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device
+
+go 1.14

--- a/src/device/nrf/go.mod
+++ b/src/device/nrf/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/nrf
+
+go 1.14

--- a/src/device/riscv/go.mod
+++ b/src/device/riscv/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/riscv
+
+go 1.14

--- a/src/device/sam/go.mod
+++ b/src/device/sam/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/sam
+
+go 1.14

--- a/src/device/stm32/go.mod
+++ b/src/device/stm32/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/device/stm32
+
+go 1.14

--- a/src/internal/bytealg/go.mod
+++ b/src/internal/bytealg/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/internal/bytealg
+
+go 1.14

--- a/src/internal/go.mod
+++ b/src/internal/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/internal
+
+go 1.14

--- a/src/internal/reflectlite/go.mod
+++ b/src/internal/reflectlite/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/internal/reflectlite
+
+go 1.14

--- a/src/internal/task/go.mod
+++ b/src/internal/task/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/internal/task
+
+go 1.14

--- a/src/machine/go.mod
+++ b/src/machine/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/machine
+
+go 1.14

--- a/src/os/go.mod
+++ b/src/os/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/os
+
+go 1.14

--- a/src/reflect/go.mod
+++ b/src/reflect/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/reflect
+
+go 1.14

--- a/src/runtime/cgo/go.mod
+++ b/src/runtime/cgo/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/cgo
+
+go 1.14

--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime
+
+go 1.14

--- a/src/runtime/internal/go.mod
+++ b/src/runtime/internal/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/internal
+
+go 1.14

--- a/src/runtime/internal/sys/go.mod
+++ b/src/runtime/internal/sys/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/internal/sys
+
+go 1.14

--- a/src/runtime/interrupt/go.mod
+++ b/src/runtime/interrupt/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/interrupt
+
+go 1.14

--- a/src/runtime/pprof/go.mod
+++ b/src/runtime/pprof/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/pprof
+
+go 1.14

--- a/src/runtime/volatile/go.mod
+++ b/src/runtime/volatile/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/runtime/volatile
+
+go 1.14

--- a/src/sync/go.mod
+++ b/src/sync/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/sync
+
+go 1.14

--- a/src/syscall/go.mod
+++ b/src/syscall/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/syscall
+
+go 1.14

--- a/src/testing/go.mod
+++ b/src/testing/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/src/testing
+
+go 1.14


### PR DESCRIPTION
#1360 
https://github.com/tinygo-org/tinygo-site/pull/107

This PR makes IDE integration easier.
Specifically, it allows you to do the following

1. Configure GOPATH.
2. If you have a go.mod, add a replace directive
3. Configuring GOOS, GOARCH and GOFLAGS

