### PR TITLE
Improve reflection

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 2 // last change: adding wasm-export-name attribute
+const Version = 3 // last change: remove runtime.typeInInterface
 
 func init() {
 	llvm.InitializeAllTargets()

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 3 // last change: remove runtime.typeInInterface
+const Version = 4 // last change: runtime.typeAssert signature
 
 func init() {
 	llvm.InitializeAllTargets()

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -286,11 +286,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				if r.debug {
 					fmt.Fprintln(os.Stderr, indent+"typeassert:", operands[1:])
 				}
-				typeInInterfacePtr, err := operands[1].asPointer(r)
-				if err != nil {
-					return nil, mem, r.errorAt(inst, err)
-				}
-				actualType, err := mem.load(typeInInterfacePtr, r.pointerSize).asPointer(r)
+				actualType, err := operands[1].asPointer(r)
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err)
 				}
@@ -310,11 +306,11 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				}
 
 				// Load various values for the interface implements check below.
-				typeInInterfacePtr, err := operands[1].asPointer(r)
+				typecodePtr, err := operands[1].asPointer(r)
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err)
 				}
-				methodSetPtr, err := mem.load(typeInInterfacePtr.addOffset(r.pointerSize), r.pointerSize).asPointer(r)
+				methodSetPtr, err := mem.load(typecodePtr.addOffset(r.pointerSize*2), r.pointerSize).asPointer(r)
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err)
 				}

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -286,16 +286,10 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				if r.debug {
 					fmt.Fprintln(os.Stderr, indent+"typeassert:", operands[1:])
 				}
-				actualType, err := operands[1].asPointer(r)
-				if err != nil {
-					return nil, mem, r.errorAt(inst, err)
-				}
-				assertedType, err := operands[2].asPointer(r)
-				if err != nil {
-					return nil, mem, r.errorAt(inst, err)
-				}
-				result := assertedType.asRawValue(r).equal(actualType.asRawValue(r))
-				if result {
+				assertedType := operands[2].toLLVMValue(inst.llvmInst.Operand(1).Type(), &mem)
+				actualTypePtrToInt := operands[1].toLLVMValue(inst.llvmInst.Operand(0).Type(), &mem)
+				actualType := actualTypePtrToInt.Operand(0)
+				if actualType.Name()+"$id" == assertedType.Name() {
 					locals[inst.localIndex] = literalValue{uint8(1)}
 				} else {
 					locals[inst.localIndex] = literalValue{uint8(0)}

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -277,7 +277,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				copy(dstBuf.buf[dst.offset():dst.offset()+nBytes], srcBuf.buf[src.offset():])
 				dstObj.buffer = dstBuf
 				mem.put(dst.index(), dstObj)
-			case callFn.name == "(reflect.Type).Elem":
+			case callFn.name == "(reflect.rawType).elem":
 				if r.debug {
 					fmt.Fprintln(os.Stderr, indent+"call (reflect.rawType).elem:", operands[1:])
 				}

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -1048,7 +1048,7 @@ func (v rawValue) rawLLVMValue(mem *memoryView) llvm.Value {
 				// There are some special pointer types that should be used as a
 				// ptrtoint, so that they can be used in certain optimizations.
 				name := elementType.StructName()
-				if name == "runtime.typeInInterface" || name == "runtime.funcValueWithSignature" {
+				if name == "runtime.typecodeID" || name == "runtime.funcValueWithSignature" {
 					uintptrType := ctx.IntType(int(mem.r.pointerSize) * 8)
 					field = llvm.ConstPtrToInt(field, uintptrType)
 				}

--- a/interp/testdata/interface.ll
+++ b/interp/testdata/interface.ll
@@ -1,14 +1,12 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i64 }
+%runtime.typecodeID = type { %runtime.typecodeID*, i64, %runtime.interfaceMethodInfo* }
 %runtime.interfaceMethodInfo = type { i8*, i64 }
-%runtime.typeInInterface = type { %runtime.typecodeID*, %runtime.interfaceMethodInfo* }
 
 @main.v1 = global i1 0
-@"reflect/types.type:named:main.foo" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i64 0 }
+@"reflect/types.type:named:main.foo" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i64 0, %runtime.interfaceMethodInfo* null }
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
-@"typeInInterface:reflect/types.type:named:main.foo" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:named:main.foo", %runtime.interfaceMethodInfo* null }
 
 
 declare i1 @runtime.typeAssert(i64, %runtime.typecodeID*, i8*, i8*)
@@ -22,7 +20,7 @@ entry:
 define internal void @main.init() unnamed_addr {
 entry:
   ; Test type asserts.
-  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:named:main.foo" to i64), %runtime.typecodeID* @"reflect/types.type:named:main.foo", i8* undef, i8* null)
+  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:main.foo" to i64), %runtime.typecodeID* @"reflect/types.type:named:main.foo", i8* undef, i8* null)
   store i1 %typecode, i1* @main.v1
   ret void
 }

--- a/interp/testdata/interface.ll
+++ b/interp/testdata/interface.ll
@@ -6,10 +6,11 @@ target triple = "x86_64--linux"
 
 @main.v1 = global i1 0
 @"reflect/types.type:named:main.foo" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i64 0, %runtime.interfaceMethodInfo* null }
