### PR TITLE
machine/clue: correct for lack of low frequency crystal

### DIFF
--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -2,7 +2,7 @@
 
 package machine
 
-const HasLowFrequencyCrystal = true
+const HasLowFrequencyCrystal = false
 
 // GPIO Pins
 const (


### PR DESCRIPTION
This PR changes the Adafruit Clue which it seems does not possess a low frequency crystal.