### PR TITLE
Automatically grow the heap on WebAssembly

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/tinygo-org/tinygo/goenv"
@@ -203,12 +202,6 @@ func (c *Config) LDFlags() []string {
 		ldflags = append(ldflags, strings.Replace(flag, "{root}", root, -1))
 	}
 	ldflags = append(ldflags, "-L", root)
-	if c.Target.GOARCH == "wasm" {
-		// Round heap size to next multiple of 65536 (the WebAssembly page
-		// size).
-		heapSize := (c.Options.HeapSize + (65536 - 1)) &^ (65536 - 1)
-		ldflags = append(ldflags, "--initial-memory="+strconv.FormatInt(heapSize, 10))
-	}
 	if c.Target.LinkerScript != "" {
 		ldflags = append(ldflags, "-T", c.Target.LinkerScript)
 	}

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -30,7 +30,6 @@ type Options struct {
 	LDFlags       []string
 	Tags          string
 	WasmAbi       string
-	HeapSize      int64
 	TestConfig    TestConfig
 	Programmer    string
 }

--- a/src/runtime/arch_wasm.go
+++ b/src/runtime/arch_wasm.go
@@ -17,6 +17,9 @@ var heapStartSymbol [0]byte
 //export llvm.wasm.memory.size.i32
 func wasm_memory_size(index int32) int32
 
+//export llvm.wasm.memory.grow.i32
+func wasm_memory_grow(index int32, delta int32) int32
+
 var (
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd   = uintptr(wasm_memory_size(0) * wasmPageSize)
@@ -30,3 +33,20 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr
+
+// growHeap tries to grow the heap size. It returns true if it succeeds, false
+// otherwise.
+func growHeap() bool {
+	// Grow memory by the available size, which means the heap size is doubled.
+	memorySize := wasm_memory_size(0)
+	result := wasm_memory_grow(0, memorySize)
+	if result == -1 {
+		// Grow failed.
+		return false
+	}
+
+	setHeapEnd(uintptr(wasm_memory_size(0) * wasmPageSize))
+
+	// Heap has grown successfully.
+	return true
+}

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -29,6 +29,13 @@ var (
 	stackTop     = uintptr(unsafe.Pointer(&stackTopSymbol))
 )
 
+// growHeap tries to grow the heap size. It returns true if it succeeds, false
+// otherwise.
+func growHeap() bool {
+	// On baremetal, there is no way the heap can be grown.
+	return false
+}
+
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
 	return alloc(size)

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -20,7 +20,12 @@ func alloc(size uintptr) unsafe.Pointer {
 	size = align(size)
 	addr := heapptr
 	heapptr += size
-	if heapptr >= heapEnd {
+	for heapptr >= heapEnd {
+		// Try to increase the heap and check again.
+		if growHeap() {
+			continue
+		}
+		// Failed to make the heap bigger, so we must really be out of memory.
 		runtimePanic("out of memory")
 	}
 	for i := uintptr(0); i < uintptr(size); i += 4 {
@@ -48,4 +53,11 @@ func SetFinalizer(obj interface{}, finalizer interface{}) {
 
 func initHeap() {
 	// Nothing to initialize.
+}
+
+// setHeapEnd sets a new (larger) heapEnd pointer.
+func setHeapEnd(newHeapEnd uintptr) {
+	// This "heap" is so simple that simply assigning a new value is good
+	// enough.
+	heapEnd = newHeapEnd
 }

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -31,3 +31,7 @@ func SetFinalizer(obj interface{}, finalizer interface{}) {
 func initHeap() {
 	// Nothing to initialize.
 }
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Nothing to do here, this function is never actually called.
+}

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -217,6 +217,13 @@ func setupHeap() {
 	}
 }
 
+// growHeap tries to grow the heap size. It returns true if it succeeds, false
+// otherwise.
+func growHeap() bool {
+	// Growing the heap is unimplemented.
+	return false
+}
+
 // getHeapBase returns the start address of the heap
 // this is externally linked by gonx
 func getHeapBase() uintptr {

--- a/src/runtime/runtime_unix_heap.go
+++ b/src/runtime/runtime_unix_heap.go
@@ -13,3 +13,12 @@ func preinit() {
 	heapStart = uintptr(malloc(heapSize))
 	heapEnd = heapStart + heapSize
 }
+
+// growHeap tries to grow the heap size. It returns true if it succeeds, false
+// otherwise.
+func growHeap() bool {
+	// At the moment, this is not possible. However it shouldn't be too
+	// difficult (at least on Linux) to allocate a large amount of virtual
+	// memory at startup that is then slowly used.
+	return false
+}


### PR DESCRIPTION
This commit makes the heap growable on WebAssembly. The heap design is not fundamentally changed although the heap layout is changed. This has been something I wanted to implement long ago but I never got around doing it. In the end, it took me a lot less time than I expected.

This should have very little impact on baremetal targets. Firmware size increased slightly but while working on this I also found an optimization in the heap to make things easier for the optimizer so that firmware size is in fact usually reduced a little bit with this PR on baremetal targets. The WebAssembly output has grown a little bit of course, with this new ability to grow the heap when it is full.

This fixes https://github.com/tinygo-org/tinygo/issues/1535 and https://github.com/tinygo-org/tinygo/issues/460 and improves https://github.com/tinygo-org/tinygo/issues/1327