### PR TITLE
atsamd5x: improve SPI

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -10,6 +10,7 @@ package machine
 import (
 	"device/arm"
 	"device/sam"
+	"errors"
 	"runtime/interrupt"
 	"runtime/volatile"
 	"unsafe"
@@ -1467,6 +1468,96 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 
 	// return data
 	return byte(spi.Bus.DATA.Get()), nil
+}
+
+var (
+	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
+)
+
+// Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+// interface, there must always be the same number of bytes written as bytes read.
+// The Tx method knows about this, and offers a few different ways of calling it.
+//
+// This form sends the bytes in tx buffer, putting the resulting bytes read into the rx buffer.
+// Note that the tx and rx buffers must be the same size:
+//
+// 		spi.Tx(tx, rx)
+//
+// This form sends the tx buffer, ignoring the result. Useful for sending "commands" that return zeros
+// until all the bytes in the command packet have been received:
+//
+// 		spi.Tx(tx, nil)
+//
+// This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
+//
+// 		spi.Tx(nil, rx)
+//
+func (spi SPI) Tx(w, r []byte) error {
+	switch {
+	case w == nil:
+		// read only, so write zero and read a result.
+		spi.rx(r)
+	case r == nil:
+		// write only
+		spi.tx(w)
+
+	default:
+		// write/read
+		if len(w) != len(r) {
+			return ErrTxInvalidSliceSize
+		}
+
+		spi.txrx(w, r)
+	}
+
+	return nil
+}
+
+func (spi SPI) tx(tx []byte) {
+	for i := 0; i < len(tx); i++ {
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+		}
+		spi.Bus.DATA.Set(uint32(tx[i]))
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_TXC) {
+	}
+
+	// read to clear RXC register
+	for spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		spi.Bus.DATA.Get()
+	}
+}
+
+func (spi SPI) rx(rx []byte) {
+	spi.Bus.DATA.Set(0)
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+	}
+
+	for i := 1; i < len(rx); i++ {
+		spi.Bus.DATA.Set(0)
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		}
+		rx[i-1] = byte(spi.Bus.DATA.Get())
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+	}
+	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
+}
+
+func (spi SPI) txrx(tx, rx []byte) {
+	spi.Bus.DATA.Set(uint32(tx[0]))
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+	}
+
+	for i := 1; i < len(rx); i++ {
+		spi.Bus.DATA.Set(uint32(tx[i]))
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		}
+		rx[i-1] = byte(spi.Bus.DATA.Get())
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+	}
+	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
 }
 
 // The QSPI peripheral on ATSAMD51 is only available on the following pins

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build !baremetal sam stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
+// +build !baremetal atsamd21 stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
 
 package machine
 


### PR DESCRIPTION
I made it faster by rewriting SPI.Tx().
Originally, there was a gap of about 400ns per byte, but this is a significant improvement.

After this PR is merged, drivers/ili9341 should be able to simplify it.
https://github.com/tinygo-org/drivers/pull/208


old: 6ab0106af37abf65bdc9e41912d7e8a46db9bd8d
![image](https://user-images.githubusercontent.com/9251039/96716205-b2015a80-13df-11eb-9c1c-b96f2fb310ee.png)

new txrx():
![image](https://user-images.githubusercontent.com/9251039/96716234-b9c0ff00-13df-11eb-99b8-a1dad80e25d3.png)

new tx():
![image](https://user-images.githubusercontent.com/9251039/96716255-bfb6e000-13df-11eb-95c0-fa1db30f16a7.png)

new rx():
![image](https://user-images.githubusercontent.com/9251039/97123901-4ae1fe00-1771-11eb-95f7-63162ba2cf87.png)

