### PR TITLE
Add missing return pointer restore for regular coroutine tail calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ tinygo-test:
 	$(TINYGO) test encoding/base32
 	$(TINYGO) test encoding/hex
 	$(TINYGO) test hash/fnv
+	$(TINYGO) test hash/crc64
 	$(TINYGO) test math
 	$(TINYGO) test text/scanner
 	$(TINYGO) test unicode/utf8


### PR DESCRIPTION
This fixes #1467 where a normal suspending call followed by a plain tail call would result in the tail return value being written to the return pointer of the normal suspending call. This is fixed by saving the return pointer at the start of the function and restoring it before initiating a plain tail call.