### PR TITLE
add wasm-abi field in TargetSpec && set generic for WASI by default

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -79,10 +79,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// keep functions interoperable, pass int64 types as pointers to
 	// stack-allocated values.
 	// Use -wasm-abi=generic to disable this behaviour.
-	if config.Options.WasmAbi != "" {
-		config.Target.WasmAbi = config.Options.WasmAbi
-	}
-	if config.Target.WasmAbi == "js" {
+	if config.WasmAbi() == "js" {
 		err := transform.ExternalInt64AsPtr(mod)
 		if err != nil {
 			return err

--- a/builder/build.go
+++ b/builder/build.go
@@ -79,7 +79,10 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// keep functions interoperable, pass int64 types as pointers to
 	// stack-allocated values.
 	// Use -wasm-abi=generic to disable this behaviour.
-	if config.Options.WasmAbi == "js" && strings.HasPrefix(config.Triple(), "wasm") {
+	if config.Options.WasmAbi != "" {
+		config.Target.WasmAbi = config.Options.WasmAbi
+	}
+	if config.Target.WasmAbi == "js" {
 		err := transform.ExternalInt64AsPtr(mod)
 		if err != nil {
 			return err

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -329,6 +329,15 @@ func (c *Config) RelocationModel() string {
 	return "static"
 }
 
+// WasmAbi returns the WASM ABI which is specified in the target JSON file, and
+// the value is overridden by `-wasm-abi` flag if it is provided
+func (c *Config) WasmAbi() string {
+	if c.Options.WasmAbi != "" {
+		return c.Options.WasmAbi
+	}
+	return c.Target.WasmAbi
+}
+
 type TestConfig struct {
 	CompileTestBinary bool
 	// TODO: Filter the test functions to run, include verbose flag, etc

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -55,7 +55,7 @@ type TargetSpec struct {
 	JLinkDevice      string   `json:"jlink-device"`
 	CodeModel        string   `json:"code-model"`
 	RelocationModel  string   `json:"relocation-model"`
-	WasmAbi          string   `json:"wasm_abi"`
+	WasmAbi          string   `json:"wasm-abi"`
 }
 
 // overrideProperties overrides all properties that are set in child into itself using reflection.

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -55,6 +55,7 @@ type TargetSpec struct {
 	JLinkDevice      string   `json:"jlink-device"`
 	CodeModel        string   `json:"code-model"`
 	RelocationModel  string   `json:"relocation-model"`
+	WasmAbi          string   `json:"wasm_abi"`
 }
 
 // overrideProperties overrides all properties that are set in child into itself using reflection.

--- a/main.go
+++ b/main.go
@@ -816,7 +816,7 @@ func main() {
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	cFlags := flag.String("cflags", "", "additional cflags for compiler")
 	ldFlags := flag.String("ldflags", "", "additional ldflags for linker")
-	wasmAbi := flag.String("wasm-abi", "js", "WebAssembly ABI conventions: js (no i64 params) or generic")
+	wasmAbi := flag.String("wasm-abi", "", "WebAssembly ABI conventions: js (no i64 params) or generic")
 	heapSize := flag.String("heap-size", "1M", "default heap size in bytes (only supported by WebAssembly)")
 
 	var flagJSON, flagDeps *bool

--- a/main_test.go
+++ b/main_test.go
@@ -162,11 +162,7 @@ func runTest(path, target string, t *testing.T) {
 		VerifyIR:   true,
 		Debug:      true,
 		PrintSizes: "",
-		WasmAbi:    "js",
-	}
-
-	if target == "wasi" {
-		config.WasmAbi = "generic"
+		WasmAbi:    "",
 	}
 
 	binary := filepath.Join(tmpdir, "test")

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -19,5 +19,5 @@
 		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
 	],
 	"emulator":      ["wasmtime"],
-	"wasm_abi":      "generic"
+	"wasm-abi":      "generic"
 }

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -18,5 +18,6 @@
 		"--no-demangle",
 		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
 	],
-	"emulator":      ["wasmtime"]
+	"emulator":      ["wasmtime"],
+	"wasm_abi":      "generic"
 }

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -17,5 +17,6 @@
 		"--no-demangle",
 		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
 	],
-	"emulator":      ["node", "targets/wasm_exec.js"]
+	"emulator":      ["node", "targets/wasm_exec.js"],
+	"wasm_abi":      "js"
 }

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -18,5 +18,5 @@
 		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"],
-	"wasm_abi":      "js"
+	"wasm-abi":      "js"
 }


### PR DESCRIPTION
- add `wasm-abi` field in TargetSpec (defaults to the empty string)
- change default value of `-wasm-abi` flag from `js` to the empty string
- override `wasm-abi` value by `-wasm-abi` when the flag is set to non-empty string
- set `wasm-abi` field values for `wasm.json` and `wasi.json`
    - `js` for wasm.json
    - `generic` for wasi.json