### PR TITLE
nrf: give more flexibility in picking SPI speeds

### DIFF
--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -357,23 +357,25 @@ func (spi SPI) Configure(config SPIConfig) {
 	// set frequency
 	var freq uint32
 
-	switch config.Frequency {
-	case 125000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_K125
-	case 250000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_K250
-	case 500000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_K500
-	case 1000000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_M1
-	case 2000000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_M2
-	case 4000000:
-		freq = nrf.SPI_FREQUENCY_FREQUENCY_M4
-	case 8000000:
+	if config.Frequency == 0 {
+		config.Frequency = 4000000 // 4MHz
+	}
+
+	switch {
+	case config.Frequency >= 8000000:
 		freq = nrf.SPI_FREQUENCY_FREQUENCY_M8
-	default:
+	case config.Frequency >= 4000000:
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_M4
+	case config.Frequency >= 2000000:
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_M2
+	case config.Frequency >= 1000000:
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_M1
+	case config.Frequency >= 500000:
 		freq = nrf.SPI_FREQUENCY_FREQUENCY_K500
+	case config.Frequency >= 250000:
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_K250
+	default: // below 250kHz, default to the lowest speed available
+		freq = nrf.SPI_FREQUENCY_FREQUENCY_K125
 	}
 	spi.Bus.FREQUENCY.Set(freq)
 


### PR DESCRIPTION
Instead of only allowing a limited number of speeds, use the provided
speed as an upper bound on the allowed speed. The reasoning is that
picking a higher speed than requrested will likely result in malfunction
while picking a lower speed will usually only result in slower
operation.
This behavior matches the ESP32 at least.

---

Tested on a SK9822 LED strip with an nrf52832.

It was inspired by code like this: https://github.com/tinygo-org/drivers/pull/208/files#diff-3ea9b9d98ece4f5cf1c374d3876eeda73d4b9fc617d1bc3431cd988af2bfeaebL41
Also, this behavior should allow more flexibility in configuring SPI peripherals: a driver or program should pick the maximum speed allowed by the driver instead of configuring a specific speed per chip (for portable code).