### PR TITLE
nintendoswitch: Add dynamic loader for runtime loading PIE sections

### DIFF
--- a/src/runtime/dynamic_arm64.go
+++ b/src/runtime/dynamic_arm64.go
@@ -1,37 +1,53 @@
 package runtime
 
 import (
-	"debug/elf"
 	"unsafe"
 )
 
 const debugLoader = false
 
+const (
+	R_AARCH64_RELATIVE = 1027
+	DT_NULL            = 0 /* Terminating entry. */
+	DT_RELA            = 7 /* Address of ElfNN_Rela relocations. */
+	DT_RELASZ          = 8 /* Total size of ElfNN_Rela relocations. */
+)
+
+/* ELF64 relocations that need an addend field. */
+type Rela64 struct {
+	Off    uint64 /* Location to be relocated. */
+	Info   uint64 /* Relocation type and symbol index. */
+	Addend int64  /* Addend. */
+}
+
+// ELF64 Dynamic structure. The ".dynamic" section contains an array of them.
+type Dyn64 struct {
+	Tag int64  /* Entry type. */
+	Val uint64 /* Integer/address value */
+}
+
 //export __dynamic_loader
-func dynamicLoader(base uintptr, dyn *elf.Dyn64) {
-	var rela *elf.Rela64
+func dynamicLoader(base uintptr, dyn *Dyn64) {
+	var rela *Rela64
 	relasz := uint64(0)
 
 	if debugLoader {
 		println("ASLR Base: ", base)
 	}
 
-	for dyn.Tag != int64(elf.DT_NULL) {
-		switch elf.DynTag(dyn.Tag) {
-		case elf.DT_RELA:
-			rela = (*elf.Rela64)(unsafe.Pointer(base + uintptr(dyn.Val)))
-		case elf.DT_RELASZ:
-			relasz = uint64(dyn.Val) / uint64(unsafe.Sizeof(elf.Rela64{}))
+	for dyn.Tag != DT_NULL {
+		switch dyn.Tag {
+		case DT_RELA:
+			rela = (*Rela64)(unsafe.Pointer(base + uintptr(dyn.Val)))
+		case DT_RELASZ:
+			relasz = uint64(dyn.Val) / uint64(unsafe.Sizeof(Rela64{}))
 		}
 
 		ptr := uintptr(unsafe.Pointer(dyn))
-		ptr += unsafe.Sizeof(elf.Dyn64{})
-		dyn = (*elf.Dyn64)(unsafe.Pointer(ptr))
+		ptr += unsafe.Sizeof(Dyn64{})
+		dyn = (*Dyn64)(unsafe.Pointer(ptr))
 	}
 
-	if rela == nil {
-		runtimePanic("bad reloc")
-	}
 	if rela == nil {
 		runtimePanic("bad reloc")
 	}
@@ -41,15 +57,15 @@ func dynamicLoader(base uintptr, dyn *elf.Dyn64) {
 	}
 
 	for relasz > 0 && rela != nil {
-		switch elf.R_AARCH64(rela.Info) {
-		case elf.R_AARCH64_RELATIVE:
+		switch rela.Info {
+		case R_AARCH64_RELATIVE:
 			ptr := (*uint64)(unsafe.Pointer(base + uintptr(rela.Off)))
 			*ptr = uint64(base + uintptr(rela.Addend))
 		}
 
 		rptr := uintptr(unsafe.Pointer(rela))
-		rptr += unsafe.Sizeof(elf.Rela64{})
-		rela = (*elf.Rela64)(unsafe.Pointer(rptr))
+		rptr += unsafe.Sizeof(Rela64{})
+		rela = (*Rela64)(unsafe.Pointer(rptr))
 		relasz--
 	}
 }

--- a/src/runtime/dynamic_arm64.go
+++ b/src/runtime/dynamic_arm64.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"debug/elf"
+	"unsafe"
+)
+
+const debugLoader = false
+
+//export __dynamic_loader
+func dynamicLoader(base uintptr, dyn *elf.Dyn64) {
+	var rela *elf.Rela64
+	relasz := uint64(0)
+
+	if debugLoader {
+		println("ASLR Base: ", base)
+	}
+
+	for dyn.Tag != int64(elf.DT_NULL) {
+		switch elf.DynTag(dyn.Tag) {
+		case elf.DT_RELA:
+			rela = (*elf.Rela64)(unsafe.Pointer(base + uintptr(dyn.Val)))
+		case elf.DT_RELASZ:
+			relasz = uint64(dyn.Val) / uint64(unsafe.Sizeof(elf.Rela64{}))
+		}
+
+		ptr := uintptr(unsafe.Pointer(dyn))
+		ptr += unsafe.Sizeof(elf.Dyn64{})
+		dyn = (*elf.Dyn64)(unsafe.Pointer(ptr))
+	}
+
+	if rela == nil {
+		runtimePanic("bad reloc")
+	}
+	if rela == nil {
+		runtimePanic("bad reloc")
+	}
+
+	if debugLoader {
+		println("Sections to load: ", relasz)
+	}
+
+	for relasz > 0 && rela != nil {
+		switch elf.R_AARCH64(rela.Info) {
+		case elf.R_AARCH64_RELATIVE:
+			ptr := (*uint64)(unsafe.Pointer(base + uintptr(rela.Off)))
+			*ptr = uint64(base + uintptr(rela.Addend))
+		}
+
+		rptr := uintptr(unsafe.Pointer(rela))
+		rptr += unsafe.Sizeof(elf.Rela64{})
+		rela = (*elf.Rela64)(unsafe.Pointer(rptr))
+		relasz--
+	}
+}

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -2,6 +2,8 @@
 
 package runtime
 
+import "unsafe"
+
 type timeUnit int64
 
 const asyncScheduler = false
@@ -58,6 +60,16 @@ func abort() {
 	for {
 		exit(1)
 	}
+}
+
+//export write
+func write(fd int32, buf *byte, count int) int {
+	// TODO: Proper handling write
+	for i := 0; i < count; i++ {
+		putchar(*buf)
+		buf = (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(buf)) + 1))
+	}
+	return count
 }
 
 //export sleepThread

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -20,6 +20,10 @@
     "-fno-exceptions", "-fno-unwind-tables",
     "-ffunction-sections", "-fdata-sections"
   ],
