### PR TITLE
fix pca10040 flashing

### DIFF
--- a/targets/pca10040.json
+++ b/targets/pca10040.json
@@ -1,7 +1,7 @@
 {
 	"inherits": ["nrf52"],
 	"build-tags": ["pca10040"],
-	"flash-method": "openocd",
+	"flash-method": "command",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",
 	"openocd-transport": "swd"


### PR DESCRIPTION
The webpage https://tinygo.org/microcontrollers/pca10040/ states to install the nordic nrfjprog and the segger jlink tools .

This was the only way I was able to get tinygo flash --target pca10040 working on windows. Current configuration choses openocd (not mentioned on the webpage) which does work on macos and linux, but not on windows. On windows openocd (from scoop) does complain about some libusb support missing.

I double checked that nrfjprog works correctly on Windows and MacOS with tinygo. 

Personally I prefer to set it to nrfjprog, even though one has to install additional tools.