### PR TITLE
build: improve error messages in getDefaultPort(), support for multiple ports

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"tinygo.org/x/go-llvm"
 
 	"go.bug.st/serial"
+	"go.bug.st/serial/enumerator"
 )
 
 var (
@@ -240,15 +241,12 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 	return builder.Build(pkgName, fileExt, config, func(result builder.BuildResult) error {
 		// do we need port reset to put MCU into bootloader mode?
 		if config.Target.PortReset == "true" && flashMethod != "openocd" {
-			if port == "" {
-				var err error
-				port, err = getDefaultPort()
-				if err != nil {
-					return err
-				}
+			port, err := getDefaultPort(strings.FieldsFunc(port, func(c rune) bool { return c == ',' }))
+			if err != nil {
+				return err
 			}
 
-			err := touchSerialPortAt1200bps(port)
+			err = touchSerialPortAt1200bps(port)
 			if err != nil {
 				return &commandError{"failed to reset port", result.Binary, err}
 			}
@@ -264,9 +262,9 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 			fileToken := "{" + fileExt[1:] + "}"
 			flashCmd = strings.ReplaceAll(flashCmd, fileToken, result.Binary)
 
-			if port == "" && strings.Contains(flashCmd, "{port}") {
+			if strings.Contains(flashCmd, "{port}") {
 				var err error
-				port, err = getDefaultPort()
+				port, err = getDefaultPort(strings.FieldsFunc(port, func(c rune) bool { return c == ',' }))
 				if err != nil {
 					return err
 				}
@@ -665,41 +663,66 @@ func windowsFindUSBDrive(volume string, options *compileopts.Options) (string, e
 }
 
 // getDefaultPort returns the default serial port depending on the operating system.
-func getDefaultPort() (port string, err error) {
-	var portPath string
+func getDefaultPort(portCandidates []string) (port string, err error) {
+	if len(portCandidates) == 1 {
+		return portCandidates[0], nil
+	}
+
+	var ports []string
 	switch runtime.GOOS {
-	case "darwin":
-		portPath = "/dev/cu.usb*"
-	case "linux":
-		portPath = "/dev/ttyACM*"
 	case "freebsd":
-		portPath = "/dev/cuaU*"
-	case "windows":
-		ports, err := serial.GetPortsList()
+		ports, err = filepath.Glob("/dev/cuaU*")
+	case "darwin", "linux", "windows":
+		var portsList []*enumerator.PortDetails
+		portsList, err = enumerator.GetDetailedPortsList()
 		if err != nil {
 			return "", err
 		}
 
-		if len(ports) == 0 {
-			return "", errors.New("no serial ports available")
-		} else if len(ports) > 1 {
-			return "", errors.New("multiple serial ports available - use -port flag")
+		for _, p := range portsList {
+			ports = append(ports, p.Name)
 		}
 
-		return ports[0], nil
+		if ports == nil || len(ports) == 0 {
+			// fallback
+			switch runtime.GOOS {
+			case "darwin":
+				ports, err = filepath.Glob("/dev/cu.usb*")
+			case "linux":
+				ports, err = filepath.Glob("/dev/ttyACM*")
+			case "windows":
+				ports, err = serial.GetPortsList()
+			}
+		}
 	default:
 		return "", errors.New("unable to search for a default USB device to be flashed on this OS")
 	}
 
-	d, err := filepath.Glob(portPath)
 	if err != nil {
 		return "", err
-	}
-	if d == nil {
+	} else if ports == nil {
 		return "", errors.New("unable to locate a serial port")
+	} else if len(ports) == 0 {
+		return "", errors.New("no serial ports available")
 	}
 
-	return d[0], nil
+	if len(portCandidates) == 0 {
+		if len(ports) == 1 {
+			return ports[0], nil
+		} else {
+			return "", errors.New("multiple serial ports available - use -port flag, available ports are " + strings.Join(ports, ", "))
+		}
+	}
+
+	for _, ps := range portCandidates {
+		for _, p := range ports {
+			if p == ps {
+				return p, nil
+			}
+		}
+	}
+
+	return "", errors.New("port you specified '" + strings.Join(portCandidates, ",") + "' does not exist, available ports are " + strings.Join(ports, ", "))
 }
 
 func usage() {
@@ -834,7 +857,7 @@ func main() {
 	printCommands := flag.Bool("x", false, "Print commands")
 	nodebug := flag.Bool("no-debug", false, "disable DWARF debug symbol generation")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
-	port := flag.String("port", "", "flash port")
+	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	cFlags := flag.String("cflags", "", "additional cflags for compiler")
 	ldFlags := flag.String("ldflags", "", "additional ldflags for linker")


### PR DESCRIPTION
I think this will be useful for people who don't use the debugger in their environment.

The environments affected by this change are darwin, linux, and windows.
`go.bug.st/serial/enumurator` does not support freebsd, so this change does not support freebsd.

I have checked it on windows 10 and ubuntu 20.04, but not on macos.

The changes are as follows

* Improved error messages when multiple ports are found
* Multiple port candidates can now be specified

## Improved error messages when multiple ports are found

Added support for displaying the names of existing ports.
This is useful when the port names are complex, such as windows.
This is also useful if the ports are placed in slightly different locations depending on the OS.
ex: `/dev/ttyACM*` , `/dev/ttyUSB*` , ...

before:
```
$ ./build/tinygo flash --target feather-m4 --size short examples/blinky1
   code    data     bss |   flash     ram
   8244      20    6360 |    8264    6380
error: multiple serial ports available - use -port flag
```

after:
```
$ ./build/tinygo flash --target feather-m4 --size short examples/blinky1
   code    data     bss |   flash     ram
   8244      20    6360 |    8264    6380
error: multiple ports exist, available ports are COM1, COM10
```

## Multiple port candidates can now be specified

Use the port found first, separated by commas
If a port cannot be found, an error message will be displayed.


For windows users, the port name changes when it is put into bootloader, so command line input was troublesome.
With this change, you can now specify multiple ports and develop comfortably.

after:
```
$ ./build/tinygo flash --target feather-m4 --size short --port COM10,COM11 examples/blinky1
   code    data     bss |   flash     ram
   8244      20    6360 |    8264    6380
```

after + error:
```
$ ./build/tinygo flash --target feather-m4 --size short --port COMx,COMy examples/blinky1
   code    data     bss |   flash     ram
   8244      20    6360 |    8264    6380
error: port you specified 'COMx,COMy' does not exist, available ports are COM1, COM10
```