### PR TITLE
Examples for Dragino lgt92 device

### DIFF
--- a/src/examples/lgt92/01_button_interrupt.go
+++ b/src/examples/lgt92/01_button_interrupt.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"device/stm32"
+	"machine"
+	"runtime/interrupt"
+	"time"
+)
+
+var (
+	colorFlag uint8
+)
+
+// Interrupt handler for GPIO interrupts
+func gpios_int(inter interrupt.Interrupt) {
+	irqStatus := stm32.EXTI.PR.Get()
+	stm32.EXTI.PR.Set(irqStatus)
+
+	if (irqStatus & 0x4000) > 0 { // PB14 : Button
+		colorFlag = colorFlag << 1
+		if colorFlag == 8 {
+			colorFlag = 1
+		}
+
+		println("ColorFlag change", colorFlag)
+
+		machine.LED_RED.Set((colorFlag & 1) > 0)
+		machine.LED_GREEN.Set((colorFlag & 2) > 0)
+		machine.LED_BLUE.Set((colorFlag & 4) > 0)
+	}
+
+}
+
+func hw_init() {
+
+	// SYSCFGEN is NEEDED FOR IRQ HANDLERS (button + Dio) .. Do not remove
+	stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_SYSCFGEN)
+
+	// BUTTON PB14
+	machine.BUTTON.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
+	stm32.SYSCFG.EXTICR4.ReplaceBits(0b001, 0xf, stm32.SYSCFG_EXTICR4_EXTI14_Pos) // Enable PORTB On line 14
+	//	stm32.EXTI.RTSR.SetBits(stm32.EXTI_RTSR_RT14)                                      // Detect Rising Edge of EXTI14 Line
+	stm32.EXTI.FTSR.SetBits(stm32.EXTI_FTSR_FT14) // Detect Falling Edge of EXTI14 Line
+	stm32.EXTI.IMR.SetBits(stm32.EXTI_IMR_IM14)   // Enable EXTI14 line
+
+	// Led GPIO init
+	machine.LED_RED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LED_GREEN.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LED_BLUE.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	// Switch off LEDS
+	machine.LED_RED.Low()
+	machine.LED_GREEN.Low()
+	machine.LED_BLUE.Low()
+
+	// Enable UART
+	uartConsole := &machine.UART0
+	uartConsole.Configure(machine.UARTConfig{TX: machine.UART_TX_PIN, RX: machine.UART_TX_PIN, BaudRate: 9600})
+
+	// Enable interrupts (For handling button interrupts)
+	intr := interrupt.New(stm32.IRQ_EXTI4_15, gpios_int)
+	intr.SetPriority(0x0)
+	intr.Enable()
+
+}
+
+//----------------------------------------------------------------------------------------------//
+
+func main() {
+
+	println("*** LGT92 gpio interrupt demo 1  ***")
+	println("Press button to change LED color")
+
+	hw_init()
+
+	colorFlag = 1
+	for {
+		time.Sleep(1 * time.Second)
+	}
+
+}

--- a/src/examples/lgt92/02_simple_blink.go
+++ b/src/examples/lgt92/02_simple_blink.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+func hw_init() {
+
+	// Led GPIO init
+	machine.LED_RED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	// Switch off LEDS
+	machine.LED_RED.Low()
+
+	// Enable UART
+	uartConsole := &machine.UART0
+	uartConsole.Configure(machine.UARTConfig{TX: machine.UART_TX_PIN, RX: machine.UART_TX_PIN, BaudRate: 9600})
+
+}
+
+//----------------------------------------------------------------------------------------------//
+
+func main() {
+
+	println("*** LGT92 demo 2 : Led is toggling every second")
+
+	hw_init()
+
+	for {
+		time.Sleep(1 * time.Second)
+		machine.LED_RED.Set(!machine.LED_RED.Get())
+	}
+
+}

