### PR TITLE
Add os.LookupEnv() stub

### DIFF
--- a/src/os/env.go
+++ b/src/os/env.go
@@ -3,3 +3,7 @@ package os
 func Getenv(key string) string {
 	return ""
 }
+
+func LookupEnv(key string) (string, bool) {
+	return "", false
+}


### PR DESCRIPTION
os.Getenv() was already stubbed out, but os.LookupEnv() wasn't. This
will allow me to compile my program unmodified without using separate
files and build tags.