### PR TITLE
make: fixes error detecting llvm-nm tool for wasi-libc build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 detect = $(shell command -v $(1) 2> /dev/null && echo $(1))
 CLANG ?= $(word 1,$(abspath $(call detect,llvm-build/bin/clang))$(call detect,clang-11)$(call detect,clang-10)$(call detect,clang))
 LLVM_AR ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-ar))$(call detect,llvm-ar-11)$(call detect,llvm-ar-10)$(call detect,llvm-ar))
-LLVM_NM ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-nm))$(call detect,llvm-ar-11)$(call detect,llvm-ar-10)$(call detect,llvm-ar))
+LLVM_NM ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-nm))$(call detect,llvm-nm-11)$(call detect,llvm-nm-10)$(call detect,llvm-nm))
 
 # Go binary and GOROOT to select
 GO ?= go


### PR DESCRIPTION
This PR fixes an error detecting llvm-nm tool for wasi-libc build.