### PR TITLE
all: add -output= flag for setting print/panic output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,10 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-nrf52840  examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=teensy36            examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/serial
+	@$(MD5SUM) test.nro
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex
@@ -379,8 +383,9 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=1     examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/serial
-	@$(MD5SUM) test.nro
+	$(TINYGO) build             -o test.wasm -target=wasm    -output=none examples/serial
+	$(TINYGO) build -size short -o test.hex -target=pca10040 -output=none examples/serial
+	@$(MD5SUM) test.hex
 
 wasmtest:
 	$(GO) test ./tests/wasm

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -79,7 +79,7 @@ func (c *Config) GOARCH() string {
 
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
-	tags := append(c.Target.BuildTags, []string{"tinygo", "gc." + c.GC(), "scheduler." + c.Scheduler()}...)
+	tags := append(c.Target.BuildTags, []string{"tinygo", "gc." + c.GC(), "scheduler." + c.Scheduler(), "output." + c.Output()}...)
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}
@@ -140,6 +140,18 @@ func (c *Config) Scheduler() string {
 	}
 	// Fall back to coroutines, which are supported everywhere.
 	return "coroutines"
+}
+
+// Output returns the selected output for logging from the runtime, such as for
+// println and panic.
+func (c *Config) Output() string {
+	if c.Options.Output != "" {
+		return c.Options.Output
+	}
+	if c.Target.Output != "" {
+		return c.Target.Output
+	}
+	return "uart"
 }
 
 // FuncImplementation picks an appropriate func value implementation for the

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -8,6 +8,7 @@ import (
 var (
 	validGCOptions            = []string{"none", "leaking", "extalloc", "conservative"}
 	validSchedulerOptions     = []string{"none", "tasks", "coroutines"}
+	validOutputOptions        = []string{"none", "native", "uart", "custom"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
 )
@@ -20,6 +21,7 @@ type Options struct {
 	GC            string
 	PanicStrategy string
 	Scheduler     string
+	Output        string
 	PrintIR       bool
 	DumpSSA       bool
 	VerifyIR      bool
@@ -52,6 +54,15 @@ func (o *Options) Verify() error {
 			return fmt.Errorf(`invalid scheduler option '%s': valid values are %s`,
 				o.Scheduler,
 				strings.Join(validSchedulerOptions, ", "))
+		}
+	}
+
+	if o.Output != "" {
+		valid := isInArray(validOutputOptions, o.Output)
+		if !valid {
+			return fmt.Errorf(`invalid output option '%s': valid values are %s`,
+				o.Output,
+				strings.Join(validOutputOptions, ", "))
 		}
 	}
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -30,6 +30,7 @@ type TargetSpec struct {
 	BuildTags        []string `json:"build-tags"`
 	GC               string   `json:"gc"`
 	Scheduler        string   `json:"scheduler"`
+	Output           string   `json:"output"` // output for println etc
 	Compiler         string   `json:"compiler"`
 	Linker           string   `json:"linker"`
 	RTLib            string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
@@ -236,6 +237,7 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		GOOS:      goos,
 		GOARCH:    goarch,
 		BuildTags: []string{goos, goarch},
+		Output:    "native",
 		Compiler:  "clang",
 		Linker:    "cc",
 		CFlags:    []string{"--target=" + triple},

--- a/main.go
+++ b/main.go
@@ -815,6 +815,7 @@ func main() {
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, extalloc, conservative)")
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, coroutines, tasks)")
+	output := flag.String("output", "", "which output to use for panic and print functions")
 	printIR := flag.Bool("printir", false, "print LLVM IR")
 	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
@@ -864,6 +865,7 @@ func main() {
 		GC:            *gc,
 		PanicStrategy: *panicStrategy,
 		Scheduler:     *scheduler,
+		Output:        *output,
 		PrintIR:       *printIR,
 		DumpSSA:       *dumpSSA,
 		VerifyIR:      *verifyIR,

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -115,6 +115,12 @@ type UART struct {
 	Buffer *RingBuffer
 }
 
+// UART
+var (
+	// UART0 is the hardware serial port on the AVR.
+	UART0 = UART{Buffer: NewRingBuffer()}
+)
+
 // Configure the UART on the AVR. Defaults to 9600 baud on Arduino.
 func (uart UART) Configure(config UARTConfig) {
 	if config.BaudRate == 0 {

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -2,23 +2,6 @@
 
 package machine
 
-// UART on the AVR is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-type UART struct {
-	Buffer *RingBuffer
-}
-
-// Configure is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-func (uart UART) Configure(config UARTConfig) {
-}
-
-// WriteByte is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-func (uart UART) WriteByte(c byte) error {
-	return nil
-}
-
 // Tx is a dummy implementation. I2C has not been implemented for ATtiny
 // devices.
 func (i2c I2C) Tx(addr uint16, w, r []byte) error {

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -148,9 +148,3 @@ type I2C struct {
 
 // I2C0 is the only I2C interface on most AVRs.
 var I2C0 = I2C{}
-
-// UART
-var (
-	// UART0 is the hardware serial port on the AVR.
-	UART0 = UART{Buffer: NewRingBuffer()}
-)

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -1,4 +1,4 @@
-// +build avr esp nrf sam sifive stm32 k210 nxp
+// +build atmega esp nrf sam sifive stm32 k210 nxp
 
 package machine
 

--- a/src/runtime/output_custom.go
+++ b/src/runtime/output_custom.go
@@ -1,0 +1,24 @@
+// +build output.custom
+
+package runtime
+
+// The "custom" output allows setting a custom function for putchar, for full
+// control over where output goes.
+
+var outputFunc func(c byte)
+
+func initOutput() {
+}
+
+func putchar(c byte) {
+	if outputFunc != nil {
+		outputFunc(c)
+	}
+}
+
+// SetOutput sets a custom function that may be used as an output. This may be
+// anything, for example it can be used to redirect output to ARM semihosting if
+// needed while debugging.
+func SetOutput(output func(byte)) {
+	outputFunc = output
+}

--- a/src/runtime/output_native.go
+++ b/src/runtime/output_native.go
@@ -1,0 +1,13 @@
+// +build output.native
+
+package runtime
+
+// The "native" output is useful on devices with a native stdout, usually real
+// operating systems (Linux, etc).
+
+func initOutput() {
+}
+
+func putchar(c byte) {
+	nativePutchar(c)
+}

--- a/src/runtime/output_none.go
+++ b/src/runtime/output_none.go
@@ -1,0 +1,13 @@
+// +build output.none
+
+package runtime
+
+// The "none" output drops all logging output (println, panic, ...). This may be
+// useful on targets that do not need output logging (for code size, battery
+// consumption, or other reasons) or do not have an output at all.
+
+func initOutput() {
+}
+
+func putchar(c byte) {
+}

--- a/src/runtime/output_uart.go
+++ b/src/runtime/output_uart.go
@@ -1,0 +1,16 @@
+// +build output.uart
+
+package runtime
+
+import "machine"
+
+// The "uart" output writes all output over a serial (UART) or USB-CDC
+// connection. Most, but not all, microcontrollers have an UART available.
+
+func initOutput() {
+	machine.UART0.Configure(machine.UARTConfig{})
+}
+
+func putchar(c byte) {
+	machine.UART0.WriteByte(c)
+}

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -9,10 +9,6 @@ import (
 
 type timeUnit int64
 
-func putchar(c byte) {
-	// dummy, TODO
-}
-
 //go:extern _sbss
 var _sbss [0]byte
 

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -5,7 +5,6 @@ package runtime
 import (
 	"device/arm"
 	"device/sam"
-	"machine"
 	"runtime/interrupt"
 	"runtime/volatile"
 	"unsafe"
@@ -29,12 +28,8 @@ func init() {
 	initUSBClock()
 	initADCClock()
 
-	// connect to USB CDC interface
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	// configure stdout (usually USB-CDC)
+	initOutput()
 }
 
 func initClocks() {

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -5,7 +5,6 @@ package runtime
 import (
 	"device/arm"
 	"device/sam"
-	"machine"
 	"runtime/interrupt"
 	"runtime/volatile"
 )
@@ -28,12 +27,8 @@ func init() {
 	initUSBClock()
 	initADCClock()
 
-	// connect to USB CDC interface
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	// configure stdout (usually USB-CDC)
+	initOutput()
 }
 
 func initClocks() {

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -4,7 +4,6 @@ package runtime
 
 import (
 	"device/avr"
-	"machine"
 	"unsafe"
 )
 
@@ -37,6 +36,7 @@ var _ebss [0]byte
 //export main
 func main() {
 	preinit()
+	initOutput()
 	run()
 	abort()
 }
@@ -53,18 +53,6 @@ func preinit() {
 func postinit() {
 	// Enable interrupts after initialization.
 	avr.Asm("sei")
-}
-
-func init() {
-	initUART()
-}
-
-func initUART() {
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
 }
 
 const asyncScheduler = false

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -49,7 +49,7 @@ func ticks() timeUnit {
 // UART0 output register.
 var stdoutWrite = (*volatile.Register8)(unsafe.Pointer(uintptr(0x4000c000)))
 
-func putchar(c byte) {
+func nativePutchar(c byte) {
 	stdoutWrite.Set(uint8(c))
 }
 

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -5,17 +5,12 @@ package runtime
 import (
 	"device"
 	"device/esp"
-	"machine"
 	"unsafe"
 )
 
 type timeUnit int64
 
 var currentTime timeUnit
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
-}
 
 func postinit() {}
 
@@ -52,8 +47,7 @@ func main() {
 	// faster.
 	preinit()
 
-	// Initialize UART.
-	machine.UART0.Configure(machine.UARTConfig{})
+	initOutput()
 
 	// Configure timer 0 in timer group 0, for timekeeping.
 	//   EN:       Enable the timer.

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -5,17 +5,12 @@ package runtime
 import (
 	"device"
 	"device/esp"
-	"machine"
 	"unsafe"
 )
 
 type timeUnit int64
 
 var currentTime timeUnit = 0
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
-}
 
 // Write to the internal control bus (using I2C?).
 // Signature found here:
@@ -37,7 +32,7 @@ func main() {
 	rom_i2c_writeReg(103, 4, 2, 145)
 
 	// Initialize UART.
-	machine.UART0.Configure(machine.UARTConfig{})
+	initOutput()
 
 	// Initialize timer. Bits:
 	//  ENABLE:   timer enable

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -6,7 +6,6 @@
 package runtime
 
 import (
-	"machine"
 	"unsafe"
 
 	"device/riscv"
@@ -93,11 +92,7 @@ func initPeripherals() {
 	sifive.RTC.RTCCFG.Set(sifive.RTC_RTCCFG_ENALWAYS)
 
 	// Configure the UART.
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	initOutput()
 }
 
 const asyncScheduler = false

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -8,7 +8,6 @@ package runtime
 import (
 	"device/kendryte"
 	"device/riscv"
-	"machine"
 	"runtime/volatile"
 	"unsafe"
 )
@@ -105,11 +104,7 @@ func initPeripherals() {
 	// Enable FPIOA peripheral.
 	kendryte.SYSCTL.CLK_EN_PERI.SetBits(kendryte.SYSCTL_CLK_EN_PERI_FPIOA_CLK_EN)
 
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	initOutput()
 }
 
 const asyncScheduler = false

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -58,7 +58,7 @@ func ticks() timeUnit {
 var stdoutBuffer = make([]byte, 120)
 var position = 0
 
-func putchar(c byte) {
+func nativePutchar(c byte) {
 	if c == '\n' || position >= len(stdoutBuffer) {
 		nxOutputString(&stdoutBuffer[0], uint64(position))
 		position = 0

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -25,7 +25,7 @@ func main() {
 }
 
 func init() {
-	machine.UART0.Configure(machine.UARTConfig{})
+	initOutput()
 	initLFCLK()
 	initRTC()
 }
@@ -49,10 +49,6 @@ func initRTC() {
 	})
 	intr.SetPriority(0xc0) // low priority
 	intr.Enable()
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
 }
 
 const asyncScheduler = false

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -56,6 +56,7 @@ func main() {
 	initSystem()
 	arm.Asm("CPSIE i")
 	initInternal()
+	initOutput()
 
 	run()
 	abort()
@@ -228,10 +229,6 @@ func initInternal() {
 }
 
 func postinit() {}
-
-func putchar(c byte) {
-	machine.PutcharUART(&machine.UART0, c)
-}
 
 // ???
 const asyncScheduler = false

--- a/src/runtime/runtime_stm32f103xx.go
+++ b/src/runtime/runtime_stm32f103xx.go
@@ -14,11 +14,7 @@ func init() {
 	initCLK()
 	initRTC()
 	initTIM()
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	initOutput()
 }
 
 // initCLK sets clock to 72MHz using HSE 8MHz crystal w/ PLL X 9 (8MHz x 9 = 72MHz).

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -5,16 +5,15 @@ package runtime
 import (
 	"device/arm"
 	"device/stm32"
-	"machine"
 	"runtime/interrupt"
 	"runtime/volatile"
 )
 
 func init() {
-	initOSC() // configure oscillators
-	initCLK() // configure CPU, AHB, and APB bus clocks
-	initTIM() // configure timers
-	initCOM() // configure serial comm interfaces
+	initOSC()    // configure oscillators
+	initCLK()    // configure CPU, AHB, and APB bus clocks
+	initTIM()    // configure timers
+	initOutput() // configure default output for println etc
 }
 
 const (
@@ -176,12 +175,6 @@ func initTIM() {
 	tim7.Enable()
 }
 
-func initCOM() {
-	if machine.NUM_UART_INTERFACES > 0 {
-		machine.UART0.Configure(machine.UARTConfig{})
-	}
-}
-
 var (
 	// tick in milliseconds
 	tickCount   timeUnit
@@ -241,8 +234,4 @@ func handleTIM7(interrupt.Interrupt) {
 		stm32.TIM7.SR.ClearBits(stm32.TIM_SR_UIF) // clear the update flag
 		tickCount++
 	}
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
 }

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -5,7 +5,6 @@ package runtime
 import (
 	"device/arm"
 	"device/stm32"
-	"machine"
 	"runtime/interrupt"
 	"runtime/volatile"
 )
@@ -13,12 +12,8 @@ import (
 func init() {
 	initCLK()
 	initTIM3()
-	machine.UART0.Configure(machine.UARTConfig{})
+	initOutput()
 	initTIM7()
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
 }
 
 const (

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -54,7 +54,7 @@ var (
 	testFinisher = (*volatile.Register16)(unsafe.Pointer(uintptr(0x100000)))
 )
 
-func putchar(c byte) {
+func nativePutchar(c byte) {
 	stdoutWrite.Set(uint8(c))
 }
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -62,7 +62,7 @@ func runMain() {
 	run()
 }
 
-func putchar(c byte) {
+func nativePutchar(c byte) {
 	_putchar(int(c))
 }
 

--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func putchar(c byte) {
+func nativePutchar(c byte) {
 	// write to stdout
 	const stdout = 1
 	var nwritten uint

--- a/targets/cortex-m-qemu.json
+++ b/targets/cortex-m-qemu.json
@@ -2,6 +2,7 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "armv7m-none-eabi",
 	"build-tags": ["qemu", "lm3s6965"],
+	"output": "native",
 	"cflags": [
 		"--target=armv7m-none-eabi",
 		"-Qunused-arguments"

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -2,6 +2,7 @@
 	"inherits": ["avr"],
 	"cpu": "attiny85",
 	"build-tags": ["digispark", "attiny85", "attiny", "avr2", "avr25"],
+	"output": "none",
 	"cflags": [
 		"-mmcu=attiny85"
 	],

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -4,6 +4,7 @@
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
+	"output": "none",
 	"compiler": "clang",
 	"linker": "ld.lld",
 	"rtlib": "compiler-rt",

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -3,6 +3,7 @@
   "build-tags": ["nintendoswitch", "arm64"],
   "goos": "linux",
   "goarch": "arm64",
+  "output": "native",
   "compiler": "clang",
   "linker": "ld.lld",
   "rtlib": "compiler-rt",

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -2,6 +2,7 @@
 	"inherits": ["riscv32"],
 	"features": ["+a", "+c", "+m"],
 	"build-tags": ["virt", "qemu"],
+	"output": "native",
 	"linkerscript": "targets/riscv-qemu.ld",
 	"emulator": ["qemu-system-riscv32", "-machine", "virt", "-nographic", "-bios", "none", "-kernel"]
 }

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -1,6 +1,7 @@
 {
 	"llvm-target":   "wasm32--wasi",
 	"build-tags":    ["wasm", "wasi"],
+	"output":        "native",
 	"goos":          "linux",
 	"goarch":        "arm",
 	"compiler":      "clang",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -3,6 +3,7 @@
 	"build-tags":    ["js", "wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
+	"output":        "native",
 	"compiler":      "clang",
 	"linker":        "wasm-ld",
 	"cflags": [


### PR DESCRIPTION
This flag allows setting the standard output to a few different values:

*   `-output=none`:   do not produce output. This is useful for some systems that lack a native output (e.g. Digispark) or for WebAssembly where the additional wasi output dependency may be a problem.
*   `-output=native`: use native output for the target, for example stdout on an OS or the native output of QEMU under emulation.
* `-output=uart`:   use UART output, the default for most microcontrollers.
*  `-output=custom`: allow setting a custom output with runtime.SetOutput. This provides flexibility for those who need it.

It is quite an invasive change, and it might break things. I have not tested this extensively.

In particular, this includes a change to the Teensy 3.6 to be more like other targets. It now configures the UART at startup and thus no longer needs to configure it on demand when needed. It also doesn't call `runtime.Gosched()` from the machine package anymore, greatly simplifying the code (this is better solved with #1172 anyway).

Even though there are some more calls, I compared code size before and after and it doesn't change, except for atmega where it is two bytes (one instruction) reduced for some reason. But examples/serial still works on my Uno so I don't think this is something to worry about.