### PR TITLE
stm32: move f103 (bluepill) to common i2c code

### DIFF
--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -85,6 +85,6 @@ const (
 
 // I2C pins
 const (
-	SDA_PIN = PB7
-	SCL_PIN = PB6
+	I2C0_SDA_PIN = PB7
+	I2C0_SCL_PIN = PB6
 )

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -120,6 +120,6 @@ const (
 
 // I2C pins
 const (
-	SCL_PIN = PB6
-	SDA_PIN = PB7
+	I2C0_SCL_PIN = PB6
+	I2C0_SDA_PIN = PB7
 )

--- a/src/machine/machine_stm32_i2c.go
+++ b/src/machine/machine_stm32_i2c.go
@@ -1,4 +1,4 @@
-// +build stm32,!stm32f103,!stm32f7x2,!stm32l5x2,!stm32l0
+// +build stm32,!stm32f7x2,!stm32l5x2,!stm32l0
 
 package machine
 


### PR DESCRIPTION
The I2C implementation in the F103 chips is register-compatible with the implementation in F405 / F407, so use that implementation.

Further reduction of duplicate code is possible since these per-chip functions are all essentially identical across all three processors, except for the clock frequency:

- `getFreqRange`
- `getRiseTime`
- `getSpeed`

I'll look at removing that duplication as a separate change.