### PR TITLE
wasm: allow users to provide custom sections

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -86,6 +86,10 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		}
 	}
 
+	if len(config.Options.WasmCustomSections) > 0 {
+		transform.AddWASMCustomSections(mod, config.Options.WasmCustomSections)
+	}
+
 	// Optimization levels here are roughly the same as Clang, but probably not
 	// exactly.
 	errs = nil

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -15,24 +15,25 @@ var (
 // Options contains extra options to give to the compiler. These options are
 // usually passed from the command line.
 type Options struct {
-	Target        string
-	Opt           string
-	GC            string
-	PanicStrategy string
-	Scheduler     string
-	PrintIR       bool
-	DumpSSA       bool
-	VerifyIR      bool
-	Debug         bool
-	PrintSizes    string
-	PrintStacks   bool
-	CFlags        []string
-	LDFlags       []string
-	Tags          string
-	WasmAbi       string
-	HeapSize      int64
-	TestConfig    TestConfig
-	Programmer    string
+	Target             string
+	Opt                string
+	GC                 string
+	PanicStrategy      string
+	Scheduler          string
+	PrintIR            bool
+	DumpSSA            bool
+	VerifyIR           bool
+	Debug              bool
+	PrintSizes         string
+	PrintStacks        bool
+	CFlags             []string
+	LDFlags            []string
+	Tags               string
+	WasmAbi            string
+	WasmCustomSections [][2]string
+	HeapSize           int64
+	TestConfig         TestConfig
+	Programmer         string
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
+github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
 github.com/chromedp/cdproto v0.0.0-20200709115526-d1f6fc58448b h1:LF+GRwyzxrO3MUzPvejv+yBup0lNG+/QdIRrkxOPseA=
 github.com/chromedp/cdproto v0.0.0-20200709115526-d1f6fc58448b/go.mod h1:E6LPWRdIJc11h/di5p0rwvRmUYbhGpBEH7ZbPfzDIOE=
+github.com/chromedp/chromedp v0.5.4-0.20200303084119-2bb39134ab9e/go.mod h1:vmQMRHFZrY3T+Jv51T0n87OK/i6bK+5P9a+Fg5jPwgQ=
 github.com/creack/goselect v0.1.1 h1:tiSSgKE1eJtxs1h/VgGQWuXUP0YS4CDIFMp6vaI1ls0=
 github.com/creack/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,6 +17,7 @@ github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf h1:7+FW5aGwISbqUtkfmI
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/knq/sysutil v0.0.0-20191005231841-15668db23d08 h1:V0an7KRw92wmJysvFvtqtKMAPmvS5O0jtB0nYo6t+gs=
 github.com/knq/sysutil v0.0.0-20191005231841-15668db23d08/go.mod h1:dFWs1zEqDjFtnBXsd1vPOZaLsESovai349994nHx3e0=
+github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892 h1:6J+qramlHVLmiBOgRiBOnQkno8uprqG6YFFQTt6uYIw=

--- a/main.go
+++ b/main.go
@@ -829,6 +829,8 @@ func main() {
 	cFlags := flag.String("cflags", "", "additional cflags for compiler")
 	ldFlags := flag.String("ldflags", "", "additional ldflags for linker")
 	wasmAbi := flag.String("wasm-abi", "", "WebAssembly ABI conventions: js (no i64 params) or generic")
+	wasmCustomSections := flag.String("wasm-custom-sections", "",
+		"space separated additional WebAssembly custom sections: Example) \"name1:content name2:content\"")
 	heapSize := flag.String("heap-size", "1M", "default heap size in bytes (only supported by WebAssembly)")
 
 	var flagJSON, flagDeps *bool
@@ -881,6 +883,22 @@ func main() {
 
 	if *ldFlags != "" {
 		options.LDFlags = strings.Split(*ldFlags, " ")
+	}
+
+	if *wasmCustomSections != "" {
+		secs := strings.Split(*wasmCustomSections, " ")
+		options.WasmCustomSections = make([][2]string, len(secs))
+		for i, sec := range strings.Split(*wasmCustomSections, " ") {
+			s := strings.Split(sec, ":")
+			if len(s) != 2 {
+				fmt.Fprintln(os.Stderr, "Given WASM custom sections are malformed. "+
+					"Sections must be space separated, and each section must be in the form of 'name:content': ",
+					*wasmCustomSections)
+				usage()
+				os.Exit(1)
+			}
+			options.WasmCustomSections[i] = [2]string{s[0], s[1]}
+		}
 	}
 
 	var err error

--- a/transform/testdata/wasm-custom-sections.ll
+++ b/transform/testdata/wasm-custom-sections.ll
@@ -1,0 +1,2 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown-wasm"

--- a/transform/testdata/wasm-custom-sections.out.ll
+++ b/transform/testdata/wasm-custom-sections.out.ll
@@ -1,0 +1,8 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown-wasm"
+
+!wasm.custom_sections = !{!0, !1, !2}
+
+!0 = !{!"red", !"foo"}
+!1 = !{!"green", !"bar"}
+!2 = !{!"green", !"qux"}

--- a/transform/wasm-custom-sections.go
+++ b/transform/wasm-custom-sections.go
@@ -1,0 +1,14 @@
+package transform
+
+import "tinygo.org/x/go-llvm"
+
+func AddWASMCustomSections(mod llvm.Module, sections [][2]string) {
+	for _, sec := range sections {
+		mod.AddNamedMetadataOperand("wasm.custom_sections",
+			mod.Context().MDNode([]llvm.Metadata{
+				llvm.GlobalContext().MDString(sec[0]),
+				llvm.GlobalContext().MDString(sec[1]),
+			}),
+		)
+	}
+}

--- a/transform/wasm-custom-sections_test.go
+++ b/transform/wasm-custom-sections_test.go
@@ -1,0 +1,18 @@
+package transform
+
+import (
+	"testing"
+
+	"tinygo.org/x/go-llvm"
+)
+
+func TestAddWasmCustomSections(t *testing.T) {
+	t.Parallel()
+	testTransform(t, "testdata/wasm-custom-sections", func(mod llvm.Module) {
+		AddWASMCustomSections(mod, [][2]string{
+			{"red", "foo"},
+			{"green", "bar"},
+			{"green", "qux"},
+		})
+	})
+}


### PR DESCRIPTION
This PR adds `wasm-custom-sections` flag for specifying WASM custom sections. Ref: https://reviews.llvm.org/D43097