### PR TITLE
interp: support GEP on fixed (MMIO) addresses

### DIFF
--- a/interp/errors.go
+++ b/interp/errors.go
@@ -11,19 +11,17 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-var errLiteralToPointer = errors.New("interp: trying to convert literal value to pointer")
-
 // These errors are expected during normal execution and can be recovered from
 // by running the affected function at runtime instead of compile time.
 var (
-	errExpectedPointer        = errors.New("interp: trying to use an integer as a pointer (memory-mapped I/O?)")
+	errIntegerAsPointer       = errors.New("interp: trying to use an integer as a pointer (memory-mapped I/O?)")
 	errUnsupportedInst        = errors.New("interp: unsupported instruction")
 	errUnsupportedRuntimeInst = errors.New("interp: unsupported instruction (to be emitted at runtime)")
 	errMapAlreadyCreated      = errors.New("interp: map already created")
 )
 
 func isRecoverableError(err error) bool {
-	return err == errExpectedPointer || err == errUnsupportedInst || err == errUnsupportedRuntimeInst || err == errMapAlreadyCreated
+	return err == errIntegerAsPointer || err == errUnsupportedInst || err == errUnsupportedRuntimeInst || err == errMapAlreadyCreated
 }
 
 // ErrorLine is one line in a traceback. The position may be missing.

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -102,7 +102,7 @@ func Run(mod llvm.Module, debug bool) error {
 		if callErr != nil {
 			if isRecoverableError(callErr.Err) {
 				if r.debug {
-					fmt.Fprintln(os.Stderr, "not interpretring", r.pkgName, "because of error:", callErr.Err)
+					fmt.Fprintln(os.Stderr, "not interpreting", r.pkgName, "because of error:", callErr.Error())
 				}
 				mem.revert()
 				continue

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -348,7 +348,7 @@ func (v literalValue) clone() value {
 }
 
 func (v literalValue) asPointer(r *runner) (pointerValue, error) {
-	return pointerValue{}, errLiteralToPointer
+	return pointerValue{}, errIntegerAsPointer
 }
 
 func (v literalValue) asRawValue(r *runner) rawValue {
@@ -949,7 +949,7 @@ func (v rawValue) clone() value {
 func (v rawValue) asPointer(r *runner) (pointerValue, error) {
 	if v.buf[0] <= 255 {
 		// Probably a null pointer or memory-mapped I/O.
-		return pointerValue{}, errExpectedPointer
+		return pointerValue{}, errIntegerAsPointer
 	}
 	return pointerValue{v.buf[0]}, nil
 }


### PR DESCRIPTION
GetElementPtr would not work on values that weren't pointers. Because fixed addresses (often used in memory-mapped I/O) are integers rather than pointers in interp, it would return an error.

This resulted in the teensy40 target not compiling correctly since the interp package rewrite. This commit should fix that.

This should fix the issue in https://github.com/tinygo-org/tinygo/pull/1650.