### PR TITLE
wasm: use the fixed length buffer for putchar

### DIFF
--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -34,16 +34,10 @@ var (
 )
 
 func putchar(c byte) {
-	if putcharPosition >= putcharBufferSize {
-		putcharIOVec.bufLen = putcharPosition
-		fd_write(stdout, &putcharIOVec, 1, &putcharNWritten)
-		putcharPosition = 0
-	}
-
 	putcharBuffer[putcharPosition] = c
 	putcharPosition++
 
-	if c == '\n' {
+	if c == '\n' || putcharPosition >= putcharBufferSize {
 		putcharIOVec.bufLen = putcharPosition
 		fd_write(stdout, &putcharIOVec, 1, &putcharNWritten)
 		putcharPosition = 0


### PR DESCRIPTION
this PR follows the Nintendo Switch's implementation of puchar for WASM/WASI target