### PR TITLE
ci: remove bad symlink workaround on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,11 +24,7 @@ jobs:
       displayName: Download LLVM source
       inputs:
         targetType: inline
-        script: |
-          make llvm-source
-          # Workaround for bad symlinks:
-          # https://github.com/microsoft/azure-pipelines-tasks/issues/13418
-          rm -f llvm-project/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/bad_symlink
+        script: make llvm-source
     - task: CacheBeta@0
       displayName: Cache LLVM build
       inputs:


### PR DESCRIPTION
This workaround is no longer needed as the symlink in the LLVM source tree has been removed.

I have tested this in https://github.com/tinygo-org/tinygo/pull/1623 and verified that the `bad_symlink` symlink has been removed from the LLVM tree in LLVM 11. Therefore, there is no reason to (attempt to) remove this symlink anymore.

Upstream bug that I reported: https://github.com/microsoft/azure-pipelines-tasks/issues/13418