### PR TITLE
spi: switch default frequency to 4MHz

### DIFF
--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -310,7 +310,7 @@ type SPIConfig struct {
 // Configure and make the SPI peripheral ready to use.
 func (spi SPI) Configure(config SPIConfig) error {
 	if config.Frequency == 0 {
-		config.Frequency = 1e6 // default to 1MHz
+		config.Frequency = 4e6 // default to 4MHz
 	}
 
 	// Configure the SPI clock. This assumes a peripheral clock of 80MHz.

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -123,7 +123,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 
 	// set default frequency
 	if config.Frequency == 0 {
-		config.Frequency = 4000000
+		config.Frequency = 4000000 // 4MHz
 	}
 
 	// div = (SPI_CFG(dev)->f_sys / (2 * frequency)) - 1;

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -442,7 +442,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 
 	// Set default frequency.
 	if config.Frequency == 0 {
-		config.Frequency = 500000
+		config.Frequency = 4000000 // 4MHz
 	}
 
 	baudr := CPUFrequency() / config.Frequency


### PR DESCRIPTION
Let's use the same default frequency everywhere, for consistency.
It could be any frequency, but 4MHz is already used for other chips and
it seems like a reasonable frequency to me (not too fast for most chips
but still reasonably fast). Oh, and 4MHz is slow enough that it can be
inspected by a Saleae Logic 4 (that sadly has been discontinued).

Related to #1446 which also changes the default from 500kHz to 4MHz.