### PR TITLE
nice!nano board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 44 microcontroller boards are currently supported:
+The following 45 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -71,6 +71,7 @@ The following 44 microcontroller boards are currently supported:
 * [ESP8266](https://www.espressif.com/en/products/socs/esp8266)
 * [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
 * [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
+* [nice!nano](https://docs.nicekeyboards.com/#/nice!nano/)
 * [Nintendo Switch](https://www.nintendo.com/switch/)
 * [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF51-Dongle)
 * [Nordic Semiconductor PCA10040](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52-DK)

--- a/src/machine/board_nicenano.go
+++ b/src/machine/board_nicenano.go
@@ -12,7 +12,7 @@ const (
 	D020 = P0_20
 	D022 = P0_22
 	D024 = P0_24
-	D100 = P0_24
+	D100 = P1_00
 	D011 = P0_11
 	D104 = P1_04
 	D106 = P1_06
@@ -50,8 +50,8 @@ const (
 
 // UART0 pins (logical UART1)
 const (
-	UART_RX_PIN = P0_00
-	UART_TX_PIN = P0_00
+	UART_RX_PIN = P0_06
+	UART_TX_PIN = P0_08
 )
 
 // UART0 is the USB device
@@ -61,15 +61,15 @@ var (
 
 // I2C pins
 const (
-	SDA_PIN = P0_00 // I2C0 external
-	SCL_PIN = P0_00 // I2C0 external
+	SDA_PIN = P0_17 // I2C0 external
+	SCL_PIN = P0_20 // I2C0 external
 )
 
 // SPI pins
 const (
-	SPI0_SCK_PIN = P0_00 // SCK
-	SPI0_SDO_PIN = P0_00 // SDO
-	SPI0_SDI_PIN = P0_00 // SDI
+	SPI0_SCK_PIN = P0_22 // SCK
+	SPI0_SDO_PIN = P0_24 // SDO
+	SPI0_SDI_PIN = P1_00 // SDI
 )
 
 // USB CDC identifiers

--- a/src/machine/board_nicenano.go
+++ b/src/machine/board_nicenano.go
@@ -1,0 +1,84 @@
+// +build nicenano
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// GPIO Pins
+const (
+	D006 = P0_06
+	D008 = P0_08
+	D017 = P0_17
+	D020 = P0_20
+	D022 = P0_22
+	D024 = P0_24
+	D100 = P0_24
+	D011 = P0_11
+	D104 = P1_04
+	D106 = P1_06
+
+	D004 = P0_04 // AIN2; P0.04 (AIN2) is used to read the voltage of the battery via ADC. It can’t be used for any other function.
+	D013 = P0_13 // VCC 3.3V; P0.13 on VCC shuts off the power to VCC when you set it to high; This saves on battery immensely for LEDs of all kinds that eat power even when off
+	D115 = P1_15
+	D113 = P1_13
+	D031 = P0_31 // AIN7
+	D029 = P0_29 // AIN5
+	D002 = P0_02 // AIN0
+
+	D111 = P1_11
+	D010 = P0_10 // NFC2
+	D009 = P0_09 // NFC1
+
+	D026 = P0_26
+	D012 = P0_12
+	D101 = P1_01
+	D102 = P1_02
+	D107 = P1_07
+)
+
+// Analog Pins
+const (
+	AIN2 = P0_04 // Battery
+	AIN7 = P0_31
+	AIN5 = P0_29
+	AIN0 = P0_02
+)
+
+const (
+	LED = P0_15
+)
+
+// UART0 pins (logical UART1)
+const (
+	UART_RX_PIN = P0_00
+	UART_TX_PIN = P0_00
+)
+
+// UART0 is the USB device
+var (
+	UART0 = USB
+)
+
+// I2C pins
+const (
+	SDA_PIN = P0_00 // I2C0 external
+	SCL_PIN = P0_00 // I2C0 external
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = P0_00 // SCK
+	SPI0_SDO_PIN = P0_00 // SDO
+	SPI0_SDI_PIN = P0_00 // SDI
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "nice!nano"
+	usb_STRING_MANUFACTURER = "Nice Keyboards"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x0029
+)

--- a/targets/nicenano.json
+++ b/targets/nicenano.json
@@ -1,0 +1,10 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["nicenano","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "msd-volume-name": "NICENANO",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
Fixes #1477

I'm trying to add nicenano board support but having no experience in this I'd appreciate someone have a look at this.

Board documentation: https://docs.nicekeyboards.com/#/nice!nano/pinout_schematic

I copied Feather nRF52840 board as a starting point, renamed the pins based on the pinout. On the board the pins are labeled only with a number, e.g. "106" for P1_06, I named the constant D106. 

I need help with UART, I2C, SPI constants as I don't know much about that and cannot see anyting in the documentation and if I try to remove them `make` succeeds but compiling the blinky example fails. 

Also, in the JSON file I'm not sure about the following values:
- build-tags
- flash-1200-bps-reset
- uf2-family-id
- linkerscript

But in the current state this allows me to flash blinky1 example with the following command:
```
make && ./build/tinygo flash -target=nicenano src/examples/blinky1/blinky1.go
```