### PR TITLE
Add instanceof support for WebAssembly

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -407,9 +407,9 @@
 					},
 
 					// func valueInstanceOf(v ref, t ref) bool
-					//"syscall/js.valueInstanceOf": (sp) => {
-					//	mem().setUint8(sp + 24, loadValue(sp + 8) instanceof loadValue(sp + 16));
-					//},
+					"syscall/js.valueInstanceOf": (v_addr, t_addr) => {
+ 						return loadValue(v_attr) instanceof loadValue(t_addr);
+					},
 
 					// func copyBytesToGo(dst []byte, src ref) (int, bool)
 					"syscall/js.copyBytesToGo": (ret_addr, dest_addr, dest_len, dest_cap, source_addr) => {


### PR DESCRIPTION
The `instanceOf` is commented out in the `wasm_exec.js`, but it can simply be implemented in this case.

I think using `sp` and `sp + 8` and return bool can work correctly, and also confirmed in my local machine.
