### PR TITLE
testing: implement some benchmark stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,9 @@ tinygo-test:
 	$(TINYGO) test container/heap
 	$(TINYGO) test container/list
 	$(TINYGO) test container/ring
+	$(TINYGO) test crypto/des
 	$(TINYGO) test encoding/ascii85
+	$(TINYGO) test encoding/hex
 	$(TINYGO) test math
 	$(TINYGO) test text/scanner
 	$(TINYGO) test unicode/utf8

--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -20,3 +20,15 @@ type InternalBenchmark struct {
 	Name string
 	F    func(b *B)
 }
+
+func (b *B) SetBytes(n int64) {
+	panic("testing: unimplemented: B.SetBytes")
+}
+
+func (b *B) ResetTimer() {
+	panic("testing: unimplemented: B.ResetTimer")
+}
+
+func (b *B) Run(name string, f func(b *B)) bool {
+	panic("testing: unimplemented: B.Run")
+}


### PR DESCRIPTION
This allows the following packages to pass tests:

  * crypto/des
  * ~crypto/rc4~
  * encoding/hex

... which are two outdated ciphers and one potentially useful package. Still, it's a good thing to get as many packages to pass tests, if nothing else it helps to catch regressions in the compiler.