### PR TITLE
wasm: only export explicitly exported functions

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 1
+const Version = 2 // last change: adding wasm-export-name attribute
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -780,6 +780,12 @@ func (b *builder) createFunction() {
 	if !b.info.exported {
 		b.llvmFn.SetVisibility(llvm.HiddenVisibility)
 		b.llvmFn.SetUnnamedAddr(true)
+	}
+	if b.info.exported && strings.HasPrefix(b.Triple, "wasm") {
+		// Set the exported name. This is necessary for WebAssembly because
+		// otherwise the function is not exported.
+		functionAttr := b.ctx.CreateStringAttribute("wasm-export-name", b.info.linkName)
+		b.llvmFn.AddFunctionAttr(functionAttr)
 	}
 
 	// Some functions have a pragma controlling the inlining level.

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -14,7 +14,6 @@
 	"ldflags": [
 		"--allow-undefined",
 		"--stack-first",
-		"--export-all",
 		"--no-demangle"
 	],
 	"emulator":      ["node", "targets/wasm_exec.js"],


### PR DESCRIPTION
Previously we used the `--export-all` linker flag to export most functions. However, this is not needed and increases WebAssembly binary size by around 200 bytes. Instead, we should only export the functions marked with the `//export` pragma.

I'm investigating how feasible it is to do some post-link transformations (for stack switching and garbage collection). While looking into it, I found that there were a lot more symbols exported from WebAssembly than I would expect. Hence this PR to fix this.