### PR TITLE
version: update TinyGo version to 0.18.0-dev

### DIFF
--- a/goenv/version.go
+++ b/goenv/version.go
@@ -12,7 +12,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const Version = "0.17.0"
+const Version = "0.18.0-dev"
 
 // GetGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.


### PR DESCRIPTION
This PR updates the TinyGo version to 0.18.0-dev for the next dev cycle.