### PR TITLE
machine/nrf52840: ensure that USB CDC interface is only initialized once

### DIFF
--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -58,7 +58,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = USB
+	UART0 = &USB
 )
 
 // I2C pins

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -105,7 +105,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = USB
+	UART0 = &USB
 )
 
 // I2C pins

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -77,7 +77,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = USB
+	UART0 = &USB
 )
 
 // I2C pins

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -72,7 +72,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = USB
+	UART0 = &USB
 )
 
 // I2C pins

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
+	Serial = &USB
 	UART0  = NRF_UART0
 )
 

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
+	Serial = &USB
 	UART0  = NRF_UART0
 )
 

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
+	Serial = &USB
 	UART0  = NRF_UART0
 )
 


### PR DESCRIPTION
This PR is to ensure that the USB CDC interface is only initialized once. This avoids a lockup when performing a soft reset, such as when using the UF2 bootloader.