### PR TITLE
atsamd21, atsamd51, nrf52840: unify usbcdc code

### DIFF
--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -65,7 +65,7 @@ func (usbcdc *USBCDC) Flush() error {
 }
 
 // WriteByte writes a byte of data to the USB CDC interface.
-func (usbcdc USBCDC) WriteByte(c byte) error {
+func (usbcdc *USBCDC) WriteByte(c byte) error {
 	// Supposedly to handle problem with Windows USB serial ports?
 	if usbLineInfo.lineState > 0 {
 		ok := false
@@ -199,6 +199,7 @@ func (usbcdc *USBCDC) handleInterrupt(interrupt.Interrupt) {
 	if nrf.USBD.EVENTS_SOF.Get() == 1 {
 		nrf.USBD.EVENTS_SOF.Set(0)
 		USB.Flush()
+		// if you want to blink LED showing traffic, this would be the place...
 	}
 
 	// USBD ready event


### PR DESCRIPTION
The code for the three targets has the same form of USBCDC speedup.
In this PR, I unified the points where each was slightly different.
This change will make it easier to maintain in the future.

The changes are as follows

* Move `usbcdc.waitTxcRetryCount++` to `USBCDC.Flush()`
* Make `USBCDC.WriteByte()` not a pointer receiver.
* `USBCDC.FLush()` is now called from SoF only.