### PR TITLE
Implement time.NewTimer and time.NewTicker

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -64,6 +64,13 @@ func nanotime() int64 {
 	return ticksToNanoseconds(ticks())
 }
 
+// Go 1.11 compatibility.
+// See: https://github.com/golang/go/commit/ff51353c3887b9d83130d958fb503ff1f2291fde
+//go:linkname timeRuntimeNano time.runtimeNano
+func timeRuntimeNano() int64 {
+	return nanotime()
+}
+
 // timeOffset is how long the monotonic clock started after the Unix epoch. It
 // should be a positive integer under normal operation or zero when it has not
 // been set.

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"internal/task"
+	"runtime/interrupt"
 )
 
 const schedulerDebug = false
@@ -27,6 +28,7 @@ var (
 	runqueue           task.Queue
 	sleepQueue         *task.Task
 	sleepQueueBaseTime timeUnit
+	timerQueue         *timerNode
 )
 
 // Simple logging, for debugging.
@@ -112,6 +114,46 @@ func addSleepTask(t *task.Task, duration timeUnit) {
 	*q = t
 }
 
+// addTimer adds the given timer node to the timer queue. It must not be in the
+// queue already.
+// This function is very similar to addSleepTask but for timerQueue instead of
+// sleepQueue.
+func addTimer(tim *timerNode) {
+	mask := interrupt.Disable()
+
+	// Add to timer queue.
+	q := &timerQueue
+	for ; *q != nil; q = &(*q).next {
+		if tim.whenTicks() < (*q).whenTicks() {
+			// this will finish earlier than the next - insert here
+			break
+		}
+	}
+	tim.next = *q
+	*q = tim
+	interrupt.Restore(mask)
+}
+
+// removeTimer is the implementation of time.stopTimer. It removes a timer from
+// the timer queue, returning true if the timer is present in the timer queue.
+func removeTimer(tim *timer) bool {
+	removedTimer := false
+	mask := interrupt.Disable()
+	for t := &timerQueue; *t != nil; t = &(*t).next {
+		if (*t).timer == tim {
+			scheduleLog("removed timer")
+			*t = (*t).next
+			removedTimer = true
+			break
+		}
+	}
+	if !removedTimer {
+		scheduleLog("did not remove timer")
+	}
+	interrupt.Restore(mask)
+	return removedTimer
+}
+
 // Run the scheduler until all tasks have finished.
 func scheduler() {
 	// Main scheduler loop.
@@ -119,7 +161,7 @@ func scheduler() {
 	for !schedulerDone {
 		scheduleLog("")
 		scheduleLog("  schedule")
-		if sleepQueue != nil {
+		if sleepQueue != nil || timerQueue != nil {
 			now = ticks()
 		}
 
@@ -134,20 +176,43 @@ func scheduler() {
 			runqueue.Push(t)
 		}
 
+		// Check for expired timers to trigger.
+		if timerQueue != nil && now >= timerQueue.whenTicks() {
+			scheduleLog("--- timer awoke")
+			// Pop timer from queue.
+			tn := timerQueue
+			timerQueue = tn.next
+			tn.next = nil
+			// Run the callback stored in this timer node.
+			tn.callback(tn)
+		}
+
 		t := runqueue.Pop()
 		if t == nil {
-			if sleepQueue == nil {
+			if sleepQueue == nil && timerQueue == nil {
 				if asyncScheduler {
 					return
 				}
 				waitForEvents()
 				continue
 			}
-			timeLeft := timeUnit(sleepQueue.Data) - (now - sleepQueueBaseTime)
+			var timeLeft timeUnit
+			if sleepQueue != nil {
+				timeLeft = timeUnit(sleepQueue.Data) - (now - sleepQueueBaseTime)
+			}
+			if timerQueue != nil {
+				timeLeftForTimer := timerQueue.whenTicks() - now
+				if sleepQueue == nil || timeLeftForTimer < timeLeft {
+					timeLeft = timeLeftForTimer
+				}
+			}
 			if schedulerDebug {
-				println("  sleeping...", sleepQueue, uint(timeLeft))
+				println("--- sleeping...", uint(timeLeft))
 				for t := sleepQueue; t != nil; t = t.Next {
-					println("    task sleeping:", t, timeUnit(t.Data))
+					println("---   task sleeping:", t, timeUnit(t.Data))
+				}
+				for tim := timerQueue; tim != nil; tim = tim.next {
+					println("---   timer waiting:", tim, tim.whenTicks())
 				}
 			}
 			sleepTicks(timeLeft)

--- a/src/runtime/timer.go
+++ b/src/runtime/timer.go
@@ -1,0 +1,50 @@
+package runtime
+
+// timerNode is an element in a linked list of timers.
+type timerNode struct {
+	next     *timerNode
+	timer    *timer
+	callback func(*timerNode)
+}
+
+// whenTicks returns the (absolute) time when this timer should trigger next.
+func (t *timerNode) whenTicks() timeUnit {
+	return nanosecondsToTicks(t.timer.when)
+}
+
+// Defined in the time package, implemented here in the runtime.
+//go:linkname startTimer time.startTimer
+func startTimer(tim *timer) {
+	addTimer(&timerNode{
+		timer:    tim,
+		callback: timerCallback,
+	})
+	scheduleLog("adding timer")
+}
+
+// timerCallback is called when a timer expires. It makes sure to call the
+// callback in the time package and to re-add the timer to the queue if this is
+// a ticker (repeating timer).
+// This is intentionally used as a callback and not a direct call (even though a
+// direct call would be trivial), because otherwise a circular dependency
+// between scheduler, addTimer and timerQueue would form. Such a circular
+// dependency causes timerQueue not to get optimized away.
+// If timerQueue doesn't get optimized away, small programs (that don't call
+// time.NewTimer etc) would still pay the cost of these timers.
+func timerCallback(tn *timerNode) {
+	// Run timer function (implemented in the time package).
+	// The seq parameter to the f function is not used in the time
+	// package so is left zero.
+	tn.timer.f(tn.timer.arg, 0)
+
+	// If this is a periodic timer (a ticker), re-add it to the queue.
+	if tn.timer.period != 0 {
+		tn.timer.when += tn.timer.period
+		addTimer(tn)
+	}
+}
+
+//go:linkname stopTimer time.stopTimer
+func stopTimer(tim *timer) bool {
+	return removeTimer(tim)
+}

--- a/src/runtime/timer_go113.go
+++ b/src/runtime/timer_go113.go
@@ -1,0 +1,23 @@
+// +build !go1.14
+
+package runtime
+
+// Runtime timer, must be kept in sync with src/time/sleep.go of the Go stdlib.
+// The layout changed in Go 1.14, so this is only supported on Go 1.13 and
+// below.
+//
+// The fields used by the time package are:
+//   when:    time to wake up (in nanoseconds)
+//   period:  if not 0, a repeating time (of the given nanoseconds)
+//   f:       the function called when the timer expires
+//   arg:     parameter to f
+type timer struct {
+	tb uintptr
+	i  int
+
+	when   int64
+	period int64
+	f      func(interface{}, uintptr)
+	arg    interface{}
+	seq    uintptr
+}

--- a/src/runtime/timer_go114.go
+++ b/src/runtime/timer_go114.go
@@ -1,0 +1,23 @@
+// +build go1.14
+
+package runtime
+
+// Runtime timer, must be kept in sync with src/time/sleep.go of the Go stdlib.
+// The layout changed in Go 1.14, so this is only supported on Go 1.14 and
+// above.
+//
+// The fields used by the time package are:
+//   when:    time to wake up (in nanoseconds)
+//   period:  if not 0, a repeating time (of the given nanoseconds)
+//   f:       the function called when the timer expires
+//   arg:     parameter to f
+type timer struct {
+	pp       uintptr
+	when     int64
+	period   int64
+	f        func(interface{}, uintptr)
+	arg      interface{}
+	seq      uintptr
+	nextwhen int64
+	status   uint32
+}

--- a/testdata/coroutines.go
+++ b/testdata/coroutines.go
@@ -71,6 +71,42 @@ func main() {
 	startSimpleFunc(emptyFunc)
 
 	time.Sleep(2 * time.Millisecond)
+
+	// Test ticker.
+	ticker := time.NewTicker(time.Millisecond * 10)
+	println("waiting on ticker")
+	go func() {
+		time.Sleep(time.Millisecond * 5)
+		println(" - after 5ms")
+		time.Sleep(time.Millisecond * 10)
+		println(" - after 15ms")
+		time.Sleep(time.Millisecond * 10)
+		println(" - after 25ms")
+	}()
+	<-ticker.C
+	println("waited on ticker at 10ms")
+	<-ticker.C
+	println("waited on ticker at 20ms")
+	ticker.Stop()
+	time.Sleep(time.Millisecond * 20)
+	select {
+	case <-ticker.C:
+		println("fail: ticker should have stopped!")
+	default:
+		println("ticker was stopped (didn't send anything after 50ms)")
+	}
+
+	timer := time.NewTimer(time.Millisecond * 10)
+	println("waiting on timer")
+	go func() {
+		time.Sleep(time.Millisecond * 5)
+		println(" - after 5ms")
+		time.Sleep(time.Millisecond * 10)
+		println(" - after 15ms")
+	}()
+	<-timer.C
+	println("waited on timer at 10ms")
+	time.Sleep(time.Millisecond * 10)
 }
 
 func acquire(m *sync.Mutex) {

--- a/testdata/coroutines.txt
+++ b/testdata/coroutines.txt
@@ -20,3 +20,14 @@ acquired mutex from goroutine
 released mutex from goroutine
 re-acquired mutex
 done
+waiting on ticker
+ - after 5ms
+waited on ticker at 10ms
+ - after 15ms
+waited on ticker at 20ms
+ - after 25ms
+ticker was stopped (didn't send anything after 50ms)
+waiting on timer
+ - after 5ms
+waited on timer at 10ms
+ - after 15ms


### PR DESCRIPTION
This has been requested before in #1037 and it is necessary for using the stdlib testing package. I have compared the code size before and after and except for very nontrivial cases the code size is the same (even with the scheduler additions). All examples in the drivers repo remain the same.