### PR TITLE
Use rust SVD library for STM32

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "lib/picolibc"]
 	path = lib/picolibc
 	url = https://github.com/keith-packard/picolibc.git
+[submodule "lib/stm32-rs"]
+	path = lib/stm32-rs
+	url = https://github.com/stm32-rs/stm32-rs.git

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,12 @@ gen-device-kendryte: build/gen-device-svd
 	GO111MODULE=off $(GO) fmt ./src/device/kendryte
 
 gen-device-stm32: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/STMicro lib/cmsis-svd/data/STMicro/ src/device/stm32/
+	make -C ./lib/stm32-rs/ svd/.extracted
+	make -C ./lib/stm32-rs/ patch
+	mkdir -p ./lib/stm32-rs/patched
+	$(foreach file, $(wildcard ./lib/stm32-rs/svd/*.svd.patched), \
+		cp $(file) $(patsubst ./lib/stm32-rs/svd/%.svd.patched,./lib/stm32-rs/patched/%.svd,$(file)) &&) true
+	./build/gen-device-svd -source=https://github.com/stm32-rs/stm32-rs lib/stm32-rs/patched/ src/device/stm32/
 	GO111MODULE=off $(GO) fmt ./src/device/stm32
 
 


### PR DESCRIPTION
Have validated using `make smoketest`.

Had to adjust `gen-device-svd` to put a 'read', 'write', 'read-write' suffix when needed, because of this patch:
https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/wwdg/wwdg.yaml

This was resulting in two identical constant declarations for 'Finished' in the Go source.  Solved by taking into account this 'usage' field which is set to 'read', 'write' or 'read-write' per the SVD XML schema.

The suffix is only added when there are multiple 'enumeratedValues' sections, indicating there is potential for a naming collision.  Otherwise suffix is not added so as to avoid gratuitous changes to symbolic names.

This change requires some environment changes to generate the device/stm32 source:

- python3 to be installed
- svdtools to be installed (`pip3 install --upgrade --user svdtools`)