### PR TITLE
gdb: support daemonization on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892
 	go.bug.st/serial v1.1.2
+	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78
 	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2
 	tinygo.org/x/go-llvm v0.0.0-20210206225315-7fe719483a0f
 )

--- a/util_windows.go
+++ b/util_windows.go
@@ -4,10 +4,15 @@ package main
 
 import (
 	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // setCommandAsDaemon makes sure this command does not receive signals sent to
-// the parent. It is unimplemented on Windows.
+// the parent.
 func setCommandAsDaemon(daemon *exec.Cmd) {
-	// Not implemented.
+	daemon.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS,
+	}
 }


### PR DESCRIPTION
In this PR, Ctrl-C will be passed only to gdb when Ctrl-C is pressed in the windows environment.
The following environment was checked.

* windows 10 + xiao + cmsis-dap
* windows 10 + feather-nrf52840 + jlink

### before: when I press Ctrl-C, openocd exits.

```
$ tinygo gdb --target xiao --size short --programmer cmsis-dap ./b1
   code    data     bss |   flash     ram
   8508      20    4312 |    8528    4332
GNU gdb (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.1.90.20201028-git
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=i686-w64-mingw32 --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from C:\Users\sago3\AppData\Local\Temp\tinygo143508647\main...
Remote debugging using :3333
0x00000000 in ?? ()
Halt timed out, wake up GDB.
timed out while waiting for target halted

Loading section .text, size 0x213c lma 0x2000
Loading section .tinygo_stacksizes, size 0x4 lma 0x413c
Loading section .data, size 0x10 lma 0x4140
Start address 0x00003248, load size 8528
Transfer rate: 8 KB/sec, 2842 bytes/write.
target halted due to debug-request, current mode: Thread
xPSR: 0x71000000 pc: 0x00000288 msp: 0x20002dd8
(gdb) c
Continuing.
Remote communication error.  Target disconnected.: No such file or directory.
(gdb) c
The program is not being run.
```

### after: when I press Ctrl-C, openocd not exits.

```
$ tinygo gdb --target xiao --size short --programmer cmsis-dap ./b1
   code    data     bss |   flash     ram
   8508      20    4312 |    8528    4332
GNU gdb (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.1.90.20201028-git
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=i686-w64-mingw32 --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from C:\Users\sago3\AppData\Local\Temp\tinygo268028655\main...
Remote debugging using :3333
runtime.ticks ()
    at C:\Users\sago3\AppData\Local\tinygo\goroot-go1.15.6-6575eaa4627788dbffaa3c87c509b5898db1ce83b604e7c843292ff239e190ae-syscall\src\r
untime/runtime_atsamd21.go:280
280             timerLastCounter = rtcCounter
Loading section .text, size 0x213c lma 0x2000
Loading section .tinygo_stacksizes, size 0x4 lma 0x413c
Loading section .data, size 0x10 lma 0x4140
Start address 0x00003248, load size 8528
Transfer rate: 8 KB/sec, 2842 bytes/write.
target halted due to debug-request, current mode: Thread
xPSR: 0x61000000 pc: 0x00000288 msp: 0x20002dd8
(gdb) c
Continuing.

Program received signal SIGINT, Interrupt.
runtime.ticks ()
    at C:\Users\sago3\AppData\Local\tinygo\goroot-go1.15.6-6575eaa4627788dbffaa3c87c509b5898db1ce83b604e7c843292ff239e190ae-syscall\src\r
untime/runtime_atsamd21.go:280
280             timerLastCounter = rtcCounter
(gdb) c
Continuing.

Program received signal SIGINT, Interrupt.
0x00003374 in (*runtime/volatile.Register8).Get (r=<optimized out>)
    at C:\Users\sago3\AppData\Local\tinygo\goroot-go1.15.6-6575eaa4627788dbffaa3c87c509b5898db1ce83b604e7c843292ff239e190ae-syscall\src\r
untime\volatile/register.go:18
18              return LoadUint8(&r.Reg)
(gdb)
```
