### PR TITLE
testing: add Run method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,9 @@ tinygo-test:
 	$(TINYGO) test container/ring
 	$(TINYGO) test crypto/des
 	$(TINYGO) test encoding/ascii85
+	$(TINYGO) test encoding/base32
 	$(TINYGO) test encoding/hex
+	$(TINYGO) test hash/fnv
 	$(TINYGO) test math
 	$(TINYGO) test text/scanner
 	$(TINYGO) test unicode/utf8


### PR DESCRIPTION
This patch adds subtests via the Run function. This gets two more
packages to pass tests: encoding/base32 and hash/fnv.