### PR TITLE
Teensy 4.0: Fix UART capability

### DIFF
--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -136,6 +136,7 @@ const (
 )
 
 var (
+	UART0 = &UART1 // alias UART0 to UART1
 	UART1 = UART{
 		Bus:      nxp.LPUART6,
 		Buffer:   NewRingBuffer(),

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -137,8 +137,9 @@ const (
 
 var (
 	UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART6,
+		Bus:      nxp.LPUART6,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D0 (PA3 [AD_B0_03])
 			mux: nxp.IOMUXC_LPUART6_RX_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART6_RX_SELECT_INPUT,
@@ -149,8 +150,9 @@ var (
 		},
 	}
 	UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART4,
+		Bus:      nxp.LPUART4,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D7 (PB17 [B1_01])
 			mux: nxp.IOMUXC_LPUART4_RX_SELECT_INPUT_DAISY_GPIO_B1_01_ALT2,
 			sel: &nxp.IOMUXC.LPUART4_RX_SELECT_INPUT,
@@ -161,8 +163,9 @@ var (
 		},
 	}
 	UART3 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART2,
+		Bus:      nxp.LPUART2,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D15 (PA19 [AD_B1_03])
 			mux: nxp.IOMUXC_LPUART2_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART2_RX_SELECT_INPUT,
@@ -173,8 +176,9 @@ var (
 		},
 	}
 	UART4 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART3,
+		Bus:      nxp.LPUART3,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D16 (PA23 [AD_B1_07])
 			mux: nxp.IOMUXC_LPUART3_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT2,
 			sel: &nxp.IOMUXC.LPUART3_RX_SELECT_INPUT,
@@ -185,8 +189,9 @@ var (
 		},
 	}
 	UART5 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART8,
+		Bus:      nxp.LPUART8,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D21 (PA27 [AD_B1_11])
 			mux: nxp.IOMUXC_LPUART8_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_11_ALT2,
 			sel: &nxp.IOMUXC.LPUART8_RX_SELECT_INPUT,
@@ -197,15 +202,17 @@ var (
 		},
 	}
 	UART6 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART1,
+		Bus:      nxp.LPUART1,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		// LPUART1 not connected via IOMUXC
 		//   RX: D24 (PA12 [AD_B0_12])
 		//   TX: D25 (PA13 [AD_B0_13])
 	}
 	UART7 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    nxp.LPUART7,
+		Bus:      nxp.LPUART7,
+		Buffer:   NewRingBuffer(),
+		txBuffer: NewRingBuffer(),
 		muxRX: muxSelect{ // D28 (PC18 [EMC_32])
 			mux: nxp.IOMUXC_LPUART7_RX_SELECT_INPUT_DAISY_GPIO_EMC_32_ALT2,
 			sel: &nxp.IOMUXC.LPUART7_RX_SELECT_INPUT,


### PR DESCRIPTION
This PR addresses issue (#1649), where UART stopped functioning after `interp` package rewrite.

After the rewrite, it was observed that `interp` no longer supports referring to memory-mapped registers from global contexts such as package-level `var` and `func init`.