### PR TITLE
machine: remove TWI_FREQ_* constants

### DIFF
--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -6,12 +6,6 @@ import (
 	"errors"
 )
 
-// TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
-const (
-	TWI_FREQ_100KHZ = 100000
-	TWI_FREQ_400KHZ = 400000
-)
-
 var (
 	errI2CWriteTimeout       = errors.New("I2C timeout during write")
 	errI2CReadTimeout        = errors.New("I2C timeout during read")

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -16,7 +16,7 @@ type I2CConfig struct {
 func (i2c I2C) Configure(config I2CConfig) {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // default to 100kHz
 	}
 
 	// Activate internal pullups for twi.

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -669,7 +669,7 @@ const i2cTimeout = 1000
 func (i2c I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // default to 100kHz
 	}
 	if config.SDA == 0 && config.SCL == 0 {
 		config.SDA = SDA_PIN

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1105,7 +1105,7 @@ const i2cTimeout = 1000
 func (i2c I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // default to 100kHz
 	}
 
 	// Use default I2C pins if not set.

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -197,7 +197,7 @@ type I2CConfig struct {
 func (i2c I2C) Configure(config I2CConfig) error {
 	var i2cClockFrequency uint32 = 32000000
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // default to 100kHz
 	}
 
 	if config.SDA == 0 && config.SCL == 0 {

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -507,7 +507,7 @@ type I2CConfig struct {
 func (i2c I2C) Configure(config I2CConfig) error {
 
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // default to 100kHz
 	}
 
 	if config.SDA == 0 && config.SCL == 0 {

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -171,7 +171,7 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 	// default to 100 kHz (Sm, standard mode) if no frequency is set
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // 100kHz
 	}
 
 	// configure I2C input clock

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -220,7 +220,7 @@ type I2CConfig struct {
 func (i2c I2C) Configure(config I2CConfig) {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100e3 // 100kHz
 	}
 
 	// enable clock for I2C
@@ -253,22 +253,8 @@ func (i2c I2C) Configure(config I2CConfig) {
 	pclk1Mhz := pclk1 / 1000000
 	i2c.Bus.CR2.SetBits(pclk1Mhz)
 
-	switch config.Frequency {
-	case TWI_FREQ_100KHZ:
-		// Normal mode speed calculation
-		ccr := pclk1 / (config.Frequency * 2)
-		i2c.Bus.CCR.Set(ccr)
-
-		// duty cycle 2
-		i2c.Bus.CCR.ClearBits(stm32.I2C_CCR_DUTY)
-
-		// frequency standard mode
-		i2c.Bus.CCR.ClearBits(stm32.I2C_CCR_F_S)
-
-		// Set Maximum Rise Time for standard mode
-		i2c.Bus.TRISE.Set(pclk1Mhz)
-
-	case TWI_FREQ_400KHZ:
+	switch {
+	case config.Frequency >= 400e3: // 400kHz
 		// Fast mode speed calculation
 		ccr := pclk1 / (config.Frequency * 3)
 		i2c.Bus.CCR.Set(ccr)
@@ -281,6 +267,19 @@ func (i2c I2C) Configure(config I2CConfig) {
 
 		// Set Maximum Rise Time for fast mode
 		i2c.Bus.TRISE.Set(((pclk1Mhz * 300) / 1000))
+	default:
+		// Normal mode speed calculation
+		ccr := pclk1 / (config.Frequency * 2)
+		i2c.Bus.CCR.Set(ccr)
+
+		// duty cycle 2
+		i2c.Bus.CCR.ClearBits(stm32.I2C_CCR_DUTY)
+
+		// frequency standard mode
+		i2c.Bus.CCR.ClearBits(stm32.I2C_CCR_F_S)
+
+		// Set Maximum Rise Time for standard mode
+		i2c.Bus.TRISE.Set(pclk1Mhz)
 	}
 
 	// re-enable the selected I2C peripheral


### PR DESCRIPTION
These constants:

  * Have the wrong name (TWI instead of I2C)
  * Are not formatted according to Go guidelines
  * Are not necessary: if you want `TWI_FREQ_400KHZ` you could write that directly with 400e3.

Therefore I propose that we removed them.

There is also a small change to nrf chips to also support 250kHz I2C and to machine_stm32_i2c.go to accept other values than just 100kHz/400kHz (but 100kHz/400kHz will be picked anyway). These changes allow the use of other frequencies than just 100kHz and 400kHz in I2CConfig while still doing something reasonable.

---

I have tested this on the pca10040 board. Also see https://github.com/tinygo-org/drivers/pull/229.