### PR TITLE
Nucleo stm32l432

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-l552ze       examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nucleo-l432kc       examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=p1am-100            examples/blinky1
 	@$(MD5SUM) test.hex
 	# test pwm

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -120,19 +120,22 @@ const (
 
 var (
 	UART1 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART3,
-		AltFuncSelector: AF7_USART1_2_3,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART3,
+		TxAltFuncSelector: AF7_USART1_2_3,
+		RxAltFuncSelector: AF7_USART1_2_3,
 	}
 	UART2 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART6,
-		AltFuncSelector: AF8_USART4_5_6,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART6,
+		TxAltFuncSelector: AF8_USART4_5_6,
+		RxAltFuncSelector: AF8_USART4_5_6,
 	}
 	UART3 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART1,
-		AltFuncSelector: AF7_USART1_2_3,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART1,
+		TxAltFuncSelector: AF7_USART1_2_3,
+		RxAltFuncSelector: AF7_USART1_2_3,
 	}
 	UART0 = UART1
 )

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -54,16 +54,18 @@ var (
 
 	// Console UART (LPUSART1)
 	UART0 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.LPUART1,
-		AltFuncSelector: 6,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.LPUART1,
+		TxAltFuncSelector: 6,
+		RxAltFuncSelector: 6,
 	}
 
 	// Gps UART
 	UART1 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART1,
-		AltFuncSelector: 0,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART1,
+		TxAltFuncSelector: 0,
+		RxAltFuncSelector: 0,
 	}
 
 	// SPI

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -33,9 +33,10 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to USART2.
 	UART0 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART3,
-		AltFuncSelector: UART_ALT_FN,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART3,
+		TxAltFuncSelector: UART_ALT_FN,
+		RxAltFuncSelector: UART_ALT_FN,
 	}
 	UART1 = &UART0
 )

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -1,0 +1,46 @@
+// +build nucleol432kc
+
+package machine
+
+import (
+	"device/stm32"
+	"runtime/interrupt"
+)
+
+const (
+	LED         = LED_BUILTIN
+	LED_BUILTIN = LED_GREEN
+	LED_GREEN   = PB3
+)
+
+// UART pins
+const (
+	// PA2 and PA15 are connected to the ST-Link Virtual Com Port (VCP)
+	UART_TX_PIN = PA2
+	UART_RX_PIN = PA15
+)
+
+// I2C pins
+const (
+	// PB6 and PB7 are mapped to CN4 pin 7 and CN4 pin 8 respectively with the
+	// default solder bridge settings
+	I2C0_SCL_PIN = PB6
+	I2C0_SDA_PIN = PB7
+)
+
+var (
+	// USART2 is the hardware serial port connected to the onboard ST-LINK
+	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
+	// Both UART0 and UART1 refer to USART2.
+	UART0 = UART{
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART2,
+		TxAltFuncSelector: 7,
+		RxAltFuncSelector: 3,
+	}
+	UART1 = &UART0
+)
+
+func init() {
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+}

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -33,9 +33,10 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to LPUART1.
 	UART0 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.LPUART1,
