### PR TITLE
ci: switch to Go 1.15 for MacOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,8 @@ commands:
       - run:
           name: "Install dependencies"
           command: |
-            curl https://dl.google.com/go/go1.14.darwin-amd64.tar.gz -o go1.14.darwin-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.14.darwin-amd64.tar.gz
+            curl https://dl.google.com/go/go1.15.5.darwin-amd64.tar.gz -o go1.15.5.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.15.5.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
             HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
       - install-xtensa-toolchain:


### PR DESCRIPTION
Unfortunately, CircleCI doesn't seem to provide Debian stretch builds
with Go 1.15. We should be using Debian stretch (an older distro) to
make sure the tinygo binary runs on as many Linux systems as possible
(including older ones), and I think using Go 1.14 for these builds is
unfortunate but the better tradeoff.