### PR TITLE
builder: add support for -opt=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/serial
 	@$(MD5SUM) test.nro
+	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go
+	@$(MD5SUM) test.hex
 
 wasmtest:
 	$(GO) test ./tests/wasm

--- a/builder/build.go
+++ b/builder/build.go
@@ -411,15 +411,8 @@ func compileWholeProgram(pkgName string, config *compileopts.Config, compilerCon
 	// exactly.
 	errs = nil
 	switch config.Options.Opt {
-	/*
-		Currently, turning optimizations off causes compile failures.
-		We rely on the optimizer removing some dead symbols.
-		Avoid providing an option that does not work right now.
-		In the future once everything has been fixed we can re-enable this.
-
-		case "none", "0":
-			errs = transform.Optimize(mod, config, 0, 0, 0) // -O0
-	*/
+	case "none", "0":
+		errs = transform.Optimize(mod, config, 0, 0, 0) // -O0
 	case "1":
 		errs = transform.Optimize(mod, config, 1, 0, 0) // -O1
 	case "2":

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -111,6 +111,12 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		if len(errs) > 0 {
 			return errs
 		}
+
+		// Clean up some leftover symbols of the previous transformations.
+		goPasses := llvm.NewPassManager()
+		defer goPasses.Dispose()
+		goPasses.AddGlobalDCEPass()
+		goPasses.Run(mod)
 	}
 
 	// Lower async implementations.


### PR DESCRIPTION
This optimization level wasn't working before because some passes expect some globals to be cleaned up afterwards. Cleaning these globals is easy, just add the pass necessary for it. This shouldn't reduce the usefulness of the -opt=0 build flag as most optimizations are still skipped.