### PR TITLE
atsamd21: improve SPI

### DIFF
--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build !baremetal atsamd21 stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
+// +build !baremetal stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
 
 package machine
 


### PR DESCRIPTION
This is the samd21 version of #1453 .

Since samd21 has a slower CPU than samd51, we created a special function to speed it up.

I think it will be necessary for tinygo-org/drivers/ili9341 to run faster.
It's also better to be fast for the sdcard SPI driver.

I will eventually use DMA to send/receive, but it will be very late to work on DMA support for samd21.

----

### old

old: 7d1ce24be5c60525e14b25a29bc0833b454ab7d4
![image](https://user-images.githubusercontent.com/9251039/111136304-ec52da80-85c0-11eb-8f9d-d83c712579b6.png)

----

### new
txrx24mhz: 3bc7451c04c63486638d37d0d38279265823157c
![image](https://user-images.githubusercontent.com/9251039/111136358-01c80480-85c1-11eb-9c1f-9747fbdeac02.png)

tx24mhz: 3bc7451c04c63486638d37d0d38279265823157c
![image](https://user-images.githubusercontent.com/9251039/111136397-0db3c680-85c1-11eb-8aa1-1c8f05f67999.png)

rx: 3bc7451c04c63486638d37d0d38279265823157c
![image](https://user-images.githubusercontent.com/9251039/111136449-1b694c00-85c1-11eb-96ec-0bfefa5f6e19.png)

txrx with SPI.Freq == 12MHz: 3bc7451c04c63486638d37d0d38279265823157c
When the SPI Freq is less than 12Mhz, it seems that no special processing is required.
![image](https://user-images.githubusercontent.com/9251039/111136606-45227300-85c1-11eb-872c-964154bdbf11.png)
