### PR TITLE
Improve caching / speed up build by running interp per package

### DIFF
--- a/interp/errors.go
+++ b/interp/errors.go
@@ -20,6 +20,11 @@ var (
 	errMapAlreadyCreated      = errors.New("interp: map already created")
 )
 
+// This is one of the errors that can be returned from toLLVMValue when the
+// passed type does not fit the data to serialize. It is recoverable by
+// serializing without a type (using rawValue.rawLLVMValue).
+var errInvalidPtrToIntSize = errors.New("interp: ptrtoint integer size does not equal pointer size")
+
 func isRecoverableError(err error) bool {
 	return err == errIntegerAsPointer || err == errUnsupportedInst || err == errUnsupportedRuntimeInst || err == errMapAlreadyCreated
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -125,7 +125,10 @@ func Run(mod llvm.Module, debug bool) error {
 		if obj.buffer == nil {
 			continue
 		}
-		initializer := obj.buffer.toLLVMValue(obj.llvmGlobal.Type().ElementType(), &mem)
+		initializer, err := obj.buffer.toLLVMValue(obj.llvmGlobal.Type().ElementType(), &mem)
+		if err != nil {
+			return err
+		}
 		if checks && initializer.Type() != obj.llvmGlobal.Type().ElementType() {
 			panic("initializer type mismatch")
 		}


### PR DESCRIPTION
Run package initializers per package, in addition to once for the entire program. It is still run for the entire program (to benefit from whole-program visibility), but it doesn't have to do much in that case so it can be very fast.

This results in a significant speedup in some cases. For example, this runs over twice as fast with a warm cache:

    tinygo build -o test.elf ./testdata/stdlib.go

This should help a lot with edit-compile-test cycles, that typically only modify a single package.

This required some changes to the interp package to deal with globals created in a previous run of the interp package and to deal with external globals (that can't be loaded from).

The main package that is sped up is the unicode package, which may take over a second to run `interp.RunFunc` for. Moving this into the (cached) package build saves this time in recompilations.