### PR TITLE
board/teensy40: Add external interrupt support

### DIFF
--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -19,39 +19,39 @@ type PinMode uint8
 
 const (
 	// GPIO
-	PinInput           PinMode = 0
-	PinInputPullUp     PinMode = 1
-	PinInputPullDown   PinMode = 2
-	PinOutput          PinMode = 3
-	PinOutputOpenDrain PinMode = 4
-	PinDisable         PinMode = 5
+	PinInput PinMode = iota
+	PinInputPullUp
+	PinInputPullDown
+	PinOutput
+	PinOutputOpenDrain
+	PinDisable
 
 	// ADC
-	PinInputAnalog PinMode = 6
+	PinInputAnalog
 
 	// UART
-	PinModeUARTTX PinMode = 7
-	PinModeUARTRX PinMode = 8
+	PinModeUARTTX
+	PinModeUARTRX
 
 	// SPI
-	PinModeSPISDI PinMode = 9
-	PinModeSPISDO PinMode = 10
-	PinModeSPICLK PinMode = 11
-	PinModeSPICS  PinMode = 12
+	PinModeSPISDI
+	PinModeSPISDO
+	PinModeSPICLK
+	PinModeSPICS
 
 	// I2C
-	PinModeI2CSDA PinMode = 13
-	PinModeI2CSCL PinMode = 14
+	PinModeI2CSDA
+	PinModeI2CSCL
 )
 
 type PinChange uint8
 
 const (
-	PinLow     PinChange = 0
-	PinHigh    PinChange = 1
-	PinRising  PinChange = 2
-	PinFalling PinChange = 3
-	PinToggle  PinChange = 4
+	PinLow PinChange = iota
+	PinHigh
+	PinRising
+	PinFalling
+	PinToggle
 )
 
 // pinJumpTable represents a function lookup table for all 128 GPIO pins.


### PR DESCRIPTION
### This PR is baselined on top of the original Teensy 4.0 BSP PR (#1425)

This PR adds support for external interrupts on _**all**_ GPIO pins (both routed and not routed to board headers).

This allows the user to attach interrupt handlers via `func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error`.

There are 5 detection modes (of type `PinChange`) supported, using the conventional identifiers as other TinyGo boards. Their purpose should be self-evident:

```go
const (
	PinLow     PinChange = 0
	PinHigh    PinChange = 1
	PinRising  PinChange = 2
	PinFalling PinChange = 3
	PinToggle  PinChange = 4
)
```

There are no other publicly visible changes to the existing Teensy 4 API other than this one method added to the `machine` package.