### PR TITLE
stm32: add i2c for stm32f407

### DIFF
--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -66,3 +66,15 @@ var (
 	}
 	SPI1 = &SPI0
 )
+
+const (
+	I2C0_SCL_PIN = PB6
+	I2C0_SDA_PIN = PB9
+)
+
+var (
+	I2C0 = I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: AF4_I2C1_2_3,
+	}
+)

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf sam stm32,!stm32f407,!stm32f7x2,!stm32l5x2,!stm32l0 fe310 k210
+// +build avr nrf sam stm32,!stm32f7x2,!stm32l5x2,!stm32l0 fe310 k210
 
 package machine
 

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -120,3 +120,81 @@ func (spi SPI) configurePins(config SPIConfig) {
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
 	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
 }
+
+// -- I2C ----------------------------------------------------------------------
+
+type I2C struct {
+	Bus             *stm32.I2C_Type
+	AltFuncSelector uint8
+}
+
+func (i2c I2C) configurePins(config I2CConfig) {
+	config.SCL.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSCL}, i2c.AltFuncSelector)
+	config.SDA.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSDA}, i2c.AltFuncSelector)
+}
+
+func (i2c I2C) getFreqRange(config I2CConfig) uint32 {
+	// all I2C interfaces are on APB1 (42 MHz)
+	clock := CPUFrequency() / 4
+	// convert to MHz
+	clock /= 1000000
+	// must be between 2 MHz (or 4 MHz for fast mode (Fm)) and 50 MHz, inclusive
+	var min, max uint32 = 2, 50
+	if config.Frequency > 100000 {
+		min = 4 // fast mode (Fm)
+	}
+	if clock < min {
+		clock = min
+	} else if clock > max {
+		clock = max
+	}
+	return clock << stm32.I2C_CR2_FREQ_Pos
+}
+
+func (i2c I2C) getRiseTime(config I2CConfig) uint32 {
+	// These bits must be programmed with the maximum SCL rise time given in the
+	// I2C bus specification, incremented by 1.
+	// For instance: in Sm mode, the maximum allowed SCL rise time is 1000 ns.
+	// If, in the I2C_CR2 register, the value of FREQ[5:0] bits is equal to 0x08
+	// and PCLK1 = 125 ns, therefore the TRISE[5:0] bits must be programmed with
+	// 09h (1000 ns / 125 ns = 8 + 1)
+	freqRange := i2c.getFreqRange(config)
+	if config.Frequency > 100000 {
+		// fast mode (Fm) adjustment
+		freqRange *= 300
+		freqRange /= 1000
+	}
+	return (freqRange + 1) << stm32.I2C_TRISE_TRISE_Pos
+}
+
+func (i2c I2C) getSpeed(config I2CConfig) uint32 {
+	ccr := func(pclk uint32, freq uint32, coeff uint32) uint32 {
+		return (((pclk - 1) / (freq * coeff)) + 1) & stm32.I2C_CCR_CCR_Msk
+	}
+	sm := func(pclk uint32, freq uint32) uint32 { // standard mode (Sm)
+		if s := ccr(pclk, freq, 2); s < 4 {
+			return 4
+		} else {
+			return s
+		}
+	}
+	fm := func(pclk uint32, freq uint32, duty uint8) uint32 { // fast mode (Fm)
+		if duty == DutyCycle2 {
+			return ccr(pclk, freq, 3)
+		} else {
+			return ccr(pclk, freq, 25) | stm32.I2C_CCR_DUTY
+		}
+	}
+	// all I2C interfaces are on APB1 (42 MHz)
+	clock := CPUFrequency() / 4
+	if config.Frequency <= 100000 {
+		return sm(clock, config.Frequency)
+	} else {
+		s := fm(clock, config.Frequency, config.DutyCycle)
+		if (s & stm32.I2C_CCR_CCR_Msk) == 0 {
+			return 1
+		} else {
+			return s | stm32.I2C_CCR_F_S
+		}
+	}
+}


### PR DESCRIPTION
Verified on a STM32F407G-DISC1 board using a BME280 sensor + SSD1306 led display over i2c.

The new code in machine_stm32f407.go is a direct copy of the i2c code in machine_stm32f405.go - at some point this logic should probably be harmonized.

The fixes to stm32_i2c are enough to make this work for me.  I have found that a startup delay before initializing i2c is necessary - i suspect there may be power/voltage transients or similar causing issues if i2c is enabled too quickly after boot.  Why i think this: (at least on my disco board)
- startup delay not required with debugging hardware attached (i2c logic analyzer, scope, UART)
- UART has a tendency to back-feed the board
- The delay is not needed for a soft reset
- I've occasionally seen a 'double boot' on power-up where it looks like the MCU does a reset (possible 'brown-out'?)