### PR TITLE
unix: support command line arguments

### DIFF
--- a/interp/scan.go
+++ b/interp/scan.go
@@ -60,6 +60,10 @@ func (e *evalPackage) hasSideEffects(fn llvm.Value) (*sideEffectResult, *Error) 
 		return &sideEffectResult{severity: sideEffectNone}, nil
 	case name == "runtime.trackPointer":
 		return &sideEffectResult{severity: sideEffectNone}, nil
+	case name == "os.runtime_args":
+		// Special-casing this one because the (only) global it accesses changes
+		// before runtime.initAll is called.
+		return &sideEffectResult{severity: sideEffectLimited}, nil
 	case name == "llvm.dbg.value":
 		return &sideEffectResult{severity: sideEffectNone}, nil
 	case name == "(*sync/atomic.Value).Load" || name == "(*sync/atomic.Value).Store":

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -27,6 +27,9 @@ func GOROOT() string {
 // TODO: fill with real args.
 var args = []string{"/proc/self/exe"}
 
+// This function is called from the os package. It is special-cased by the
+// interp package to not run at init time, otherwise it would find the
+// uninitialized args slice.
 //go:linkname os_runtime_args os.runtime_args
 func os_runtime_args() []string {
 	return args

--- a/testdata/environment.go
+++ b/testdata/environment.go
@@ -1,0 +1,10 @@
+package main
+
+import "os"
+
+func main() {
+	println("args:", len(os.Args))
+	for _, arg := range os.Args {
+		println("arg:", arg)
+	}
+}


### PR DESCRIPTION
This has been a long requested feature.

fixes #456 and #541 

example usage:

```go
package main

import "os"

func main() {
	println("num args:", len(os.Args))
	for _, arg := range os.Args {
		println("arg:", arg)
	}
}
```

```
$ tinygo build -o args ./args.go
$ ./args hello world
num args: 3
arg: ./args
arg: hello
arg: world
```