### PR TITLE
machine/pin: add pin.ConfigureAsInput() and pin.ConfigureAsOutput() helper functions

### DIFF
--- a/src/examples/blinky1/blinky1.go
+++ b/src/examples/blinky1/blinky1.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	led := machine.LED
-	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	led.ConfigureAsOutput()
 	for {
 		led.Low()
 		time.Sleep(time.Millisecond * 500)

--- a/src/examples/blinky2/blinky2.go
+++ b/src/examples/blinky2/blinky2.go
@@ -17,7 +17,7 @@ func main() {
 
 func led1() {
 	led := machine.LED1
-	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	led.ConfigureAsOutput()
 	for {
 		println("+")
 		led.Low()
@@ -31,7 +31,7 @@ func led1() {
 
 func led2() {
 	led := machine.LED2
-	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	led.ConfigureAsOutput()
 	for {
 		println("  +")
 		led.Low()

--- a/src/examples/button/button.go
+++ b/src/examples/button/button.go
@@ -11,8 +11,8 @@ const (
 )
 
 func main() {
-	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
-	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
+	led.ConfigureAsOutput()
+	button.ConfigureAsInput()
 
 	for {
 		if button.Get() {

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -33,6 +33,18 @@ const (
 	PinInputPulldown PinMode = 12
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 type PinChange uint8
 
 // Pin change interrupt constants for SetInterrupt.

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -44,6 +44,18 @@ const (
 	PinInputPulldown PinMode = 18
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 type PinChange uint8
 
 // Pin change interrupt constants for SetInterrupt.

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -16,6 +16,18 @@ const (
 	PinOutput
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 // In all the AVRs I've looked at, the PIN/DDR/PORT registers followed a regular
 // pattern: PINx, DDRx, PORTx in this order without registers in between.
 // Therefore, if you know any of them, you can calculate the other two.

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -30,6 +30,18 @@ const (
 	PinInputPulldown
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 // Configure this pin with the given configuration.
 func (p Pin) Configure(config PinConfig) {
 	// Output function 256 is a special value reserved for use as a regular GPIO

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -18,6 +18,18 @@ const (
 	PinInput
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInput})
+	return nil
+}
+
 // Pins that are fixed by the chip.
 const (
 	UART_TX_PIN Pin = 1

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -21,6 +21,18 @@ const (
 	PinI2C = PinSPI
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInput})
+	return nil
+}
+
 // Configure this pin with the given configuration.
 func (p Pin) Configure(config PinConfig) {
 	sifive.GPIO0.INPUT_EN.SetBits(1 << uint8(p))

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -19,6 +19,18 @@ const (
 	PinInputPulldown
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 func (p Pin) Configure(config PinConfig) {
 	gpioConfigure(p, config)
 }

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -25,6 +25,18 @@ const (
 	PinOutput
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullUp})
+	return nil
+}
+
 // FPIOA internal pull resistors.
 const (
 	fpioaPullNone fpioaPullMode = iota

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -44,6 +44,18 @@ const (
 	PinModeI2CSCL
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullUp})
+	return nil
+}
+
 type PinChange uint8
 
 const (

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -21,6 +21,18 @@ const (
 	PinOutput        PinMode = (nrf.GPIO_PIN_CNF_DIR_Output << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Disconnect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 type PinChange uint8
 
 // Pin change interrupt constants for SetInterrupt.

--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -48,6 +48,18 @@ const (
 	PinDisable
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullUp})
+	return nil
+}
+
 const (
 	PA00 Pin = iota
 	PA01

--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -60,6 +60,18 @@ const (
 	gpioOutputSpeedMask = 0x3
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInputPullup})
+	return nil
+}
+
 // Configure this pin with the given configuration
 func (p Pin) Configure(config PinConfig) {
 	// Use the default system alternate function; this

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -32,6 +32,18 @@ const (
 	PinOutputModeAltOpenDrain PinMode = 12 // Output mode alt. purpose open drain
 )
 
+// ConfigureAsOutput is a convenience function that configures a pin for default output mode.
+func (p Pin) ConfigureAsOutput() error {
+	p.Configure(PinConfig{Mode: PinOutput})
+	return nil
+}
+
+// ConfigureAsInput is a convenience function that configures a pin for default input mode.
+func (p Pin) ConfigureAsInput() error {
+	p.Configure(PinConfig{Mode: PinInput})
+	return nil
+}
+
 // Configure this pin with the given I/O settings.
 // stm32f1xx uses different technique for setting the GPIO pins than the stm32f407
 func (p Pin) Configure(config PinConfig) {


### PR DESCRIPTION
This PR adds the PinConfigInput() and PinConfigOut() helper functions to avoid so much repetition when just using the default values for config:

Before:

```go
	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
```

After:

```go
	led.Configure(machine.PinConfigOutput())
```

You can still use the longer form, this is just a shortened form since the defaults are so often used.