### PR TITLE
Add support for Go 1.16.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,8 +268,8 @@ commands:
       - run:
           name: "Install dependencies"
           command: |
-            curl https://dl.google.com/go/go1.15.5.darwin-amd64.tar.gz -o go1.15.5.darwin-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.15.5.darwin-amd64.tar.gz
+            curl https://dl.google.com/go/go1.16.darwin-amd64.tar.gz -o go1.16.darwin-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.16.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
             HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
       - install-xtensa-toolchain:
@@ -370,6 +370,12 @@ jobs:
     steps:
       - test-linux:
           llvm: "11"
+  test-llvm11-go116:
+    docker:
+      - image: circleci/golang:1.16-buster
+    steps:
+      - test-linux:
+          llvm: "11"
   assert-test-linux:
     docker:
       - image: circleci/golang:1.14-stretch
@@ -396,6 +402,7 @@ workflows:
       - test-llvm10-go113
       - test-llvm10-go114
       - test-llvm11-go115
+      - test-llvm11-go116
       - build-linux
       - build-macos
       - assert-test-linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
     - task: GoTool@0
       inputs:
-        version: '1.15'
+        version: '1.16'
     - checkout: self
       fetchDepth: 1
     - task: Cache@2

--- a/builder/config.go
+++ b/builder/config.go
@@ -25,8 +25,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 11 || minor > 15 {
-		return nil, fmt.Errorf("requires go version 1.11 through 1.15, got go%d.%d", major, minor)
+	if major != 1 || minor < 11 || minor > 16 {
+		return nil, fmt.Errorf("requires go version 1.11 through 1.16, got go%d.%d", major, minor)
 	}
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
 	return &compileopts.Config{

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/format"
 	"go/parser"
 	"go/token"
@@ -41,6 +42,20 @@ func TestCGo(t *testing.T) {
 	for _, name := range []string{"basic", "errors", "types", "flags", "const"} {
 		name := name // avoid a race condition
 		t.Run(name, func(t *testing.T) {
+			// Skip tests that require specific Go version.
+			if name == "errors" {
+				ok := false
+				for _, version := range build.Default.ReleaseTags {
+					if version == "go1.16" {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					t.Skip("Results for errors test are only valid for Go 1.16+")
+				}
+			}
+
 			// Read the AST in memory.
 			path := filepath.Join("testdata", name+".go")
 			fset := token.NewFileSet()

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -4,10 +4,10 @@
 //     testdata/errors.go:13:23: unexpected token )
 
 // Type checking errors after CGo processing:
-//     testdata/errors.go:102: 2 << 10 (untyped int constant 2048) overflows uint8
+//     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as uint8 value in variable declaration (overflows)
 //     testdata/errors.go:105: unknown field z in struct literal
 //     testdata/errors.go:108: undeclared name: C.SOME_CONST_1
-//     testdata/errors.go:110: C.SOME_CONST_3 (untyped int constant 1234) overflows byte
+//     testdata/errors.go:110: cannot use C.SOME_CONST_3 (untyped int constant 1234) as byte value in variable declaration (overflows)
 
 package main
 


### PR DESCRIPTION
This is not yet available in CircleCI images, but it is in testing in Fedora Rawhide. As such, these are only the changes needed to get it to work right now, without any attempt at backwards-compatibility.