### PR TITLE
goenv: Support Go snap installations by finding the goroot

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -171,8 +171,9 @@ func getGoroot() string {
 	switch runtime.GOOS {
 	case "linux":
 		candidates = []string{
-			"/usr/local/go", // manually installed
-			"/usr/lib/go",   // from the distribution
+			"/usr/local/go",     // manually installed
+			"/usr/lib/go",       // from the distribution
+			"/snap/go/current/", // installed using snap
 		}
 	case "darwin":
 		candidates = []string{


### PR DESCRIPTION
I guess this does not need many words :) 

Fixes #1706 

Tested it and i can now build & flash code using TinyGo with a snap installation. 
Also tinygo version output looks good now :) 

```bash
$ which go
/snap/bin/go
```

```bash
./my_tinygo_18 version
tinygo version 0.18.0-dev linux/amd64 (using go version go1.16.2 and LLVM version 11.1.0)
```

current seems to always link on the currenty installed version
```bash
$ ls -lra /snap/go/
insgesamt 8
lrwxrwxrwx  1 root root    4 Mär 19 16:17 current -> 7221
drwxr-xr-x 12 root root  390 Mär 16 23:36 7221
drwxr-xr-x 20 root root 4096 Mär 19 16:17 ..
drwxr-xr-x  3 root root 4096 Mär 19 16:17 .
```