### PR TITLE
compiler: fix use of global context: llvm.Int32Type()

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -103,8 +103,8 @@ func (c *compilerContext) makeStructTypeFields(typ *types.Struct) llvm.Value {
 		fieldName.SetLinkage(llvm.PrivateLinkage)
 		fieldName.SetUnnamedAddr(true)
 		fieldName = llvm.ConstGEP(fieldName, []llvm.Value{
-			llvm.ConstInt(llvm.Int32Type(), 0, false),
-			llvm.ConstInt(llvm.Int32Type(), 0, false),
+			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+			llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 		})
 		fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, fieldName, []uint32{1})
 		if typ.Tag(i) != "" {
@@ -112,8 +112,8 @@ func (c *compilerContext) makeStructTypeFields(typ *types.Struct) llvm.Value {
 			fieldTag.SetLinkage(llvm.PrivateLinkage)
 			fieldTag.SetUnnamedAddr(true)
 			fieldTag = llvm.ConstGEP(fieldTag, []llvm.Value{
-				llvm.ConstInt(llvm.Int32Type(), 0, false),
-				llvm.ConstInt(llvm.Int32Type(), 0, false),
+				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 			})
 			fieldGlobalValue = llvm.ConstInsertValue(fieldGlobalValue, fieldTag, []uint32{2})
 		}


### PR DESCRIPTION
This patch fixes a use of the global context. I've seen a few instances of crashes in the `llvm.ConstInt` function when called from `makeStructTypeFields`, which I believe are caused by this bug.

Workflows that have failed and that should be fixed with this PR:

* https://app.circleci.com/pipelines/github/tinygo-org/tinygo/4586/workflows/fbb8c8f4-5df4-483f-96a7-2fe8cdc18a79/jobs/25805
* https://app.circleci.com/pipelines/github/tinygo-org/tinygo/4591/workflows/3dd597ef-2c43-461b-8157-9287f8cea25e/jobs/25841

Probably this was an existing bug that is only now triggered now that packages are compiled in parallel (see #1612).