### PR TITLE
machine/clue: correct volume name and add alias for release version of Adafruit Clue

### DIFF
--- a/targets/clue-alpha.json
+++ b/targets/clue-alpha.json
@@ -3,7 +3,7 @@
     "build-tags": ["clue_alpha","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "msd-volume-name": "FTHR840BOOT",
+    "msd-volume-name": "CLUEBOOT",
     "msd-firmware-name": "firmware.uf2",
     "uf2-family-id": "0xADA52840",
     "linkerscript": "targets/circuitplay-bluefruit.ld"

--- a/targets/clue.json
+++ b/targets/clue.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["clue-alpha"]
+}


### PR DESCRIPTION
This PR corrects the volume name and adds an alias for release version of Adafruit Clue board so we can use `-target=clue`.