### PR TITLE
Use clang to do linking.

### DIFF
--- a/builder/tools.go
+++ b/builder/tools.go
@@ -38,6 +38,19 @@ func runCCompiler(command string, flags ...string) error {
 
 // link invokes a linker with the given name and flags.
 func link(linker string, flags ...string) error {
+	if hasBuiltinTools && linker == "clang" {
+		// Compile this with the internal Clang compiler.
+		headerPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
+		if headerPath == "" {
+			return errors.New("could not locate Clang headers")
+		}
+		flags = append(flags, "-I"+headerPath)
+		cmd := exec.Command(os.Args[0], append([]string{"clang"}, flags...)...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
 	if hasBuiltinTools && (linker == "ld.lld" || linker == "wasm-ld") {
 		// Run command with internal linker.
 		cmd := exec.Command(os.Args[0], append([]string{linker}, flags...)...)

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -238,8 +238,9 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		GOARCH:    goarch,
 		BuildTags: []string{goos, goarch},
 		Compiler:  "clang",
-		Linker:    "cc",
 		CFlags:    []string{"--target=" + triple},
+		Linker:    "clang",
+		LDFlags:   []string{"--target=" + triple, "-fuse-ld=lld"},
 		GDB:       "gdb",
 		PortReset: "false",
 	}
@@ -256,17 +257,11 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		spec.GDB = "gdb-multiarch"
 		if goarch == "arm" && goos == "linux" {
 			spec.CFlags = append(spec.CFlags, "--sysroot=/usr/arm-linux-gnueabihf")
-			spec.Linker = "arm-linux-gnueabihf-gcc"
 			spec.Emulator = []string{"qemu-arm", "-L", "/usr/arm-linux-gnueabihf"}
 		}
 		if goarch == "arm64" && goos == "linux" {
 			spec.CFlags = append(spec.CFlags, "--sysroot=/usr/aarch64-linux-gnu")
-			spec.Linker = "aarch64-linux-gnu-gcc"
 			spec.Emulator = []string{"qemu-aarch64", "-L", "/usr/aarch64-linux-gnu"}
-		}
-		if goarch == "386" && runtime.GOARCH == "amd64" {
-			spec.CFlags = append(spec.CFlags, "-m32")
-			spec.LDFlags = append(spec.LDFlags, "-m32")
 		}
 	}
 	return &spec, nil


### PR DESCRIPTION
This avoids having to guess what the linker name-with-build-triplet is, as we can just pass the target to it in the same way as the compilation stage.

Close #1536.