### PR TITLE
reflect: implement a number of stub functions

### DIFF
--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -532,6 +532,14 @@ func maskAndShift(value, offset, size uintptr) uintptr {
 	return (uintptr(value) >> (offset * 8)) & mask
 }
 
+func (v Value) NumMethod() int {
+	return v.typecode.NumMethod()
+}
+
+func (v Value) OverflowFloat(x float64) bool {
+	panic("unimplemented: (reflect.Value).OverflowFloat()")
+}
+
 func (v Value) MapKeys() []Value {
 	panic("unimplemented: (reflect.Value).MapKeys()")
 }
@@ -653,6 +661,18 @@ func (v Value) SetString(x string) {
 	default:
 		panic(&ValueError{"SetString"})
 	}
+}
+
+func (v Value) SetBytes(x []byte) {
+	panic("unimplemented: (reflect.Value).SetBytes()")
+}
+
+func (v Value) SetCap(n int) {
+	panic("unimplemented: (reflect.Value).SetCap()")
+}
+
+func (v Value) SetLen(n int) {
+	panic("unimplemented: (reflect.Value).SetLen()")
 }
 
 func (v Value) checkAddressable() {


### PR DESCRIPTION
These stub functions are necessary for the encoding/json package. They don't seem to be called in trivial cases, so leave them as simple stubs for now.

Together with #1727 this gets the encoding/json package to compile. It doesn't work yet (`.Implements` needs to be implemented) but it's a big step forward.