### PR TITLE
atsamd5x atsamd2x: add a length check to findPinPadMapping

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -136,7 +136,8 @@ var pinPadMapping = [32]byte{
 // found" (indicated by returning ok=false). The pad number is returned to
 // calculate the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
-	if len(pinPadMapping) <= int(pin)/2 {
+	if int(pin)/2 >= len(pinPadMapping) {
+		// This is probably NoPin, for which no mapping is available.
 		return
 	}
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -136,7 +136,7 @@ var pinPadMapping = [32]byte{
 // found" (indicated by returning ok=false). The pad number is returned to
 // calculate the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
-	if len(pinPadMapping) <= int(pin) {
+	if len(pinPadMapping) <= int(pin)/2 {
 		return
 	}
 

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -136,6 +136,10 @@ var pinPadMapping = [32]byte{
 // found" (indicated by returning ok=false). The pad number is returned to
 // calculate the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
+	if len(pinPadMapping) <= int(pin) {
+		return
+	}
+
 	nibbles := pinPadMapping[pin/2]
 	upper := nibbles >> 4
 	lower := nibbles & 0xf

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -322,7 +322,7 @@ var pinPadMapping = [64]uint16{
 // (indicated by returning ok=false). The pad number is returned to calculate
 // the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
-	if len(pinPadMapping) <= int(pin) {
+	if len(pinPadMapping) <= int(pin)/2 {
 		return
 	}
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -322,7 +322,8 @@ var pinPadMapping = [64]uint16{
 // (indicated by returning ok=false). The pad number is returned to calculate
 // the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
-	if len(pinPadMapping) <= int(pin)/2 {
+	if int(pin)/2 >= len(pinPadMapping) {
+		// This is probably NoPin, for which no mapping is available.
 		return
 	}
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -322,6 +322,10 @@ var pinPadMapping = [64]uint16{
 // (indicated by returning ok=false). The pad number is returned to calculate
 // the DOPO/DIPO bitfields of the various serial peripherals.
 func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok bool) {
+	if len(pinPadMapping) <= int(pin) {
+		return
+	}
+
 	bytes := pinPadMapping[pin/2]
 	upper := byte(bytes >> 8)
 	lower := byte(bytes & 0xff)


### PR DESCRIPTION
findPinPadMapping does not have a length check, which causes a crash.

Related to the following issues and PR
#1483 
#1408 
