### PR TITLE
esp8266: add target for d1mini board and add pin mappings for SPI/I2C

### DIFF
--- a/src/machine/board_nodemcu.go
+++ b/src/machine/board_nodemcu.go
@@ -19,3 +19,17 @@ const (
 
 // Onboard blue LED (on the AI-Thinker module).
 const LED = D4
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = D5
+	SPI0_SDO_PIN = D7
+	SPI0_SDI_PIN = D6
+	SPI0_CS0_PIN = D8
+)
+
+// I2C pins
+const (
+	SDA_PIN = D2
+	SCL_PIN = D1
+)

--- a/targets/d1mini.json
+++ b/targets/d1mini.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["nodemcu"]
+}


### PR DESCRIPTION
This PR adds target for the ESP8266 based D1mini board and also adds pin mappings for SPI/I2C to help out any future implementation.