### PR TITLE
Namespaced Wasm Imports so they don't conflict across modules, or reserved LLVM IR

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -283,7 +283,7 @@ func CompileProgram(lprogram *loader.Program, machine llvm.TargetMachine, config
 			initFuncs = append(initFuncs, c.getFunction(f))
 		}
 		if f.Blocks == nil {
-      fmt.Printf("External Function: %v \n\n%#v\n\n%#v\n\n", f, f, f.targets);
+      // fmt.Printf("External Function: %v \n\n%#v\n\n%#v\n\n", f, f, f.targets);
 			continue // external function
 		}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -283,8 +283,19 @@ func CompileProgram(lprogram *loader.Program, machine llvm.TargetMachine, config
 			initFuncs = append(initFuncs, c.getFunction(f))
 		}
 		if f.Blocks == nil {
+      fmt.Printf("External Function: %v \n\n%#v\n\n%#v\n\n", f, f, f.targets);
 			continue // external function
 		}
+
+    // TODO torch2424: Trying to fix bug #1559, to allow for non-conflicting wasm import names
+    // Actually, it's a bit more complicated
+    // The name really needs to be write on non-wasm systems but apparently the symbol should not be renamed on wasm
+    // The IR is currently generated here:
+    // https://github.com/tinygo-org/tinygo/blob/release/compiler/compiler.go#L703
+    // But things will change with this PR:
+    // https://github.com/tinygo-org/tinygo/pull/1584
+    // fmt.Printf("Yooooo \n\n%+v\n\n", config.Options);
+    // fmt.Printf("WasmAbi \n\n%s\n\n", config.Options.WasmAbi);
 
 		// Create the function definition.
 		b := newBuilder(c, irbuilder, f)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -283,7 +283,6 @@ func CompileProgram(lprogram *loader.Program, machine llvm.TargetMachine, config
 			initFuncs = append(initFuncs, c.getFunction(f))
 		}
 		if f.Blocks == nil {
-      // fmt.Printf("External Function: %v \n\n%#v\n\n%#v\n\n", f, f, f.targets);
 			continue // external function
 		}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -287,16 +287,6 @@ func CompileProgram(lprogram *loader.Program, machine llvm.TargetMachine, config
 			continue // external function
 		}
 
-    // TODO torch2424: Trying to fix bug #1559, to allow for non-conflicting wasm import names
-    // Actually, it's a bit more complicated
-    // The name really needs to be write on non-wasm systems but apparently the symbol should not be renamed on wasm
-    // The IR is currently generated here:
-    // https://github.com/tinygo-org/tinygo/blob/release/compiler/compiler.go#L703
-    // But things will change with this PR:
-    // https://github.com/tinygo-org/tinygo/pull/1584
-    // fmt.Printf("Yooooo \n\n%+v\n\n", config.Options);
-    // fmt.Printf("WasmAbi \n\n%s\n\n", config.Options.WasmAbi);
-
 		// Create the function definition.
 		b := newBuilder(c, irbuilder, f)
 		b.createFunction()

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -174,14 +174,6 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 	return llvmFn
 }
 
-
-// TODO (torch2424): 
-// Ayke said: 
-// Actually, functions are never renamed
-// The name you're looking for is stored in functionInfo.linkName, which is determined here:
-// `getFunctionInfo`
-// Right below it is parsePragmas, which is where the //go: pragmas are parsed.
-
 // getFunctionInfo returns information about a function that is not directly
 // present in *ssa.Function, such as the link name and whether it should be
 // exported.

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -202,7 +202,7 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 	if decl, ok := f.Syntax().(*ast.FuncDecl); ok && decl.Doc != nil {
 
 		// Our importName for a wasm module (if we are compiling to wasm), or llvm link name
-		var importName string = ""
+		var importName string
 
 		for _, comment := range decl.Doc.List {
 			text := comment.Text

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -216,8 +216,18 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 			case "//go:export":
 				if len(parts) != 2 {
 					continue
-				}
+				}  
+
 				info.linkName = parts[1]
+
+        if info.linkName == "write" {
+          // TODO: torch2424
+          info.linkName = "yo";
+        }
+
+        // TODO: torch2424
+        fmt.Printf("torch2424 go:export \n\n%+v\n\n", info); 
+
 				info.exported = true
 			case "//go:wasm-module":
 				// Alternative comment for setting the import module.

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -4,7 +4,6 @@ package compiler
 // pragmas, determines the link name, etc.
 
 import (
-  "fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -191,7 +190,6 @@ func (c *compilerContext) getFunctionInfo(f *ssa.Function) functionInfo {
 	}
 	// Check for //go: pragmas, which may change the link name (among others).
 	info.parsePragmas(f)
-  fmt.Println(info);
 	return info
 }
 
