### PR TITLE
//go:section pragma

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -715,11 +715,11 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 		member := pkg.Members[name]
 		switch member := member.(type) {
 		case *ssa.Function:
+			// Create the function definition.
+			b := newBuilder(c, irbuilder, member)
 			if member.Blocks == nil {
 				continue // external function
 			}
-			// Create the function definition.
-			b := newBuilder(c, irbuilder, member)
 			b.createFunction()
 		case *ssa.Type:
 			if types.IsInterface(member.Type()) {
@@ -758,8 +758,8 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 		case *ssa.Global:
 			// Global variable.
 			info := c.getGlobalInfo(member)
+			global := c.getGlobal(member)
 			if !info.extern {
-				global := c.getGlobal(member)
 				global.SetInitializer(llvm.ConstNull(global.Type().ElementType()))
 				global.SetVisibility(llvm.HiddenVisibility)
 			}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -762,6 +762,9 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 			if !info.extern {
 				global.SetInitializer(llvm.ConstNull(global.Type().ElementType()))
 				global.SetVisibility(llvm.HiddenVisibility)
+				if info.section != "" {
+					global.SetSection(info.section)
+				}
 			}
 		}
 	}
@@ -786,6 +789,9 @@ func (b *builder) createFunction() {
 	if !b.info.exported {
 		b.llvmFn.SetVisibility(llvm.HiddenVisibility)
 		b.llvmFn.SetUnnamedAddr(true)
+	}
+	if b.info.section != "" {
+		b.llvmFn.SetSection(b.info.section)
 	}
 	if b.info.exported && strings.HasPrefix(b.Triple, "wasm") {
 		// Set the exported name. This is necessary for WebAssembly because

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -45,6 +45,7 @@ func TestCompiler(t *testing.T) {
 		{"float.go", ""},
 		{"interface.go", ""},
 		{"func.go", ""},
+		{"pragma.go", ""},
 		{"goroutine.go", "wasm"},
 		{"goroutine.go", "cortex-m-qemu"},
 	}

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -24,6 +24,7 @@ type functionInfo struct {
 	module     string     // go:wasm-module
 	importName string     // go:linkname, go:export - The name the developer assigns
 	linkName   string     // go:linkname, go:export - The name that we map for the particular module -> importName
+	section    string     // go:section - object file section name
 	exported   bool       // go:export, CGo
 	nobounds   bool       // go:nobounds
 	variadic   bool       // go:variadic (CGo only)
@@ -270,6 +271,10 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 				if hasUnsafeImport(f.Pkg.Pkg) {
 					info.linkName = parts[2]
 				}
+			case "//go:section":
+				if len(parts) == 2 && hasUnsafeImport(f.Pkg.Pkg) {
+					info.section = parts[1]
+				}
 			case "//go:nobounds":
 				// Skip bounds checking in this function. Useful for some
 				// runtime functions.
@@ -325,6 +330,7 @@ type globalInfo struct {
 	linkName string // go:extern
 	extern   bool   // go:extern
 	align    int    // go:align
+	section  string // go:section
 }
 
 // loadASTComments loads comments on globals from the AST, for use later in the
@@ -437,6 +443,10 @@ func (info *globalInfo) parsePragmas(doc *ast.CommentGroup) {
 			align, err := strconv.Atoi(parts[1])
 			if err == nil {
 				info.align = align
+			}
+		case "//go:section":
+			if len(parts) == 2 {
+				info.section = parts[1]
 			}
 		}
 	}

--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -39,3 +39,28 @@ func inlineFunc() {
 //go:noinline
 func noinlineFunc() {
 }
+
+// This function should have the specified section.
+//go:section .special_function_section
+func functionInSection() {
+}
+
+//export exportedFunctionInSection
+//go:section .special_function_section
+func exportedFunctionInSection() {
+}
+
+// This function should not: it's only a declaration and not a definition.
+//go:section .special_function_section
+func undefinedFunctionNotInSection()
+
+//go:section .special_global_section
+var globalInSection uint32
+
+//go:section .special_global_section
+//go:extern undefinedGlobalNotInSection
+var undefinedGlobalNotInSection uint32
+
+//go:align 1024
+//go:section .global_section
+var multipleGlobalPragmas uint32

--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -1,0 +1,41 @@
+package main
+
+import _ "unsafe"
+
+// Creates an external global with name extern_global.
+//go:extern extern_global
+var externGlobal [0]byte
+
+// Creates a
+//go:align 32
+var alignedGlobal [4]uint32
+
+// Test conflicting pragmas (the last one counts).
+//go:align 64
+//go:align 16
+var alignedGlobal16 [4]uint32
+
+// Test exported functions.
+//export extern_func
+func externFunc() {
+}
+
+// Define a function in a different package using go:linkname.
+//go:linkname withLinkageName1 somepkg.someFunction1
+func withLinkageName1() {
+}
+
+// Import a function from a different package using go:linkname.
+//go:linkname withLinkageName2 somepkg.someFunction2
+func withLinkageName2()
+
+// Function has an 'inline hint', similar to the inline keyword in C.
+//go:inline
+func inlineFunc() {
+}
+
+// Function should never be inlined, equivalent to GCC
+// __attribute__((noinline)).
+//go:noinline
+func noinlineFunc() {
+}

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -6,6 +6,9 @@ target triple = "wasm32--wasi"
 @extern_global = external global [0 x i8], align 1
 @main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32
 @main.alignedGlobal16 = hidden global [4 x i32] zeroinitializer, align 16
+@main.globalInSection = hidden global i32 0, section ".special_global_section", align 4
+@undefinedGlobalNotInSection = external global i32, align 4
+@main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
@@ -38,6 +41,19 @@ entry:
   ret void
 }
 
+define hidden void @main.functionInSection(i8* %context, i8* %parentHandle) unnamed_addr section ".special_function_section" {
+entry:
+  ret void
+}
+
+define void @exportedFunctionInSection() #3 section ".special_function_section" {
+entry:
+  ret void
+}
+
+declare void @main.undefinedFunctionNotInSection(i8*, i8*)
+
 attributes #0 = { "wasm-export-name"="extern_func" }
 attributes #1 = { inlinehint }
 attributes #2 = { noinline }
+attributes #3 = { "wasm-export-name"="exportedFunctionInSection" }

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -1,0 +1,43 @@
+; ModuleID = 'pragma.go'
+source_filename = "pragma.go"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32--wasi"
+
+@extern_global = external global [0 x i8], align 1
+@main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32
+@main.alignedGlobal16 = hidden global [4 x i32] zeroinitializer, align 16
+
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
+}
+
+define void @extern_func() #0 {
+entry:
+  ret void
+}
+
+define hidden void @somepkg.someFunction1(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
+}
+
+declare void @somepkg.someFunction2(i8*, i8*)
+
+; Function Attrs: inlinehint
+define hidden void @main.inlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #1 {
+entry:
+  ret void
+}
+
+; Function Attrs: noinline
+define hidden void @main.noinlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #2 {
+entry:
+  ret void
+}
+
+attributes #0 = { "wasm-export-name"="extern_func" }
+attributes #1 = { inlinehint }
+attributes #2 = { noinline }

