### PR TITLE
Use httptest to serve wasm test files.

### DIFF
--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -11,6 +11,9 @@ func TestChan(t *testing.T) {
 
 	t.Parallel()
 
+	wasmTmpDir, server, cleanup := startServer(t)
+	defer cleanup()
+
 	err := run("tinygo build -o " + wasmTmpDir + "/chan.wasm -target wasm testdata/chan.go")
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +23,7 @@ func TestChan(t *testing.T) {
 	defer cancel()
 
 	err = chromedp.Run(ctx,
-		chromedp.Navigate("http://localhost:8826/run?file=chan.wasm"),
+		chromedp.Navigate(server.URL+"/run?file=chan.wasm"),
 		waitLog(`1
 2
 4

--- a/tests/wasm/event_test.go
+++ b/tests/wasm/event_test.go
@@ -13,6 +13,9 @@ func TestEvent(t *testing.T) {
 
 	t.Parallel()
 
+	wasmTmpDir, server, cleanup := startServer(t)
+	defer cleanup()
+
 	err := run("tinygo build -o " + wasmTmpDir + "/event.wasm -target wasm testdata/event.go")
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +26,7 @@ func TestEvent(t *testing.T) {
 
 	var log1, log2 string
 	err = chromedp.Run(ctx,
-		chromedp.Navigate("http://localhost:8826/run?file=event.wasm"),
+		chromedp.Navigate(server.URL+"/run?file=event.wasm"),
 		chromedp.WaitVisible("#log"),
 		chromedp.Sleep(time.Second),
 		chromedp.InnerHTML("#log", &log1),

--- a/tests/wasm/fmt_test.go
+++ b/tests/wasm/fmt_test.go
@@ -20,6 +20,9 @@ func TestFmt(t *testing.T) {
 
 	t.Parallel()
 
+	wasmTmpDir, server, cleanup := startServer(t)
+	defer cleanup()
+
 	err := run("tinygo build -o " + wasmTmpDir + "/fmt.wasm -target wasm testdata/fmt.go")
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +33,7 @@ func TestFmt(t *testing.T) {
 
 	var log1 string
 	err = chromedp.Run(ctx,
-		chromedp.Navigate("http://localhost:8826/run?file=fmt.wasm"),
+		chromedp.Navigate(server.URL+"/run?file=fmt.wasm"),
 		chromedp.Sleep(time.Second),
 		chromedp.InnerHTML("#log", &log1),
 		waitLog(`did not panic`),

--- a/tests/wasm/fmtprint_test.go
+++ b/tests/wasm/fmtprint_test.go
@@ -13,6 +13,9 @@ func TestFmtprint(t *testing.T) {
 
 	t.Parallel()
 
+	wasmTmpDir, server, cleanup := startServer(t)
+	defer cleanup()
+
 	err := run("tinygo build -o " + wasmTmpDir + "/fmtprint.wasm -target wasm testdata/fmtprint.go")
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +26,7 @@ func TestFmtprint(t *testing.T) {
 
 	var log1 string
 	err = chromedp.Run(ctx,
-		chromedp.Navigate("http://localhost:8826/run?file=fmtprint.wasm"),
+		chromedp.Navigate(server.URL+"/run?file=fmtprint.wasm"),
 		chromedp.Sleep(time.Second),
 		chromedp.InnerHTML("#log", &log1),
 		waitLog(`test from fmtprint 1

--- a/tests/wasm/log_test.go
+++ b/tests/wasm/log_test.go
@@ -13,6 +13,9 @@ func TestLog(t *testing.T) {
 
 	t.Parallel()
 
+	wasmTmpDir, server, cleanup := startServer(t)
+	defer cleanup()
+
 	err := run("tinygo build -o " + wasmTmpDir + "/log.wasm -target wasm testdata/log.go")
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +26,7 @@ func TestLog(t *testing.T) {
 
 	var log1 string
 	err = chromedp.Run(ctx,
-		chromedp.Navigate("http://localhost:8826/run?file=log.wasm"),
+		chromedp.Navigate(server.URL+"/run?file=log.wasm"),
 		chromedp.Sleep(time.Second),
 		chromedp.InnerHTML("#log", &log1),
 		waitLogRe(`^..../../.. ..:..:.. log 1


### PR DESCRIPTION
This picks a port automatically, so avoids any conflicts that might arise from running the tests in parallel.