@@ -224,10 +222,6 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 				}
 
         importName = parts[1]
-
-        fmt.Println("Uiiiii", importName);
-
-
 				info.exported = true
 			case "//go:wasm-module":
 				// Alternative comment for setting the import module.
@@ -269,28 +263,20 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 					info.variadic = true
 				}
 			}
+		}
 
-      fmt.Println("Yooo", info.module, info.linkName, info.importName);
-
-
-      // TODO: torch2424 Why is this not working?!?! unexpected signal during runtime execution
-      // Set the importName for our exported function
+    // Set the importName for our exported function if we have one
+    if importName != "" {
       if info.module == "" {
         info.linkName = importName
       } else {
         // WebAssembly import
+        // info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName)
         info.importName = importName
       }
-
-
-		}
-
-    fmt.Println("TTTTggghhhh");
-
+    }
 
 	}
-
-  
 }
 
 // globalInfo contains some information about a specific global. By default,

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -227,10 +227,10 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
         // Set the wasmimport name and the llvm link name
 				info.importName = parts[1];
 
-        if info.importName == "_start" {
+        if info.module == ""  {
           info.linkName = info.importName;
         } else {
-          info.linkName = fmt.Sprintf("wasm_import_%s_%s", info.module, info.importName);
+          info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName);
         }
 
 				info.exported = true

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -22,13 +22,13 @@ import (
 // The linkName value contains a valid link name, even if //go:linkname is not
 // present.
 type functionInfo struct {
-	module   string     // go:wasm-module
-  importName string   // go:linkname, go:export - The name the developer assigns
-	linkName string     // go:linkname, go:export - The name that we map for the particular module -> importName
-	exported bool       // go:export, CGo
-	nobounds bool       // go:nobounds
-	variadic bool       // go:variadic (CGo only)
-	inline   inlineType // go:inline
+	module     string     // go:wasm-module
+	importName string     // go:linkname, go:export - The name the developer assigns
+	linkName   string     // go:linkname, go:export - The name that we map for the particular module -> importName
+	exported   bool       // go:export, CGo
+	nobounds   bool       // go:nobounds
+	variadic   bool       // go:variadic (CGo only)
+	inline     inlineType // go:inline
 }
 
 type inlineType int

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -157,11 +157,11 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 			wasmImportModuleAttr := c.ctx.CreateStringAttribute("wasm-import-module", info.module)
 			llvmFn.AddFunctionAttr(wasmImportModuleAttr)
 
-      // Add the Wasm Import Name, if we are a named wasm import
-      if info.importName != "" {
-        wasmImportNameAttr := c.ctx.CreateStringAttribute("wasm-import-name", info.importName)
-        llvmFn.AddFunctionAttr(wasmImportNameAttr)
-      }
+			// Add the Wasm Import Name, if we are a named wasm import
+			if info.importName != "" {
+				wasmImportNameAttr := c.ctx.CreateStringAttribute("wasm-import-name", info.importName)
+				llvmFn.AddFunctionAttr(wasmImportNameAttr)
+			}
 		}
 		nocaptureKind := llvm.AttributeKindID("nocapture")
 		nocapture := c.ctx.CreateEnumAttribute(nocaptureKind, 0)
@@ -201,8 +201,8 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 	}
 	if decl, ok := f.Syntax().(*ast.FuncDecl); ok && decl.Doc != nil {
 
-    // Our importName for a wasm module (if we are compiling to wasm), or llvm link name
-    var importName string = ""
+		// Our importName for a wasm module (if we are compiling to wasm), or llvm link name
+		var importName string = ""
 
 		for _, comment := range decl.Doc.List {
 			text := comment.Text
@@ -221,7 +221,7 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 					continue
 				}
 
-        importName = parts[1]
+				importName = parts[1]
 				info.exported = true
 			case "//go:wasm-module":
 				// Alternative comment for setting the import module.
@@ -265,16 +265,16 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 			}
 		}
 
