### PR TITLE
targets/wasi: remove --no-threads flag as no longer in LLVM 11 linker

### DIFF
--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -12,7 +12,6 @@
 	],
 	"ldflags": [
 		"--allow-undefined",
-		"--no-threads",
 		"--stack-first",
 		"--export-dynamic",
 		"--no-demangle",


### PR DESCRIPTION
This PR removes the `--no-threads` flag from the wasi.json target file, as that flag as no longer in the LLVM 11 linker.