### PR TITLE
ci: work around bug in Go 1.15.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
           llvm: "10"
   test-llvm11-go115:
     docker:
-      - image: circleci/golang:1.15-buster
+      - image: circleci/golang:1.15.2-buster
     steps:
       - test-linux:
           llvm: "11"


### PR DESCRIPTION
This works around a bug in Go 1.15.3 by pinning an older version.
See: https://github.com/golang/go/issues/42032