### PR TITLE
board/teensy40: Add ADC support

### DIFF
--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -878,13 +878,6 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 	}
 }
 
-// ADCConfig holds optional configuration parameters for ADC initialization.
-// If left unspecified, the defaults are assumed: 10-bit, 4-sample averaging.
-type ADCConfig struct {
-	Resolution uint32 // 8, 10, or 12 (bits)
-	Samples    uint32 // 0, 4, 8, 16, or 32 (0 = hardware averaging disabled)
-}
-
 // maximum ADC value for the currently configured resolution (used for scaling)
 var adcMaximum uint32
 

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -7,7 +7,6 @@ import (
 	"math/bits"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"sync"
 )
 
 // Peripheral abstraction layer for the MIMXRT1062
@@ -879,10 +878,15 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 	}
 }
 
+// ADCConfig holds optional configuration parameters for ADC initialization.
+// If left unspecified, the defaults are assumed: 10-bit, 4-sample averaging
 type ADCConfig struct {
-	Resolution uint32
-	Samples    uint32
+	Resolution uint32 // 8, 10, or 12 (bits)
+	Samples    uint32 // 0, 4, 8, 16, or 32 (0 = hardware averaging disabled)
 }
+
+// maximum ADC value for the currently configured resolution (used for scaling)
+var adcMaximum uint32
 
 // InitADC is not used by this machine. Use `(ADC).Configure()`.
 func InitADC() {}