-    // Set the importName for our exported function if we have one
-    if importName != "" {
-      if info.module == "" {
-        info.linkName = importName
-      } else {
-        // WebAssembly import
-        // info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName)
-        info.importName = importName
-      }
-    }
+		// Set the importName for our exported function if we have one
+		if importName != "" {
+			if info.module == "" {
+				info.linkName = importName
+			} else {
+				// WebAssembly import
+				// info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName)
+				info.importName = importName
+			}
+		}
 
 	}
 }

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -4,13 +4,12 @@ package compiler
 // pragmas, determines the link name, etc.
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
 	"strconv"
 	"strings"
-
-  "fmt"
 
 	"github.com/tinygo-org/tinygo/loader"
 	"golang.org/x/tools/go/ssa"
@@ -155,12 +154,12 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 		// Set the wasm-import-module attribute if the function's module is set.
 		if info.module != "" {
 
-      // We need to add the wasm-import-module and the wasm-import-name
+			// We need to add the wasm-import-module and the wasm-import-name
 			wasmImportModuleAttr := c.ctx.CreateStringAttribute("wasm-import-module", info.module)
 			llvmFn.AddFunctionAttr(wasmImportModuleAttr)
 
-      wasmImportNameAttr := c.ctx.CreateStringAttribute("wasm-import-name", info.importName)
-      llvmFn.AddFunctionAttr(wasmImportNameAttr)
+			wasmImportNameAttr := c.ctx.CreateStringAttribute("wasm-import-name", info.importName)
+			llvmFn.AddFunctionAttr(wasmImportNameAttr)
 		}
 		nocaptureKind := llvm.AttributeKindID("nocapture")
 		nocapture := c.ctx.CreateEnumAttribute(nocaptureKind, 0)
@@ -214,16 +213,16 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 			case "//go:export":
 				if len(parts) != 2 {
 					continue
-				}  
+				}
 
-        // Set the wasmimport name and the llvm link name
-				info.importName = parts[1];
+				// Set the wasmimport name and the llvm link name
+				info.importName = parts[1]
 
-        if info.module == ""  {
-          info.linkName = info.importName;
-        } else {
-          info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName);
-        }
+				if info.module == "" {
+					info.linkName = info.importName
+				} else {
+					info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName)
+				}
 
 				info.exported = true
 			case "//go:wasm-module":

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+  "fmt"
+
 	"github.com/tinygo-org/tinygo/loader"
 	"golang.org/x/tools/go/ssa"
 	"tinygo.org/x/go-llvm"
@@ -165,6 +167,14 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 
 	return llvmFn
 }
+
+
+// TODO (torch2424): 
+// Ayke said: 
+// Actually, functions are never renamed
+// The name you're looking for is stored in functionInfo.linkName, which is determined here:
+// `getFunctionInfo`
+// Right below it is parsePragmas, which is where the //go: pragmas are parsed.
 
 // getFunctionInfo returns information about a function that is not directly
 // present in *ssa.Function, such as the link name and whether it should be

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -271,7 +271,6 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 				info.linkName = importName
 			} else {
 				// WebAssembly import
-				// info.linkName = fmt.Sprintf("tinygo_wasm_import_%s_%s", info.module, info.importName)
 				info.importName = importName
 			}
 		}


### PR DESCRIPTION
closes #1643
closes #1559

Kind of relates to #1647
Doesn't fix, but puts on the right path I think, for relates to #1648

So this PR was opened from a discussion in the tinygo slack: https://gophers.slack.com/archives/CDJD3SUP6/p1614201204223100 . Involving a conflict with wasm imports with the name of `write`. Which conflicts with the LLVM IR `@write`, and requires decoupling the LLVM IR symbol, and the `wasm-import-name`.

I tested this pr with the following code: https://github.com/torch2424/tinygo-compiler-playground (Which also contains the output LLVM IR of this current PR) , and ran the tests: `go test -target=wasm` and `make wasmtest`. 

### Screenshots of tests and things

![Screenshot from 2021-02-24 18-20-02](https://user-images.githubusercontent.com/1448289/109099144-76510700-76d7-11eb-8aee-3c568c71b758.png)
![Screenshot from 2021-02-24 18-15-57](https://user-images.githubusercontent.com/1448289/109099146-76e99d80-76d7-11eb-8904-26703ba9a264.png)
![Screenshot from 2021-02-24 18-14-04](https://user-images.githubusercontent.com/1448289/109099147-77823400-76d7-11eb-9371-e23d0071b06e.png)

