### PR TITLE
nintendoswitch: Fix invalid memory read / write in print calls

### DIFF
--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -40,11 +40,11 @@ func ticks() timeUnit {
 	return timeUnit(ticksToNanoseconds(timeUnit(getArmSystemTick())))
 }
 
-var stdoutBuffer = make([]byte, 120, 120)
+var stdoutBuffer = make([]byte, 120)
 var position = 0
 
 func putchar(c byte) {
-	if c == '\n' || position >= 119 {
+	if c == '\n' || position > len(stdoutBuffer) {
 		nxOutputString(&stdoutBuffer[0], uint64(position))
 		position = 0
 		return

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -40,21 +40,18 @@ func ticks() timeUnit {
 	return timeUnit(ticksToNanoseconds(timeUnit(getArmSystemTick())))
 }
 
-var stdoutBuffer = make([]byte, 0, 120)
+var stdoutBuffer = make([]byte, 120, 120)
+var position = 0
 
 func putchar(c byte) {
-	if c == '\n' || len(stdoutBuffer)+1 >= 120 {
-		NxOutputString(string(stdoutBuffer))
-		stdoutBuffer = stdoutBuffer[:0]
+	if c == '\n' || position >= 119 {
+		nxOutputString(&stdoutBuffer[0], uint64(position))
+		position = 0
 		return
 	}
 
-	stdoutBuffer = append(stdoutBuffer, c)
-}
-
-func usleep(usec uint) int {
-	sleepThread(uint64(usec) * 1000)
-	return 0
+	stdoutBuffer[position] = c
+	position++
 }
 
 func abort() {

--- a/src/runtime/runtime_nintendoswitch_heap.go
+++ b/src/runtime/runtime_nintendoswitch_heap.go
@@ -4,17 +4,12 @@
 
 package runtime
 
-import "unsafe"
-
 const heapSize = 0x2000000 * 16 // Default by libnx
-
-//go:extern _stack_top
-var stackTopSymbol [0]byte
 
 var (
 	heapStart = uintptr(0)
 	heapEnd   = uintptr(0)
-	stackTop  = uintptr(unsafe.Pointer(&stackTopSymbol))
+	failedToAllocateHeapString = []byte("failed to allocate heap")
 )
 
 //export setHeapSize
@@ -24,7 +19,12 @@ func preinit() {
 	setHeapSize(&heapStart, heapSize)
 
 	if heapStart == 0 {
-		panic("failed to allocate heap")
+		// Panic should work, but if we call panic here, it triggers a compiler bug that breaks
+		// all print calls in the whole application. So far we couldn't figure out why, that's
+		// why we're using a byte array and nxOutputString directly
+		nxOutputString(&failedToAllocateHeapString[0], uint64(len(failedToAllocateHeapString)))
+		exit(1)
+		//panic("failed to allocate heap")
 	}
 
 	heapEnd = heapStart + heapSize

--- a/src/runtime/runtime_nintendoswitch_heap.go
+++ b/src/runtime/runtime_nintendoswitch_heap.go
@@ -7,9 +7,8 @@ package runtime
 const heapSize = 0x2000000 * 16 // Default by libnx
 
 var (
-	heapStart                  = uintptr(0)
-	heapEnd                    = uintptr(0)
-	failedToAllocateHeapString = []byte("failed to allocate heap")
+	heapStart = uintptr(0)
+	heapEnd   = uintptr(0)
 )
 
 //export setHeapSize
@@ -19,12 +18,7 @@ func preinit() {
 	setHeapSize(&heapStart, heapSize)
 
 	if heapStart == 0 {
-		// Panic should work, but if we call panic here, it triggers a compiler bug that breaks
-		// all print calls in the whole application. So far we couldn't figure out why, that's
-		// why we're using a byte array and nxOutputString directly
-		nxOutputString(&failedToAllocateHeapString[0], uint64(len(failedToAllocateHeapString)))
-		exit(1)
-		//panic("failed to allocate heap")
+		runtimePanic("failed to allocate heap")
 	}
 
 	heapEnd = heapStart + heapSize

--- a/src/runtime/runtime_nintendoswitch_heap.go
+++ b/src/runtime/runtime_nintendoswitch_heap.go
@@ -7,8 +7,8 @@ package runtime
 const heapSize = 0x2000000 * 16 // Default by libnx
 
 var (
-	heapStart = uintptr(0)
-	heapEnd   = uintptr(0)
+	heapStart                  = uintptr(0)
+	heapEnd                    = uintptr(0)
 	failedToAllocateHeapString = []byte("failed to allocate heap")
 )
 


### PR DESCRIPTION
These fixes are for what it looks like a compiler bug. Me and @deadprogram tried for a while to debug what caused that problems, and it looks like it is some unknown compiler bug which it doesn't seens to happen for other platforms.

There are two bugs:

1. Depending on how the compiler optimizes the `putchar`, the slicing of a pre-allocated slice triggers a new memory allocation, which in some parts of the code isn't possible.
2. The panic call in `runtime_nintendoswitch_heap.go` if only there, works just fine. But if the target code has another panic, neither of the panic's output is printed correctly (the string passed to the print call has a null pointer)

I can't be sure what's causing these errors, but this fixes it for now. I haven't got any issues in target code if that runtime code is like this.

@aykevl with this, the issues you were having in https://github.com/tinygo-org/tinygo/pull/1226 should be gone.