### PR TITLE
nrf: Added support for writing with nrfjprog on all nrf boards

### DIFF
--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -14,6 +14,7 @@
 		"lib/nrfx/mdk/system_nrf51.c",
 		"src/device/nrf/nrf51.s"
 	],
+	"flash-command": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
 	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -12,6 +12,7 @@
 		"lib/nrfx/mdk/system_nrf52.c",
 		"src/device/nrf/nrf52.s"
 	],
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }

--- a/targets/nrf52833.json
+++ b/targets/nrf52833.json
@@ -12,6 +12,7 @@
 		"lib/nrfx/mdk/system_nrf52833.c",
 		"src/device/nrf/nrf52833.s"
 	],
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-transport": "swd",
 	"openocd-target": "nrf52"
 }

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -12,6 +12,7 @@
 		"lib/nrfx/mdk/system_nrf52840.c",
 		"src/device/nrf/nrf52840.s"
 	],
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-transport": "swd",
 	"openocd-target": "nrf51"
 }

--- a/targets/pca10031.json
+++ b/targets/pca10031.json
@@ -1,6 +1,5 @@
 {
 	"inherits": ["nrf51"],
 	"build-tags": ["pca10031"],
-	"flash-command": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
 	"openocd-interface": "cmsis-dap"
 }

--- a/targets/pca10040.json
+++ b/targets/pca10040.json
@@ -2,7 +2,6 @@
 	"inherits": ["nrf52"],
 	"build-tags": ["pca10040"],
 	"flash-method": "openocd",
-	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",
 	"openocd-transport": "swd"
 }

--- a/targets/pca10056.json
+++ b/targets/pca10056.json
@@ -2,7 +2,6 @@
 	"inherits": ["nrf52840"],
 	"build-tags": ["pca10056"],
 	"flash-method": "command",
-	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"msd-volume-name": "JLINK",
 	"msd-firmware-name": "firmware.hex",
 	"openocd-interface": "jlink",

--- a/targets/pinetime-devkit0.json
+++ b/targets/pinetime-devkit0.json
@@ -2,7 +2,6 @@
 	"inherits": ["nrf52"],
 	"build-tags": ["pinetime_devkit0"],
 	"flash-method": "openocd",
-	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",
 	"openocd-transport": "swd"
 }

--- a/targets/x9pro.json
+++ b/targets/x9pro.json
@@ -2,7 +2,6 @@
 	"inherits": ["nrf52"],
 	"build-tags": ["x9pro"],
 	"flash-method": "openocd",
-	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",
 	"openocd-transport": "swd"
 }


### PR DESCRIPTION
`tinygo flash -programmer command` to write using nrfjprog


This PR makes it possible for all nrf devices to support the same writing style.
Basically, it should be possible to write with openocd, but if for some reason someone wants to use nrfjprog, the `-programmer command` option can be used.

It is related to the following
https://github.com/tinygo-org/tinygo-site/pull/157