### PR TITLE
runtime: fix UTF-8 decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ tinygo-test:
 	$(TINYGO) test container/list
 	$(TINYGO) test container/ring
 	$(TINYGO) test text/scanner
+	$(TINYGO) test unicode/utf8
 
 .PHONY: smoketest
 smoketest:

--- a/src/runtime/strings_go111.go
+++ b/src/runtime/strings_go111.go
@@ -4,11 +4,17 @@ package runtime
 
 import "internal/bytealg"
 
-// indexByte provides compatibility with Go 1.11.
+// The following functions provide compatibility with Go 1.11.
 // See the following:
 // https://github.com/tinygo-org/tinygo/issues/351
 // https://github.com/golang/go/commit/ad4a58e31501bce5de2aad90a620eaecdc1eecb8
+
 //go:linkname indexByte strings.IndexByte
 func indexByte(s string, c byte) int {
 	return bytealg.IndexByteString(s, c)
+}
+
+//go:linkname bytesEqual bytes.Equal
+func bytesEqual(a, b []byte) bool {
+	return bytealg.Equal(a, b)
 }


### PR DESCRIPTION
The algorithm now checks for invalid UTF-8 sequences, which is required by the Go spec.

This gets the tests of the unicode/utf8 package to pass (which also implicitly tests UTF-8 decoding of strings).