### PR TITLE
esp32: get float32/float64 to work correctly

### DIFF
--- a/src/device/esp/esp32.S
+++ b/src/device/esp/esp32.S
@@ -42,6 +42,11 @@ call_start_cpu0:
     wsr.ps a2
     rsync
 
+    // Enable the FPU (coprocessor 0 so the lowest bit).
+    movi a2, 1
+    wsr.cpenable a2
+    rsync
+
     // Jump to the runtime start function written in Go.
     call4 main
 

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -8,6 +8,7 @@
 	"cflags": [
 		"-mcpu=esp32"
 	],
+	"rtlib": "compiler-rt",
 	"linkerscript": "targets/esp32.ld",
 	"extra-files": [
 		"src/device/esp/esp32.S",


### PR DESCRIPTION
This PR gets float (both float32 and float64) to work, with this pr testdata/float.go can be run on the ESP32.

It depends on #1520 for correct functioning but it should be possible to merge before #1520 is merged (it shouldn't result in a regression). You can test whether it works with the following command:

    tinygo flash -target=esp32-mini32 -port=/dev/ttyUSB0 ./testdata/float.go

EDIT: or maybe it needs to be based on #1520 anyway.