### PR TITLE
atsamd5x: add SPI.TxN()

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1560,6 +1560,76 @@ func (spi SPI) txrx(tx, rx []byte) {
 	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
 }
 
+// TxN handles read/write operation for SPI interface. The difference with Tx() is that
+// it repeats the process n times.
+//
+func (spi SPI) TxN(w, r []byte, n int) error {
+	switch {
+	case w == nil:
+		// read only, so write zero and read a result.
+		spi.rxn(r, n)
+	case r == nil:
+		// write only
+		spi.txn(w, n)
+
+	default:
+		// write/read
+		if len(w) != len(r) {
+			return ErrTxInvalidSliceSize
+		}
+
+		spi.txrxn(w, r, n)
+	}
+	return nil
+}
+
+func (spi SPI) txn(tx []byte, n int) {
+	for i := 0; i < len(tx)*n; i++ {
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+		}
+		spi.Bus.DATA.Set(uint32(tx[i%len(tx)]))
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_TXC) {
+	}
+
+	// read to clear RXC register
+	for spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		spi.Bus.DATA.Get()
+	}
+}
+
+func (spi SPI) rxn(rx []byte, n int) {
+	spi.Bus.DATA.Set(0)
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+	}
+
+	for i := 1; i < len(rx)*n; i++ {
+		spi.Bus.DATA.Set(0)
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		}
+		rx[(i-1)%len(rx)] = byte(spi.Bus.DATA.Get())
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+	}
+	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
+}
+
+func (spi SPI) txrxn(tx, rx []byte, n int) {
+	spi.Bus.DATA.Set(uint32(tx[0]))
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
+	}
+
+	for i := 1; i < len(rx)*n; i++ {
+		spi.Bus.DATA.Set(uint32(tx[i%len(rx)]))
+		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+		}
+		rx[(i-1)%len(rx)] = byte(spi.Bus.DATA.Get())
+	}
+	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_RXC) {
+	}
+	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
+}
+
 // The QSPI peripheral on ATSAMD51 is only available on the following pins
 const (
 	QSPI_SCK   = PB10


### PR DESCRIPTION
I created `SPI.TxN()` to repeat `SPI.Tx()` n times.

```go
// pseudo code
SPI.TxN(tx, rx []byte, n int) {
    for i := 0; i < n; i++ {
        SPI.Tx(tx, rx)
    }
}
```

`SPI.Tx()` is not enough to run ili9341 on standard SPI for speed reasons.
In particular, `SPI.TxN()` is faster than SPI.Tx() in the following applications.

* Fill with a specific color in ili9341
    * https://github.com/tinygo-org/drivers/pull/242

`SPI.Tx()` is slower because it waits for the SPI to finish communication for each function call.


testcode:

```go
package main

import (
	"fmt"
	"machine"
	"time"
)

func main() {
	//led := machine.LED
	//led.Configure(machine.PinConfig{Mode: machine.PinOutput})

	spi := machine.SPI0
	spi.Configure(machine.SPIConfig{
		SCK:       machine.SPI0_SCK_PIN,
		SDO:       machine.SPI0_SDO_PIN,
		SDI:       machine.SPI0_SDI_PIN,
		Frequency: 48000000,
	})

	txbuf := make([]byte, 4)
	rxbuf := make([]byte, 4)

	for i := range txbuf {
		txbuf[i] = byte(i * 2)
		rxbuf[i] = byte(i * 2)
	}

	testNo := 0
	for {
		//led.Toggle()
		time.Sleep(time.Millisecond * 500)

		switch testNo % 4 {
		case 0:
			// txrx
			spi.TxN(txbuf, rxbuf, 16)

			for i := range txbuf {
				if txbuf[i] != rxbuf[i] {
					fmt.Printf("%d : got %02X want %02X\r\n", i, rxbuf[i], txbuf[i])
				} else {
					fmt.Printf(".")
				}
				rxbuf[i] = 0
			}
		case 1:
			// tx
			spi.TxN(txbuf, nil, 16)
		case 2:
			// rx
			spi.TxN(nil, rxbuf, 16)
		case 4:
			// skip
		}

		testNo++
	}
}
```

The speed is about the same compared to #1453.

txrxn:
![image](https://user-images.githubusercontent.com/9251039/112788255-760ca880-9095-11eb-908e-867864b41cee.png)

txn:
![image](https://user-images.githubusercontent.com/9251039/112788289-86bd1e80-9095-11eb-9c0a-1bbb2d0da40d.png)

rxn:
![image](https://user-images.githubusercontent.com/9251039/112788315-93da0d80-9095-11eb-85a4-4570a8dc27dc.png)
