### PR TITLE
ADC: Accept configuration struct as argument to method Configure

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -343,7 +343,7 @@ func (a ADC) Configure(config ADCConfig) {
 
 	// Averaging (see datasheet table in AVGCTRL register description)
 	var samples uint32
-	switch config.Resolution {
+	switch config.Samples {
 	case 1:
 		samples = sam.ADC_AVGCTRL_SAMPLENUM_1
 	case 2:

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -757,7 +757,7 @@ func (a ADC) Configure(config ADCConfig) {
 
 		// Averaging (see datasheet table in AVGCTRL register description)
 		var samples uint32
-		switch config.Resolution {
+		switch config.Samples {
 		case 1:
 			samples = sam.ADC_AVGCTRL_SAMPLENUM_1
 		case 2:

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -4,7 +4,6 @@ package machine
 
 import (
 	"device/nrf"
-	"unsafe"
 )
 
 // Hardware pins
@@ -60,122 +59,6 @@ func (uart UART) setPins(tx, rx Pin) {
 func (i2c I2C) setPins(scl, sda Pin) {
 	i2c.Bus.PSELSCL.Set(uint32(scl))
 	i2c.Bus.PSELSDA.Set(uint32(sda))
-}
-
-// SPI
-func (spi SPI) setPins(sck, sdo, sdi Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if sdo == 0 {
-		sdo = SPI0_SDO_PIN
-	}
-	if sdi == 0 {
-		sdi = SPI0_SDI_PIN
-	}
-	spi.Bus.PSEL.SCK.Set(uint32(sck))
-	spi.Bus.PSEL.MOSI.Set(uint32(sdo))
-	spi.Bus.PSEL.MISO.Set(uint32(sdi))
-}
-
-// InitADC initializes the registers needed for ADC.
-func InitADC() {
-	return // no specific setup on nrf52 machine.
-}
-
-// Configure configures an ADC pin to be able to read analog data.
-func (a ADC) Configure(ADCConfig) {
-	return // no pin specific setup on nrf52 machine.
-}
-
-// Get returns the current value of a ADC pin in the range 0..0xffff.
-func (a ADC) Get() uint16 {
-	var pwmPin uint32
-	var value int16
-
-	switch a.Pin {
-	case 2:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput0
-
-	case 3:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput1
-
-	case 4:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput2
-
-	case 5:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput3
-
-	case 28:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput4
-
-	case 29:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput5
-
-	case 30:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
-
-	case 31:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
-
-	default:
-		return 0
-	}
-
-	nrf.SAADC.RESOLUTION.Set(nrf.SAADC_RESOLUTION_VAL_12bit)
-
-	// Enable ADC.
-	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Enabled << nrf.SAADC_ENABLE_ENABLE_Pos)
-	for i := 0; i < 8; i++ {
-		nrf.SAADC.CH[i].PSELN.Set(nrf.SAADC_CH_PSELP_PSELP_NC)
-		nrf.SAADC.CH[i].PSELP.Set(nrf.SAADC_CH_PSELP_PSELP_NC)
-	}
-
-	// Configure ADC.
-	nrf.SAADC.CH[0].CONFIG.Set(((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESP_Pos) & nrf.SAADC_CH_CONFIG_RESP_Msk) |
-		((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESN_Pos) & nrf.SAADC_CH_CONFIG_RESN_Msk) |
-		((nrf.SAADC_CH_CONFIG_GAIN_Gain1_5 << nrf.SAADC_CH_CONFIG_GAIN_Pos) & nrf.SAADC_CH_CONFIG_GAIN_Msk) |
-		((nrf.SAADC_CH_CONFIG_REFSEL_Internal << nrf.SAADC_CH_CONFIG_REFSEL_Pos) & nrf.SAADC_CH_CONFIG_REFSEL_Msk) |
-		((nrf.SAADC_CH_CONFIG_TACQ_3us << nrf.SAADC_CH_CONFIG_TACQ_Pos) & nrf.SAADC_CH_CONFIG_TACQ_Msk) |
-		((nrf.SAADC_CH_CONFIG_MODE_SE << nrf.SAADC_CH_CONFIG_MODE_Pos) & nrf.SAADC_CH_CONFIG_MODE_Msk))
-
-	// Set pin to read.
-	nrf.SAADC.CH[0].PSELN.Set(pwmPin)
-	nrf.SAADC.CH[0].PSELP.Set(pwmPin)
-
-	// Destination for sample result.
-	nrf.SAADC.RESULT.PTR.Set(uint32(uintptr(unsafe.Pointer(&value))))
-	nrf.SAADC.RESULT.MAXCNT.Set(1) // One sample
-
-	// Start tasks.
-	nrf.SAADC.TASKS_START.Set(1)
-	for nrf.SAADC.EVENTS_STARTED.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_STARTED.Set(0x00)
-
-	// Start the sample task.
-	nrf.SAADC.TASKS_SAMPLE.Set(1)
-
-	// Wait until the sample task is done.
-	for nrf.SAADC.EVENTS_END.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_END.Set(0x00)
-
-	// Stop the ADC
-	nrf.SAADC.TASKS_STOP.Set(1)
-	for nrf.SAADC.EVENTS_STOPPED.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_STOPPED.Set(0)
-
-	// Disable the ADC.
-	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Disabled << nrf.SAADC_ENABLE_ENABLE_Pos)
-
-	if value < 0 {
-		value = 0
-	}
-
-	// Return 16-bit result from 12-bit value.
-	return uint16(value << 4)
 }
 
 // PWM

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -4,7 +4,6 @@ package machine
 
 import (
 	"device/nrf"
-	"unsafe"
 )
 
 // Hardware pins
@@ -76,122 +75,6 @@ func (uart UART) setPins(tx, rx Pin) {
 func (i2c I2C) setPins(scl, sda Pin) {
 	i2c.Bus.PSEL.SCL.Set(uint32(scl))
 	i2c.Bus.PSEL.SDA.Set(uint32(sda))
-}
-
-// SPI
-func (spi SPI) setPins(sck, sdo, sdi Pin) {
-	if sck == 0 {
-		sck = SPI0_SCK_PIN
-	}
-	if sdo == 0 {
-		sdo = SPI0_SDO_PIN
-	}
-	if sdi == 0 {
-		sdi = SPI0_SDI_PIN
-	}
-	spi.Bus.PSEL.SCK.Set(uint32(sck))
-	spi.Bus.PSEL.MOSI.Set(uint32(sdo))
-	spi.Bus.PSEL.MISO.Set(uint32(sdi))
-}
-
-// InitADC initializes the registers needed for ADC.
-func InitADC() {
-	return // no specific setup on nrf52840 machine.
-}
-
-// Configure configures an ADC pin to be able to read analog data.
-func (a ADC) Configure(ADCConfig) {
-	return // no pin specific setup on nrf52840 machine.
-}
-
-// Get returns the current value of a ADC pin in the range 0..0xffff.
-func (a ADC) Get() uint16 {
-	var pwmPin uint32
-	var value int16
-
-	switch a.Pin {
-	case 2:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput0
-
-	case 3:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput1
-
-	case 4:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput2
-
-	case 5:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput3
-
-	case 28:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput4
-
-	case 29:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput5
-
-	case 30:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
-
-	case 31:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
-
-	default:
-		return 0
-	}
-
-	nrf.SAADC.RESOLUTION.Set(nrf.SAADC_RESOLUTION_VAL_12bit)
-
-	// Enable ADC.
-	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Enabled << nrf.SAADC_ENABLE_ENABLE_Pos)
-	for i := 0; i < 8; i++ {
-		nrf.SAADC.CH[i].PSELN.Set(nrf.SAADC_CH_PSELP_PSELP_NC)
-		nrf.SAADC.CH[i].PSELP.Set(nrf.SAADC_CH_PSELP_PSELP_NC)
-	}
-
-	// Configure ADC.
-	nrf.SAADC.CH[0].CONFIG.Set(((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESP_Pos) & nrf.SAADC_CH_CONFIG_RESP_Msk) |
-		((nrf.SAADC_CH_CONFIG_RESP_Bypass << nrf.SAADC_CH_CONFIG_RESN_Pos) & nrf.SAADC_CH_CONFIG_RESN_Msk) |
-		((nrf.SAADC_CH_CONFIG_GAIN_Gain1_5 << nrf.SAADC_CH_CONFIG_GAIN_Pos) & nrf.SAADC_CH_CONFIG_GAIN_Msk) |
-		((nrf.SAADC_CH_CONFIG_REFSEL_Internal << nrf.SAADC_CH_CONFIG_REFSEL_Pos) & nrf.SAADC_CH_CONFIG_REFSEL_Msk) |
-		((nrf.SAADC_CH_CONFIG_TACQ_3us << nrf.SAADC_CH_CONFIG_TACQ_Pos) & nrf.SAADC_CH_CONFIG_TACQ_Msk) |
-		((nrf.SAADC_CH_CONFIG_MODE_SE << nrf.SAADC_CH_CONFIG_MODE_Pos) & nrf.SAADC_CH_CONFIG_MODE_Msk))
-
-	// Set pin to read.
-	nrf.SAADC.CH[0].PSELN.Set(pwmPin)
-	nrf.SAADC.CH[0].PSELP.Set(pwmPin)
-
-	// Destination for sample result.
-	nrf.SAADC.RESULT.PTR.Set(uint32(uintptr(unsafe.Pointer(&value))))
-	nrf.SAADC.RESULT.MAXCNT.Set(1) // One sample
-
-	// Start tasks.
-	nrf.SAADC.TASKS_START.Set(1)
-	for nrf.SAADC.EVENTS_STARTED.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_STARTED.Set(0x00)
-
-	// Start the sample task.
-	nrf.SAADC.TASKS_SAMPLE.Set(1)
-
-	// Wait until the sample task is done.
-	for nrf.SAADC.EVENTS_END.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_END.Set(0x00)
-
-	// Stop the ADC
-	nrf.SAADC.TASKS_STOP.Set(1)
-	for nrf.SAADC.EVENTS_STOPPED.Get() == 0 {
-	}
-	nrf.SAADC.EVENTS_STOPPED.Set(0)
-
-	// Disable the ADC.
-	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Disabled << nrf.SAADC_ENABLE_ENABLE_Pos)
-
-	if value < 0 {
-		value = 0
-	}
-
-	// Return 16-bit result from 12-bit value.
-	return uint16(value << 4)
 }
 
 // PWM

--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -17,7 +17,7 @@ func InitADC() {
 }
 
 // Configure configures an ADC pin to be able to read analog data.
-func (a ADC) Configure() {
+func (a ADC) Configure(ADCConfig) {
 	return // no pin specific setup on nrf52 machine.
 }
 


### PR DESCRIPTION
This PR provides a basic implementation for #1533 

Currently, none of the targets affected make use of the field `Reference` (AREF), although both `atsamd21` and `atsamd51` are capable of using it and will should be updated to handle it in the future.