-		AltFuncSelector: UART_ALT_FN,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.LPUART1,
+		TxAltFuncSelector: UART_ALT_FN,
+		RxAltFuncSelector: UART_ALT_FN,
 	}
 	UART1 = &UART0
 )

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -28,9 +28,10 @@ const (
 
 var (
 	UART0 = UART{
-		Buffer:          NewRingBuffer(),
-		Bus:             stm32.USART2,
-		AltFuncSelector: AF7_USART1_2_3,
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART2,
+		TxAltFuncSelector: AF7_USART1_2_3,
+		RxAltFuncSelector: AF7_USART1_2_3,
 	}
 	UART1 = &UART0
 )

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-// +build avr nrf sam stm32,!stm32f7x2,!stm32l5x2,!stm32l0 fe310 k210
+// +build avr nrf sam stm32,!stm32f7x2,!stm32l5x2,!stm32l0,!stm32l4x2 fe310 k210
 
 package machine
 

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -1,4 +1,4 @@
-// +build stm32,!stm32f7x2,!stm32l5x2,!stm32l0
+// +build stm32,!stm32f7x2,!stm32l5x2,!stm32l0,!stm32l4x2
 
 package machine
 

--- a/src/machine/machine_stm32_spi.go
+++ b/src/machine/machine_stm32_spi.go
@@ -1,4 +1,4 @@
-// +build stm32,!stm32f7x2,!stm32l5x2
+// +build stm32,!stm32f7x2,!stm32l5x2,!stm32l4x2
 
 package machine
 

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -13,10 +13,11 @@ import (
 
 // UART representation
 type UART struct {
-	Buffer          *RingBuffer
-	Bus             *stm32.USART_Type
-	Interrupt       interrupt.Interrupt
-	AltFuncSelector uint8
+	Buffer            *RingBuffer
+	Bus               *stm32.USART_Type
+	Interrupt         interrupt.Interrupt
+	TxAltFuncSelector uint8
+	RxAltFuncSelector uint8
 
 	// Registers specific to the chip
 	rxReg       *volatile.Register32

--- a/src/machine/machine_stm32f405.go
+++ b/src/machine/machine_stm32f405.go
@@ -37,8 +37,8 @@ const (
 
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.AltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.AltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 func (uart *UART) getBaudRateDivisor(baudRate uint32) uint32 {

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -37,8 +37,8 @@ const (
 // Configure the UART.
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.AltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.AltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -17,8 +17,8 @@ func CPUFrequency() uint32 {
 // Configure the UART.
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.AltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.AltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -191,8 +191,8 @@ func enableAltFuncClock(bus unsafe.Pointer) {
 // Configure the UART.
 func (uart UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.AltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.AltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -1,0 +1,184 @@
+// +build stm32l4
+
+package machine
+
+import (
+	"device/stm32"
+	"unsafe"
+)
+
+// Peripheral abstraction layer for the stm32l4
+
+const (
+	PA0  = portA + 0
+	PA1  = portA + 1
+	PA2  = portA + 2
+	PA3  = portA + 3
+	PA4  = portA + 4
+	PA5  = portA + 5
+	PA6  = portA + 6
+	PA7  = portA + 7
+	PA8  = portA + 8
+	PA9  = portA + 9
+	PA10 = portA + 10
+	PA11 = portA + 11
+	PA12 = portA + 12
+	PA13 = portA + 13
+	PA14 = portA + 14
+	PA15 = portA + 15
+
+	PB0  = portB + 0
+	PB1  = portB + 1
+	PB2  = portB + 2
+	PB3  = portB + 3
+	PB4  = portB + 4
+	PB5  = portB + 5
+	PB6  = portB + 6
+	PB7  = portB + 7
+	PB8  = portB + 8
+	PB9  = portB + 9
+	PB10 = portB + 10
+	PB11 = portB + 11
+	PB12 = portB + 12
+	PB13 = portB + 13
+	PB14 = portB + 14
+	PB15 = portB + 15
+
+	PC0  = portC + 0
+	PC1  = portC + 1
+	PC2  = portC + 2
+	PC3  = portC + 3
+	PC4  = portC + 4
+	PC5  = portC + 5
+	PC6  = portC + 6
+	PC7  = portC + 7
+	PC8  = portC + 8
+	PC9  = portC + 9
+	PC10 = portC + 10
+	PC11 = portC + 11
+	PC12 = portC + 12
+	PC13 = portC + 13
+	PC14 = portC + 14
+	PC15 = portC + 15
+
+	PD0  = portD + 0
+	PD1  = portD + 1
+	PD2  = portD + 2
+	PD3  = portD + 3
+	PD4  = portD + 4
+	PD5  = portD + 5
+	PD6  = portD + 6
+	PD7  = portD + 7
+	PD8  = portD + 8
+	PD9  = portD + 9
+	PD10 = portD + 10
+	PD11 = portD + 11
+	PD12 = portD + 12
+	PD13 = portD + 13
+	PD14 = portD + 14
+	PD15 = portD + 15
+
+	PE0  = portE + 0
+	PE1  = portE + 1
+	PE2  = portE + 2
+	PE3  = portE + 3
+	PE4  = portE + 4
+	PE5  = portE + 5
+	PE6  = portE + 6
+	PE7  = portE + 7
+	PE8  = portE + 8
+	PE9  = portE + 9
+	PE10 = portE + 10
+	PE11 = portE + 11
+	PE12 = portE + 12
+	PE13 = portE + 13
+	PE14 = portE + 14
+	PE15 = portE + 15
+)
+
+func (p Pin) getPort() *stm32.GPIO_Type {
+	switch p / 16 {
+	case 0:
+		return stm32.GPIOA
+	case 1:
+		return stm32.GPIOB
+	case 2:
+		return stm32.GPIOC
+	case 3:
+		return stm32.GPIOD
+	case 4:
+		return stm32.GPIOE
+	default:
+		panic("machine: unknown port")
+	}
+}
+
+// enableClock enables the clock for this desired GPIO port.
+func (p Pin) enableClock() {
+	switch p / 16 {
+	case 0:
+		stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_GPIOAEN)
+	case 1:
+		stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_GPIOBEN)
+	case 2:
+		stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_GPIOCEN)
+	case 3:
+		stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_GPIODEN)
+	case 4:
+		stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_GPIOEEN)
+	default:
+		panic("machine: unknown port")
+	}
+}
+
+// Enable peripheral clock
+func enableAltFuncClock(bus unsafe.Pointer) {
+	switch bus {
+	case unsafe.Pointer(stm32.PWR): // Power interface clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_PWREN)
+	case unsafe.Pointer(stm32.I2C3): // I2C3 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_I2C3EN)
+	case unsafe.Pointer(stm32.I2C2): // I2C2 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_I2C2EN)
+	case unsafe.Pointer(stm32.I2C1): // I2C1 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_I2C1EN)
+	case unsafe.Pointer(stm32.UART4): // UART4 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_UART4EN)
+	case unsafe.Pointer(stm32.USART3): // USART3 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_USART3EN)
+	case unsafe.Pointer(stm32.USART2): // USART2 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_USART2EN)
+	case unsafe.Pointer(stm32.SPI3): // SPI3 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_SPI3EN)
+	case unsafe.Pointer(stm32.SPI2): // SPI2 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_SPI2EN)
+	case unsafe.Pointer(stm32.WWDG): // Window watchdog clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_WWDGEN)
+	case unsafe.Pointer(stm32.TIM7): // TIM7 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_TIM7EN)
+	case unsafe.Pointer(stm32.TIM6): // TIM6 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_TIM6EN)
+	case unsafe.Pointer(stm32.TIM3): // TIM3 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_TIM3EN)
+	case unsafe.Pointer(stm32.TIM2): // TIM2 clock enable
+		stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_TIM2EN)
+	case unsafe.Pointer(stm32.LPTIM2): // LPTIM2 clock enable
+		stm32.RCC.APB1ENR2.SetBits(stm32.RCC_APB1ENR2_LPTIM2EN)
+	case unsafe.Pointer(stm32.I2C4): // I2C4 clock enable
+		stm32.RCC.APB1ENR2.SetBits(stm32.RCC_APB1ENR2_I2C4EN)
+	case unsafe.Pointer(stm32.LPUART1): // LPUART1 clock enable
+		stm32.RCC.APB1ENR2.SetBits(stm32.RCC_APB1ENR2_LPUART1EN)
+	case unsafe.Pointer(stm32.TIM16): // TIM16 clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_TIM16EN)
+	case unsafe.Pointer(stm32.TIM15): // TIM15 clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_TIM15EN)
+	case unsafe.Pointer(stm32.SYSCFG): // System configuration controller clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_SYSCFGEN)
+	case unsafe.Pointer(stm32.SPI1): // SPI1 clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_SPI1EN)
+	case unsafe.Pointer(stm32.USART1): // USART1 clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_USART1EN)
+	case unsafe.Pointer(stm32.TIM1): // TIM1 clock enable
+		stm32.RCC.APB2ENR.SetBits(stm32.RCC_APB2ENR_TIM1EN)
+	}
+}

--- a/src/machine/machine_stm32l4x2.go
+++ b/src/machine/machine_stm32l4x2.go
@@ -1,0 +1,36 @@
+// +build stm32l4x2
+
+package machine
+
+// Peripheral abstraction layer for the stm32l4x2
+
+import (
+	"device/stm32"
+)
+
+func CPUFrequency() uint32 {
+	return 80000000
+}
+
+//---------- UART related code
+
+// Configure the UART.
+func (uart *UART) configurePins(config UARTConfig) {
+	// enable the alternate functions on the TX and RX pins
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+}
+
+// UART baudrate calc based on the bus and clockspeed
+// NOTE: keep this in sync with the runtime/runtime_stm32l5x2.go clock init code
+func (uart *UART) getBaudRateDivisor(baudRate uint32) uint32 {
+	return (CPUFrequency() / baudRate)
+}
+
+// Register names vary by ST processor, these are for STM L5
+func (uart *UART) setRegisters() {
+	uart.rxReg = &uart.Bus.RDR
+	uart.txReg = &uart.Bus.TDR
+	uart.statusReg = &uart.Bus.ISR
+	uart.txEmptyFlag = stm32.USART_ISR_TXE
+}

--- a/src/machine/machine_stm32l5x2.go
+++ b/src/machine/machine_stm32l5x2.go
@@ -22,8 +22,8 @@ func (uart *UART) configurePins(config UARTConfig) {
 	}
 
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.AltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.AltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build !baremetal stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
+// +build !baremetal stm32,!stm32f7x2,!stm32l5x2,!stm32l4x2 fe310 k210 atmega
 
 package machine
 

--- a/src/runtime/runtime_stm32l4x2.go
+++ b/src/runtime/runtime_stm32l4x2.go
@@ -1,0 +1,262 @@
+// +build stm32,stm32l4x2
+
+package runtime
+
+import (
+	"device/stm32"
+	"machine"
+)
+
+/*
+   clock settings
+   +-------------+-----------+
+   | LSE         | 32.768khz |
+   | SYSCLK      | 80mhz     |
+   | HCLK        | 80mhz     |
+   | APB1(PCLK1) | 80mhz     |
+   | APB2(PCLK2) | 80mhz     |
+   +-------------+-----------+
+*/
+const (
+	HSE_STARTUP_TIMEOUT = 0x0500
+	PLL_M               = 1
+	PLL_N               = 40
+	PLL_P               = RCC_PLLP_DIV7
+	PLL_Q               = RCC_PLLQ_DIV2
+	PLL_R               = RCC_PLLR_DIV2
+
+	MSIRANGE = stm32.RCC_CR_MSIRANGE_Range4M
+
+	PWR_CR1_VOS_0                = 1 << stm32.PWR_CR1_VOS_Pos
+	PWR_CR1_VOS_1                = 2 << stm32.PWR_CR1_VOS_Pos
+	PWR_REGULATOR_VOLTAGE_SCALE1 = PWR_CR1_VOS_0
+	PWR_REGULATOR_VOLTAGE_SCALE2 = PWR_CR1_VOS_1
+
+	FLASH_LATENCY_0 = 0
+	FLASH_LATENCY_1 = 1
+	FLASH_LATENCY_2 = 2
+	FLASH_LATENCY_3 = 3
+	FLASH_LATENCY_4 = 4
+
+	RCC_PLLP_DIV7 = 7
+	RCC_PLLQ_DIV2 = 2
+	RCC_PLLR_DIV2 = 2
+
+	RCC_CFGR_SWS_MSI = 0x0
+	RCC_CFGR_SWS_PLL = 0xC
+
+	RCC_PLLSOURCE_MSI = 1
+
+	RCC_PLL_SYSCLK = stm32.RCC_PLLCFGR_PLLREN
+)
+
+/*
+   timer settings used for tick and sleep.
+
+   note: TICK_TIMER_FREQ and SLEEP_TIMER_FREQ are controlled by PLL / clock
+   settings above, so must be kept in sync if the clock settings are changed.
+*/
+const (
+	TICK_RATE        = 1000 // 1 KHz
+	TICK_TIMER_IRQ   = stm32.IRQ_TIM1_UP_TIM16
+	TICK_TIMER_FREQ  = 80000000 // 80 MHz
+	SLEEP_TIMER_IRQ  = stm32.IRQ_TIM1_BRK_TIM15
+	SLEEP_TIMER_FREQ = 80000000 // 84 MHz
+)
+
+type arrtype = uint32
+
+const asyncScheduler = false
+
+func init() {
+	initCLK()
+
+	initSleepTimer(&timerInfo{
+		EnableRegister: &stm32.RCC.APB2ENR,
+		EnableFlag:     stm32.RCC_APB2ENR_TIM15EN,
+		Device:         stm32.TIM15,
+	})
+
+	machine.UART0.Configure(machine.UARTConfig{})
+
+	initTickTimer(&timerInfo{
+		EnableRegister: &stm32.RCC.APB2ENR,
+		EnableFlag:     stm32.RCC_APB2ENR_TIM16EN,
+		Device:         stm32.TIM16,
+	})
+}
+
+func putchar(c byte) {
+	machine.UART0.WriteByte(c)
+}
+
+func initCLK() {
+	// PWR_CLK_ENABLE
+	stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_PWREN)
+	_ = stm32.RCC.APB1ENR1.Get()
+
+	// Disable Backup domain protection
+	if !stm32.PWR.CR1.HasBits(stm32.PWR_CR1_DBP) {
+		stm32.PWR.CR1.SetBits(stm32.PWR_CR1_DBP)
+		for !stm32.PWR.CR1.HasBits(stm32.PWR_CR1_DBP) {
+		}
+	}
+
+	// Set LSE Drive to LOW
+	stm32.RCC.BDCR.ReplaceBits(0, stm32.RCC_BDCR_LSEDRV_Msk, 0)
+
+	// Initialize the High-Speed External Oscillator
+	initOsc()
+
+	// PWR_VOLTAGESCALING_CONFIG
+	stm32.PWR.CR1.ReplaceBits(0, stm32.PWR_CR1_VOS_Msk, 0)
+	_ = stm32.PWR.CR1.Get()
+
+	// Set flash wait states (min 5 latency units) based on clock
+	if (stm32.FLASH.ACR.Get() & 0xF) < 5 {
+		stm32.FLASH.ACR.ReplaceBits(5, 0xF, 0)
+	}
+
+	// Ensure HCLK does not exceed max during transition
+	stm32.RCC.CFGR.ReplaceBits(8<<stm32.RCC_CFGR_HPRE_Pos, stm32.RCC_CFGR_HPRE_Msk, 0)
+
+	// Set SYSCLK source and wait
+	// (3 = RCC_SYSCLKSOURCE_PLLCLK, 2=RCC_CFGR_SWS_Pos)
+	stm32.RCC.CFGR.ReplaceBits(3, stm32.RCC_CFGR_SW_Msk, 0)
+	for stm32.RCC.CFGR.Get()&(3<<2) != (3 << 2) {
+	}
+
+	// Set HCLK
+	// (0 = RCC_SYSCLKSOURCE_PLLCLK)
+	stm32.RCC.CFGR.ReplaceBits(0, stm32.RCC_CFGR_HPRE_Msk, 0)
+
+	// Set flash wait states (max 5 latency units) based on clock
+	if (stm32.FLASH.ACR.Get() & 0xF) > 5 {
+		stm32.FLASH.ACR.ReplaceBits(5, 0xF, 0)
+	}
+
+	// Set APB1 and APB2 clocks (0 = DIV1)
+	stm32.RCC.CFGR.ReplaceBits(0, stm32.RCC_CFGR_PPRE1_Msk, 0)
+	stm32.RCC.CFGR.ReplaceBits(0, stm32.RCC_CFGR_PPRE2_Msk, 0)
+}
+
+func initOsc() {
+	sysclkSource := stm32.RCC.CFGR.Get() & stm32.RCC_CFGR_SWS_Msk
+	pllConfig := stm32.RCC.PLLCFGR.Get() & stm32.RCC_PLLCFGR_PLLSRC_Msk
+
+	// Enable MSI, adjusting flash latency
+	if sysclkSource == RCC_CFGR_SWS_MSI ||
+		(sysclkSource == RCC_CFGR_SWS_PLL && pllConfig == RCC_PLLSOURCE_MSI) {
+		if MSIRANGE > getMSIRange() {
+			setFlashLatencyFromMSIRange(MSIRANGE)
+
+			setMSIFreq(MSIRANGE, 0)
+		} else {
+			setMSIFreq(MSIRANGE, 0)
+
+			if sysclkSource == RCC_CFGR_SWS_MSI {
+				setFlashLatencyFromMSIRange(MSIRANGE)
+			}
+		}
+	} else {
+		stm32.RCC.CR.SetBits(stm32.RCC_CR_MSION)
+		for !stm32.RCC.CR.HasBits(stm32.RCC_CR_MSIRDY) {
+		}
+
+		setMSIFreq(MSIRANGE, 0)
+	}
+
+	// Enable LSE, wait until ready
+	stm32.RCC.BDCR.SetBits(stm32.RCC_BDCR_LSEON)
+	for !stm32.RCC.BDCR.HasBits(stm32.RCC_BDCR_LSEON) {
+	}
+
+	// Disable the PLL, wait until disabled
+	stm32.RCC.CR.ClearBits(stm32.RCC_CR_PLLON)
+	for stm32.RCC.CR.HasBits(stm32.RCC_CR_PLLRDY) {
+	}
+
+	// Configure the PLL
+	stm32.RCC.PLLCFGR.ReplaceBits(
+		(1)| // 1 = RCC_PLLSOURCE_MSI
+			(PLL_M-1)<<stm32.RCC_PLLCFGR_PLLM_Pos|
+			(PLL_N<<stm32.RCC_PLLCFGR_PLLN_Pos)|
+			(((PLL_Q>>1)-1)<<stm32.RCC_PLLCFGR_PLLQ_Pos)|
+			(((PLL_R>>1)-1)<<stm32.RCC_PLLCFGR_PLLR_Pos)|
+			(PLL_P<<stm32.RCC_PLLCFGR_PLLPDIV_Pos),
+		stm32.RCC_PLLCFGR_PLLSRC_Msk|stm32.RCC_PLLCFGR_PLLM_Msk|
+			stm32.RCC_PLLCFGR_PLLN_Msk|stm32.RCC_PLLCFGR_PLLP_Msk|
+			stm32.RCC_PLLCFGR_PLLR_Msk|stm32.RCC_PLLCFGR_PLLPDIV_Msk,
+		0)
+
+	// Enable the PLL and PLL System Clock Output, wait until ready
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_PLLON)
+	stm32.RCC.PLLCFGR.SetBits(stm32.RCC_PLLCFGR_PLLREN) // = RCC_PLL_SYSCLK
+	for !stm32.RCC.CR.HasBits(stm32.RCC_CR_PLLRDY) {
+	}
+
+	// Enable system clock output
+	stm32.RCC.PLLCFGR.SetBits(RCC_PLL_SYSCLK)
+}
+
+func getMSIRange() uint32 {
+	if stm32.RCC.CR.HasBits(stm32.RCC_CR_MSIRGSEL) {
+		return (stm32.RCC.CR.Get() & stm32.RCC_CR_MSIRANGE_Msk) >> stm32.RCC_CR_MSIRANGE_Pos
+	}
+
+	return (stm32.RCC.CSR.Get() & stm32.RCC_CSR_MSISRANGE_Msk) >> stm32.RCC_CSR_MSISRANGE_Pos
+}
+
+func setMSIFreq(r uint32, calibration uint32) {
+	stm32.RCC.CR.SetBits(stm32.RCC_CR_MSIRGSEL)
+	stm32.RCC.CR.ReplaceBits(r<<stm32.RCC_CR_MSIRANGE_Pos, stm32.RCC_CR_MSIRANGE_Msk, 0)
+
+	stm32.RCC.ICSCR.ReplaceBits(calibration<<stm32.RCC_ICSCR_MSITRIM_Pos, stm32.RCC_ICSCR_MSITRIM_Msk, 0)
+}
+
+func setFlashLatencyFromMSIRange(r uint32) {
+	var vos uint32
+	if pwrIsClkEnabled() {
+		vos = pwrExGetVoltageRange()
+	} else {
+		pwrClkEnable()
+		vos = pwrExGetVoltageRange()
+		pwrClkDisable()
+	}
+
+	latency := uint32(FLASH_LATENCY_0)
+	if vos == PWR_REGULATOR_VOLTAGE_SCALE1 {
+		if r > stm32.RCC_CR_MSIRANGE_Range16M {
+			if r > stm32.RCC_CR_MSIRANGE_Range32M {
+				latency = FLASH_LATENCY_2
+			} else {
+				latency = FLASH_LATENCY_1
+			}
+		}
+	} else if r > stm32.RCC_CR_MSIRANGE_Range16M {
+		latency = FLASH_LATENCY_3
+	} else {
+		if r == stm32.RCC_CR_MSIRANGE_Range16M {
+			latency = FLASH_LATENCY_2
+		} else if r == stm32.RCC_CR_MSIRANGE_Range8M {
+			latency = FLASH_LATENCY_1
+		}
+	}
+
+	stm32.FLASH.ACR.ReplaceBits(latency, stm32.Flash_ACR_LATENCY_Msk, 0)
+}
+
+func pwrIsClkEnabled() bool {
+	return stm32.RCC.APB1ENR1.HasBits(stm32.RCC_APB1ENR1_PWREN)
+}
+
+func pwrClkEnable() {
+	stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_PWREN)
+}
+func pwrClkDisable() {
+	stm32.RCC.APB1ENR1.ClearBits(stm32.RCC_APB1ENR1_PWREN)
+}
+
+func pwrExGetVoltageRange() uint32 {
+	return stm32.PWR.CR1.Get() & stm32.PWR_CR1_VOS_Msk
+}

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -3,6 +3,7 @@
 	"llvm-target": "armv7em-none-eabi",
 	"cflags": [
 		"--target=armv7em-none-eabi",
-		"-mfloat-abi=soft"
+		"-mfloat-abi=soft",
+		"-Qunused-arguments"
 	]
 }

--- a/targets/nucleo-l432kc.json
+++ b/targets/nucleo-l432kc.json
@@ -1,0 +1,11 @@
+{
+    "inherits": ["cortex-m4"],
+    "build-tags": ["nucleol432kc", "stm32l432", "stm32l4x2", "stm32l4", "stm32"],
+    "linkerscript": "targets/stm32l4x2.ld",
+    "extra-files": [
+      "src/device/stm32/stm32l4x2.s"
+    ],
+    "flash-method": "openocd",
+    "openocd-interface": "stlink-v2-1",
+    "openocd-target": "stm32l4x"
+  }

--- a/targets/stm32l4x2.ld
+++ b/targets/stm32l4x2.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+  FLASH_TEXT (rx) : ORIGIN = 0x08000000, LENGTH = 256K
+  RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+_stack_size = 4K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
Adds basic support for the board (UART and LED).

Because UART function is on different alt funcs for Tx/Rx, extended common UART code to support that.