--- a/src/examples/lgt92/03_gps_read.go
+++ b/src/examples/lgt92/03_gps_read.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"machine"
+	"time"
+)
+
+var uartGps, uartConsole *machine.UART
+
+// serialGps() function handles communication with GPS Module UART
+func serialGps(uart *machine.UART) string {
+	input := make([]byte, 300)
+
+	i := 0
+
+	for {
+
+		if i == 300 {
+			println("Serial Buffer overrun")
+			i = 0
+		}
+		if uart.Buffered() > 0 {
+
+			data, _ := uart.ReadByte() // read a character
+
+			switch data {
+			case '\n': // We received a Frame
+			case '\r':
+				cmd := string(input[:i])
+				i = 0
+				println(cmd)
+			//	uartConsole.Write([]byte(cmd))
+			//	uartConsole.Write([]byte("\r\n"))
+			default: // pressed any other key
+				machine.LED_RED.Set(!machine.LED_RED.Get())
+				input[i] = data
+				i++
+			}
+		}
+
+		//time.Sleep(3 * time.Millisecond)
+	}
+
+}
+
+//----------------------------------------------------------------------------------------------//
+
+func main() {
+
+	// Turn RED led for 1sec
+	machine.LED_RED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.LED_RED.Set(true)
+	time.Sleep(1000 * time.Millisecond)
+	machine.LED_RED.Set(false)
+
+	// Enable UART0 (Console)
+	uartConsole := &machine.UART0
+	uartConsole.Configure(machine.UARTConfig{TX: machine.UART_TX_PIN, RX: machine.UART_TX_PIN, BaudRate: 9600})
+	println("*** LGT92 demo 3 : Enable GPS and read sentences")
+
+	// Enable UART1 (GPS)
+	uartGps = &machine.UART1
+	uartGps.Configure(machine.UARTConfig{TX: machine.UART1_TX_PIN, RX: machine.UART1_TX_PIN, BaudRate: 9600})
+
+	// Power On GPS
+	machine.GPS_STANDBY_PIN.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.GPS_RESET_PIN.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.GPS_POWER_PIN.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	machine.GPS_STANDBY_PIN.Set(false) // GPS Pin Standby_L (PB3)
+	machine.GPS_RESET_PIN.Set(false)   // GPS Pin Reset OFF (PB4)
+	machine.GPS_POWER_PIN.Set(true)    // GPS Pin Power ON (PB5)
+
+	// Run a Go routine for handling GPS UART messages
+	go serialGps(uartGps)
+
+	for {
+		time.Sleep(1 * time.Second)
+		machine.LED_RED.Set(!machine.LED_RED.Get())
+	}
+
+}

--- a/src/examples/lgt92/README.md
+++ b/src/examples/lgt92/README.md
@@ -1,0 +1,88 @@
+
+Some examples for testing Dragino LGT92 devices (UARTs, SPI, LED, GPS, LORA ...) 
+
+
+# Flashing LGT92 
+
+  # With STLINKv2
+
+You can flash LGT92 with the provided USB cable adapter and STLinkV2 adapter:
+
+|LGT92 Cable|ST Link v2|
+|-|-|
+|RED| +5V|
+|WHITE|SWDIO|
+|GREEN|SWCLK|
+|BLACK|GND|
+
+  # With Black Magic
+
+... Or with a BlackMagic adapter: 
+
+|LGT92 Cable|BlackMagic|
+|-|-|
+|RED|+5V|
+|WHITE|PB14(SWDIO)|
+|GREEN|PA5(SWCLK) |
+|BLACK|GND|
+
+
+# LGT92 console uart
+
+After flashing, the firmware turns SWD LGT92 pins (green/white wires) into a UART.
+
+You can connect a UART interface to these pins to read the messages. 
+
+(Note : You can't connect UART interface and SWD Flasher at the same time)
+
+
+|LGT92 Cable|USART adapter|
+|-|-|
+|WHITE| TX  |
+|GREEN| RX |
+
+If you use black magic extra uart: 
+
+|LGT92 Cable|Black Magic|
+|-|-|
+|WHITE| PA2 (TX)  |
+|GREEN| PA3 (RX) |
+
+
+# Building examples
+
+
+|File|Description|
+|-|-|
+|01_gpio_int_button.go|Handle button GPIO with interrupt|
+|02_simple_blink.go| Red led will blink every seconds|
+|03_gps_read.go|Read NMEA sentences from UART|
+
+
+Example:
+
+```
+tinygo build --size=full --target=lgt92 -o main.elf gpio_int1.go
+```
+
+# How to flash
+
+Either use tinygo flash command: 
+
+```
+tinygo flash --target=lgt92  01_gpio_int_button.go
+```
+
+Or  do it 'by hand': 
+
+```
+openocd -f /usr/share/openocd/scripts/interface/stlink-v2.cfg -c "transport select hla_swd" -f /usr/share/openocd/scripts/target/stm32l0.cfg -c init -c 'program main.elf verify reset exit'
+```
+
+Or even with BlackMagic interface : 
+
+```
+tinygo build -size=full -target=lgt92 -opt=z -o 03_gps.elf 03_gps.go
+
+arm-none-eabi-gdb -nx --batch -ex "target extended-remote /dev/ttyACM1" -ex "monitor swdp_scan" -ex "attach 1" -ex load -ex compare-sections -ex kill 03_gps
+```

--- a/targets/lgt92.json
+++ b/targets/lgt92.json
@@ -8,5 +8,5 @@
 	"linkerscript": "targets/stm32l072czt6.ld",
 	"flash-method": "openocd",
 	"openocd-interface": "stlink-v2",
-	"openocd-target": "stm32f0x"
+	"openocd-target": "stm32l0"
 }


### PR DESCRIPTION
- Fix bad openocd-target definition in lgt92.json
- Example applications for Dragino LGT92 device