+  "ldflags": [
+    "-pie",
+    "-z", "notext"
+  ],
   "linkerscript": "targets/nintendoswitch.ld",
   "extra-files": [
     "targets/nintendoswitch.s",

--- a/targets/nintendoswitch.ld
+++ b/targets/nintendoswitch.ld
@@ -1,69 +1,84 @@
+PHDRS
+{
+  text    PT_LOAD FLAGS(5) /* Read | Execute */;
+  rodata  PT_LOAD FLAGS(4) /* Read */;
+  data    PT_LOAD FLAGS(6) /* Read | Write */;
+  bss     PT_LOAD FLAGS(6) /* Read | Write */;
+  dynamic PT_DYNAMIC;
+}
+
 SECTIONS
 {
+  /* Code and file header */
   . = 0;
 
-  /* Code and file header */
-
-  .text : {
+  .text : ALIGN(0x1000) {
     HIDDEN(__text_start = .);
     KEEP(*(.text.jmp))
 
     . = 0x80;
 
     *(.text .text.*)
+    *(.plt .plt.*)
 
-    . = ALIGN(0x1000);
     HIDDEN(__text_end = .);
     HIDDEN(__text_size = . - __text_start);
   }
 
   /* Read-only sections */
+  . = ALIGN(0x1000);
 
-  .rodata : {
-    HIDDEN(__rodata_start = .);
+  HIDDEN(__rodata_start = .);
+  .rodata : { *(.rodata .rodata.*) }  :rodata
 
-    *(.rodata .rodata.*)
-
-    *(.got)
-
+  .mod0 : {
     KEEP(crt0.nso.o(.data.mod0))
     KEEP(crt0.nro.o(.data.mod0))
     KEEP(crt0.lib.nro.o(.data.mod0))
-    KEEP(*(.data.mod0))
-
-    HIDDEN(__dynamic_start = .);
-    *(.dynamic)
-
-    . = ALIGN(0x1000);
-    HIDDEN(__rodata_end = .);
-    HIDDEN(__rodata_size = . - __rodata_start);
   }
 
+  .dynsym            : { *(.dynsym) } :rodata
+  .dynstr            : { *(.dynstr) } :rodata
+  .rela.dyn          : { *(.rela.*) } :rodata
+
+  HIDDEN(__rodata_end = .);
+  HIDDEN(__rodata_size = . - __rodata_start);
+
   /* Read-write sections */
+  . = ALIGN(0x1000);
 
   .data : {
     HIDDEN(__data_start = .);
 
     *(.data .data.*)
+    *(.got .got.*)
+    *(.got.plt .got.plt.*)
 
     HIDDEN(__data_end = .);
     HIDDEN(__data_size = . - __data_start);
+  } :data
+
+  .dynamic : {
+    HIDDEN(__dynamic_start = .);
+    *(.dynamic)
   }
 
   /* BSS section */
-
+  . = ALIGN(0x1000);
   .bss : {
     HIDDEN(__bss_start = .);
 
     *(.bss .bss.*)
     *(COMMON)
+    . = ALIGN(8);
 
     HIDDEN(__bss_end = .);
     HIDDEN(__bss_size = . - __bss_start);
-  }
+  } : bss
 
   /DISCARD/ :
   {
     *(.eh_frame) /* This is probably unnecessary and bloats the binary. */
+    *(.eh_frame_hdr)
   }
 }

--- a/targets/nintendoswitch.s
+++ b/targets/nintendoswitch.s
@@ -51,9 +51,8 @@ start:
     mov  x5, x0
     mov  x4, x1
 
-    // Save lr, context pointer, main thread handler
-    adrp x0, _aslr_base
-    str  x6, [x0, #:lo12:_aslr_base]
+    // Save ASLR Base to use later
+    mov x0, x6
 
     // clear .bss
     adrp x5, __bss_start
@@ -70,26 +69,10 @@ bssloop:
 
 run:
     // process .dynamic section
-    adrp x0, _aslr_base
-    ldr  x0, [x0, #:lo12:_aslr_base]
+    // ASLR base on x0
     adrp x1, _DYNAMIC
     add  x1, x1, #:lo12:_DYNAMIC
     bl   __dynamic_loader
 
-    // set LR to svcExitProcess if it's null
-    adrp x3, exit
-    add x3, x3, #:lo12:exit
-    cmp x30, xzr
-    csel x30, x3, x30, eq
-
     // call entrypoint
-    mov x3, sp
-    sub sp, sp, 0x10
-    stp x29, x30, [sp]
     b    main
-
-.section .data.horizon
-.align 8
-.global _aslr_base // Placeholder for ASLR Base Address
-_aslr_base:
-    .dword 0


### PR DESCRIPTION
Since Nintendo Switch has mandatory [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization) it is required to build executables as PIE. That means some sections might be re-alocated by the application loader.

This patch adds a dynamic loader function for AArch64 elf that patches the entries with a provided image base. In case of Nintendo Switch that image base is loaded early before getting into preinit to be sure that nothing that requires a dynamic portion is called.

That also adds a maximum of 4095 bytes pad into romExtract function, because since Nintendo Switch OS requires a page-aligned   section, it might have up to 4095 bytes of difference between sections.

I also added a dummy `write` call to allow `fmt.printf` statements to be used. This is a easy way to test the dynamic loading since  the embedded `println` is inlined in the code not requiring any dynamic section.

That makes work both with internal .nro file generation and external generation by a elf file.

With that, a bit more complex program runs without any error in the emulator:

```go
package main

import (
    "fmt"
    "time"
)

func main() {
    println("Hello world!")

    if true {
        fmt.Printf("Number %d - String %s\n", 1234, "Test")
    }

    println("HUEBR\n")
    i := 0
    for i < 10 {
       fmt.Printf("Cycle %d\n", i)
       time.Sleep(time.Second)
       i++
    }
    panic("FINISH")
}
```

![image](https://user-images.githubusercontent.com/578310/93032411-e8d99900-f607-11ea-9171-59fa9bea4412.png)