--- a/transform/globals.go
+++ b/transform/globals.go
@@ -11,7 +11,7 @@ import "tinygo.org/x/go-llvm"
 func ApplyFunctionSections(mod llvm.Module) {
 	llvmFn := mod.FirstFunction()
 	for !llvmFn.IsNil() {
-		if !llvmFn.IsDeclaration() {
+		if !llvmFn.IsDeclaration() && llvmFn.Section() == "" {
 			name := llvmFn.Name()
 			llvmFn.SetSection(".text." + name)
 		}


### PR DESCRIPTION
This PR adds a new pragma for functions and globals to set the
section name. This can be useful to place a function or global in a
special device specific section, for example:

  * Functions may be placed in RAM to make them run faster, or in flash
    (if RAM is the default) to not let them take up RAM.
  * DMA memory may only be placed in a special memory area.
  * Some RAM may be faster than other RAM, and some globals may be
    performance critical thus placing them in this special RAM area can
    help.
  * Some (large) global variables may need to be placed in external RAM,
    which can be done by placing them in a special section.

To use it, you have to place a function or global in a special section,
for example:

```go
//go:section .externalram
var externalRAMBuffer [1024]byte
```

This can then be placed in a special section of the linker script, for
example something like this:

    .bss.extram (NOLOAD) : {
        *(.externalram)
    } > ERAM

This PR also adds some testing for pragmas, for regression testing.