### PR TITLE
Better Digispark board support

### DIFF
--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -7,6 +7,7 @@ func CPUFrequency() uint32 {
 	return 16000000
 }
 
+// Digital pins
 const (
 	P0 Pin = PB0
 	P1 Pin = PB1
@@ -14,6 +15,15 @@ const (
 	P3 Pin = PB3
 	P4 Pin = PB4
 	P5 Pin = PB5
+)
 
-	LED = P1
+// LED pin
+const LED Pin = P1
+
+// Analog pins
+const (
+	ADC0 Pin = PB5
+	ADC1 Pin = PB2
+	ADC2 Pin = PB4
+	ADC3 Pin = PB3
 )


### PR DESCRIPTION
This pull request intends to add better support for the Digispark board, based on the ATTiny85. The related issue is #1700.

TODO:
* [x] Add analog pins
* [ ] Add UART
* [ ] Add PWM