### PR TITLE
compiler: move settings to a separate Config struct

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -28,7 +28,17 @@ func TestCompiler(t *testing.T) {
 		Options: &compileopts.Options{},
 		Target:  target,
 	}
-	machine, err := NewTargetMachine(config)
+	compilerConfig := &Config{
+		Triple:             config.Triple(),
+		GOOS:               config.GOOS(),
+		GOARCH:             config.GOARCH(),
+		CodeModel:          config.CodeModel(),
+		RelocationModel:    config.RelocationModel(),
+		Scheduler:          config.Scheduler(),
+		FuncImplementation: config.FuncImplementation(),
+		AutomaticStackSize: config.AutomaticStackSize(),
+	}
+	machine, err := NewTargetMachine(compilerConfig)
 	if err != nil {
 		t.Fatal("failed to create target machine:", err)
 	}
@@ -56,7 +66,7 @@ func TestCompiler(t *testing.T) {
 
 			// Compile AST to IR.
 			pkg := lprogram.MainPkg()
-			mod, errs := CompilePackage(testCase, pkg, machine, config)
+			mod, errs := CompilePackage(testCase, pkg, machine, compilerConfig, false)
 			if errs != nil {
 				for _, err := range errs {
 					t.Log("error:", err)

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -220,7 +220,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		allocCall := b.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "defer.alloc.call")
 		alloca = b.CreateBitCast(allocCall, llvm.PointerType(deferFrameType, 0), "defer.alloc")
 	}
-	if b.NeedsStackObjects() {
+	if b.NeedsStackObjects {
 		b.trackPointer(alloca)
 	}
 	b.CreateStore(deferFrame, alloca)

--- a/compiler/goroutine.go
+++ b/compiler/goroutine.go
@@ -21,10 +21,10 @@ import (
 func (b *builder) createGoInstruction(funcPtr llvm.Value, params []llvm.Value, prefix string, pos token.Pos) llvm.Value {
 	paramBundle := b.emitPointerPack(params)
 	var callee, stackSize llvm.Value
-	switch b.Scheduler() {
+	switch b.Scheduler {
 	case "none", "tasks":
 		callee = b.createGoroutineStartWrapper(funcPtr, prefix, pos)
-		if b.AutomaticStackSize() {
+		if b.AutomaticStackSize {
 			// The stack size is not known until after linking. Call a dummy
 			// function that will be replaced with a load from a special ELF
 			// section that contains the stack size (and is modified after
@@ -34,7 +34,7 @@ func (b *builder) createGoInstruction(funcPtr llvm.Value, params []llvm.Value, p
 		} else {
 			// The stack size is fixed at compile time. By emitting it here as a
 			// constant, it can be optimized.
-			stackSize = llvm.ConstInt(b.uintptrType, b.Target.DefaultStackSize, false)
+			stackSize = llvm.ConstInt(b.uintptrType, b.DefaultStackSize, false)
 		}
 	case "coroutines":
 		callee = b.CreatePtrToInt(funcPtr, b.uintptrType, "")
@@ -90,7 +90,7 @@ func (c *compilerContext) createGoroutineStartWrapper(fn llvm.Value, prefix stri
 		entry := c.ctx.AddBasicBlock(wrapper, "entry")
 		builder.SetInsertPointAtEnd(entry)
 
-		if c.Debug() {
+		if c.Debug {
 			pos := c.program.Fset.Position(pos)
 			diFuncType := c.dibuilder.CreateSubroutineType(llvm.DISubroutineType{
 				File:       c.getDIFile(pos.Filename),
@@ -147,7 +147,7 @@ func (c *compilerContext) createGoroutineStartWrapper(fn llvm.Value, prefix stri
 		entry := c.ctx.AddBasicBlock(wrapper, "entry")
 		builder.SetInsertPointAtEnd(entry)
 
-		if c.Debug() {
+		if c.Debug {
 			pos := c.program.Fset.Position(pos)
 			diFuncType := c.dibuilder.CreateSubroutineType(llvm.DISubroutineType{
 				File:       c.getDIFile(pos.Filename),

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -478,7 +478,7 @@ func (c *compilerContext) getInterfaceInvokeWrapper(fn *ssa.Function, llvmFn llv
 	defer b.Builder.Dispose()
 
 	// add debug info if needed
-	if c.Debug() {
+	if c.Debug {
 		pos := c.program.Fset.Position(fn.Pos())
 		difunc := c.attachDebugInfoRaw(fn, wrapper, "$invoke", pos.Filename, pos.Line)
 		b.SetCurrentDebugLocation(uint(pos.Line), uint(pos.Column), difunc, llvm.Metadata{})

--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -55,7 +55,7 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	global.SetInitializer(initializer)
 
 	// Add debug info to the interrupt global.
-	if b.Debug() {
+	if b.Debug {
 		pos := b.program.Fset.Position(instr.Pos())
 		diglobal := b.dibuilder.CreateGlobalVariableExpression(b.getDIFile(pos.Filename), llvm.DIGlobalVariableExpression{
 			Name:        "interrupt" + strconv.FormatInt(id.Int64(), 10),
@@ -79,7 +79,7 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	// PLIC where each interrupt must be enabled using the interrupt number, and
 	// thus keeps the Interrupt object alive.
 	// This call is removed during interrupt lowering.
-	if strings.HasPrefix(b.Triple(), "avr") {
+	if strings.HasPrefix(b.Triple, "avr") {
 		useFn := b.mod.NamedFunction("runtime/interrupt.use")
 		if useFn.IsNil() {
 			useFnType := llvm.FunctionType(b.ctx.VoidType(), []llvm.Type{interrupt.Type()}, false)

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -44,7 +44,7 @@ func (b *builder) emitLifetimeEnd(ptr, size llvm.Value) {
 // bitcasts, or else allocates a value on the heap if it cannot be packed in the
 // pointer value directly. It returns the pointer with the packed data.
 func (b *builder) emitPointerPack(values []llvm.Value) llvm.Value {
-	return llvmutil.EmitPointerPack(b.Builder, b.mod, b.Config, values)
+	return llvmutil.EmitPointerPack(b.Builder, b.mod, b.NeedsStackObjects, values)
 }
 
 // emitPointerUnpack extracts a list of values packed using emitPointerPack.

--- a/compiler/llvmutil/wordpack.go
+++ b/compiler/llvmutil/wordpack.go
@@ -5,7 +5,6 @@ package llvmutil
 // itself if possible and legal.
 
 import (
-	"github.com/tinygo-org/tinygo/compileopts"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -13,7 +12,7 @@ import (
 // bitcasts, or else allocates a value on the heap if it cannot be packed in the
 // pointer value directly. It returns the pointer with the packed data.
 // If the values are all constants, they are be stored in a constant global and deduplicated.
-func EmitPointerPack(builder llvm.Builder, mod llvm.Module, config *compileopts.Config, values []llvm.Value) llvm.Value {
+func EmitPointerPack(builder llvm.Builder, mod llvm.Module, needsStackObjects bool, values []llvm.Value) llvm.Value {
 	ctx := mod.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
 	i8ptrType := llvm.PointerType(mod.Context().Int8Type(), 0)
@@ -101,7 +100,7 @@ func EmitPointerPack(builder llvm.Builder, mod llvm.Module, config *compileopts.
 			llvm.Undef(i8ptrType),            // unused context parameter
 			llvm.ConstPointerNull(i8ptrType), // coroutine handle
 		}, "")
-		if config.NeedsStackObjects() {
+		if needsStackObjects {
 			trackPointer := mod.NamedFunction("runtime.trackPointer")
 			builder.CreateCall(trackPointer, []llvm.Value{
 				packedHeapAlloc,

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -295,7 +295,7 @@ func (c *compilerContext) getGlobal(g *ssa.Global) llvm.Value {
 			}
 		}
 
-		if c.Debug() && !info.extern {
+		if c.Debug && !info.extern {
 			// Add debug info.
 			// TODO: this should be done for every global in the program, not just
 			// the ones that are referenced from some code.

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -16,8 +16,8 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 	num := b.getValue(call.Args[0])
 	var syscallResult llvm.Value
 	switch {
-	case b.GOARCH() == "amd64":
-		if b.GOOS() == "darwin" {
+	case b.GOARCH == "amd64":
+		if b.GOOS == "darwin" {
 			// Darwin adds this magic number to system call numbers:
 			//
 			// > Syscall classes for 64-bit system call entry.
@@ -58,7 +58,7 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
 		target := llvm.InlineAsm(fnType, "syscall", constraints, true, false, llvm.InlineAsmDialectIntel)
 		syscallResult = b.CreateCall(target, args, "")
-	case b.GOARCH() == "386" && b.GOOS() == "linux":
+	case b.GOARCH == "386" && b.GOOS == "linux":
 		// Sources:
 		//   syscall(2) man page
 		//   https://stackoverflow.com/a/2538212
@@ -84,7 +84,7 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
 		target := llvm.InlineAsm(fnType, "int 0x80", constraints, true, false, llvm.InlineAsmDialectIntel)
 		syscallResult = b.CreateCall(target, args, "")
-	case b.GOARCH() == "arm" && b.GOOS() == "linux":
+	case b.GOARCH == "arm" && b.GOOS == "linux":
 		// Implement the EABI system call convention for Linux.
 		// Source: syscall(2) man page.
 		args := []llvm.Value{}
@@ -116,7 +116,7 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
 		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0)
 		syscallResult = b.CreateCall(target, args, "")
-	case b.GOARCH() == "arm64" && b.GOOS() == "linux":
+	case b.GOARCH == "arm64" && b.GOOS == "linux":
 		// Source: syscall(2) man page.
 		args := []llvm.Value{}
 		argTypes := []llvm.Type{}
@@ -149,9 +149,9 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0)
 		syscallResult = b.CreateCall(target, args, "")
 	default:
-		return llvm.Value{}, b.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+b.GOOS()+"/"+b.GOARCH())
+		return llvm.Value{}, b.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+b.GOOS+"/"+b.GOARCH)
 	}
-	switch b.GOOS() {
+	switch b.GOOS {
 	case "linux", "freebsd":
 		// Return values: r0, r1 uintptr, err Errno
 		// Pseudocode:
@@ -187,6 +187,6 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		retval = b.CreateInsertValue(retval, errResult, 2, "")
 		return retval, nil
 	default:
-		return llvm.Value{}, b.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+b.GOOS()+"/"+b.GOARCH())
+		return llvm.Value{}, b.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+b.GOOS+"/"+b.GOARCH)
 	}
 }

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -85,7 +85,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 			return errs
 		}
 
-		if config.FuncImplementation() == compileopts.FuncValueSwitch {
+		if config.FuncImplementation() == "switch" {
 			LowerFuncValues(mod)
 		}
 
@@ -104,7 +104,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		if err != nil {
 			return []error{err}
 		}
-		if config.FuncImplementation() == compileopts.FuncValueSwitch {
+		if config.FuncImplementation() == "switch" {
 			LowerFuncValues(mod)
 		}
 		errs := LowerInterrupts(mod)


### PR DESCRIPTION
Moving settings to a separate config struct has two benefits:
  - It decouples the compiler a bit from other packages, most
    importantly the compileopts package. Decoupling is generally a good
    thing.
  - Perhaps more importantly, it precisely specifies which settings are
    used while compiling and affect the resulting LLVM module. This will
    be necessary for caching the LLVM module.
    While it would have been possible to cache without this refactor, it
    would have been very easy to miss a setting and thus let the
    compiler work with invalid/stale data.

---

This commit is extracted from a local branch that caches built packages and that way slightly speeds up incremental builds (where you modify only one package).