### PR TITLE
Fix data shift/mask in func newUSBSetup

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -547,8 +547,8 @@ func newUSBSetup(data []byte) usbSetup {
 	u.bRequest = uint8(data[1])
 	u.wValueL = uint8(data[2])
 	u.wValueH = uint8(data[3])
-	u.wIndex = uint16(data[4]) | uint16(data[5]<<8)
-	u.wLength = uint16(data[6]) | uint16(data[7]<<8)
+	u.wIndex = uint16(data[4]) | (uint16(data[5]) << 8)
+	u.wLength = uint16(data[6]) | (uint16(data[7]) << 8)
 	return u
 }
 


### PR DESCRIPTION
My Go linter pointed me to a suspicious piece of code in `src/machine/usb.go` where a shift is performed that is wider than its operand. The exact error message was:

> data[5] (8 bits) too small for shift of 8

I'm not sure how to exercise this bug, but, left as-is, the logic doesn't make sense. This PR widens the operand to 16 bits before applying the left-shift, which seems to be what was originally intended.