### PR TITLE
cgo: add support for variadic functions

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -54,9 +54,10 @@ type constantInfo struct {
 // functionInfo stores some information about a CGo function found by libclang
 // and declared in the AST.
 type functionInfo struct {
-	args    []paramInfo
-	results *ast.FieldList
-	pos     token.Pos
+	args     []paramInfo
+	results  *ast.FieldList
+	pos      token.Pos
+	variadic bool
 }
 
 // paramInfo is a parameter of a CGo function (see functionInfo).
@@ -483,6 +484,16 @@ func (p *cgoPackage) addFuncDecls() {
 				},
 				Results: fn.results,
 			},
+		}
+		if fn.variadic {
+			decl.Doc = &ast.CommentGroup{
+				List: []*ast.Comment{
+					&ast.Comment{
+						Slash: fn.pos,
+						Text:  "//go:variadic",
+					},
+				},
+			}
 		}
 		obj.Decl = decl
 		for i, arg := range fn.args {

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -152,12 +152,10 @@ func tinygo_clang_globals_visitor(c, parent C.GoCXCursor, client_data C.CXClient
 			return C.CXChildVisit_Continue
 		}
 		cursorType := C.tinygo_clang_getCursorType(c)
-		if C.clang_isFunctionTypeVariadic(cursorType) != 0 {
-			return C.CXChildVisit_Continue // not supported
-		}
 		numArgs := int(C.tinygo_clang_Cursor_getNumArguments(c))
 		fn := &functionInfo{
-			pos: pos,
+			pos:      pos,
+			variadic: C.clang_isFunctionTypeVariadic(cursorType) != 0,
 		}
 		p.functions[name] = fn
 		for i := 0; i < numArgs; i++ {

--- a/cgo/testdata/types.go
+++ b/cgo/testdata/types.go
@@ -104,6 +104,10 @@ typedef struct {
 	unsigned char e : 3;
 	// Note that C++ allows bitfields bigger than the underlying type.
 } bitfield_t;
+
+// Function signatures.
+void variadic0();
+void variadic2(int x, int y, ...);
 */
 import "C"
 
@@ -162,4 +166,10 @@ func accessUnion() {
 	var union2d C.union2d_t
 	var _ *C.int = union2d.unionfield_i()
 	var _ *[2]float64 = union2d.unionfield_d()
+}
+
+// Test function signatures.
+func accessFunctions() {
+	C.variadic0()
+	C.variadic2(3, 5)
 }

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -4,6 +4,11 @@ import "unsafe"
 
 var _ unsafe.Pointer
 
+func C.variadic0() //go:variadic
+func C.variadic2(x C.int, y C.int) //go:variadic
+var C.variadic0$funcaddr unsafe.Pointer
+var C.variadic2$funcaddr unsafe.Pointer
+
 const C.option2A = 20
 const C.optionA = 0
 const C.optionB = 1

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -34,6 +34,14 @@ int doCallback(int a, int b, binop_t callback) {
 	return callback(a, b);
 }
 
+int variadic0() {
+	return 1;
+}
+
+int variadic2(int x, int y, ...) {
+	return x * y;
+}
+
 void store(int value, int *ptr) {
 	*ptr = value;
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -36,6 +36,10 @@ func main() {
 	cb = C.binop_t(C.mul)
 	println("callback 2:", C.doCallback(20, 30, cb))
 
+	// variadic functions
+	println("variadic0:", C.variadic0())
+	println("variadic2:", C.variadic2(3, 5))
+
 	// equivalent types
 	var goInt8 int8 = 5
 	var _ C.int8_t = goInt8

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -10,6 +10,9 @@ int doCallback(int a, int b, binop_t cb);
 typedef int * intPointer;
 void store(int value, int *ptr);
 
+int variadic0();
+int variadic2(int x, int y, ...);
+
 # define CONST_INT 5
 # define CONST_INT2 5llu
 # define CONST_FLOAT 5.8

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -12,6 +12,8 @@ defined char: 99
 25: 25
 callback 1: 50
 callback 2: 600
+variadic0: 1
+variadic2: 15
 bool: true true
 float: +3.100000e+000
 double: +3.200000e+000


### PR DESCRIPTION
This doesn't yet add support for actually making use of variadic functions, but at least allows (unintended) variadic functions like the following to work:

    void foo();