### PR TITLE
build: add apt update that seems needed for when dependencies update …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ commands:
       - run:
           name: "Install apt dependencies"
           command: |
+            sudo apt-get update
             sudo apt-get install \
                 gcc-arm-linux-gnueabihf \
                 libc6-dev-armel-cross \
@@ -190,6 +191,7 @@ commands:
       - run:
           name: "Install apt dependencies"
           command: |
+            sudo apt-get update
             sudo apt-get install \
                 gcc-arm-linux-gnueabihf \
                 libc6-dev-armel-cross \


### PR DESCRIPTION
This PR adds an apt update to steps that seem to need them for when dependencies update or packages are removed.