### PR TITLE
transform: show better error message in coroutines lowering

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 	"github.com/tinygo-org/tinygo/interp"
 	"github.com/tinygo-org/tinygo/loader"
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 
 	"go.bug.st/serial"
@@ -774,6 +775,15 @@ func printCompilerError(logln func(...interface{}), err error) {
 				logln(line.Pos.String() + ":")
 				line.Inst.Dump()
 				logln()
+			}
+		}
+	case transform.CoroutinesError:
+		logln(err.Pos.String() + ": " + err.Msg)
+		logln("\ntraceback:")
+		for _, line := range err.Traceback {
+			logln(line.Name)
+			if line.Position.IsValid() {
+				logln("\t" + line.Position.String())
 			}
 		}
 	case loader.Errors:


### PR DESCRIPTION
A common error is when someone tries to export a blocking function. This is not possible with the coroutines scheduler. Previously, it resulted in an error like this:

    panic: trying to make exported function async: messageHandler

With this change, the error is much better and shows where it comes from exactly:

    /home/ayke/tmp/export-async.go:8: blocking operation in exported function: messageHandler

    traceback:
    messageHandler
            /home/ayke/tmp/export-async.go:9:5
    main.foo
            /home/ayke/tmp/export-async.go:15:2
    runtime.chanSend
            /home/ayke/src/github.com/tinygo-org/tinygo/src/runtime/chan.go:494:12

This should make it easier to identify and fix the problem. And it avoids a compiler panic, which is a really bad way of showing diagnostics.