### PR TITLE
feather-stm32f405: add I2C support

### DIFF
--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -186,11 +186,11 @@ const (
 	// #===========#==========#==============#==============#=======#=======#
 	// | Interface | Hardware |  Bus(Freq)   | SDA/SCL Pins | AltFn | Alias |
 	// #===========#==========#==============#==============#=======#=======#
-	// |   I2C1    |   I2C1   |              |   D14/D15    |       |   ~   |
-	// |   I2C2    |   I2C2   |              |    D0/D1     |       |   ~   |
-	// |   I2C3    |   I2C1   |              |    D9/D10    |       |   ~   |
+	// |   I2C1    |   I2C1   | APB1(42 MHz) |   D14/D15    |   4   |   ~   |
+	// |   I2C2    |   I2C2   | APB1(42 MHz) |    D0/D1     |   4   |   ~   |
+	// |   I2C3    |   I2C1   | APB1(42 MHz) |    D9/D10    |   4   |   ~   |
 	// | --------- | -------- | ------------ | ------------ | ----- | ----- |
-	// |   I2C0    |   I2C1   |              |   D14/D15    |       | I2C1  |
+	// |   I2C0    |   I2C1   | APB1(42 MHz) |   D14/D15    |   4   | I2C1  |
 	// #===========#==========#==============#==============#=======#=======#
 	NUM_I2C_INTERFACES = 3
 
@@ -208,6 +208,22 @@ const (
 
 	I2C_SDA_PIN = I2C0_SDA_PIN // default/primary I2C pins
 	I2C_SCL_PIN = I2C0_SCL_PIN //
+)
+
+var (
+	I2C1 = I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: stm32.AF4_I2C1_2_3,
+	}
+	I2C2 = I2C{
+		Bus:             stm32.I2C2,
+		AltFuncSelector: stm32.AF4_I2C1_2_3,
+	}
+	I2C3 = I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: stm32.AF4_I2C1_2_3,
+	}
+	I2C0 = I2C1
 )
 
 func initI2C() {}

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf sam stm32 fe310 k210
+// +build avr nrf sam stm32,!stm32f407 fe310 k210
 
 package machine
 

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf sam stm32,!stm32f4 fe310 k210
+// +build avr nrf sam stm32 fe310 k210
 
 package machine
 

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -1,0 +1,34 @@
+// +build stm32
+
+package machine
+
+// Peripheral abstraction layer for I2C on the stm32 family
+
+import (
+	"unsafe"
+)
+
+// I2CConfig is used to store config info for I2C.
+type I2CConfig struct {
+	Frequency uint32
+	SCL       Pin
+	SDA       Pin
+}
+
+// Configure is intended to setup the STM32 I2C interface.
+func (i2c I2C) Configure(config I2CConfig) {
+
+	// enable clock for I2C
+	enableAltFuncClock(unsafe.Pointer(i2c.Bus))
+
+	// init pins
+	if config.SCL == 0 && config.SDA == 0 {
+		config.SCL = I2C0_SCL_PIN
+		config.SDA = I2C0_SDA_PIN
+	}
+	i2c.configurePins(config)
+
+	// Get I2C baud rate based on the bus speed it's attached to
+	var conf uint32 = i2c.getBaudRate(config)
+
+}

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -5,7 +5,14 @@ package machine
 // Peripheral abstraction layer for I2C on the stm32 family
 
 import (
+	"device/stm32"
 	"unsafe"
+)
+
+// I2C fast mode (Fm) duty cycle
+const (
+	Duty2    = 0
+	Duty16_9 = 1
 )
 
 // I2CConfig is used to store config info for I2C.
@@ -13,10 +20,22 @@ type I2CConfig struct {
 	Frequency uint32
 	SCL       Pin
 	SDA       Pin
+	DutyCycle uint8
 }
 
 // Configure is intended to setup the STM32 I2C interface.
 func (i2c I2C) Configure(config I2CConfig) {
+
+	// The following is the required sequence in master mode.
+	// 1. Program the peripheral input clock in I2C_CR2 Register in order to
+	//    generate correct timings
+	// 2. Configure the clock control registers
+	// 3. Configure the rise time register
+	// 4. Program the I2C_CR1 register to enable the peripheral
+	// 5. Set the START bit in the I2C_CR1 register to generate a Start condition
+
+	// disable I2C interface before any configuration changes
+	i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_PE)
 
 	// enable clock for I2C
 	enableAltFuncClock(unsafe.Pointer(i2c.Bus))
