### PR TITLE
esp8266: add compiler-rt library 

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -171,7 +171,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// Add compiler-rt dependency if needed. Usually this is a simple load from
 	// a cache.
 	if config.Target.RTLib == "compiler-rt" {
-		path, job, err := CompilerRT.load(config.Triple(), dir)
+		path, job, err := CompilerRT.load(config.Triple(), config.CPU(), dir)
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 
 	// Add libc dependency if needed.
 	if config.Target.Libc == "picolibc" {
-		path, job, err := Picolibc.load(config.Triple(), dir)
+		path, job, err := Picolibc.load(config.Triple(), config.CPU(), dir)
 		if err != nil {
 			return err
 		}

--- a/builder/buildcache.go
+++ b/builder/buildcache.go
@@ -30,10 +30,7 @@ func cacheTimestamp(paths []string) (time.Time, error) {
 // Try to load a given file from the cache. Return "", nil if no cached file can
 // be found (or the file is stale), return the absolute path if there is a cache
 // and return an error on I/O errors.
-//
-// TODO: the configKey is currently ignored. It is supposed to be used as extra
-// data for the cache key, like the compiler version and arguments.
-func cacheLoad(name, configKey string, sourceFiles []string) (string, error) {
+func cacheLoad(name string, sourceFiles []string) (string, error) {
 	cachepath := filepath.Join(goenv.Get("GOCACHE"), name)
 	cacheStat, err := os.Stat(cachepath)
 	if os.IsNotExist(err) {
@@ -58,9 +55,7 @@ func cacheLoad(name, configKey string, sourceFiles []string) (string, error) {
 
 // Store the file located at tmppath in the cache with the given name. The
 // tmppath may or may not be gone afterwards.
-//
-// Note: the configKey is ignored, see cacheLoad.
-func cacheStore(tmppath, name, configKey string, sourceFiles []string) (string, error) {
+func cacheStore(tmppath, name string, sourceFiles []string) (string, error) {
 	// get the last modified time
 	if len(sourceFiles) == 0 {
 		panic("cache: no source files")

--- a/builder/library.go
+++ b/builder/library.go
@@ -71,7 +71,7 @@ func (l *Library) load(target, tmpdir string) (path string, job *compileJob, err
 	outfile := l.name + "-" + target + ".a"
 
 	// Try to fetch this library from the cache.
-	if path, err := cacheLoad(outfile, commands["clang"][0], l.sourcePaths(target)); path != "" || err != nil {
+	if path, err := cacheLoad(outfile, l.sourcePaths(target)); path != "" || err != nil {
 		// Cache hit.
 		return path, nil, err
 	}
@@ -112,7 +112,7 @@ func (l *Library) load(target, tmpdir string) (path string, job *compileJob, err
 				return err
 			}
 			// Store this archive in the cache.
-			_, err = cacheStore(arpath, outfile, commands["clang"][0], l.sourcePaths(target))
+			_, err = cacheStore(arpath, outfile, l.sourcePaths(target))
 			return err
 		},
 	}

--- a/builder/library.go
+++ b/builder/library.go
@@ -42,7 +42,7 @@ func (l *Library) sourcePaths(target string) []string {
 // The resulting file is stored in the provided tmpdir, which is expected to be
 // removed after the Load call.
 func (l *Library) Load(target, tmpdir string) (path string, err error) {
-	path, job, err := l.load(target, tmpdir)
+	path, job, err := l.load(target, "", tmpdir)
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,7 @@ func (l *Library) Load(target, tmpdir string) (path string, err error) {
 // path is valid.
 // The provided tmpdir will be used to store intermediary files and possibly the
 // output archive file, it is expected to be removed after use.
-func (l *Library) load(target, tmpdir string) (path string, job *compileJob, err error) {
+func (l *Library) load(target, cpu, tmpdir string) (path string, job *compileJob, err error) {
 	// Try to load a precompiled library.
 	precompiledPath := filepath.Join(goenv.Get("TINYGOROOT"), "pkg", target, l.name+".a")
 	if _, err := os.Stat(precompiledPath); err == nil {
@@ -68,7 +68,12 @@ func (l *Library) load(target, tmpdir string) (path string, job *compileJob, err
 		return precompiledPath, nil, nil
 	}
 
-	outfile := l.name + "-" + target + ".a"
+	var outfile string
+	if cpu != "" {
+		outfile = l.name + "-" + target + "-" + cpu + ".a"
+	} else {
+		outfile = l.name + "-" + target + ".a"
+	}
 
 	// Try to fetch this library from the cache.
 	if path, err := cacheLoad(outfile, l.sourcePaths(target)); path != "" || err != nil {
@@ -89,6 +94,9 @@ func (l *Library) load(target, tmpdir string) (path string, job *compileJob, err
 	// reproducible. Otherwise the temporary directory is stored in the archive
 	// itself, which varies each run.
 	args := append(l.cflags(), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
+	if cpu != "" {
+		args = append(args, "-mcpu="+cpu)
+	}
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
 		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft")
 	}

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -9,6 +9,7 @@
 		"-mcpu=esp32"
 	],
 	"rtlib": "compiler-rt",
+	"libc": "picolibc",
 	"linkerscript": "targets/esp32.ld",
 	"extra-files": [
 		"src/device/esp/esp32.S",

--- a/targets/esp8266.json
+++ b/targets/esp8266.json
@@ -9,6 +9,7 @@
 		"-mcpu=esp8266"
 	],
 	"rtlib": "compiler-rt",
+	"libc": "picolibc",
 	"linkerscript": "targets/esp8266.ld",
 	"extra-files": [
 		"src/device/esp/esp8266.S",

--- a/targets/esp8266.json
+++ b/targets/esp8266.json
@@ -8,6 +8,7 @@
 	"cflags": [
 		"-mcpu=esp8266"
 	],
+	"rtlib": "compiler-rt",
 	"linkerscript": "targets/esp8266.ld",
 	"extra-files": [
 		"src/device/esp/esp8266.S",


### PR DESCRIPTION
With this change, it is possible to compile ./testdata/float.go for the ESP8266 and run it successfully. Previously it would result in many linker error like this:

    /tmp/tinygo494494333/main.o:(.literal.runtime.printfloat64+0x0): undefined reference to `__unorddf2'
    /tmp/tinygo494494333/main.o:(.literal.runtime.printfloat64+0x4): undefined reference to `__gtdf2'
    /tmp/tinygo494494333/main.o:(.literal.runtime.printfloat64+0xc): undefined reference to `__nedf2'
    /tmp/tinygo494494333/main.o:(.literal.runtime.printfloat64+0x10): undefined reference to `__ltdf2'
    /tmp/tinygo494494333/main.o:(.literal.runtime.printfloat64+0x1c): undefined reference to `__gedf2'

I have verified that the output on the serial console matches ./testdata/float.txt when run on the ESP8266.

In the future the second commit will also be necessary for adding compiler-rt to AVR targets.