### PR TITLE
cgo: add support for CFLAGS in .c files

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -430,7 +430,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		job := &compileJob{
 			description: "compile extra file " + path,
 			run: func(job *compileJob) error {
-				result, err := compileAndCacheCFile(abspath, dir, config)
+				result, err := compileAndCacheCFile(abspath, dir, config.CFlags(), config)
 				job.result = result
 				return err
 			},
@@ -443,12 +443,13 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// TODO: do this as part of building the package to be able to link the
 	// bitcode files together.
 	for _, pkg := range lprogram.Sorted() {
+		pkg := pkg
 		for _, filename := range pkg.CFiles {
 			abspath := filepath.Join(pkg.Dir, filename)
 			job := &compileJob{
 				description: "compile CGo file " + abspath,
 				run: func(job *compileJob) error {
-					result, err := compileAndCacheCFile(abspath, dir, config)
+					result, err := compileAndCacheCFile(abspath, dir, pkg.CFlags, config)
 					job.result = result
 					return err
 				},

--- a/builder/cc.go
+++ b/builder/cc.go
@@ -57,7 +57,7 @@ import (
 //   depfile but without invalidating its name. For this reason, the depfile is
 //   written on each new compilation (even when it seems unnecessary). However, it
 //   could in rare cases lead to a stale file fetched from the cache.
-func compileAndCacheCFile(abspath, tmpdir string, config *compileopts.Config) (string, error) {
+func compileAndCacheCFile(abspath, tmpdir string, cflags []string, config *compileopts.Config) (string, error) {
 	// Hash input file.
 	fileHash, err := hashFile(abspath)
 	if err != nil {
@@ -121,7 +121,7 @@ func compileAndCacheCFile(abspath, tmpdir string, config *compileopts.Config) (s
 		return "", err
 	}
 	depTmpFile.Close()
-	flags := config.CFlags()
+	flags := append([]string{}, cflags...)                                   // copy cflags
 	flags = append(flags, "-MD", "-MV", "-MTdeps", "-MF", depTmpFile.Name()) // autogenerate dependencies
 	flags = append(flags, "-c", "-o", objTmpFile.Name(), abspath)
 	if config.Options.PrintCommands {

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -65,7 +65,7 @@ func TestCGo(t *testing.T) {
 			}
 
 			// Process the AST with CGo.
-			cgoAST, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
+			cgoAST, _, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
 
 			// Check the AST for type errors.
 			var typecheckErrors []error

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -382,14 +382,14 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 
 	// Do CGo processing.
 	if len(p.CgoFiles) != 0 {
-		var cflags []string
-		cflags = append(cflags, p.program.config.CFlags()...)
-		cflags = append(cflags, "-I"+p.Dir)
+		var initialCFlags []string
+		initialCFlags = append(initialCFlags, p.program.config.CFlags()...)
+		initialCFlags = append(initialCFlags, "-I"+p.Dir)
 		if p.program.clangHeaders != "" {
-			cflags = append(cflags, "-Xclang", "-internal-isystem", "-Xclang", p.program.clangHeaders)
+			initialCFlags = append(initialCFlags, "-Xclang", "-internal-isystem", "-Xclang", p.program.clangHeaders)
 		}
-		p.CFlags = cflags
-		generated, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, cflags)
+		generated, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, initialCFlags)
+		p.CFlags = append(initialCFlags, cflags...)
 		for path, hash := range accessedFiles {
 			p.FileHashes[path] = hash
 		}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -20,6 +20,8 @@ int globalUnionSize = sizeof(globalUnion);
 option_t globalOption = optionG;
 bitfield_t globalBitfield = {244, 15, 1, 2, 47, 5};
 
+int cflagsConstant = SOME_CONSTANT;
+
 int smallEnumWidth = sizeof(option2_t);
 
 int fortytwo() {

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -5,6 +5,7 @@ int fortytwo(void);
 #include "main.h"
 int mul(int, int);
 #include <string.h>
+#cgo CFLAGS: -DSOME_CONSTANT=17
 */
 import "C"
 
@@ -117,6 +118,9 @@ func main() {
 
 	// Check that enums are considered the same width in C and CGo.
 	println("enum width matches:", unsafe.Sizeof(C.option2_t(0)) == uintptr(C.smallEnumWidth))
+
+	// Check whether CFLAGS are correctly passed on to compiled C files.
+	println("CFLAGS value:", C.cflagsConstant)
 
 	// libc: test whether C functions work at all.
 	buf1 := []byte("foobar\x00")

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -139,6 +139,8 @@ extern bitfield_t globalBitfield;
 
 extern int smallEnumWidth;
 
+extern int cflagsConstant;
+
 // test duplicate definitions
 int add(int a, int b);
 extern int global;

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -58,4 +58,5 @@ option G: 12
 option 2A: 20
 option 3A: 21
 enum width matches: true
+CFLAGS value: 17
 copied string: foobar


### PR DESCRIPTION
This patch adds support for passing CFLAGS added in #cgo lines of the CGo preprocessing phase to the compiler when compiling C files inside packages. This is expected and convenient but didn't work before.

This fixes https://github.com/tinygo-org/tinygo/issues/1624. It is a draft because it needs #1612 to be merged first.