### PR TITLE
compiler: emit a nil check when slicing an array pointer

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1852,6 +1852,7 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 				low,
 			}
 
+			b.createNilCheck(expr.X, value, "slice")
 			b.createSliceBoundsCheck(llvmLen, low, high, max, lowType, highType, maxType)
 
 			// Truncate ints bigger than uintptr. This is after the bounds


### PR DESCRIPTION
Fixes #1575 

Once the compiler testing gets a bit further we can probably add some tests to verify that assertions are inserted correctly.