### PR TITLE
runtime: implement debug.ReadGCStats

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -160,6 +160,7 @@ func runTest(path, target string, t *testing.T) {
 		Debug:      true,
 		PrintSizes: "",
 		WasmAbi:    "js",
+		Tags:       "gc.debugmetric",
 	}
 	binary := filepath.Join(tmpdir, "test")
 	err = runBuild("./"+path, binary, config)

--- a/src/runtime/debug/garbage.go
+++ b/src/runtime/debug/garbage.go
@@ -1,0 +1,16 @@
+package debug
+
+import "time"
+
+type GCStats struct {
+	PauseTotal time.Duration
+	NumGC      int64
+}
+
+func ReadGCStats(stats *GCStats) {
+	data := [2]int64{}
+	readGCStats(&data)
+
+	stats.NumGC = data[0]
+	stats.PauseTotal = time.Duration(data[1])
+}

--- a/src/runtime/debug/stubs.go
+++ b/src/runtime/debug/stubs.go
@@ -1,0 +1,4 @@
+package debug
+
+// defined in the runtime package
+func readGCStats(*[2]int64)

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -293,6 +293,11 @@ func GC() {
 		println("running collection cycle...")
 	}
 
+	if gcDebugMetric {
+		gcDebugIncrementNumGC()
+		gcDebugGCPauseStart()
+	}
+
 	// Mark phase: mark all reachable objects, recursively.
 	markStack()
 	markGlobals()
@@ -335,6 +340,10 @@ func GC() {
 	// Show how much has been sweeped, for debugging.
 	if gcDebug {
 		dumpHeap()
+	}
+
+	if gcDebugMetric {
+		gcDebugGCPauseEnd()
 	}
 }
 

--- a/src/runtime/gc_extalloc.go
+++ b/src/runtime/gc_extalloc.go
@@ -429,6 +429,12 @@ func GC() {
 	if gcDebug {
 		println("running GC")
 	}
+
+	if gcDebugMetric {
+		gcDebugIncrementNumGC()
+		gcDebugGCPauseStart()
+	}
+
 	if allocations.empty() {
 		// Skip collection because the heap is empty.
 		if gcDebug {
@@ -513,6 +519,10 @@ runqueueScan:
 
 	if gcAsserts {
 		gcrunning = false
+	}
+
+	if gcDebugMetric {
+		gcDebugGCPauseEnd()
 	}
 }
 

--- a/src/runtime/gc_metric.go
+++ b/src/runtime/gc_metric.go
@@ -1,0 +1,18 @@
+// +build !gc.debugmetric
+
+package runtime
+
+const (
+	gcDebugMetric = false
+)
+
+func gcDebugIncrementNumGC() {}
+
+func gcDebugGCPauseStart() {}
+
+func gcDebugGCPauseEnd() {}
+
+//go:linkname readGCStats runtime/debug.readGCStats
+func readGCStats(data *[2]int64) {
+	panic("unimplemented: debug.readGCStats is only available with 'gc.debugmetric' build tag")
+}

--- a/src/runtime/gc_metric_debug.go
+++ b/src/runtime/gc_metric_debug.go
@@ -1,0 +1,38 @@
+// +build gc.debugmetric
+
+package runtime
+
+const (
+	gcDebugMetric = true
+)
+
+var (
+	numGC                 int64
+	pauseTotalNanoseconds int64
+	start                 int64
+)
+
+func gcDebugIncrementNumGC() {
+	numGC++
+}
+
+func gcDebugGCPauseStart() {
+	procPin()
+	start = int64(ticks())
+	procUnpin()
+}
+
+func gcDebugGCPauseEnd() {
+	procPin()
+	pauseTotalNanoseconds += int64(ticks()) - start
+	start = 0
+	procUnpin()
+}
+
+//go:linkname readGCStats runtime/debug.readGCStats
+func readGCStats(data *[2]int64) {
+	procPin()
+	data[0] = numGC
+	data[1] = pauseTotalNanoseconds
+	procUnpin()
+}

--- a/testdata/gcstats.go
+++ b/testdata/gcstats.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+func main() {
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+	}
+
+	s := &debug.GCStats{}
+	debug.ReadGCStats(s)
+
+	if s.NumGC < 100 {
+		println(s.NumGC)
+		panic("NumGC must be greater than or equal to 100")
+	}
+}


### PR DESCRIPTION
this PR adds the minimum implementation of `runtime/debug` package by introducing `gc.debugmetric` tag, which is disabled by default.

This is especially useful for us in proxy-wasm/Envoyproxy community to see the GC impacts on the performance, and I also hope this would help us (including TinyGo community) explore new GC implementations tailored for specific applications like proxy-wasm.
___

resolves #1400 
