### PR TITLE
teensy36: add to smoketest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=teensy40            examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=teensy36            examples/blinky1
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex


### PR DESCRIPTION
This required some changes to the UART code to get it to compile on Go 1.11.

Smoke tests are very important to make sure `-target=teensy36` doesn't break unexpectedly.

@ardnew can you take a look at these changes and test them on a Teensy 3.6? I don't have such a device.