### PR TITLE
stm32: housekeeping - remove empty file

### DIFF
--- a/src/machine/board_stm32.go
+++ b/src/machine/board_stm32.go
@@ -1,5 +1,0 @@
-// +build bluepill nucleof103rb stm32f4
-
-package machine
-
-// Peripheral abstraction layer for the stm32.


### PR DESCRIPTION
This file appears unused and the build tag seems a little odd, might as well remove it