### PR TITLE
machine: make I2C.Configure signature consistent

### DIFF
--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -13,7 +13,7 @@ type I2CConfig struct {
 }
 
 // Configure is intended to setup the I2C interface.
-func (i2c I2C) Configure(config I2CConfig) {
+func (i2c I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
 		config.Frequency = TWI_FREQ_100KHZ
@@ -33,6 +33,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 	// Enable twi module.
 	avr.TWCR.Set(avr.TWCR_TWEN)
+
+	return nil
 }
 
 // Tx does a single I2C transaction at the specified address.

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -115,8 +115,9 @@ type I2CConfig struct {
 }
 
 // Configure is intended to setup the I2C interface.
-func (i2c I2C) Configure(config I2CConfig) {
+func (i2c I2C) Configure(config I2CConfig) error {
 	i2cConfigure(i2c.Bus, config.SCL, config.SDA)
+	return nil
 }
 
 // Tx does a single I2C transaction at the specified address.

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -220,7 +220,7 @@ type I2CConfig struct {
 }
 
 // Configure is intended to setup the I2C interface.
-func (i2c I2C) Configure(config I2CConfig) {
+func (i2c I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
 		config.Frequency = TWI_FREQ_100KHZ
@@ -254,6 +254,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 	i2c.Bus.ENABLE.Set(nrf.TWI_ENABLE_ENABLE_Enabled)
 	i2c.setPins(config.SCL, config.SDA)
+
+	return nil
 }
 
 // Tx does a single I2C transaction at the specified address.

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -142,7 +142,7 @@ type I2CConfig struct {
 }
 
 // Configure is intended to setup the STM32 I2C interface.
-func (i2c I2C) Configure(config I2CConfig) {
+func (i2c I2C) Configure(config I2CConfig) error {
 
 	// The following is the required sequence in controller mode.
 	// 1. Program the peripheral input clock in I2C_CR2 Register in order to
@@ -188,6 +188,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 	// enable I2C interface
 	i2c.Bus.CR1.ClearBits(stm32.I2C_CR1_PE)
+
+	return nil
 }
 
 func (i2c I2C) Tx(addr uint16, w, r []byte) error {

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -217,7 +217,7 @@ type I2CConfig struct {
 }
 
 // Configure is intended to setup the I2C interface.
-func (i2c I2C) Configure(config I2CConfig) {
+func (i2c I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
 		config.Frequency = TWI_FREQ_100KHZ
@@ -285,6 +285,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 	// re-enable the selected I2C peripheral
 	i2c.Bus.CR1.SetBits(stm32.I2C_CR1_PE)
+
+	return nil
 }
 
 // Tx does a single I2C transaction at the specified address.


### PR DESCRIPTION
It's better to always return an error value (even if it is nil) for consistency. I noticed this while working on some documentation.