### PR TITLE
wasi: specify wasi-libc in a different way

### DIFF
--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -5,6 +5,7 @@
 	"goarch":        "arm",
 	"compiler":      "clang",
 	"linker":        "wasm-ld",
+	"libc":          "wasi-libc",
 	"cflags": [
 		"--target=wasm32--wasi",
 		"--sysroot={root}/lib/wasi-libc/sysroot",
@@ -14,8 +15,7 @@
 		"--allow-undefined",
 		"--stack-first",
 		"--export-dynamic",
-		"--no-demangle",
-		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
+		"--no-demangle"
 	],
 	"emulator":      ["wasmtime"],
 	"wasm-abi":      "generic"

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -5,6 +5,7 @@
 	"goarch":        "wasm",
 	"compiler":      "clang",
 	"linker":        "wasm-ld",
+	"libc":          "wasi-libc",
 	"cflags": [
 		"--target=wasm32--wasi",
 		"--sysroot={root}/lib/wasi-libc/sysroot",
@@ -14,8 +15,7 @@
 		"--allow-undefined",
 		"--stack-first",
 		"--export-all",
-		"--no-demangle",
-		"{root}/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a"
+		"--no-demangle"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"],
 	"wasm-abi":      "js"


### PR DESCRIPTION
This way is more consistent with how picolibc is specified and allows
generating a helpful error message. This error message should never be
generated for TinyGo binary releases, only when doing local development.

This should improve https://github.com/tinygo-org/tinygo/issues/1678. It's a common question so it seems like a idea to me to make the error message more helpful.