### PR TITLE
compiler: remove unnecessary main.main call workaround

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -297,14 +297,6 @@ func CompileProgram(pkgName string, lprogram *loader.Program, machine llvm.Targe
 	}
 	irbuilder.CreateRetVoid()
 
-	// Conserve for goroutine lowering. Without marking these as external, they
-	// would be optimized away.
-	realMain := c.mod.NamedFunction(lprogram.MainPkg().Pkg.Path() + ".main")
-	realMain.SetLinkage(llvm.ExternalLinkage) // keep alive until goroutine lowering
-
-	// Replace callMain placeholder with actual main function.
-	c.mod.NamedFunction("runtime.callMain").ReplaceAllUsesWith(realMain)
-
 	// Load some attributes
 	getAttr := func(attrName string) llvm.Attribute {
 		attrKind := llvm.AttributeKindID(attrName)

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -10,8 +10,7 @@ const Compiler = "tinygo"
 // package.
 func initAll()
 
-// callMain is a placeholder for the program main function.
-// All references to this are replaced with references to the program main function by the compiler.
+//go:linkname callMain main.main
 func callMain()
 
 func GOMAXPROCS(n int) int {


### PR DESCRIPTION
Since https://github.com/tinygo-org/tinygo/pull/1571 (in particular, the first
commit that sets the main package path), the main package is always named
"main". This makes the callMain() workaround in the runtime unnecessary and
allows directly calling the main.main function with a //go:linkname pragma.

This is just a small refactor to clean up the code a bit.