### PR TITLE
attiny: remove dummy UART

### DIFF
--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -114,6 +114,12 @@ func (i2c I2C) readByte() byte {
 	return byte(avr.TWDR.Get())
 }
 
+// UART
+var (
+	// UART0 is the hardware serial port on the AVR.
+	UART0 = UART{Buffer: NewRingBuffer()}
+)
+
 // UART on the AVR.
 type UART struct {
 	Buffer *RingBuffer

--- a/src/machine/machine_attiny.go
+++ b/src/machine/machine_attiny.go
@@ -2,23 +2,6 @@
 
 package machine
 
-// UART on the AVR is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-type UART struct {
-	Buffer *RingBuffer
-}
-
-// Configure is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-func (uart UART) Configure(config UARTConfig) {
-}
-
-// WriteByte is a dummy implementation. UART has not been implemented for ATtiny
-// devices.
-func (uart UART) WriteByte(c byte) error {
-	return nil
-}
-
 // Tx is a dummy implementation. I2C has not been implemented for ATtiny
 // devices.
 func (i2c I2C) Tx(addr uint16, w, r []byte) error {

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -148,9 +148,3 @@ type I2C struct {
 
 // I2C0 is the only I2C interface on most AVRs.
 var I2C0 = I2C{}
-
-// UART
-var (
-	// UART0 is the hardware serial port on the AVR.
-	UART0 = UART{Buffer: NewRingBuffer()}
-)

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -1,4 +1,4 @@
-// +build avr esp nrf sam sifive stm32 k210 nxp
+// +build atmega esp nrf sam sifive stm32 k210 nxp
 
 package machine
 

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -4,7 +4,16 @@ package runtime
 
 import (
 	"device/avr"
+	"machine"
 )
+
+func initUART() {
+	machine.UART0.Configure(machine.UARTConfig{})
+}
+
+func putchar(c byte) {
+	machine.UART0.WriteByte(c)
+}
 
 // Sleep for a given period. The period is defined by the WDT peripheral, and is
 // on most chips (at least) 3 bits wide, in powers of two from 16ms to 2s

--- a/src/runtime/runtime_attiny.go
+++ b/src/runtime/runtime_attiny.go
@@ -6,6 +6,13 @@ import (
 	"device/avr"
 )
 
+func initUART() {
+}
+
+func putchar(c byte) {
+	// UART is not supported.
+}
+
 func sleepWDT(period uint8) {
 	// TODO: use the watchdog timer instead of a busy loop.
 	for i := 0x45; i != 0; i-- {

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -4,7 +4,6 @@ package runtime
 
 import (
 	"device/avr"
-	"machine"
 	"unsafe"
 )
 
@@ -57,14 +56,6 @@ func postinit() {
 
 func init() {
 	initUART()
-}
-
-func initUART() {
-	machine.UART0.Configure(machine.UARTConfig{})
-}
-
-func putchar(c byte) {
-	machine.UART0.WriteByte(c)
 }
 
 const asyncScheduler = false


### PR DESCRIPTION
I think it's better not to provide a UART0 global at all than one that does nothing.