### PR TITLE
compiler: fix "fragment covers entire variable" bug

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 5 // last change: add method set to interface types
+const Version = 6 // last change: fix issue 1304
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -829,7 +829,7 @@ func (b *builder) createFunction() {
 	for _, param := range b.fn.Params {
 		llvmType := b.getLLVMType(param.Type())
 		fields := make([]llvm.Value, 0, 1)
-		for _, info := range expandFormalParamType(llvmType, param.Name(), param.Type()) {
+		for _, info := range b.expandFormalParamType(llvmType, param.Name(), param.Type()) {
 			param := b.llvmFn.Param(llvmParamIndex)
 			param.SetName(info.name)
 			fields = append(fields, param)

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -124,13 +124,13 @@ func (c *compilerContext) getRawFuncType(typ *types.Signature) llvm.Type {
 			// The receiver is not an interface, but a i8* type.
 			recv = c.i8ptrType
 		}
-		for _, info := range expandFormalParamType(recv, "", nil) {
+		for _, info := range c.expandFormalParamType(recv, "", nil) {
 			paramTypes = append(paramTypes, info.llvmType)
 		}
 	}
 	for i := 0; i < typ.Params().Len(); i++ {
 		subType := c.getLLVMType(typ.Params().At(i).Type())
-		for _, info := range expandFormalParamType(subType, "", nil) {
+		for _, info := range c.expandFormalParamType(subType, "", nil) {
 			paramTypes = append(paramTypes, info.llvmType)
 		}
 	}

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -456,7 +456,7 @@ func (c *compilerContext) getInterfaceInvokeWrapper(fn *ssa.Function, llvmFn llv
 	// Get the expanded receiver type.
 	receiverType := c.getLLVMType(fn.Signature.Recv().Type())
 	var expandedReceiverType []llvm.Type
-	for _, info := range expandFormalParamType(receiverType, "", nil) {
+	for _, info := range c.expandFormalParamType(receiverType, "", nil) {
 		expandedReceiverType = append(expandedReceiverType, info.llvmType)
 	}
 

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -74,7 +74,7 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 	var paramInfos []paramInfo
 	for _, param := range getParams(fn.Signature) {
 		paramType := c.getLLVMType(param.Type())
-		paramFragmentInfos := expandFormalParamType(paramType, param.Name(), param.Type())
+		paramFragmentInfos := c.expandFormalParamType(paramType, param.Name(), param.Type())
 		paramInfos = append(paramInfos, paramFragmentInfos...)
 	}
 

--- a/testdata/calls.go
+++ b/testdata/calls.go
@@ -74,6 +74,14 @@ func main() {
 	//Test deferred builtins
 	testDeferBuiltinClose()
 	testDeferBuiltinDelete()
+
+	// Check for issue 1304.
+	// There are two fields in this struct, one of which is zero-length so the
+	// other covers the entire struct. This led to a verification error for
+	// debug info, which used DW_OP_LLVM_fragment for a field that practically
+	// covered the entire variable.
+	var x issue1304
+	x.call()
 }
 
 func runFunc(f func(int), arg int) {
@@ -210,4 +218,13 @@ func foo(bar *Bar) error {
 	defer c.Close()
 
 	return nil
+}
+
+type issue1304 struct {
+	a [0]int // zero-length field
+	b int    // field 'b' covers entire struct
+}
+
+func (x issue1304) call() {
+	// nothing to do
 }


### PR DESCRIPTION
This bug could sometimes be triggered by syscall/js code it seems. But it's a generic bug, not specific to WebAssembly.

I have fixed it by skipping zero-length fields of structs when splitting them for variable passing.