### PR TITLE
Fix typo in wasm_exec.js

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -408,7 +408,7 @@
 
 					// func valueInstanceOf(v ref, t ref) bool
 					"syscall/js.valueInstanceOf": (v_addr, t_addr) => {
- 						return loadValue(v_attr) instanceof loadValue(t_addr);
+ 						return loadValue(v_addr) instanceof loadValue(t_addr);
 					},
 
 					// func copyBytesToGo(dst []byte, src ref) (int, bool)


### PR DESCRIPTION
There seems to be a typo in the `syscall/js.valueLoadString` implementation.

https://github.com/tinygo-org/tinygo/blob/b689f14bb2c49c39fdd958be318ef3fb2e6d5ffb/targets/wasm_exec.js#L409-L412

I think it should be `loadValue(v_addr)`, not `v_attr`.