### PR TITLE
Use physical path instead of cached GOROOT in function getGoroot (fixes #433, #1658)

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -228,7 +228,7 @@ func isCachedGoroot(goroot string) (bool, string) {
 	}
 	for _, f := range info {
 		if mode, ok := cacheEntry[f.Name()]; ok {
-			if mode != f.Mode().Type() {
+			if mode != f.Mode()&os.ModeType {
 				return false, ""
 			}
 			// Remove the verified entry

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -4,7 +4,6 @@ package goenv
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"os/user"
@@ -215,11 +214,11 @@ func isCachedGoroot(goroot string) (bool, string) {
 	// As these are encountered, they are deleted from the map. If, after
 	// reading all entries in the given path, this map has zero remaining
 	// elements, then we have a cached GOROOT.
-	cacheEntry := map[string]fs.FileMode{
-		"src": fs.ModeDir,
-		"bin": fs.ModeSymlink,
-		"lib": fs.ModeSymlink,
-		"pkg": fs.ModeSymlink,
+	cacheEntry := map[string]os.FileMode{
+		"src": os.ModeDir,
+		"bin": os.ModeSymlink,
+		"lib": os.ModeSymlink,
+		"pkg": os.ModeSymlink,
 	}
 
 	entry, _ := os.ReadDir(goroot)
@@ -230,7 +229,7 @@ func isCachedGoroot(goroot string) (bool, string) {
 			}
 			// Remove the verified entry
 			delete(cacheEntry, e.Name())
-			if mode&fs.ModeSymlink == 0 {
+			if mode&os.ModeSymlink == 0 {
 				continue
 			}
 			// Entry is a symlink, get the physical GOROOT to which it points


### PR DESCRIPTION
I keep running into the same error as others (#433 and #1658), where TinyGo resolves an incorrect Go runtime version, and generates the message:

```
error: requires go version 1.11 through 1.15, got go0.1
error: command failed
```

On Linux, this appears to be caused by the symlink created in the cached `GOROOT`:

```sh
andrew@trip ~ readlink -f $( tinygo info teensy40 | \grep -oP "GOROOT:\s*\K.+" )/src/runtime/internal/sys/zversion.go
/usr/local/src/tinygo/src/runtime/internal/sys/zversion.go
andrew@trip ~ cat /usr/local/src/tinygo/src/runtime/internal/sys/zversion.go
package sys

const TheVersion = `go0.1.0`
```

The problem is manifested here: https://github.com/tinygo-org/tinygo/blob/c60c36f0a8bbfd62fc61a583d4d2c7a8bf64bd58/goenv/version.go#L51-L52

This PR adds logic that tries to resolve a better path to `zversion.go` by checking if `GOROOT/bin` is a symlink (which it always will be inside TinyGo's cached `GOROOT`), and using the real, physical path to `GOROOT/bin` as the root directory for finding `src/runtime/internal/sys/zversion.go`. This way we are using the actual Go runtime directory's `zversion.go`, and not the one stored in TinyGo's sources.

Note that if this method fails, it falls back to using the original method currently implemented.