### PR TITLE
wasm: switch to wasi_snapshot_preview1

### DIFF
--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -12,7 +12,7 @@ type __wasi_iovec_t struct {
 	bufLen uint
 }
 
-//go:wasm-module wasi_unstable
+//go:wasm-module wasi_snapshot_preview1
 //export fd_write
 func fd_write(id uint32, iovs *__wasi_iovec_t, iovs_len uint, nwritten *uint) (errno uint)
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -58,13 +58,13 @@ func ticks() timeUnit {
 	return timeUnit(nano)
 }
 
-// Implementations of wasi_unstable APIs
+// Implementations of wasi_snapshot_preview1 APIs
 
-//go:wasm-module wasi_unstable
+//go:wasm-module wasi_snapshot_preview1
 //export clock_time_get
 func clock_time_get(clockid uint32, precision uint64, time *int64) (errno uint16)
 
-//go:wasm-module wasi_unstable
+//go:wasm-module wasi_snapshot_preview1
 //export poll_oneoff
 func poll_oneoff(in *__wasi_subscription_t, out *__wasi_event_t, nsubscriptions uint32, nevents *uint32) (errno uint16)
 

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -247,7 +247,7 @@
 
 			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
-				wasi_unstable: {
+				wasi_snapshot_preview1: {
 					// https://github.com/bytecodealliance/wasmtime/blob/master/docs/WASI-api.md#__wasi_fd_write
 					fd_write: function(fd, iovs_ptr, iovs_len, nwritten_ptr) {
 						let nwritten = 0;


### PR DESCRIPTION
This is a hopefully more stable interface and it appears more people are using wasi_snapshot_preview1 than wasi_unstable, so let's switch to it.