### PR TITLE
compiler: fix non-int integer constants

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2320,15 +2320,15 @@ func (b *builder) createConst(prefix string, expr *ssa.Const) llvm.Value {
 			return strObj
 		} else if typ.Kind() == types.UnsafePointer {
 			if !expr.IsNil() {
-				value, _ := constant.Uint64Val(expr.Value)
+				value, _ := constant.Uint64Val(constant.ToInt(expr.Value))
 				return llvm.ConstIntToPtr(llvm.ConstInt(b.uintptrType, value, false), b.i8ptrType)
 			}
 			return llvm.ConstNull(b.i8ptrType)
 		} else if typ.Info()&types.IsUnsigned != 0 {
-			n, _ := constant.Uint64Val(expr.Value)
+			n, _ := constant.Uint64Val(constant.ToInt(expr.Value))
 			return llvm.ConstInt(llvmType, n, false)
 		} else if typ.Info()&types.IsInteger != 0 { // signed
-			n, _ := constant.Int64Val(expr.Value)
+			n, _ := constant.Int64Val(constant.ToInt(expr.Value))
 			return llvm.ConstInt(llvmType, uint64(n), true)
 		} else if typ.Info()&types.IsFloat != 0 {
 			n, _ := constant.Float64Val(expr.Value)

--- a/testdata/binop.go
+++ b/testdata/binop.go
@@ -70,6 +70,11 @@ func main() {
 	println(ashrNeg == -1)
 	println(ashrOverflow == 0)
 	println(ashrNegOverflow == -1)
+
+	// fix for a bug in constant numbers
+	println("constant number")
+	x := uint32(5)
+	println(uint32(x) / (20e0 / 1))
 }
 
 var x = true

--- a/testdata/binop.txt
+++ b/testdata/binop.txt
@@ -62,3 +62,5 @@ true
 true
 true
 true
+constant number
+0


### PR DESCRIPTION
Before this change, the compiler could panic with the following message:

    panic: 20 not an Int

That of course doesn't make much sense. But it apparently is expected behavior, see https://github.com/golang/go/issues/43165 for details.

This commit fixes this issue by converting the constant to an integer if needed.