### PR TITLE
Add tests to the compiler package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
           key: wasi-libc-sysroot-systemclang-v2
           paths:
             - lib/wasi-libc/sysroot
-      - run: go test -v -tags=llvm<<parameters.llvm>> ./cgo ./compileopts ./interp ./transform .
+      - run: go test -v -tags=llvm<<parameters.llvm>> ./cgo ./compileopts ./compiler ./interp ./transform .
       - run: make gen-device -j4
       - run: make smoketest XTENSA=0
       - run: make tinygo-test

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ tinygo:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm -ldflags="-X main.gitSha1=`git rev-parse --short HEAD`" .
 
 test: wasi-libc
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -buildmode exe -tags byollvm ./cgo ./compileopts ./interp ./transform .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -buildmode exe -tags byollvm ./cgo ./compileopts ./compiler ./interp ./transform .
 
 # Test known-working standard library packages.
 # TODO: do this in one command, parallelize, and only show failing tests (no

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1,0 +1,161 @@
+package compiler
+
+import (
+	"flag"
+	"go/types"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/loader"
+	"tinygo.org/x/go-llvm"
+)
+
+// Pass -update to go test to update the output of the test files.
+var flagUpdate = flag.Bool("update", false, "update tests based on test output")
+
+// Basic tests for the compiler. Build some Go files and compare the output with
+// the expected LLVM IR for regression testing.
+func TestCompiler(t *testing.T) {
+	target, err := compileopts.LoadTarget("i686--linux")
+	if err != nil {
+		t.Fatal("failed to load target:", err)
+	}
+	config := &compileopts.Config{
+		Options: &compileopts.Options{},
+		Target:  target,
+	}
+	machine, err := NewTargetMachine(config)
+	if err != nil {
+		t.Fatal("failed to create target machine:", err)
+	}
+
+	tests := []string{
+		"basic.go",
+		"pointer.go",
+		"slice.go",
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase, func(t *testing.T) {
+			// Load entire program AST into memory.
+			lprogram, err := loader.Load(config, []string{"./testdata/" + testCase}, config.ClangHeaders, types.Config{
+				Sizes: Sizes(machine),
+			})
+			if err != nil {
+				t.Fatal("failed to create target machine:", err)
+			}
+			err = lprogram.Parse()
+			if err != nil {
+				t.Fatalf("could not parse test case %s: %s", testCase, err)
+			}
+
+			// Compile AST to IR.
+			pkg := lprogram.MainPkg()
+			mod, errs := CompilePackage(testCase, pkg, machine, config)
+			if errs != nil {
+				for _, err := range errs {
+					t.Log("error:", err)
+				}
+				return
+			}
+
+			// Optimize IR a little.
+			funcPasses := llvm.NewFunctionPassManagerForModule(mod)
+			defer funcPasses.Dispose()
+			funcPasses.AddInstructionCombiningPass()
+			funcPasses.InitializeFunc()
+			for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+				funcPasses.RunFunc(fn)
+			}
+			funcPasses.FinalizeFunc()
+
+			outfile := "./testdata/" + testCase[:len(testCase)-3] + ".ll"
+
+			// Update test if needed. Do not check the result.
+			if *flagUpdate {
+				err := ioutil.WriteFile(outfile, []byte(mod.String()), 0666)
+				if err != nil {
+					t.Error("failed to write updated output file:", err)
+				}
+				return
+			}
+
+			expected, err := ioutil.ReadFile(outfile)
+			if err != nil {
+				t.Fatal("failed to read golden file:", err)
+			}
+
+			if !fuzzyEqualIR(mod.String(), string(expected)) {
+				t.Errorf("output does not match expected output:\n%s", mod.String())
+			}
+		})
+	}
+}
+
+var alignRegexp = regexp.MustCompile(", align [0-9]+$")
+
+// fuzzyEqualIR returns true if the two LLVM IR strings passed in are roughly
+// equal. That means, only relevant lines are compared (excluding comments
+// etc.).
+func fuzzyEqualIR(s1, s2 string) bool {
+	lines1 := filterIrrelevantIRLines(strings.Split(s1, "\n"))
+	lines2 := filterIrrelevantIRLines(strings.Split(s2, "\n"))
+	if len(lines1) != len(lines2) {
+		return false
+	}
+	for i, line1 := range lines1 {
+		line2 := lines2[i]
+		match1 := alignRegexp.MatchString(line1)
+		match2 := alignRegexp.MatchString(line2)
+		if match1 != match2 {
+			// Only one of the lines has the align keyword. Remove it.
+			// This is a change to make the test work in both LLVM 10 and LLVM
+			// 11 (LLVM 11 appears to automatically add alignment everywhere).
+			line1 = alignRegexp.ReplaceAllString(line1, "")
+			line2 = alignRegexp.ReplaceAllString(line2, "")
+		}
+		if line1 != line2 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// filterIrrelevantIRLines removes lines from the input slice of strings that
+// are not relevant in comparing IR. For example, empty lines and comments are
+// stripped out.
+func filterIrrelevantIRLines(lines []string) []string {
+	var out []string
+	llvmVersion, err := strconv.Atoi(strings.Split(llvm.Version, ".")[0])
+	if err != nil {
+		// Note: this should never happen and if it does, it will always happen
+		// for a particular build because llvm.Version is a constant.
+		panic(err)
+	}
+	for _, line := range lines {
+		line = strings.Split(line, ";")[0]    // strip out comments/info
+		line = strings.TrimRight(line, "\r ") // drop '\r' on Windows and remove trailing spaces from comments
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "source_filename = ") {
+			continue
+		}
+		if llvmVersion < 10 && strings.HasPrefix(line, "attributes ") {
+			// Ignore attribute groups. These may change between LLVM versions.
+			// Right now test outputs are for LLVM 10.
+			continue
+		}
+		if llvmVersion < 10 && strings.HasPrefix(line, "target datalayout ") {
+			// Ignore the target layout. This may change between LLVM versions.
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/compiler/testdata/basic.go
+++ b/compiler/testdata/basic.go
@@ -1,0 +1,57 @@
+package main
+
+// Basic tests that don't need to be split into a separate file.
+
+func addInt(x, y int) int {
+	return x + y
+}
+
+func equalInt(x, y int) bool {
+	return x == y
+}
+
+func floatEQ(x, y float32) bool {
+	return x == y
+}
+
+func floatNE(x, y float32) bool {
+	return x != y
+}
+
+func floatLower(x, y float32) bool {
+	return x < y
+}
+
+func floatLowerEqual(x, y float32) bool {
+	return x <= y
+}
+
+func floatGreater(x, y float32) bool {
+	return x > y
+}
+
+func floatGreaterEqual(x, y float32) bool {
+	return x >= y
+}
+
+func complexReal(x complex64) float32 {
+	return real(x)
+}
+
+func complexImag(x complex64) float32 {
+	return imag(x)
+}
+
+func complexAdd(x, y complex64) complex64 {
+	return x + y
+}
+
+func complexSub(x, y complex64) complex64 {
+	return x - y
+}
+
+func complexMul(x, y complex64) complex64 {
+	return x * y
+}
+
+// TODO: complexDiv (requires runtime call)

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -1,0 +1,98 @@
+; ModuleID = 'basic.go'
+source_filename = "basic.go"
+target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
+target triple = "i686--linux"
+
+define internal void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
+}
+
+define internal i32 @main.addInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = add i32 %x, %y
+  ret i32 %0
+}
+
+define internal i1 @main.equalInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = icmp eq i32 %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatEQ(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp oeq float %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatNE(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp une float %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatLower(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp olt float %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatLowerEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp ole float %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatGreater(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp ogt float %x, %y
+  ret i1 %0
+}
+
+define internal i1 @main.floatGreaterEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fcmp oge float %x, %y
+  ret i1 %0
+}
+
+define internal float @main.complexReal(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret float %x.r
+}
+
+define internal float @main.complexImag(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret float %x.i
+}
+
+define internal { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fadd float %x.r, %y.r
+  %1 = fadd float %x.i, %y.i
+  %2 = insertvalue { float, float } undef, float %0, 0
+  %3 = insertvalue { float, float } %2, float %1, 1
+  ret { float, float } %3
+}
+
+define internal { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fsub float %x.r, %y.r
+  %1 = fsub float %x.i, %y.i
+  %2 = insertvalue { float, float } undef, float %0, 0
+  %3 = insertvalue { float, float } %2, float %1, 1
+  ret { float, float } %3
+}
+
+define internal { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = fmul float %x.r, %y.r
+  %1 = fmul float %x.i, %y.i
+  %2 = fsub float %0, %1
+  %3 = fmul float %x.r, %y.i
+  %4 = fmul float %x.i, %y.r
+  %5 = fadd float %3, %4
+  %6 = insertvalue { float, float } undef, float %2, 0
+  %7 = insertvalue { float, float } %6, float %5, 1
+  ret { float, float } %7
+}

--- a/compiler/testdata/pointer.go
+++ b/compiler/testdata/pointer.go
@@ -1,0 +1,41 @@
+package main
+
+// This file tests various operations on pointers, such as pointer arithmetic
+// and dereferencing pointers.
+
+import "unsafe"
+
+// Dereference pointers.
+
+func pointerDerefZero(x *[0]int) [0]int {
+	return *x // This is a no-op, there is nothing to load.
+}
+
+// Unsafe pointer casts, they are sometimes a no-op.
+
+func pointerCastFromUnsafe(x unsafe.Pointer) *int {
+	return (*int)(x)
+}
+
+func pointerCastToUnsafe(x *int) unsafe.Pointer {
+	return unsafe.Pointer(x)
+}
+
+func pointerCastToUnsafeNoop(x *byte) unsafe.Pointer {
+	return unsafe.Pointer(x)
+}
+
+// The compiler has support for a few special cast+add patterns that are
+// transformed into a single GEP.
+
+func pointerUnsafeGEPFixedOffset(ptr *byte) *byte {
+	return (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + 10))
+}
+
+func pointerUnsafeGEPByteOffset(ptr *byte, offset uintptr) *byte {
+	return (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + offset))
+}
+
+func pointerUnsafeGEPIntOffset(ptr *int32, offset uintptr) *int32 {
+	return (*int32)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + offset*4))
+}

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -1,0 +1,49 @@
+; ModuleID = 'pointer.go'
+source_filename = "pointer.go"
+target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
+target triple = "i686--linux"
+
+define internal void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
+}
+
+define internal [0 x i32] @main.pointerDerefZero([0 x i32]* %x, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret [0 x i32] zeroinitializer
+}
+
+define internal i32* @main.pointerCastFromUnsafe(i8* %x, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = bitcast i8* %x to i32*
+  ret i32* %0
+}
+
+define internal i8* @main.pointerCastToUnsafe(i32* dereferenceable_or_null(4) %x, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = bitcast i32* %x to i8*
+  ret i8* %0
+}
+
+define internal i8* @main.pointerCastToUnsafeNoop(i8* dereferenceable_or_null(1) %x, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret i8* %x
+}
+
+define internal i8* @main.pointerUnsafeGEPFixedOffset(i8* dereferenceable_or_null(1) %ptr, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = getelementptr inbounds i8, i8* %ptr, i32 10
+  ret i8* %0
+}
+
+define internal i8* @main.pointerUnsafeGEPByteOffset(i8* dereferenceable_or_null(1) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = getelementptr inbounds i8, i8* %ptr, i32 %offset
+  ret i8* %0
+}
+
+define internal i32* @main.pointerUnsafeGEPIntOffset(i32* dereferenceable_or_null(4) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %0 = getelementptr i32, i32* %ptr, i32 %offset
+  ret i32* %0
+}