@@ -28,7 +47,389 @@ func (i2c I2C) Configure(config I2CConfig) {
 	}
 	i2c.configurePins(config)
 
-	// Get I2C baud rate based on the bus speed it's attached to
-	var conf uint32 = i2c.getBaudRate(config)
+	// default to 100 kHz (Sm, standard mode) if no frequency is set
+	if config.Frequency == 0 {
+		config.Frequency = TWI_FREQ_100KHZ
+	}
 
+	// configure I2C input clock
+	i2c.Bus.CR2.SetBits(i2c.getFreqRange(config))
+
+	// configure clock control
+	i2c.Bus.CCR.Set(i2c.getSpeed(config))
+
+	// configure rise time
+	i2c.Bus.TRISE.Set(i2c.getRiseTime(config))
+
+	// enable I2C interface
+	i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_PE)
+}
+
+// Tx does a single I2C transaction at the specified address.
+// It clocks out the given address, writes the bytes in w, reads back len(r)
+// bytes and stores them in r, and generates a stop condition on the bus.
+func (i2c I2C) Tx(addr uint16, w, r []byte) error {
+	var err error
+	if len(w) != 0 {
+		// start transmission for writing
+		err = i2c.signalStart()
+		if err != nil {
+			return err
+		}
+
+		// send address
+		err = i2c.sendAddress(uint8(addr), true)
+		if err != nil {
+			return err
+		}
+
+		for _, b := range w {
+			err = i2c.WriteByte(b)
+			if err != nil {
+				return err
+			}
+		}
+
+		// sending stop here for write
+		err = i2c.signalStop()
+		if err != nil {
+			return err
+		}
+	}
+	if len(r) != 0 {
+		// re-start transmission for reading
+		err = i2c.signalStart()
+		if err != nil {
+			return err
+		}
+
+		// 1 byte
+		switch len(r) {
+		case 1:
+			// send address
+			err = i2c.sendAddress(uint8(addr), false)
+			if err != nil {
+				return err
+			}
+
+			// Disable ACK of received data
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_ACK)
+
+			// clear timeout here
+			timeout := i2cTimeout
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
+				timeout--
+				if timeout == 0 {
+					return errI2CWriteTimeout
+				}
+			}
+
+			// Generate stop condition
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
+
+			timeout = i2cTimeout
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// Read and return data byte from I2C data register
+			r[0] = byte(i2c.Bus.DR.Get())
+
+			// wait for stop
+			return i2c.waitForStop()
+
+		case 2:
+			// enable pos
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_POS)
+
+			// Enable ACK of received data
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_ACK)
+
+			// send address
+			err = i2c.sendAddress(uint8(addr), false)
+			if err != nil {
+				return err
+			}
+
+			// clear address here
+			timeout := i2cTimeout
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
+				timeout--
+				if timeout == 0 {
+					return errI2CWriteTimeout
+				}
+			}
+
+			// Disable ACK of received data
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_ACK)
+
+			// wait for btf. we need a longer timeout here than normal.
+			timeout = 1000
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// Generate stop condition
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
+
+			// read the 2 bytes by reading twice.
+			r[0] = byte(i2c.Bus.DR.Get())
+			r[1] = byte(i2c.Bus.DR.Get())
+
+			// wait for stop
+			err = i2c.waitForStop()
+
+			//disable pos
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_POS)
+
+			return err
+
+		case 3:
+			// Enable ACK of received data
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_ACK)
+
+			// send address
+			err = i2c.sendAddress(uint8(addr), false)
+			if err != nil {
+				return err
+			}
+
+			// clear address here
+			timeout := i2cTimeout
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
+				timeout--
+				if timeout == 0 {
+					return errI2CWriteTimeout
+				}
+			}
+
+			// Enable ACK of received data
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_ACK)
+
+			// wait for btf. we need a longer timeout here than normal.
+			timeout = 1000
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// Disable ACK of received data
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_ACK)
+
+			// read the first byte
+			r[0] = byte(i2c.Bus.DR.Get())
+
+			timeout = 1000
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// Generate stop condition
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
+
+			// read the last 2 bytes by reading twice.
+			r[1] = byte(i2c.Bus.DR.Get())
+			r[2] = byte(i2c.Bus.DR.Get())
+
+			// wait for stop
+			return i2c.waitForStop()
+
+		default:
+			// more than 3 bytes of data to read
+
+			// send address
+			err = i2c.sendAddress(uint8(addr), false)
+			if err != nil {
+				return err
+			}
+
+			// clear address here
+			timeout := i2cTimeout
+			for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY) {
+				timeout--
+				if timeout == 0 {
+					return errI2CWriteTimeout
+				}
+			}
+
+			for i := 0; i < len(r)-3; i++ {
+				// Enable ACK of received data
+				i2c.Bus.CR1.SetBits(stm32.I2C_CR1_ACK)
+
+				// wait for btf. we need a longer timeout here than normal.
+				timeout = 1000
+				for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
+					timeout--
+					if timeout == 0 {
+						return errI2CReadTimeout
+					}
+				}
+
+				// read the next byte
+				r[i] = byte(i2c.Bus.DR.Get())
+			}
+
+			// wait for btf. we need a longer timeout here than normal.
+			timeout = 1000
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_BTF) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// Disable ACK of received data
+			i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_ACK)
+
+			// get third from last byte
+			r[len(r)-3] = byte(i2c.Bus.DR.Get())
+
+			// Generate stop condition
+			i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
+
+			// get second from last byte
+			r[len(r)-2] = byte(i2c.Bus.DR.Get())
+
+			timeout = i2cTimeout
+			for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_RxNE) {
+				timeout--
+				if timeout == 0 {
+					return errI2CReadTimeout
+				}
+			}
+
+			// get last byte
+			r[len(r)-1] = byte(i2c.Bus.DR.Get())
+
+			// wait for stop
+			return i2c.waitForStop()
+		}
+	}
+
+	return nil
+}
+
+const i2cTimeout = 500
+
+// signalStart sends a start signal.
+func (i2c I2C) signalStart() error {
+	// Wait until I2C is not busy
+	timeout := i2cTimeout
+	for i2c.Bus.SR2.HasBits(stm32.I2C_SR2_BUSY) {
+		timeout--
+		if timeout == 0 {
+			return errI2CSignalStartTimeout
+		}
+	}
+
+	// clear stop
+	i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_STOP)
+
+	// Generate start condition
+	i2c.Bus.CR1.SetBits(stm32.I2C_CR1_START)
+
+	// Wait for I2C EV5 aka SB flag.
+	timeout = i2cTimeout
+	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_SB) {
+		timeout--
+		if timeout == 0 {
+			return errI2CSignalStartTimeout
+		}
+	}
+
+	return nil
+}
+
+// signalStop sends a stop signal and waits for it to succeed.
+func (i2c I2C) signalStop() error {
+	// Generate stop condition
+	i2c.Bus.CR1.SetBits(stm32.I2C_CR1_STOP)
+
+	// wait for stop
+	return i2c.waitForStop()
+}
+
+// waitForStop waits after a stop signal.
+func (i2c I2C) waitForStop() error {
+	// Wait until I2C is stopped
+	timeout := i2cTimeout
+	for i2c.Bus.SR1.HasBits(stm32.I2C_SR1_STOPF) {
+		timeout--
+		if timeout == 0 {
+			return errI2CSignalStopTimeout
+		}
+	}
+
+	return nil
+}
+
+// Send address of device we want to talk to
+func (i2c I2C) sendAddress(address uint8, write bool) error {
+	data := (address << 1)
+	if !write {
+		data |= 1 // set read flag
+	}
+
+	i2c.Bus.DR.Set(uint32(data))
+
+	// Wait for I2C EV6 event.
+	// Destination device acknowledges address
+	timeout := i2cTimeout
+	if write {
+		// EV6 which is ADDR flag.
+		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
+			timeout--
+			if timeout == 0 {
+				return errI2CWriteTimeout
+			}
+		}
+
+		timeout = i2cTimeout
+		for !i2c.Bus.SR2.HasBits(stm32.I2C_SR2_MSL | stm32.I2C_SR2_BUSY | stm32.I2C_SR2_TRA) {
+			timeout--
+			if timeout == 0 {
+				return errI2CWriteTimeout
+			}
+		}
+	} else {
+		// I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED which is ADDR flag.
+		for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_ADDR) {
+			timeout--
+			if timeout == 0 {
+				return errI2CWriteTimeout
+			}
+		}
+	}
+
+	return nil
+}
+
+// WriteByte writes a single byte to the I2C bus.
+func (i2c I2C) WriteByte(data byte) error {
+	// Send data byte
+	i2c.Bus.DR.Set(uint32(data))
+
+	// Wait for I2C EV8_2 when data has been physically shifted out and
+	// output on the bus.
+	// I2C_EVENT_MASTER_BYTE_TRANSMITTED is TXE flag.
+	timeout := i2cTimeout
+	for !i2c.Bus.SR1.HasBits(stm32.I2C_SR1_TxE) {
+		timeout--
+		if timeout == 0 {
+			return errI2CWriteTimeout
+		}
+	}
+
+	return nil
 }

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -1,4 +1,4 @@
-// +build stm32
+// +build stm32,!stm32f103xx
 
 package machine
 

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -1,4 +1,4 @@
-// +build stm32,!stm32f103xx
+// +build stm32,!stm32f103xx,!stm32f407
 
 package machine
 

