### PR TITLE
runtime: allow ranging over a nil map

### DIFF
--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -261,6 +261,13 @@ func hashmapDelete(m *hashmap, key unsafe.Pointer, hash uint32, keyEqual func(x,
 // Iterate over a hashmap.
 //go:nobounds
 func hashmapNext(m *hashmap, it *hashmapIterator, key, value unsafe.Pointer) bool {
+	if m == nil {
+		// Iterating over a nil slice appears to be allowed by the Go spec:
+		// https://groups.google.com/g/golang-nuts/c/gVgVLQU1FFE?pli=1
+		// https://play.golang.org/p/S8jxAMytKDB
+		return false
+	}
+
 	numBuckets := uintptr(1) << m.bucketBits
 	for {
 		if it.bucketIndex >= 8 {

--- a/testdata/map.go
+++ b/testdata/map.go
@@ -49,6 +49,9 @@ func main() {
 	println(testmapIntInt[2])
 	testmapIntInt[2] = 42
 	println(testmapIntInt[2])
+	for k := range nilmap {
+		println(k) // unreachable
+	}
 
 	arrKey := ArrayKey([4]byte{4, 3, 2, 1})
 	println(testMapArrayKey[arrKey])


### PR DESCRIPTION
This appears to be allowed by the specification, at least it is allowed by the main Go implementation: https://play.golang.org/p/S8jxAMytKDB

Allow it in TinyGo too, for consistency.

Found because it is triggered with `tinygo test flags`. This doesn't make the flags package pass all tests, but is a step closer.