### PR TITLE
Add nrf52840-mdk-usb-dongle target

### DIFF
--- a/src/machine/board_nrf52840-mdk-usb-dongle.go
+++ b/src/machine/board_nrf52840-mdk-usb-dongle.go
@@ -1,15 +1,20 @@
-// +build nrf52840_mdk
+// +build nrf52840_mdk_usb_dongle
 
 package machine
 
 const HasLowFrequencyCrystal = true
 
-// LEDs on the nrf52840-mdk (nRF52840 dev board)
+// LEDs on the nrf52840-mdk-usb-dongle
 const (
 	LED       Pin = LED_GREEN
 	LED_GREEN Pin = 22
 	LED_RED   Pin = 23
 	LED_BLUE  Pin = 24
+)
+
+// RESET/USR button, depending on value of PSELRESET UICR register
+const (
+	BUTTON Pin = 18
 )
 
 // UART pins
@@ -38,7 +43,7 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Makerdiary nRF52840 MDK"
+	usb_STRING_PRODUCT      = "Makerdiary nRF52840 MDK USB Dongle"
 	usb_STRING_MANUFACTURER = "Makerdiary"
 )
 

--- a/src/machine/board_nrf52840-mdk-usb-dongle.go
+++ b/src/machine/board_nrf52840-mdk-usb-dongle.go
@@ -19,8 +19,8 @@ const (
 
 // UART pins
 const (
-	UART_TX_PIN Pin = 20
-	UART_RX_PIN Pin = 19
+	UART_TX_PIN Pin = NoPin
+	UART_RX_PIN Pin = NoPin
 )
 
 // UART0 is the USB device

--- a/targets/nrf52840-mdk-usb-dongle.json
+++ b/targets/nrf52840-mdk-usb-dongle.json
@@ -1,0 +1,10 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["nrf52840_mdk_usb_dongle", "nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "msd-volume-name": "MDK-DONGLE",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
Adds support for the [nrf52840-mdk-usb-dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/), with the now-default UF2 bootloader. 

This target also expects the S140 v6 SoftDevice to be present, which might not be the case if one of the non-bluetooth C++ examples, like the [C++ blinky example](https://github.com/makerdiary/nrf52840-mdk-usb-dongle/tree/cbb51081997ce31fdf355bd533cad5f5d575f347/examples/nrf5-sdk/blinky) has been flashed (see [linker script](https://github.com/makerdiary/nrf52840-mdk-usb-dongle/blob/cbb51081997ce31fdf355bd533cad5f5d575f347/examples/nrf5-sdk/blinky/armgcc/blinky_gcc_nrf52.ld#L8)). If this is the case, one should flash the S140 SoftDevice first, for which you can find the instructions [here](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/nrf5-sdk/#running-examples-that-use-a-softdevice).

I can confirm that this board works with https://github.com/tinygo-org/bluetooth as well.

---

Also renames the incorrect `usb_STRING_PRODUCT` for the [nrf52840-mdk](https://wiki.makerdiary.com/nrf52840-mdk), which is a different board.

Fixes #1147