--- a/src/machine/machine_stm32f405.go
+++ b/src/machine/machine_stm32f405.go
@@ -55,3 +55,6 @@ type I2C struct {
 	Bus             *stm32.I2C_Type
 	AltFuncSelector stm32.AltFunc
 }
+
+func (i2c I2C) configurePins(config I2CConfig)      {}
+func (i2c I2C) getBaudRate(config I2CConfig) uint32 { return 0 }

--- a/src/machine/machine_stm32f405.go
+++ b/src/machine/machine_stm32f405.go
@@ -96,18 +96,6 @@ func (i2c I2C) getRiseTime(config I2CConfig) uint32 {
 }
 
 func (i2c I2C) getSpeed(config I2CConfig) uint32 {
-	// getSpeed is based on the following STM32CubeMX macros:
-	//
-	//	 #define I2C_MIN_PCLK_FREQ(__PCLK__, __SPEED__)             (((__SPEED__) <= 100000U) ? ((__PCLK__) < I2C_MIN_PCLK_FREQ_STANDARD) : ((__PCLK__) < I2C_MIN_PCLK_FREQ_FAST))
-	//	 #define I2C_CCR_CALCULATION(__PCLK__, __SPEED__, __COEFF__)     (((((__PCLK__) - 1U)/((__SPEED__) * (__COEFF__))) + 1U) & I2C_CCR_CCR)
-	//	 #define I2C_FREQRANGE(__PCLK__)                            ((__PCLK__)/1000000U)
-	//	 #define I2C_RISE_TIME(__FREQRANGE__, __SPEED__)            (((__SPEED__) <= 100000U) ? ((__FREQRANGE__) + 1U) : ((((__FREQRANGE__) * 300U) / 1000U) + 1U))
-	//	 #define I2C_SPEED_STANDARD(__PCLK__, __SPEED__)            ((I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 2U) < 4U)? 4U:I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 2U))
-	//	 #define I2C_SPEED_FAST(__PCLK__, __SPEED__, __DUTYCYCLE__) (((__DUTYCYCLE__) == I2C_DUTYCYCLE_2)? I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 3U) : (I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 25U) | I2C_DUTYCYCLE_16_9))
-	//	 #define I2C_SPEED(__PCLK__, __SPEED__, __DUTYCYCLE__)      (((__SPEED__) <= 100000U)? (I2C_SPEED_STANDARD((__PCLK__), (__SPEED__))) : \
-	//	                                                                   ((I2C_SPEED_FAST((__PCLK__), (__SPEED__), (__DUTYCYCLE__)) & I2C_CCR_CCR) == 0U)? 1U : \
-	//	                                                                   ((I2C_SPEED_FAST((__PCLK__), (__SPEED__), (__DUTYCYCLE__))) | I2C_CCR_FS))
-	//
 	ccr := func(pclk uint32, freq uint32, coeff uint32) uint32 {
 		return (((pclk - 1) / (freq * coeff)) + 1) & stm32.I2C_CCR_CCR_Msk
 	}
@@ -119,7 +107,7 @@ func (i2c I2C) getSpeed(config I2CConfig) uint32 {
 		}
 	}
 	fm := func(pclk uint32, freq uint32, duty uint8) uint32 { // fast mode (Fm)
-		if duty == Duty2 {
+		if duty == DutyCycle2 {
 			return ccr(pclk, freq, 3)
 		} else {
 			return ccr(pclk, freq, 25) | stm32.I2C_CCR_DUTY


### PR DESCRIPTION
This adds support for the two I2C peripherals on the target `feather-stm32f405`.

This I2C implementation supports the entire STM32 family (except for the Bluepill `stm32f103xx`, which has its own implementation).