### PR TITLE
testing: implement dummy Helper method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,10 @@ test: wasi-libc
 # implied -v flag).
 .PHONY: tinygo-test
 tinygo-test:
+	$(TINYGO) test container/heap
 	$(TINYGO) test container/list
 	$(TINYGO) test container/ring
+	$(TINYGO) test encoding/ascii85
 	$(TINYGO) test math
 	$(TINYGO) test text/scanner
 	$(TINYGO) test unicode/utf8

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -42,7 +42,7 @@ type TB interface {
 	SkipNow()
 	Skipf(format string, args ...interface{})
 	Skipped() bool
-	// Helper()
+	Helper()
 }
 
 var _ TB = (*T)(nil)
@@ -152,6 +152,11 @@ func (c *common) skip() {
 // Skipped reports whether the test was skipped.
 func (c *common) Skipped() bool {
 	return c.skipped
+}
+
+// Helper is not implemented, it is only provided for compatibility.
+func (c *common) Helper() {
+	// Unimplemented.
 }
 
 // InternalTest is a reference to a test that should be called during a test suite run.


### PR DESCRIPTION
This lets a few more packages pass tests: container/heap and encoding/ascii85.

---

After putting a lot of work in getting the standard library test package to work, I'm not sure whether that's the way forward. It consumes a lot RAM, which is often limited on microcontrollers (for example, it appears to run each test in a separate goroutine). And ideally we'd run tests directly on microcontrollers too. That's why I now plan to improve the testing package so that it is more compatible with the upstream testing package and get more packages to pass tests that way.