### PR TITLE
Support for pca10059 board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,10 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10056            examples/blinky2
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10059            examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10059            examples/blinky2
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m0          examples/blinky1
@@ -393,6 +397,7 @@ endif
 	@$(MD5SUM) test.nro
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go
 	@$(MD5SUM) test.hex
+
 
 wasmtest:
 	$(GO) test ./tests/wasm

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -39,7 +39,7 @@ const (
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Makerdiary nRF52840 MDK"
-	usb_STRING_MANUFACTURER = "Makerdiary"
+	usb_STRING_MANUFACTURER = "Nordic Semiconductor ASA"
 )
 
 var (

--- a/src/machine/board_pca10059.go
+++ b/src/machine/board_pca10059.go
@@ -1,20 +1,31 @@
-// +build nrf52840_mdk_usb_dongle
+// +build pca10059
 
 package machine
 
+// The PCA10040 has a low-frequency (32kHz) crystal oscillator on board.
 const HasLowFrequencyCrystal = true
 
-// LEDs on the nrf52840-mdk-usb-dongle
+// LEDs on the PCA10059 (nRF52840 dongle)
 const (
-	LED       Pin = LED_GREEN
-	LED_GREEN Pin = 22
-	LED_RED   Pin = 23
-	LED_BLUE  Pin = 24
+	LED  Pin = LED1
+	LED1 Pin = 6
+	LED2 Pin = 8
+	LED3 Pin = (1 << 5) | 9
+	LED4 Pin = 12
 )
 
-// RESET/USR button, depending on value of PSELRESET UICR register
+// Buttons on the PCA10059 (nRF52840 dongle)
 const (
-	BUTTON Pin = 18
+	BUTTON  Pin = BUTTON1
+	BUTTON1 Pin = (1 << 5) | 6
+)
+
+// ADC pins
+const (
+	ADC1 Pin = 2
+	ADC2 Pin = 4
+	ADC3 Pin = 29
+	ADC4 Pin = 31
 )
 
 // UART pins
@@ -43,7 +54,7 @@ const (
 
 // USB CDC identifiers
 const (
-	usb_STRING_PRODUCT      = "Makerdiary nRF52840 MDK USB Dongle"
+	usb_STRING_PRODUCT      = "nRF52840 Dongle"
 	usb_STRING_MANUFACTURER = "Nordic Semiconductor ASA"
 )
 

--- a/targets/pca10059.json
+++ b/targets/pca10059.json
@@ -1,0 +1,6 @@
+{
+	"inherits": ["nrf52840"],
+	"build-tags": ["pca10059"],
+	"linkerscript": "targets/pca10059.ld",
+	"flash-command": "nrfutil pkg generate --hw-version 52 --sd-req 0x0 --application {hex} --application-version 1 /tmp/tinygo_$$.zip && nrfutil dfu usb-serial -pkg /tmp/tinygo_$$.zip -p {port} -b 115200 && rm -f /tmp/tinygo_$$.zip"
+}

--- a/targets/pca10059.ld
+++ b/targets/pca10059.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x00001000, LENGTH = 0xDF000
+    RAM (xrw)       : ORIGIN = 0x20000008, LENGTH = 0x3FFF8
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
This is a board support without a softdevice.

The pca10059 is a NRF52840 Chip on a USB Dongle, similar to the nrf52850-mdk-usb-dongle. Amazingly most of the definitions already present for nrf52850-mdk-usb-dongle seem to be suitable for this board as well. 
It uses a MBR with "Open Firmware" to be flashed either by the nRF Connect software or by the python tool "nrfutil". 
I did my best to document the LED and ADC ports, though I only used blinky examples for now and the UART over USB serial.

Tested with tinygo build, tinygo flash on macos. 

When I am more into tinygo,  I will surely look into supporting an softdevice, in an followup patch
