### PR TITLE
microbit: reelboard: flash using OpenOCD when needed

### DIFF
--- a/targets/microbit-s110v8.json
+++ b/targets/microbit-s110v8.json
@@ -1,3 +1,4 @@
 {
-	"inherits": ["microbit", "nrf51-s110v8"]
+	"inherits": ["microbit", "nrf51-s110v8"],
+	"flash-method": "openocd"
 }

--- a/targets/reelboard-s140v7.json
+++ b/targets/reelboard-s140v7.json
@@ -1,3 +1,4 @@
 {
-	"inherits": ["reelboard", "nrf52840-s140v7"]
+	"inherits": ["reelboard", "nrf52840-s140v7"],
+	"flash-method": "openocd"
 }


### PR DESCRIPTION
When using a SoftDevice, the MSD flash method is not appropriate as it
will erase the entire flash area before writing the new firmware. This
also wipes the SoftDevice. Instead, use OpenOCD to only rewrite the
parts of flash that need to be rewritten and leave the SoftDevice alone.