@@ -894,7 +898,7 @@ func (a ADC) Configure() { a.ConfigureMode(ADCConfig{}) }
 // ConfigureMode initializes the receiver ADC's Pin and the ADC1/ADC2 instances
 // for immediate usage with given settings.
 func (a ADC) ConfigureMode(config ADCConfig) {
-
+	// if not specified, use defaults: 10-bit resolution, 4 samples/conversion
 	const (
 		defaultResolution = uint32(10)
 		defaultSamples    = uint32(4)
@@ -909,6 +913,10 @@ func (a ADC) ConfigureMode(config ADCConfig) {
 	if 0 == samples {
 		samples = defaultSamples
 	}
+	if resolution > 12 {
+		resolution = 12 // maximum resolution of 12 bits
+	}
+	adcMaximum = (uint32(1) << resolution) - 1
 
 	mode, average := a.mode(resolution, samples)
 
@@ -919,28 +927,44 @@ func (a ADC) ConfigureMode(config ADCConfig) {
 	nxp.ADC1.GC.Set(average | nxp.ADC_GC_CAL)
 	nxp.ADC2.GC.Set(average | nxp.ADC_GC_CAL)
 
-	adcStatusGlobal.startCalibrating()
-	adcStatusGlobal.waitForCalibration()
+	for a.isCalibrating() {
+	} // wait for calibration
 }
 
+// Get performs a single ADC conversion, returning a 16-bit unsigned integer.
+// The value returned will be scaled (uniformly distributed) if necessary so
+// that it is always in the range [0..65535], regardless of the ADC's configured
+// bit size (resolution).
 func (a ADC) Get() uint16 {
-	if ch1, ch2, ok := a.Pin.getChannel(); ok {
-		adcStatusGlobal.waitForCalibration()
-		if noChannel != ch1 {
+	if ch1, ch2, ok := a.Pin.getADCChannel(); ok {
+		for a.isCalibrating() {
+		} // wait for calibration
+		var val uint32
+		if noADCChannel != ch1 {
 			nxp.ADC1.HC0.Set(uint32(ch1))
 			for !nxp.ADC1.HS.HasBits(nxp.ADC_HS_COCO0) {
 			}
-			return uint16(nxp.ADC1.R0.Get() & 0xFFFF)
+			val = nxp.ADC1.R0.Get() & 0xFFFF
 		} else {
 			nxp.ADC2.HC0.Set(uint32(ch2))
 			for !nxp.ADC2.HS.HasBits(nxp.ADC_HS_COCO0) {
 			}
-			return uint16(nxp.ADC2.R0.Get() & 0xFFFF)
+			val = nxp.ADC2.R0.Get() & 0xFFFF
 		}
+		// should never be zero, but just in case, use UINT16_MAX so that the scalar
+		// gets factored out of the conversion result, leaving the original reading
+		// to be returned unaltered/unscaled.
+		if adcMaximum == 0 {
+			adcMaximum = 0xFFFF
+		}
+		// scale up to a 16-bit value
+		return uint16((val * 0xFFFF) / adcMaximum)
 	}
 	return 0
 }
 
+// mode constructs bit masks for mode and average - used in ADC configuration
+// registers - from a given ADC bit size (resolution) and sample count.
 func (a ADC) mode(resolution, samples uint32) (mode, average uint32) {
 
 	// use asynchronous clock (ADACK) (0 = IPG, 1 = IPG/2, or 3 = ADACK)
@@ -985,83 +1009,59 @@ func (a ADC) mode(resolution, samples uint32) (mode, average uint32) {
 	return mode, average
 }
 
-const noChannel = uint8(0xFF)
-
-// getChannel returns the input channel for ADC1 & ADC2 of the receiver Pin p.
-func (p Pin) getChannel() (adc1, adc2 uint8, ok bool) {
-	switch p.getPort() {
-	case portA:
-		switch p.getPos() {
-		case 12: // [AD_B0_12]:       ADC1_IN1        ~
-			return 1, noChannel, true
-		case 13: // [AD_B0_13]:       ADC1_IN2        ~
-			return 2, noChannel, true
-		case 14: // [AD_B0_14]:       ADC1_IN3        ~
-			return 3, noChannel, true
-		case 15: // [AD_B0_15]:       ADC1_IN4        ~
-			return 4, noChannel, true
-		case 16: // [AD_B1_00]:       ADC1_IN5     ADC2_IN5
-			return 5, 5, true
-		case 17: // [AD_B1_01]:       ADC1_IN6     ADC2_IN6
-			return 6, 6, true
-		case 18: // [AD_B1_02]:       ADC1_IN7     ADC2_IN7
-			return 7, 7, true
-		case 19: // [AD_B1_03]:       ADC1_IN8     ADC2_IN8
-			return 8, 8, true
-		case 20: // [AD_B1_04]:       ADC1_IN9     ADC2_IN9
-			return 9, 9, true
-		case 21: // [AD_B1_05]:       ADC1_IN10    ADC2_IN10
-			return 10, 10, true
-		case 22: // [AD_B1_06]:       ADC1_IN11    ADC2_IN11
-			return 11, 11, true
-		case 23: // [AD_B1_07]:       ADC1_IN12    ADC2_IN12
-			return 12, 12, true
-		case 24: // [AD_B1_08]:       ADC1_IN13    ADC2_IN13
-			return 13, 13, true
-		case 25: // [AD_B1_09]:       ADC1_IN14    ADC2_IN14
-			return 14, 14, true
-		case 26: // [AD_B1_10]:       ADC1_IN15    ADC2_IN15
-			return 15, 15, true
-		case 27: // [AD_B1_11]:       ADC1_IN0     ADC2_IN0
-			return 16, 16, true
-		case 28: // [AD_B1_12]:          ~         ADC2_IN1
-			return noChannel, 1, true
-		case 29: // [AD_B1_13]:          ~         ADC2_IN2
-			return noChannel, 2, true
-		case 30: // [AD_B1_14]:          ~         ADC2_IN3
-			return noChannel, 3, true
-		case 31: // [AD_B1_15]:          ~         ADC2_IN4
-			return noChannel, 4, true
-		default:
-			return noChannel, noChannel, false
-		}
-	default:
-		return noChannel, noChannel, false
-	}
+// isCalibrating returns true if and only if either one (or both) of ADC1 and
+// ADC2 have their calibrating flags set. ADC reads must wait until these flags
+// are clear before attempting a conversion.
+func (a ADC) isCalibrating() bool {
+	return nxp.ADC1.GC.HasBits(nxp.ADC_GC_CAL) || nxp.ADC2.GC.HasBits(nxp.ADC_GC_CAL)
 }
 
-type adcStatus struct{ volatile.Register32 }
+const noADCChannel = uint8(0xFF)
 
-var adcStatusGlobal adcStatus
-
-func (s adcStatus) isCalibrating() bool { return s.Get() != 0 }
-func (s adcStatus) startCalibrating()   { s.Set(1) }
-func (s adcStatus) stopCalibrating()    { s.Set(0) }
-func (s adcStatus) waitForCalibration() {
-	if s.isCalibrating() {
-		work := sync.WaitGroup{}
-		work.Add(2)
-		go func(w *sync.WaitGroup) {
-			for nxp.ADC1.GC.HasBits(nxp.ADC_GC_CAL) {
-			} // wait for calibration
-			w.Done()
-		}(&work)
-		go func(w *sync.WaitGroup) {
-			for nxp.ADC2.GC.HasBits(nxp.ADC_GC_CAL) {
-			} // wait for calibration
-			w.Done()
-		}(&work)
-		work.Wait()
-		s.stopCalibrating()
+// getADCChannel returns the input channel for ADC1/ADC2 of the receiver Pin p.
+func (p Pin) getADCChannel() (adc1, adc2 uint8, ok bool) {
+	switch p {
+	case PA12: // [AD_B0_12]:       ADC1_IN1        ~
+		return 1, noADCChannel, true
+	case PA13: // [AD_B0_13]:       ADC1_IN2        ~
+		return 2, noADCChannel, true
+	case PA14: // [AD_B0_14]:       ADC1_IN3        ~
+		return 3, noADCChannel, true
+	case PA15: // [AD_B0_15]:       ADC1_IN4        ~
+		return 4, noADCChannel, true
+	case PA16: // [AD_B1_00]:       ADC1_IN5     ADC2_IN5
+		return 5, 5, true
+	case PA17: // [AD_B1_01]:       ADC1_IN6     ADC2_IN6
+		return 6, 6, true
+	case PA18: // [AD_B1_02]:       ADC1_IN7     ADC2_IN7
+		return 7, 7, true
+	case PA19: // [AD_B1_03]:       ADC1_IN8     ADC2_IN8
+		return 8, 8, true
+	case PA20: // [AD_B1_04]:       ADC1_IN9     ADC2_IN9
+		return 9, 9, true
+	case PA21: // [AD_B1_05]:       ADC1_IN10    ADC2_IN10
+		return 10, 10, true
+	case PA22: // [AD_B1_06]:       ADC1_IN11    ADC2_IN11
+		return 11, 11, true
+	case PA23: // [AD_B1_07]:       ADC1_IN12    ADC2_IN12
+		return 12, 12, true
+	case PA24: // [AD_B1_08]:       ADC1_IN13    ADC2_IN13
+		return 13, 13, true
+	case PA25: // [AD_B1_09]:       ADC1_IN14    ADC2_IN14
+		return 14, 14, true
+	case PA26: // [AD_B1_10]:       ADC1_IN15    ADC2_IN15
+		return 15, 15, true
+	case PA27: // [AD_B1_11]:       ADC1_IN0     ADC2_IN0
+		return 16, 16, true
+	case PA28: // [AD_B1_12]:          ~         ADC2_IN1
+		return noADCChannel, 1, true
+	case PA29: // [AD_B1_13]:          ~         ADC2_IN2
+		return noADCChannel, 2, true
+	case PA30: // [AD_B1_14]:          ~         ADC2_IN3
+		return noADCChannel, 3, true
+	case PA31: // [AD_B1_15]:          ~         ADC2_IN4
+		return noADCChannel, 4, true
+	default:
+		return noADCChannel, noADCChannel, false
 	}
 }

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -879,7 +879,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 }
 
 // ADCConfig holds optional configuration parameters for ADC initialization.
-// If left unspecified, the defaults are assumed: 10-bit, 4-sample averaging
+// If left unspecified, the defaults are assumed: 10-bit, 4-sample averaging.
 type ADCConfig struct {
 	Resolution uint32 // 8, 10, or 12 (bits)
 	Samples    uint32 // 0, 4, 8, 16, or 32 (0 = hardware averaging disabled)
@@ -891,13 +891,8 @@ var adcMaximum uint32
 // InitADC is not used by this machine. Use `(ADC).Configure()`.
 func InitADC() {}
 
-// Configure initializes the receiver ADC's Pin and the ADC1/ADC2 instances for
-// immediate usage with default settings.
-func (a ADC) Configure() { a.ConfigureMode(ADCConfig{}) }
-
-// ConfigureMode initializes the receiver ADC's Pin and the ADC1/ADC2 instances
-// for immediate usage with given settings.
-func (a ADC) ConfigureMode(config ADCConfig) {
+// Configure initializes the receiver's ADC peripheral and pin for analog input.
+func (a ADC) Configure(config ADCConfig) {
 	// if not specified, use defaults: 10-bit resolution, 4 samples/conversion
 	const (
 		defaultResolution = uint32(10)


### PR DESCRIPTION
### This PR is baselined on top of the Teensy 4.0 external interrupt support PR (#1484)

This PR adds analog input support (ADC1/ADC2) for Teensy 4.0 on 14 GPIO pins (`A0`-`A13`). 

I mirrored the API used in machine `feather-m4`, assuming it is probably a good example for TinyGo convention.

This has been tested using a cheap potentiometer with `src/examples/adc/adc.go`. Note you must also change the pin from `ADC0` to one of this machine's analog pins, e.g. `A0`. All other code can be left as-is (although the call to `machine.InitADC()` is unnecessary - it is implemented as an empty stub for backwards compatibility with existing code such as this example).

The following describes each analog pin, its equivalent digital pin, its IOMUX pad, and finally which ADC channel(s) it is connected to. It is defined in `src/machine/board_teensy40.go`:

```go
// Analog pins
const (
	//  = Pin  // Dig | [Pad]      {ADC1/ADC2}
	A0  = PA18 // D14 | [AD_B1_02] {  7 / 7  }
	A1  = PA19 // D15 | [AD_B1_03] {  8 / 8  }
	A2  = PA23 // D16 | [AD_B1_07] { 12 / 12 }
	A3  = PA22 // D17 | [AD_B1_06] { 11 / 11 }
	A4  = PA17 // D18 | [AD_B1_01] {  6 / 6  }
	A5  = PA16 // D19 | [AD_B1_00] {  5 / 5  }
	A6  = PA26 // D20 | [AD_B1_10] { 15 / 15 }
	A7  = PA27 // D21 | [AD_B1_11] {  0 / 0  }
	A8  = PA24 // D22 | [AD_B1_08] { 13 / 13 }
	A9  = PA25 // D23 | [AD_B1_09] { 14 / 14 }
	A10 = PA12 // D24 | [AD_B0_12] {  1 / -  }
	A11 = PA13 // D25 | [AD_B0_13] {  2 / -  }
	A12 = PA30 // D26 | [AD_B1_14] {  - / 3  }
	A13 = PA31 // D27 | [AD_B1_15] {  - / 4  }
)
```