### PR TITLE
builder: wait for running jobs to finish

### DIFF
--- a/builder/jobs.go
+++ b/builder/jobs.go
@@ -110,6 +110,12 @@ func runJobs(jobs []*compileJob) error {
 			fmt.Println("## finished:", job.description, "(time "+job.duration.String()+")")
 		}
 		if job.err != nil {
+			// Wait for running jobs to finish.
+			for numRunningJobs != 0 {
+				<-doneChan
+				numRunningJobs--
+			}
+			// Return error of first failing job.
 			return job.err
 		}
 	}


### PR DESCRIPTION
This avoids external commands from finishing after the TinyGo command exits. For example, when testing out compiler-rt on AVR, I got the following error:

    $ go install; and tinygo run -target=atmega1284p ./testdata/calls.go
    [... Clang error removed ...]
    error: failed to build /home/ayke/src/github.com/tinygo-org/tinygo/lib/compiler-rt/lib/builtins/extendsfdf2.c: exit status 1
    error: unable to open output file '/tmp/tinygo361380649/build-lib-compiler-rt/ffsdi2.c.o': 'No such file or directory'
    1 error generated.

That last error ("unable to open output file") is a spurious error because the temporary directory has already been removed. This commit waits until all running jobs have finished before returning, so that these errors won't happen.