--- a/compiler/testdata/slice.go
+++ b/compiler/testdata/slice.go
@@ -1,0 +1,9 @@
+package main
+
+func sliceLen(ints []int) int {
+	return len(ints)
+}
+
+func sliceCap(ints []int) int {
+	return cap(ints)
+}

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -1,0 +1,19 @@
+; ModuleID = 'slice.go'
+source_filename = "slice.go"
+target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
+target triple = "i686--linux"
+
+define internal void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
+}
+
+define internal i32 @main.sliceLen(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret i32 %ints.len
+}
+
+define internal i32 @main.sliceCap(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret i32 %ints.cap
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -67,7 +67,7 @@ func NewProgram(lprogram *loader.Program) *Program {
 	program := lprogram.LoadSSA()
 	program.Build()
 
-	mainPkg := program.ImportedPackage(lprogram.MainPkg().ImportPath)
+	mainPkg := program.Package(lprogram.MainPkg().Pkg)
 	if mainPkg == nil {
 		panic("could not find main package")
 	}
@@ -79,7 +79,7 @@ func NewProgram(lprogram *loader.Program) *Program {
 	}
 
 	for _, pkg := range lprogram.Sorted() {
-		p.AddPackage(program.ImportedPackage(pkg.ImportPath))
+		p.AddPackage(program.Package(pkg.Pkg))
 	}
 
 	return p

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -43,6 +43,7 @@ type Program struct {
 type PackageJSON struct {
 	Dir        string
 	ImportPath string
+	Name       string
 	ForTest    string
 
 	// Source files
@@ -335,7 +336,16 @@ func (p *Package) Check() error {
 	// Do typechecking of the package.
 	checker.Importer = p
 
-	typesPkg, err := checker.Check(p.ImportPath, p.program.fset, p.Files, &p.info)
+	packageName := p.ImportPath
+	if p.Name == "main" {
+		// The main package normally has a different import path, such as
+		// "command-line-arguments" or "./testdata/cgo". Therefore, use the name
+		// "main" in such a case: this package isn't imported from anywhere.
+		// This is safe as it isn't possible to import a package with the name
+		// "main".
+		packageName = "main"
+	}
+	typesPkg, err := checker.Check(packageName, p.program.fset, p.Files, &p.info)
 	if err != nil {
 		if err, ok := err.(Errors); ok {
 			return err

--- a/loader/ssa.go
+++ b/loader/ssa.go
@@ -16,3 +16,11 @@ func (p *Program) LoadSSA() *ssa.Program {
 
 	return prog
 }
+
+// LoadSSA constructs the SSA form of this package.
+//
+// The program must already be parsed and type-checked with the .Parse() method.
+func (p *Package) LoadSSA() *ssa.Package {
+	prog := ssa.NewProgram(p.program.fset, ssa.SanityCheckFunctions|ssa.BareInits|ssa.GlobalDebug)
+	return prog.CreatePackage(p.Pkg, p.Files, &p.info, true)
+}


### PR DESCRIPTION
This is my next attempt to make the compiler more modular (also see #1008). This time I managed to add tests to the compiler without too many complications.

Testing is still quite limited as it isn't yet possible to test anything that refers to runtime types or functions, which are the most interesting tests. ~I did this in #1008~ but left it out in this PR to keep things simple and focused. I intend to introduce runtime types in a later PR and with that change, add more compiler tests.

The first commit of this PR is a small change that renames the main package in the IR. This could have real world impact but I think it is an improvement as output binaries now better match the symbol name conventions of the Go toolchain.

Updates #285.