+@"reflect/types.type:named:main.foo$id" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 
 
-declare i1 @runtime.typeAssert(i64, %runtime.typecodeID*, i8*, i8*)
+declare i1 @runtime.typeAssert(i64, i8*, i8*, i8*)
 
 define void @runtime.initAll() unnamed_addr {
 entry:
@@ -20,7 +21,7 @@ entry:
 define internal void @main.init() unnamed_addr {
 entry:
   ; Test type asserts.
-  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:main.foo" to i64), %runtime.typecodeID* @"reflect/types.type:named:main.foo", i8* undef, i8* null)
+  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:main.foo" to i64), i8* @"reflect/types.type:named:main.foo$id", i8* undef, i8* null)
   store i1 %typecode, i1* @main.v1
   ret void
 }

--- a/src/internal/task/task_coroutine.go
+++ b/src/internal/task/task_coroutine.go
@@ -11,7 +11,7 @@ import (
 type rawState uint8
 
 //export llvm.coro.resume
-func (s *rawState) resume()
+func coroResume(*rawState)
 
 type state struct{ *rawState }
 
@@ -20,7 +20,7 @@ func noopState() *rawState
 
 // Resume the task until it pauses or completes.
 func (t *Task) Resume() {
-	t.state.resume()
+	coroResume(t.state.rawState)
 }
 
 // setState is used by the compiler to set the state of the function at the beginning of a function call.

--- a/src/reflect/swapper.go
+++ b/src/reflect/swapper.go
@@ -21,7 +21,7 @@ func Swapper(slice interface{}) func(i, j int) {
 		return func(i, j int) {}
 	}
 
-	typ := v.Type().Elem()
+	typ := v.typecode.Elem()
 	size := typ.Size()
 
 	header := (*SliceHeader)(v.value)

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -122,30 +122,218 @@ func (k Kind) String() string {
 }
 
 // basicType returns a new Type for this kind if Kind is a basic type.
-func (k Kind) basicType() Type {
-	return Type(k << 1)
+func (k Kind) basicType() rawType {
+	return rawType(k << 1)
+}
+
+// The following Type type has been copied almost entirely from
+// https://github.com/golang/go/blob/go1.15/src/reflect/type.go#L27-L212.
+// Some methods have been commented out as they haven't yet been implemented.
+
+// Type is the representation of a Go type.
+//
+// Not all methods apply to all kinds of types. Restrictions,
+// if any, are noted in the documentation for each method.
+// Use the Kind method to find out the kind of type before
+// calling kind-specific methods. Calling a method
+// inappropriate to the kind of type causes a run-time panic.
+//
+// Type values are comparable, such as with the == operator,
+// so they can be used as map keys.
+// Two Type values are equal if they represent identical types.
+type Type interface {
+	// Methods applicable to all types.
+
+	// Align returns the alignment in bytes of a value of
+	// this type when allocated in memory.
+	Align() int
+
+	// FieldAlign returns the alignment in bytes of a value of
+	// this type when used as a field in a struct.
+	FieldAlign() int
+
+	// Method returns the i'th method in the type's method set.
+	// It panics if i is not in the range [0, NumMethod()).
+	//
+	// For a non-interface type T or *T, the returned Method's Type and Func
+	// fields describe a function whose first argument is the receiver.
+	//
+	// For an interface type, the returned Method's Type field gives the
+	// method signature, without a receiver, and the Func field is nil.
+	//
+	// Only exported methods are accessible and they are sorted in
+	// lexicographic order.
+	//Method(int) Method
+
+	// MethodByName returns the method with that name in the type's
+	// method set and a boolean indicating if the method was found.
+	//
+	// For a non-interface type T or *T, the returned Method's Type and Func
+	// fields describe a function whose first argument is the receiver.
+	//
+	// For an interface type, the returned Method's Type field gives the
+	// method signature, without a receiver, and the Func field is nil.
+	//MethodByName(string) (Method, bool)
+
+	// NumMethod returns the number of exported methods in the type's method set.
+	NumMethod() int
+
+	// Name returns the type's name within its package for a defined type.
+	// For other (non-defined) types it returns the empty string.
+	Name() string
+
+	// PkgPath returns a defined type's package path, that is, the import path
+	// that uniquely identifies the package, such as "encoding/base64".
+	// If the type was predeclared (string, error) or not defined (*T, struct{},
+	// []int, or A where A is an alias for a non-defined type), the package path
+	// will be the empty string.
+	//PkgPath() string
+
+	// Size returns the number of bytes needed to store
+	// a value of the given type; it is analogous to unsafe.Sizeof.
+	Size() uintptr
+
+	// String returns a string representation of the type.
+	// The string representation may use shortened package names
+	// (e.g., base64 instead of "encoding/base64") and is not
+	// guaranteed to be unique among types. To test for type identity,
+	// compare the Types directly.
+	String() string
+
+	// Kind returns the specific kind of this type.
+	Kind() Kind
+
+	// Implements reports whether the type implements the interface type u.
+	Implements(u Type) bool
+
+	// AssignableTo reports whether a value of the type is assignable to type u.
+	AssignableTo(u Type) bool
+
+	// ConvertibleTo reports whether a value of the type is convertible to type u.
+	ConvertibleTo(u Type) bool
+
+	// Comparable reports whether values of this type are comparable.
+	Comparable() bool
+
+	// Methods applicable only to some types, depending on Kind.
+	// The methods allowed for each kind are:
+	//
+	//	Int*, Uint*, Float*, Complex*: Bits
+	//	Array: Elem, Len
+	//	Chan: ChanDir, Elem
+	//	Func: In, NumIn, Out, NumOut, IsVariadic.
+	//	Map: Key, Elem
+	//	Ptr: Elem
+	//	Slice: Elem
+	//	Struct: Field, FieldByIndex, FieldByName, FieldByNameFunc, NumField
+
+	// Bits returns the size of the type in bits.
+	// It panics if the type's Kind is not one of the
+	// sized or unsized Int, Uint, Float, or Complex kinds.
+	Bits() int
+
+	// ChanDir returns a channel type's direction.
+	// It panics if the type's Kind is not Chan.
+	//ChanDir() ChanDir
+
+	// IsVariadic reports whether a function type's final input parameter
+	// is a "..." parameter. If so, t.In(t.NumIn() - 1) returns the parameter's
+	// implicit actual type []T.
+	//
+	// For concreteness, if t represents func(x int, y ... float64), then
+	//
+	//	t.NumIn() == 2
+	//	t.In(0) is the reflect.Type for "int"
+	//	t.In(1) is the reflect.Type for "[]float64"
+	//	t.IsVariadic() == true
+	//
+	// IsVariadic panics if the type's Kind is not Func.
+	//IsVariadic() bool
+
+	// Elem returns a type's element type.
+	// It panics if the type's Kind is not Array, Chan, Map, Ptr, or Slice.
+	Elem() Type
+
+	// Field returns a struct type's i'th field.
+	// It panics if the type's Kind is not Struct.
+	// It panics if i is not in the range [0, NumField()).
+	Field(i int) StructField
+
+	// FieldByIndex returns the nested field corresponding
+	// to the index sequence. It is equivalent to calling Field
+	// successively for each index i.
+	// It panics if the type's Kind is not Struct.
+	//FieldByIndex(index []int) StructField
+
+	// FieldByName returns the struct field with the given name
+	// and a boolean indicating if the field was found.
+	//FieldByName(name string) (StructField, bool)
+
+	// FieldByNameFunc returns the struct field with a name
+	// that satisfies the match function and a boolean indicating if
+	// the field was found.
+	//
+	// FieldByNameFunc considers the fields in the struct itself
+	// and then the fields in any embedded structs, in breadth first order,
+	// stopping at the shallowest nesting depth containing one or more
+	// fields satisfying the match function. If multiple fields at that depth
+	// satisfy the match function, they cancel each other
+	// and FieldByNameFunc returns no match.
+	// This behavior mirrors Go's handling of name lookup in
+	// structs containing embedded fields.
+	//FieldByNameFunc(match func(string) bool) (StructField, bool)
+
+	// In returns the type of a function type's i'th input parameter.
+	// It panics if the type's Kind is not Func.
+	// It panics if i is not in the range [0, NumIn()).
+	//In(i int) Type
+
+	// Key returns a map type's key type.
+	// It panics if the type's Kind is not Map.
+	Key() Type
+
+	// Len returns an array type's length.
+	// It panics if the type's Kind is not Array.
+	Len() int
+
+	// NumField returns a struct type's field count.
+	// It panics if the type's Kind is not Struct.
+	NumField() int
+
+	// NumIn returns a function type's input parameter count.
+	// It panics if the type's Kind is not Func.
+	//NumIn() int
+
+	// NumOut returns a function type's output parameter count.
+	// It panics if the type's Kind is not Func.
+	//NumOut() int
+
+	// Out returns the type of a function type's i'th output parameter.
+	// It panics if the type's Kind is not Func.
+	// It panics if i is not in the range [0, NumOut()).
+	//Out(i int) Type
 }
 
 // The typecode as used in an interface{}.
-type Type uintptr
+type rawType uintptr
 
 func TypeOf(i interface{}) Type {
 	return ValueOf(i).typecode
 }
 
 func PtrTo(t Type) Type {
-	ptrType := t<<5 | 5 // 0b0101 == 5
+	ptrType := t.(rawType)<<5 | 5 // 0b0101 == 5
 	if ptrType>>5 != t {
 		panic("reflect: PtrTo type does not fit")
 	}
 	return ptrType
 }
 
-func (t Type) String() string {
+func (t rawType) String() string {
 	return "T"
 }
 
-func (t Type) Kind() Kind {
+func (t rawType) Kind() Kind {
 	if t%2 == 0 {
 		// basic type
 		return Kind((t >> 1) % 32)
@@ -156,14 +344,18 @@ func (t Type) Kind() Kind {
 
 // Elem returns the element type for channel, slice and array types, the
 // pointed-to value for pointer types, and the key type for map types.
-func (t Type) Elem() Type {
+func (t rawType) Elem() Type {
+	return t.elem()
+}
+
+func (t rawType) elem() rawType {
 	switch t.Kind() {
 	case Chan, Ptr, Slice:
 		return t.stripPrefix()
 	case Array:
 		index := t.stripPrefix()
 		elem, _ := readVarint(unsafe.Pointer(uintptr(unsafe.Pointer(&arrayTypesSidetable)) + uintptr(index)))
-		return Type(elem)
+		return rawType(elem)
 	default: // not implemented: Map
 		panic("unimplemented: (reflect.Type).Elem()")
 	}
@@ -175,14 +367,14 @@ func (t Type) Elem() Type {
 // simply shifted off.
 //
 // The behavior is only defined for non-basic types.
-func (t Type) stripPrefix() Type {
+func (t rawType) stripPrefix() rawType {
 	// Look at the 'n' bit in the type code (see the top of this file) to see
 	// whether this is a named type.
 	if (t>>4)%2 != 0 {
 		// This is a named type. The data is stored in a sidetable.
 		namedTypeNum := t >> 5
 		n := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&namedNonBasicTypesSidetable)) + uintptr(namedTypeNum)*unsafe.Sizeof(uintptr(0))))
-		return Type(n)
+		return rawType(n)
 	}
 	// Not a named type, so the value is stored directly in the type code.
 	return t >> 5
@@ -190,7 +382,23 @@ func (t Type) stripPrefix() Type {
 
 // Field returns the type of the i'th field of this struct type. It panics if t
 // is not a struct type.
-func (t Type) Field(i int) StructField {
+func (t rawType) Field(i int) StructField {
+	field := t.rawField(i)
+	return StructField{
+		Name:      field.Name,
+		PkgPath:   field.PkgPath,
+		Type:      field.Type, // note: converts rawType to Type
+		Tag:       field.Tag,
+		Anonymous: field.Anonymous,
+		Offset:    field.Offset,
+	}
+}
+
+// rawField returns nearly the same value as Field but without converting the
+// Type member to an interface.
+//
+// For internal use only.
+func (t rawType) rawField(i int) rawStructField {
 	if t.Kind() != Struct {
 		panic(&TypeError{"Field"})
 	}
@@ -206,7 +414,7 @@ func (t Type) Field(i int) StructField {
 	// efficient, but it is easy to implement.
 	// Adding a jump table at the start to jump to the field directly would
 	// make this much faster, but that would also impact code size.
-	field := StructField{}
+	field := rawStructField{}
 	offset := uintptr(0)
 	for fieldNum := 0; fieldNum <= i; fieldNum++ {
 		// Read some flags of this field, like whether the field is an
@@ -215,15 +423,16 @@ func (t Type) Field(i int) StructField {
 		p = unsafe.Pointer(uintptr(p) + 1)
 
 		// Read the type of this struct field.
-		var fieldType uintptr
-		fieldType, p = readVarint(p)
-		field.Type = Type(fieldType)
+		var fieldTypeVal uintptr
+		fieldTypeVal, p = readVarint(p)
+		fieldType := rawType(fieldTypeVal)
+		field.Type = fieldType
 
 		// Move Offset forward to align it to this field's alignment.
 		// Assume alignment is a power of two.
-		offset = align(offset, uintptr(field.Type.Align()))
+		offset = align(offset, uintptr(fieldType.Align()))
 		field.Offset = offset
-		offset += field.Type.Size() // starting (unaligned) offset for next field
+		offset += fieldType.Size() // starting (unaligned) offset for next field
 
 		// Read the field name.
 		var nameNum uintptr
@@ -264,7 +473,7 @@ func (t Type) Field(i int) StructField {
 // Bits returns the number of bits that this type uses. It is only valid for
 // arithmetic types (integers, floats, and complex numbers). For other types, it
 // will panic.
-func (t Type) Bits() int {
+func (t rawType) Bits() int {
 	kind := t.Kind()
 	if kind >= Int && kind <= Complex128 {
 		return int(t.Size()) * 8
@@ -274,7 +483,7 @@ func (t Type) Bits() int {
 
 // Len returns the number of elements in this array. It panics of the type kind
 // is not Array.
-func (t Type) Len() int {
+func (t rawType) Len() int {
 	if t.Kind() != Array {
 		panic(TypeError{"Len"})
 	}
@@ -290,7 +499,7 @@ func (t Type) Len() int {
 
 // NumField returns the number of fields of a struct type. It panics for other
 // type kinds.
-func (t Type) NumField() int {
+func (t rawType) NumField() int {
 	if t.Kind() != Struct {
 		panic(&TypeError{"NumField"})
 	}
@@ -301,7 +510,7 @@ func (t Type) NumField() int {
 
 // Size returns the size in bytes of a given type. It is similar to
 // unsafe.Sizeof.
-func (t Type) Size() uintptr {
+func (t rawType) Size() uintptr {
 	switch t.Kind() {
 	case Bool, Int8, Uint8:
 		return 1
@@ -332,13 +541,13 @@ func (t Type) Size() uintptr {
 	case Interface:
 		return unsafe.Sizeof(interface{}(nil))
 	case Array:
-		return t.Elem().Size() * uintptr(t.Len())
+		return t.elem().Size() * uintptr(t.Len())
 	case Struct:
 		numField := t.NumField()
 		if numField == 0 {
 			return 0
 		}
-		lastField := t.Field(numField - 1)
+		lastField := t.rawField(numField - 1)
 		return lastField.Offset + lastField.Type.Size()
 	default:
 		panic("unimplemented: size of type")
@@ -347,7 +556,7 @@ func (t Type) Size() uintptr {
 
 // Align returns the alignment of this type. It is similar to calling
 // unsafe.Alignof.
-func (t Type) Align() int {
+func (t rawType) Align() int {
 	switch t.Kind() {
 	case Bool, Int8, Uint8:
 		return int(unsafe.Alignof(int8(0)))
@@ -381,14 +590,14 @@ func (t Type) Align() int {
 		numField := t.NumField()
 		alignment := 1
 		for i := 0; i < numField; i++ {
-			fieldAlignment := t.Field(i).Type.Align()
+			fieldAlignment := t.rawField(i).Type.Align()
 			if fieldAlignment > alignment {
 				alignment = fieldAlignment
 			}
 		}
 		return alignment
 	case Array:
-		return t.Elem().Align()
+		return t.elem().Align()
 	default:
 		panic("unimplemented: alignment of type")
 	}
@@ -396,14 +605,14 @@ func (t Type) Align() int {
 
 // FieldAlign returns the alignment if this type is used in a struct field. It
 // is currently an alias for Align() but this might change in the future.
-func (t Type) FieldAlign() int {
+func (t rawType) FieldAlign() int {
 	return t.Align()
 }
 
 // AssignableTo returns whether a value of type u can be assigned to a variable
 // of type t.
-func (t Type) AssignableTo(u Type) bool {
-	if t == u {
+func (t rawType) AssignableTo(u Type) bool {
+	if t == u.(rawType) {
 		return true
 	}
 	if t.Kind() == Interface {
@@ -412,7 +621,7 @@ func (t Type) AssignableTo(u Type) bool {
 	return false
 }
 
-func (t Type) Implements(u Type) bool {
+func (t rawType) Implements(u Type) bool {
 	if t.Kind() != Interface {
 		panic("reflect: non-interface type passed to Type.Implements")
 	}
@@ -420,7 +629,7 @@ func (t Type) Implements(u Type) bool {
 }
 
 // Comparable returns whether values of this type can be compared to each other.
-func (t Type) Comparable() bool {
+func (t rawType) Comparable() bool {
 	switch t.Kind() {
 	case Bool, Int, Int8, Int16, Int32, Int64, Uint, Uint8, Uint16, Uint32, Uint64, Uintptr:
 		return true
@@ -439,7 +648,7 @@ func (t Type) Comparable() bool {
 	case Slice:
 		return false
 	case Array:
-		return t.Elem().Comparable()
+		return t.elem().Comparable()
 	case Func:
 		return false
 	case Map:
@@ -447,7 +656,7 @@ func (t Type) Comparable() bool {
 	case Struct:
 		numField := t.NumField()
 		for i := 0; i < numField; i++ {
-			if !t.Field(i).Type.Comparable() {
+			if !t.rawField(i).Type.Comparable() {
 				return false
 			}
 		}
@@ -457,19 +666,19 @@ func (t Type) Comparable() bool {
 	}
 }
 
-func (t Type) ConvertibleTo(u Type) bool {
+func (t rawType) ConvertibleTo(u Type) bool {
 	panic("unimplemented: (reflect.Type).ConvertibleTo()")
 }
 
-func (t Type) NumMethod() int {
+func (t rawType) NumMethod() int {
 	panic("unimplemented: (reflect.Type).NumMethod()")
 }
 
-func (t Type) Name() string {
+func (t rawType) Name() string {
 	panic("unimplemented: (reflect.Type).Name()")
 }
 
-func (t Type) Key() Type {
+func (t rawType) Key() Type {
 	panic("unimplemented: (reflect.Type).Key()")
 }
 
@@ -484,6 +693,18 @@ type StructField struct {
 
 	Type      Type
 	Tag       StructTag // field tag string
+	Anonymous bool
+	Offset    uintptr
+}
+
+// rawStructField is the same as StructField but with the Type member replaced
+// with rawType. For internal use only. Avoiding this conversion to the Type
+// interface improves code size in many cases.
+type rawStructField struct {
+	Name      string
+	PkgPath   string
+	Type      rawType
+	Tag       StructTag
 	Anonymous bool
 	Offset    uintptr
 }

--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -351,36 +351,36 @@ func hashmapStringDelete(m *hashmap, key string) {
 
 func hashmapInterfaceHash(itf interface{}) uint32 {
 	x := reflect.ValueOf(itf)
-	if x.Type() == 0 {
+	if x.RawType() == 0 {
 		return 0 // nil interface
 	}
 
 	value := (*_interface)(unsafe.Pointer(&itf)).value
 	ptr := value
-	if x.Type().Size() <= unsafe.Sizeof(uintptr(0)) {
+	if x.RawType().Size() <= unsafe.Sizeof(uintptr(0)) {
 		// Value fits in pointer, so it's directly stored in the pointer.
 		ptr = unsafe.Pointer(&value)
 	}
 
-	switch x.Type().Kind() {
+	switch x.RawType().Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return hashmapHash(ptr, x.Type().Size())
+		return hashmapHash(ptr, x.RawType().Size())
 	case reflect.Bool, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return hashmapHash(ptr, x.Type().Size())
+		return hashmapHash(ptr, x.RawType().Size())
 	case reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
 		// It should be possible to just has the contents. However, NaN != NaN
 		// so if you're using lots of NaNs as map keys (you shouldn't) then hash
 		// time may become exponential. To fix that, it would be better to
 		// return a random number instead:
 		// https://research.swtch.com/randhash
-		return hashmapHash(ptr, x.Type().Size())
+		return hashmapHash(ptr, x.RawType().Size())
 	case reflect.String:
 		return hashmapStringHash(x.String())
 	case reflect.Chan, reflect.Ptr, reflect.UnsafePointer:
 		// It might seem better to just return the pointer, but that won't
 		// result in an evenly distributed hashmap. Instead, hash the pointer
 		// like most other types.
-		return hashmapHash(ptr, x.Type().Size())
+		return hashmapHash(ptr, x.RawType().Size())
 	case reflect.Array:
 		var hash uint32
 		for i := 0; i < x.Len(); i++ {

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -31,18 +31,21 @@ func interfaceEqual(x, y interface{}) bool {
 }
 
 func reflectValueEqual(x, y reflect.Value) bool {
-	if x.Type() == 0 || y.Type() == 0 {
+	// Note: doing a x.Type() == y.Type() comparison would not work here as that
+	// would introduce an infinite recursion: comparing two reflect.Type values
+	// is done with this reflectValueEqual runtime call.
+	if x.RawType() == 0 || y.RawType() == 0 {
 		// One of them is nil.
-		return x.Type() == y.Type()
+		return x.RawType() == y.RawType()
 	}
 
-	if x.Type() != y.Type() {
+	if x.RawType() != y.RawType() {
 		// The type is not the same, which means the interfaces are definitely
 		// not the same.
 		return false
 	}
 
-	switch x.Type().Kind() {
+	switch x.RawType().Kind() {
 	case reflect.Bool:
 		return x.Bool() == y.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -124,7 +124,7 @@ type structField struct {
 // lowering, to assign the lowest type numbers to the types with the most type
 // asserts. Also, it is replaced with const false if this type assert can never
 // happen.
-func typeAssert(actualType uintptr, assertedType *typecodeID) bool
+func typeAssert(actualType uintptr, assertedType *uint8) bool
 
 // Pseudo function call that returns whether a given type implements all methods
 // of the given interface.

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -107,6 +107,8 @@ type typecodeID struct {
 
 	// The array length, for array types.
 	length uintptr
+
+	methodSet *interfaceMethodInfo // nil or a GEP of an array
 }
 
 // structField is used by the compiler to pass information to the interface
@@ -116,15 +118,6 @@ type structField struct {
 	name     *uint8      // pointer to char array
 	tag      *uint8      // pointer to char array, or nil
 	embedded bool
-}
-
-// Pseudo type used before interface lowering. By using a struct instead of a
-// function call, this is simpler to reason about during init interpretation
-// than a function call. Also, by keeping the method set around it is easier to
-// implement interfaceImplements in the interp package.
-type typeInInterface struct {
-	typecode  *typecodeID          // element type, underlying type, or reference to struct fields
-	methodSet *interfaceMethodInfo // nil or a GEP of an array
 }
 
 // Pseudo function call used during a type assert. It is used during interface

--- a/testdata/reflect.go
+++ b/testdata/reflect.go
@@ -265,6 +265,19 @@ func main() {
 		println("type assertion failed (but should succeed)")
 	}
 
+	// Test type that is not referenced at all: not when creating the
+	// reflect.Value (except through the field) and not with a type assert.
+	// Previously this would result in a type assert failure because the Int()
+	// method wasn't picked up.
+	v = reflect.ValueOf(struct {
+		X totallyUnreferencedType
+	}{})
+	if v.Field(0).Interface().(interface {
+		Int() int
+	}).Int() != 42 {
+		println("could not call method on totally unreferenced type")
+	}
+
 	if reflect.TypeOf(new(myint)) != reflect.PtrTo(reflect.TypeOf(myint(0))) {
 		println("PtrTo failed for type myint")
 	}
@@ -362,6 +375,12 @@ func assertSize(ok bool, typ string) {
 }
 
 type unreferencedType int
+
+type totallyUnreferencedType int
+
+func (totallyUnreferencedType) Int() int {
+	return 42
+}
 
 func TestStructTag() {
 	type S struct {

--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -5,6 +5,8 @@ target triple = "armv7m-none-eabi"
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
+@"reflect/types.type:basic:uint8$id" = external constant i8
+@"reflect/types.type:basic:int16$id" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 @"func NeverImplementedMethod()" = external constant i8
 @"Unmatched$interface" = private constant [1 x i8*] [i8* @"func NeverImplementedMethod()"]
@@ -14,9 +16,10 @@ target triple = "armv7m-none-eabi"
 @"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([1 x %runtime.interfaceMethodInfo], [1 x %runtime.interfaceMethodInfo]* @"Number$methodset", i32 0, i32 0) }
 
 declare i1 @runtime.interfaceImplements(i32, i8**)
-declare i1 @runtime.typeAssert(i32, %runtime.typecodeID*)
+declare i1 @runtime.typeAssert(i32, i8*)
 declare i32 @runtime.interfaceMethod(i32, i8**, i8*)
 declare void @runtime.printuint8(i8)
+declare void @runtime.printint16(i16)
 declare void @runtime.printint32(i32)
 declare void @runtime.printptr(i32)
 declare void @runtime.printnl()
@@ -52,7 +55,7 @@ typeswitch.Doubler:
   ret void
 
 typeswitch.notDoubler:
-  %isByte = call i1 @runtime.typeAssert(i32 %typecode, %runtime.typecodeID* nonnull @"reflect/types.type:basic:uint8")
+  %isByte = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.type:basic:uint8$id")
   br i1 %isByte, label %typeswitch.byte, label %typeswitch.notByte
 
 typeswitch.byte:
@@ -62,6 +65,17 @@ typeswitch.byte:
   ret void
 
 typeswitch.notByte:
+  ; this is a type assert that always fails
+  %isInt16 = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.type:basic:int16$id")
+  br i1 %isInt16, label %typeswitch.int16, label %typeswitch.notInt16
+
+typeswitch.int16:
+  %int16 = ptrtoint i8* %value to i16
+  call void @runtime.printint16(i16 %int16)
+  call void @runtime.printnl()
+  ret void
+
+typeswitch.notInt16:
   ret void
 }
 

--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -1,21 +1,17 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32 }
-%runtime.typeInInterface = type { %runtime.typecodeID*, %runtime.interfaceMethodInfo* }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo* }
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
-@"typeInInterface:reflect/types.type:basic:uint8" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:basic:uint8", %runtime.interfaceMethodInfo* null }
-@"typeInInterface:reflect/types.type:basic:int" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:basic:int", %runtime.interfaceMethodInfo* null }
 @"func NeverImplementedMethod()" = external constant i8
 @"Unmatched$interface" = private constant [1 x i8*] [i8* @"func NeverImplementedMethod()"]
 @"func Double() int" = external constant i8
 @"Doubler$interface" = private constant [1 x i8*] [i8* @"func Double() int"]
 @"Number$methodset" = private constant [1 x %runtime.interfaceMethodInfo] [%runtime.interfaceMethodInfo { i8* @"func Double() int", i32 ptrtoint (i32 (i8*, i8*)* @"(Number).Double$invoke" to i32) }]
-@"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0 }
-@"typeInInterface:reflect/types.type:named:Number" = private constant %runtime.typeInInterface { %runtime.typecodeID* @"reflect/types.type:named:Number", %runtime.interfaceMethodInfo* getelementptr inbounds ([1 x %runtime.interfaceMethodInfo], [1 x %runtime.interfaceMethodInfo]* @"Number$methodset", i32 0, i32 0) }
+@"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([1 x %runtime.interfaceMethodInfo], [1 x %runtime.interfaceMethodInfo]* @"Number$methodset", i32 0, i32 0) }
 
 declare i1 @runtime.interfaceImplements(i32, i8**)
 declare i1 @runtime.typeAssert(i32, %runtime.typecodeID*)
@@ -27,9 +23,9 @@ declare void @runtime.printnl()
 declare void @runtime.nilPanic(i8*, i8*)
 
 define void @printInterfaces() {
-  call void @printInterface(i32 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:basic:int" to i32), i8* inttoptr (i32 5 to i8*))
-  call void @printInterface(i32 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:basic:uint8" to i32), i8* inttoptr (i8 120 to i8*))
-  call void @printInterface(i32 ptrtoint (%runtime.typeInInterface* @"typeInInterface:reflect/types.type:named:Number" to i32), i8* inttoptr (i32 3 to i8*))
+  call void @printInterface(i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:int" to i32), i8* inttoptr (i32 5 to i8*))
+  call void @printInterface(i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:uint8" to i32), i8* inttoptr (i8 120 to i8*))
+  call void @printInterface(i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:Number" to i32), i8* inttoptr (i32 3 to i8*))
 
   ret void
 }

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -1,15 +1,14 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32 }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo* }
+%runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 @"func NeverImplementedMethod()" = external constant i8
-@"Unmatched$interface" = private constant [1 x i8*] [i8* @"func NeverImplementedMethod()"]
 @"func Double() int" = external constant i8
-@"Doubler$interface" = private constant [1 x i8*] [i8* @"func Double() int"]
-@"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0 }
+@"reflect/types.type:named:Number" = private constant %runtime.typecodeID zeroinitializer
 
 declare i1 @runtime.interfaceImplements(i32, i8**)
 

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -5,6 +5,8 @@ target triple = "armv7m-none-eabi"
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
+@"reflect/types.type:basic:uint8$id" = external constant i8
+@"reflect/types.type:basic:int16$id" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 @"func NeverImplementedMethod()" = external constant i8
 @"func Double() int" = external constant i8
@@ -12,11 +14,13 @@ target triple = "armv7m-none-eabi"
 
 declare i1 @runtime.interfaceImplements(i32, i8**)
 
-declare i1 @runtime.typeAssert(i32, %runtime.typecodeID*)
+declare i1 @runtime.typeAssert(i32, i8*)
 
 declare i32 @runtime.interfaceMethod(i32, i8**, i8*)
 
 declare void @runtime.printuint8(i8)
+
+declare void @runtime.printint16(i16)
 
 declare void @runtime.printint32(i32)
 
@@ -63,6 +67,15 @@ typeswitch.byte:                                  ; preds = %typeswitch.notDoubl
   ret void
 
 typeswitch.notByte:                               ; preds = %typeswitch.notDoubler
+  br i1 false, label %typeswitch.int16, label %typeswitch.notInt16
+
+typeswitch.int16:                                 ; preds = %typeswitch.notByte
+  %int16 = ptrtoint i8* %value to i16
+  call void @runtime.printint16(i16 %int16)
+  call void @runtime.printnl()
+  ret void
+
+typeswitch.notInt16:                              ; preds = %typeswitch.notByte
   ret void
 }
 


### PR DESCRIPTION
This is a big PR (based on #1612) that improves reflect support significantly:

1. `compiler: merge runtime.typecodeID and runtime.typeInInterface`: this commit makes reflect support more correct, see testdata/reflect.go for a case where it behaved incorrectly before. It increases code size in many cases.
2. `compiler: do not check for impossible type asserts`: reduces the code size in many cases introduced in the previous commit.
3. `interp: handle (reflect.Type).Elem()`: prepare for the last commit. Shaves off a few bytes in many cases.
4. `interp: add support for runtime.interfaceMethod`: also prepares for the last commit.
5. `reflect: let reflect.Type be of interface type`: this is the big one. The encoding/json package relies on being able to compare `reflect.Type` variables with nil, which this commit makes possible by changing `reflect.Type` to an interface type (like standard Go). All the previous commits are needed to reduce the associated code size increase. There is still some code size increase, but it's only for some bigger programs (for example, that use the fmt package).

One side effect of this PR (in commit 2) is that it improves (but does not fix) issue https://github.com/tinygo-org/tinygo/issues/1415 when you're printing `error` values (e.g. `err := ...; println(err)`).

This is a draft until #1612 is merged. I think it would be possible to separate this PR from #1612 but that might make the first commit more complicated (it was causing linker errors until I rebased on top of #1612).