### PR TITLE
nrf52840: use higher priority for USB-CDC code

### DIFF
--- a/src/machine/usb_nrf52840.go
+++ b/src/machine/usb_nrf52840.go
@@ -87,9 +87,12 @@ func exitCriticalSection() {
 
 // Configure the USB CDC interface. The config is here for compatibility with the UART interface.
 func (usbcdc *USBCDC) Configure(config UARTConfig) {
-	// enable IRQ
+	// Enable IRQ. Make sure this is higher than the SWI2 interrupt handler so
+	// that it is possible to print to the console from a BLE interrupt. You
+	// shouldn't generally do that but it is useful for debugging and panic
+	// logging.
 	usbcdc.interrupt = interrupt.New(nrf.IRQ_USBD, USB.handleInterrupt)
-	usbcdc.interrupt.SetPriority(0xD0)
+	usbcdc.interrupt.SetPriority(0x40) // interrupt priority 2 (lower number means more important)
 	usbcdc.interrupt.Enable()
 
 	// enable USB


### PR DESCRIPTION
This ensures that stdout (`println` etc) keeps working in interrupts.

Generally you shouldn't print anything in an interrupt. However, printing things for debugging is very useful and printing panic messages can be critical when the code doesn't work for some reason.

This is a partial fix for https://github.com/tinygo-org/bluetooth/issues/15. It doesn't fix the underlying issue but for me I can see the panic message with this fix (while the device would just hang without this fix).