### PR TITLE
test: run tests for AVR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ commands:
             curl https://dl.google.com/go/go1.15.5.darwin-amd64.tar.gz -o go1.15.5.darwin-amd64.tar.gz
             sudo tar -C /usr/local -xzf go1.15.5.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu simavr
       - install-xtensa-toolchain:
           variant: "macos"
       - restore_cache:

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -96,7 +96,13 @@ func ticks() timeUnit {
 }
 
 func abort() {
+	avr.Asm("cli")
 	for {
-		sleepWDT(WDT_PERIOD_2S)
+		// Sleeping with interrupts disabled will mean the MCU sleeps forever.
+		// To be extra sure, put it in a loop.
+		// This mechanism is used by simavr to detect a program exit, the
+		// emulator will stop when it detects a sleep instruction with
+		// interrupts disabled.
+		avr.Asm("sleep")
 	}
 }


### PR DESCRIPTION
This runs the currently working compiler tests for AVR using simavr. I
picked the atmega1284p target as it seems like the most suitable one
(most importantly, with a lot of RAM) so that tests are less likely to
hit resource limitations.

One extra change this required is using a different implementation of
the runtime.abort() function. The new one is smaller and will prevent
interrupts from running on exit, which should at least in theory be
fine. This pattern is required as it signals to simavr the program is
finished.

---

Now that #1520 is ready, I want to work towards better AVR support and dropping the gcc-avr and avr-libc dependencies if possible. One way to track progress is by getting tests to pass, both to show improvements in new PRs and to catch regressions.