### PR TITLE
flash: add verify on openocd-flash

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -59,6 +59,7 @@ type TargetSpec struct {
 	OpenOCDTarget    string   `json:"openocd-target"`
 	OpenOCDTransport string   `json:"openocd-transport"`
 	OpenOCDCommands  []string `json:"openocd-commands"`
+	OpenOCDVerify    *bool    `json:"openocd-verify"` // enable verify when flashing with openocd
 	JLinkDevice      string   `json:"jlink-device"`
 	CodeModel        string   `json:"code-model"`
 	RelocationModel  string   `json:"relocation-model"`

--- a/main.go
+++ b/main.go
@@ -453,7 +453,11 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 			if err != nil {
 				return err
 			}
-			args = append(args, "-c", "program "+filepath.ToSlash(result.Binary)+" reset exit")
+			exit := " reset exit"
+			if config.Target.OpenOCDVerify != nil && *config.Target.OpenOCDVerify {
+				exit = " verify" + exit
+			}
+			args = append(args, "-c", "program "+filepath.ToSlash(result.Binary)+exit)
 			cmd := executeCommand(config.Options, "openocd", args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -6,5 +6,6 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",
-    "msd-firmware-name": "firmware.uf2"
+    "msd-firmware-name": "firmware.uf2",
+    "openocd-verify": true
 }


### PR DESCRIPTION
before : Sometimes bootloader mode is triggered after writing.
after : It's always working right.

https://github.com/tinygo-org/tinygo/issues/1320#issuecomment-694752172

I've tested it in the following environments.
To sum up, it looks like verifying is required in the case of samd5x.

| board | debugger | before | after |
|--------|-----------|-----|----|
| feather-m4 | cmsis-dap-v2 | ng | ok |
| feather-m4 | jlink edu mini | ng | ok |
| wioterminal | cmsis-dap-v2 | ng | ok |
| wioterminal | jlink edu mini | ng | ok |
| feather-nrf52840 | jlink edu mini | ok | ok |
| xiao | cmsis-dap-v2 | ok | ok |
| xiao | jlink edu mini | ok | ok |

