### PR TITLE
atsamd5x, atsamd2x: fix BAUD value

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1188,7 +1188,10 @@ func (spi SPI) Configure(config SPIConfig) error {
 	}
 
 	// Set synch speed for SPI
-	baudRate := (CPUFrequency() / (2 * config.Frequency)) - 1
+	baudRate := CPUFrequency() / (2 * config.Frequency)
+	if baudRate > 0 {
+		baudRate--
+	}
 	spi.Bus.BAUD.Set(uint8(baudRate))
 
 	// Enable SPI port.

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1417,6 +1417,9 @@ func (spi SPI) Configure(config SPIConfig) error {
 
 	// Set synch speed for SPI
 	baudRate := SERCOM_FREQ_REF / (2 * config.Frequency)
+	if baudRate > 0 {
+		baudRate--
+	}
 	spi.Bus.BAUD.Set(uint8(baudRate))
 
 	// Enable SPI port.


### PR DESCRIPTION
In the case of atsamd5x, the BAUD calculation was wrong.
Therefore, with Freq = 24MHz, it runs at 12MHz.

In the case of atsamd2x, BAUD calculations were underflowing when Freq > 24MHz.
If you underflow the BAUD calculation, the frequency will be 94 kHz, but maybe it should work at maximum speed.

samd21 underflow:
![image](https://user-images.githubusercontent.com/9251039/93331374-12d6c980-f85b-11ea-9b15-941a0ec6d2e3.png)
