### PR TITLE
ci: update CircleCI, Azure, and Docker builds to Go 1.15.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
           llvm: "10"
   test-llvm11-go115:
     docker:
-      - image: circleci/golang:1.15.4-buster
+      - image: circleci/golang:1.15-buster
     steps:
       - test-linux:
           llvm: "11"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
           llvm: "10"
   test-llvm11-go115:
     docker:
-      - image: circleci/golang:1.15.2-buster
+      - image: circleci/golang:1.15.4-buster
     steps:
       - test-linux:
           llvm: "11"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# TinyGo base stage installs Go 1.15.4, LLVM 10 and the TinyGo compiler itself.
-FROM golang:1.15.4 AS tinygo-base
+# TinyGo base stage installs the most recent Go 1.15.x, LLVM 10 and the TinyGo compiler itself.
+FROM golang:1.15 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" >> /etc/apt/sources.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# TinyGo base stage installs Go 1.14, LLVM 10 and the TinyGo compiler itself.
-FROM golang:1.14 AS tinygo-base
+# TinyGo base stage installs Go 1.15.4, LLVM 10 and the TinyGo compiler itself.
+FROM golang:1.15.4 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" >> /etc/apt/sources.list && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
     - task: GoTool@0
       inputs:
-        version: '1.15'
+        version: '1.15.4'
     - checkout: self
       fetchDepth: 1
     - task: Cache@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
     - task: GoTool@0
       inputs:
-        version: '1.15.4'
+        version: '1.15'
     - checkout: self
       fetchDepth: 1
     - task: Cache@2


### PR DESCRIPTION
This PR updates the CircleCI build to use Go 1.15.4 now that https://github.com/golang/go/issues/42032 has been resolved. 