### PR TITLE
build: make msd flash faster

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -44,7 +44,7 @@ type BuildResult struct {
 //
 // The error value may be of type *MultiError. Callers will likely want to check
 // for this case and print such errors individually.
-func Build(pkgName, outpath string, config *compileopts.Config, action func(BuildResult) error) error {
+func Build(pkgName, outpath string, config *compileopts.Config, preAction func() error, action func(BuildResult) error) error {
 	compilerConfig := &compiler.Config{
 		Triple:          config.Triple(),
 		CPU:             config.CPU(),
@@ -86,6 +86,14 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// This is somewhat like an in-memory Makefile with each job being a
 	// Makefile target.
 	var jobs []*compileJob
+
+	if preAction != nil {
+		// Add job to preAction.
+		jobs = append(jobs, &compileJob{
+			description: "preAction",
+			run:         preAction,
+		})
+	}
 
 	// Add job to compile and optimize all Go files at once.
 	// TODO: parallelize this.


### PR DESCRIPTION
This is mainly for cases where msd flash is used instead of openocd.
The basic idea is to run the `touchSerialPortAt1200bps()` in parallel with the build.

It makes the environment a little more comfortable for tinygopher, which doesn't have a debugger.
If the build takes more than 3 seconds, it will be at least 3 seconds faster.
If the build takes less than 3 seconds, there is not much improvement.


* Core i5-5200 + ubuntu 20.04
    * before : 8.6 sec
    * after : 3.5 sec
* Ryzen 7 3700X + Windows10
    * before : 5.0 sec
    * after : 4.5 sec