### PR TITLE
transform: optimize string comparisons against ""

### DIFF
--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -97,6 +97,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		// Run TinyGo-specific interprocedural optimizations.
 		OptimizeAllocs(mod)
 		OptimizeStringToBytes(mod)
+		OptimizeStringEqual(mod)
 
 	} else {
 		// Must be run at any optimization level.

--- a/transform/rtcalls_test.go
+++ b/transform/rtcalls_test.go
@@ -13,3 +13,11 @@ func TestOptimizeStringToBytes(t *testing.T) {
 		OptimizeStringToBytes(mod)
 	})
 }
+
+func TestOptimizeStringEqual(t *testing.T) {
+	t.Parallel()
+	testTransform(t, "testdata/stringequal", func(mod llvm.Module) {
+		// Run optimization pass.
+		OptimizeStringEqual(mod)
+	})
+}

--- a/transform/testdata/stringequal.ll
+++ b/transform/testdata/stringequal.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
+target triple = "armv7m-none-eabi"
+
+@zeroString = constant [0 x i8] zeroinitializer
+
+declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*, i8*)
+
+define i1 @main.stringCompareEqualConstantZero(i8* %s1.data, i32 %s1.len, i8* %context, i8* %parentHandle) {
+entry:
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* getelementptr inbounds ([0 x i8], [0 x i8]* @zeroString, i32 0, i32 0), i32 0, i8* undef, i8* null)
+  ret i1 %0
+}
+
+define i1 @main.stringCompareUnequalConstantZero(i8* %s1.data, i32 %s1.len, i8* %context, i8* %parentHandle) {
+entry:
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* getelementptr inbounds ([0 x i8], [0 x i8]* @zeroString, i32 0, i32 0), i32 0, i8* undef, i8* null)
+  %1 = xor i1 %0, true
+  ret i1 %1
+}

--- a/transform/testdata/stringequal.out.ll
+++ b/transform/testdata/stringequal.out.ll
@@ -1,0 +1,19 @@
+target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
+target triple = "armv7m-none-eabi"
+
+@zeroString = constant [0 x i8] zeroinitializer
+
+declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*, i8*)
+
+define i1 @main.stringCompareEqualConstantZero(i8* %s1.data, i32 %s1.len, i8* %context, i8* %parentHandle) {
+entry:
+  %0 = icmp eq i32 %s1.len, 0
+  ret i1 %0
+}
+
+define i1 @main.stringCompareUnequalConstantZero(i8* %s1.data, i32 %s1.len, i8* %context, i8* %parentHandle) {
+entry:
+  %0 = icmp eq i32 %s1.len, 0
+  %1 = xor i1 %0, true
+  ret i1 %1
+}


### PR DESCRIPTION
This optimizes a common pattern like:

    if s != "" {
        ...
    }

to:

    if len(s) != 0 {
        ...
    }

This avoids a runtime call and thus produces slightly better code. With testdata/stdlib.go I saw two instances of this and the optimization reduced binary size by 80 bytes (with `-target=cortex-m-qemu`). That's admittedly rather low, but the main goal of this optimization is so that the most readable code can be written in all cases and the compiler optimizes it as needed.