### PR TITLE
fix msd volume name of qtpy

### DIFF
--- a/targets/qtpy.json
+++ b/targets/qtpy.json
@@ -3,6 +3,6 @@
     "build-tags": ["qtpy"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "msd-volume-name": "QTPYBOOT",
+    "msd-volume-name": "QTPY_BOOT",
     "msd-firmware-name": "firmware.uf2"
 }


### PR DESCRIPTION
Fixed issue #1713.
I checked that simple I/O program (like blinky1) works on Windows and MacOS with tinygo.

↓ This is for Windows (It was same on MacOS).
```
# before fixed
$ build\tinygo.exe flash -target=qtpy --size short -port=COM8  ./src\examples\blinky1
   code    data     bss |   flash     ram
   7876      20    4312 |    7896    4332
error: failed to flash C:\Users\aki01\AppData\Local\Temp\tinygo319124815\main.uf2: unable to locate a USB device to be flashed

# after fixed
$ build\tinygo.exe flash -target=qtpy --size short -port=COM9  ./src\examples\blinky1
   code    data     bss |   flash     ram
   7876      20    4312 |    7896    4332
```