### PR TITLE
compiler: support all kinds of deferred builtins

### DIFF
--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -79,8 +79,7 @@ func (b *builder) createChanRecv(unop *ssa.UnOp) llvm.Value {
 }
 
 // createChanClose closes the given channel.
-func (b *builder) createChanClose(param ssa.Value) {
-	ch := b.getValue(param)
+func (b *builder) createChanClose(ch llvm.Value) {
 	b.createRuntimeCall("chanClose", []llvm.Value{ch}, "")
 }
 


### PR DESCRIPTION
This change extends defer support to all supported builitin functions.
Not all of them make sense (such as len, cap, real, imag, etc) but this change for example adds support for `defer(delete(m, key))` which is used in the Go 1.15 encoding/json package.