### PR TITLE
compiler: do not use llvm.GlobalContext()

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -316,14 +316,14 @@ func CompileProgram(lprogram *loader.Program, machine llvm.TargetMachine, config
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
 				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(), // Error on mismatch
-				llvm.GlobalContext().MDString("Debug Info Version"),
+				c.ctx.MDString("Debug Info Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 3, false).ConstantAsMetadata(), // DWARF version
 			}),
 		)
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
 				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(),
-				llvm.GlobalContext().MDString("Dwarf Version"),
+				c.ctx.MDString("Dwarf Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 4, false).ConstantAsMetadata(),
 			}),
 		)


### PR DESCRIPTION
This is a leftover from a long time ago, when everything was still in
the global context. The fact that this uses the global context is most
certainly a bug.

I have seen occasional crashes in the build-packages-indepedently branch
(and PRs based on it) which I suspect are caused by this bug. I think
this is a long-dormant bug that only surfaced when doing the compilation
steps in parallel.