### PR TITLE
arm64: Add support for system calls (SVC)

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1336,12 +1336,14 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.createMemoryCopyCall(fn, instr.Args)
 		case name == "runtime.memzero":
 			return b.createMemoryZeroCall(instr.Args)
-		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
+		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/arm64.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
 			return b.createInlineAsm(instr.Args)
-		case name == "device.AsmFull" || name == "device/arm.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull":
+		case name == "device.AsmFull" || name == "device/arm.AsmFull" || name == "device/arm64.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull":
 			return b.createInlineAsmFull(instr)
 		case strings.HasPrefix(name, "device/arm.SVCall"):
 			return b.emitSVCall(instr.Args)
+		case strings.HasPrefix(name, "device/arm64.SVCall"):
+			return b.emitSV64Call(instr.Args)
 		case strings.HasPrefix(name, "(device/riscv.CSR)."):
 			return b.emitCSROperation(instr)
 		case strings.HasPrefix(name, "syscall.Syscall"):

--- a/src/device/arm64/arm64.go
+++ b/src/device/arm64/arm64.go
@@ -1,0 +1,36 @@
+package arm64
+
+// Run the given assembly code. The code will be marked as having side effects,
+// as it doesn't produce output and thus would normally be eliminated by the
+// optimizer.
+func Asm(asm string)
+
+// Run the given inline assembly. The code will be marked as having side
+// effects, as it would otherwise be optimized away. The inline assembly string
+// recognizes template values in the form {name}, like so:
+//
+//     arm.AsmFull(
+//         "str {value}, {result}",
+//         map[string]interface{}{
+//             "value":  1
+//             "result": &dest,
+//         })
+//
+// You can use {} in the asm string (which expands to a register) to set the
+// return value.
+func AsmFull(asm string, regs map[string]interface{}) uintptr
+
+// Run the following system call (SVCall) with 0 arguments.
+func SVCall0(num uintptr) uintptr
+
+// Run the following system call (SVCall) with 1 argument.
+func SVCall1(num uintptr, a1 interface{}) uintptr
+
+// Run the following system call (SVCall) with 2 arguments.
+func SVCall2(num uintptr, a1, a2 interface{}) uintptr
+
+// Run the following system call (SVCall) with 3 arguments.
+func SVCall3(num uintptr, a1, a2, a3 interface{}) uintptr
+
+// Run the following system call (SVCall) with 4 arguments.
+func SVCall4(num uintptr, a1, a2, a3, a4 interface{}) uintptr


### PR DESCRIPTION
Since ARM64 (AArch64) uses `X` instead `R` on registers, this change is required to `SVCall` to work.

I also added other registers to clobbered registers by the AArch64 calling convention.