### PR TITLE
Run function passes in parallel to improve compile time

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -118,6 +118,27 @@ func (c *Config) Scheduler() string {
 	return "coroutines"
 }
 
+// OptLevels returns the optimization level (0-2), size level (0-2), and inliner
+// threshold as used in the LLVM optimization pipeline.
+func (c *Config) OptLevels() (optLevel, sizeLevel int, inlinerThreshold uint) {
+	switch c.Options.Opt {
+	case "none", "0":
+		return 0, 0, 0 // -O0
+	case "1":
+		return 1, 0, 0 // -O1
+	case "2":
+		return 2, 0, 225 // -O2
+	case "s":
+		return 2, 1, 225 // -Os
+	case "z":
+		return 2, 2, 5 // -Oz, default
+	default:
+		// This is not shown to the user: valid choices are already checked as
+		// part of Options.Verify(). It is here as a sanity check.
+		panic("unknown optimization level: -opt=" + c.Options.Opt)
+	}
+}
+
 // FuncImplementation picks an appropriate func value implementation for the
 // target.
 func (c *Config) FuncImplementation() string {

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -10,6 +10,7 @@ var (
 	validSchedulerOptions     = []string{"none", "tasks", "coroutines"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
+	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
 )
 
 // Options contains extra options to give to the compiler. These options are
@@ -70,6 +71,12 @@ func (o *Options) Verify() error {
 			return fmt.Errorf(`invalid panic option '%s': valid values are %s`,
 				o.PanicStrategy,
 				strings.Join(validPanicStrategyOptions, ", "))
+		}
+	}
+
+	if o.Opt != "" {
+		if !isInArray(validOptOptions, o.Opt) {
+			return fmt.Errorf("invalid -opt=%s: valid values are %s", o.Opt, strings.Join(validOptOptions, ", "))
 		}
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 6 // last change: fix issue 1304
+const Version = 7 // last change: don't rely on runtime.typecodeID struct type name
 
 func init() {
 	llvm.InitializeAllTargets()

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -341,7 +341,7 @@ func (b *builder) createTypeAssert(expr *ssa.TypeAssert) llvm.Value {
 		commaOk = b.createRuntimeCall("interfaceImplements", []llvm.Value{actualTypeNum, methodSet}, "")
 
 	} else {
-		globalName := "reflect/types.type:" + getTypeCodeName(expr.AssertedType) + "$id"
+		globalName := "reflect/types.typeid:" + getTypeCodeName(expr.AssertedType)
 		assertedTypeCodeGlobal := b.mod.NamedGlobal(globalName)
 		if assertedTypeCodeGlobal.IsNil() {
 			// Create a new typecode global.

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -19,7 +19,7 @@ target triple = "i686--linux"
 @"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{String() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null }
 @"func String() string" = external constant i8
 @"reflect/types.interface:interface{String() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"func String() string"]
-@"reflect/types.type:basic:int$id" = external constant i8
+@"reflect/types.typeid:basic:int" = external constant i8
 @"error$interface" = linkonce_odr constant [1 x i8*] [i8* @"func Error() string"]
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
@@ -51,7 +51,7 @@ entry:
 
 define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
-  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.type:basic:int$id", i8* undef, i8* null)
+  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.typeid:basic:int", i8* undef, i8* null)
   br i1 %typecode, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry

--- a/compiler/testdata/string.go
+++ b/compiler/testdata/string.go
@@ -1,5 +1,13 @@
 package main
 
+func someString() string {
+	return "foo"
+}
+
+func zeroLengthString() string {
+	return ""
+}
+
 func stringLen(s string) int {
 	return len(s)
 }

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -3,11 +3,25 @@ source_filename = "string.go"
 target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
 target triple = "i686--linux"
 
+%runtime._string = type { i8*, i32 }
+
+@"main.someString$string" = internal unnamed_addr constant [3 x i8] c"foo", align 1
+
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
   ret void
+}
+
+define hidden %runtime._string @main.someString(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret %runtime._string { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"main.someString$string", i32 0, i32 0), i32 3 }
+}
+
+define hidden %runtime._string @main.zeroLengthString(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret %runtime._string zeroinitializer
 }
 
 define hidden i32 @main.stringLen(i8* %s.data, i32 %s.len, i8* %context, i8* %parentHandle) unnamed_addr {

--- a/interp/compiler.go
+++ b/interp/compiler.go
@@ -135,6 +135,15 @@ func (r *runner) compileFunction(llvmFn llvm.Value) *function {
 				default:
 					panic("unknown number of operands")
 				}
+			case llvm.Switch:
+				// A switch is an array of (value, label) pairs, of which the
+				// first one indicates the to-switch value and the default
+				// label.
+				numOperands := llvmInst.OperandsCount()
+				for i := 0; i < numOperands; i += 2 {
+					inst.operands = append(inst.operands, r.getValue(llvmInst.Operand(i)))
+					inst.operands = append(inst.operands, literalValue{uint32(blockIndices[llvmInst.Operand(i+1)])})
+				}
 			case llvm.PHI:
 				inst.name = llvmInst.Name()
 				incomingCount := inst.llvmInst.IncomingCount()

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -328,7 +328,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 					return nil, mem, r.errorAt(inst, err)
 				}
 				actualType := actualTypePtrToInt.Operand(0)
-				if actualType.Name()+"$id" == assertedType.Name() {
+				if strings.TrimPrefix(actualType.Name(), "reflect/types.type:") == strings.TrimPrefix(assertedType.Name(), "reflect/types.typeid:") {
 					locals[inst.localIndex] = literalValue{uint8(1)}
 				} else {
 					locals[inst.localIndex] = literalValue{uint8(0)}

--- a/interp/testdata/basic.ll
+++ b/interp/testdata/basic.ll
@@ -65,6 +65,12 @@ entry:
   call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
   store i16 7, i16* @main.exposedValue2
 
+  ; Test switch statement.
+  %switch1 = call i64 @testSwitch(i64 1) ; 1 returns 6
+  %switch2 = call i64 @testSwitch(i64 9) ; 9 returns the default value -1
+  call void @runtime.printint64(i64 %switch1)
+  call void @runtime.printint64(i64 %switch2)
+
   ret void
 }
 
@@ -86,4 +92,23 @@ define void @willModifyGlobal() {
 entry:
   store i16 8, i16* @main.exposedValue2
   ret void
+}
+
+define i64 @testSwitch(i64 %val) {
+entry:
+  ; Test switch statement.
+  switch i64 %val, label %otherwise [ i64 0, label %zero
+                                      i64 1, label %one
+                                      i64 2, label %two ]
+zero:
+  ret i64 5
+
+one:
+  ret i64 6
+
+two:
+  ret i64 7
+
+otherwise:
+  ret i64 -1
 }

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -25,6 +25,8 @@ entry:
   store i16 5, i16* @main.exposedValue1
   call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
   store i16 7, i16* @main.exposedValue2
+  call void @runtime.printint64(i64 6)
+  call void @runtime.printint64(i64 -1)
   ret void
 }
 
@@ -43,4 +45,25 @@ define void @willModifyGlobal() {
 entry:
   store i16 8, i16* @main.exposedValue2
   ret void
+}
+
+define i64 @testSwitch(i64 %val) local_unnamed_addr {
+entry:
+  switch i64 %val, label %otherwise [
+    i64 0, label %zero
+    i64 1, label %one
+    i64 2, label %two
+  ]
+
+zero:                                             ; preds = %entry
+  ret i64 5
+
+one:                                              ; preds = %entry
+  ret i64 6
+
+two:                                              ; preds = %entry
+  ret i64 7
+
+otherwise:                                        ; preds = %entry
+  ret i64 -1
 }

--- a/interp/testdata/interface.ll
+++ b/interp/testdata/interface.ll
@@ -6,7 +6,7 @@ target triple = "x86_64--linux"
 
 @main.v1 = global i1 0
 @"reflect/types.type:named:main.foo" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i64 0, %runtime.interfaceMethodInfo* null }
-@"reflect/types.type:named:main.foo$id" = external constant i8
+@"reflect/types.typeid:named:main.foo" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 
 
@@ -21,7 +21,7 @@ entry:
 define internal void @main.init() unnamed_addr {
 entry:
   ; Test type asserts.
-  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:main.foo" to i64), i8* @"reflect/types.type:named:main.foo$id", i8* undef, i8* null)
+  %typecode = call i1 @runtime.typeAssert(i64 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:main.foo" to i64), i8* @"reflect/types.typeid:named:main.foo", i8* undef, i8* null)
   store i1 %typecode, i1* @main.v1
   ret void
 }

--- a/transform/interface-lowering.go
+++ b/transform/interface-lowering.go
@@ -163,16 +163,13 @@ func LowerInterfaces(mod llvm.Module, sizeLevel int) error {
 // run runs the pass itself.
 func (p *lowerInterfacesPass) run() error {
 	// Collect all type codes.
-	typecodeID := p.mod.GetTypeByName("runtime.typecodeID")
-	typecodeIDPtr := llvm.PointerType(typecodeID, 0)
 	var typecodeIDs []llvm.Value
 	for global := p.mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
-		switch global.Type() {
-		case typecodeIDPtr:
+		if strings.HasPrefix(global.Name(), "reflect/types.type:") {
 			// Retrieve Go type information based on an opaque global variable.
 			// Only the name of the global is relevant, the object itself is
 			// discarded afterwards.
-			name := global.Name()
+			name := strings.TrimPrefix(global.Name(), "reflect/types.type:")
 			if _, ok := p.types[name]; !ok {
 				typecodeIDs = append(typecodeIDs, global)
 				t := &typeInfo{
@@ -196,8 +193,7 @@ func (p *lowerInterfacesPass) run() error {
 	typeAssertUses := getUses(typeAssert)
 	for _, use := range typeAssertUses {
 		typecode := use.Operand(1)
-		name := typecode.Name()            // name with $id suffix
-		name = name[:len(name)-len("$id")] // remove $id suffix
+		name := strings.TrimPrefix(typecode.Name(), "reflect/types.typeid:")
 		if t, ok := p.types[name]; ok {
 			t.countTypeAsserts++
 		}
@@ -360,7 +356,7 @@ func (p *lowerInterfacesPass) run() error {
 			if use.IsAConstantExpr().IsNil() {
 				continue
 			}
-			t := p.types[global.Name()]
+			t := p.types[strings.TrimPrefix(global.Name(), "reflect/types.type:")]
 			typecode := llvm.ConstInt(p.uintptrType, t.num, false)
 			switch use.Opcode() {
 			case llvm.PtrToInt:
@@ -381,8 +377,7 @@ func (p *lowerInterfacesPass) run() error {
 	llvmFalse := llvm.ConstInt(p.ctx.Int1Type(), 0, false)
 	for _, use := range typeAssertUses {
 		actualType := use.Operand(0)
-		name := use.Operand(1).Name()      // name with $id suffix
-		name = name[:len(name)-len("$id")] // remove $id suffix
+		name := strings.TrimPrefix(use.Operand(1).Name(), "reflect/types.typeid:")
 		if t, ok := p.types[name]; ok {
 			// The type exists in the program, so lower to a regular integer
 			// comparison.
@@ -423,13 +418,12 @@ func (p *lowerInterfacesPass) run() error {
 
 	// Remove most objects created for interface and reflect lowering.
 	// Unnecessary, but cleans up the IR for inspection and testing.
-	zeroTypeCode := llvm.ConstNull(typecodeID)
 	for _, typ := range p.types {
 		// Only some typecodes have an initializer.
 		initializer := typ.typecode.Initializer()
 		if !initializer.IsNil() {
 			references := llvm.ConstExtractValue(initializer, []uint32{0})
-			typ.typecode.SetInitializer(zeroTypeCode)
+			typ.typecode.SetInitializer(llvm.ConstNull(initializer.Type()))
 			if strings.HasPrefix(typ.name, "reflect/types.type:struct:") {
 				// Structs have a 'references' field that is not a typecode but
 				// a pointer to a runtime.structField array and therefore a

--- a/transform/interface-lowering_test.go
+++ b/transform/interface-lowering_test.go
@@ -9,7 +9,7 @@ import (
 func TestInterfaceLowering(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/interface", func(mod llvm.Module) {
-		err := LowerInterfaces(mod)
+		err := LowerInterfaces(mod, 0)
 		if err != nil {
 			t.Error(err)
 		}

--- a/transform/interrupt.go
+++ b/transform/interrupt.go
@@ -22,7 +22,7 @@ import (
 // simply call the registered handlers. This might seem like it causes extra
 // overhead, but in fact inlining and const propagation will eliminate most if
 // not all of that.
-func LowerInterrupts(mod llvm.Module) []error {
+func LowerInterrupts(mod llvm.Module, sizeLevel int) []error {
 	var errs []error
 
 	// Discover interrupts. The runtime/interrupt.Register call is a compiler
@@ -182,6 +182,9 @@ func LowerInterrupts(mod llvm.Module) []error {
 		// Create the wrapper function which is the actual interrupt handler
 		// that is inserted in the interrupt vector.
 		fn.SetUnnamedAddr(true)
+		if sizeLevel >= 2 {
+			fn.AddFunctionAttr(ctx.CreateEnumAttribute(llvm.AttributeKindID("optsize"), 0))
+		}
 		fn.SetSection(".text." + name)
 		if isSoftwareVectored {
 			fn.SetLinkage(llvm.InternalLinkage)

--- a/transform/interrupt_test.go
+++ b/transform/interrupt_test.go
@@ -11,7 +11,7 @@ func TestInterruptLowering(t *testing.T) {
 	for _, subtest := range []string{"avr", "cortexm"} {
 		t.Run(subtest, func(t *testing.T) {
 			testTransform(t, "testdata/interrupt-"+subtest, func(mod llvm.Module) {
-				errs := LowerInterrupts(mod)
+				errs := LowerInterrupts(mod, 0)
 				if len(errs) != 0 {
 					t.Fail()
 					for _, err := range errs {

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -50,16 +50,6 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		}
 	}
 
-	// Run function passes for each function.
-	funcPasses := llvm.NewFunctionPassManagerForModule(mod)
-	defer funcPasses.Dispose()
-	builder.PopulateFunc(funcPasses)
-	funcPasses.InitializeFunc()
-	for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
-		funcPasses.RunFunc(fn)
-	}
-	funcPasses.FinalizeFunc()
-
 	if optLevel > 0 {
 		// Run some preparatory passes for the Go optimizer.
 		goPasses := llvm.NewPassManager()
@@ -164,6 +154,10 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 
 	// Run function passes again, because without it, llvm.coro.size.i32()
 	// doesn't get lowered.
+	funcPasses := llvm.NewFunctionPassManagerForModule(mod)
+	defer funcPasses.Dispose()
+	builder.PopulateFunc(funcPasses)
+	funcPasses.InitializeFunc()
 	for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
 		funcPasses.RunFunc(fn)
 	}

--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -5,8 +5,8 @@ target triple = "armv7m-none-eabi"
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
-@"reflect/types.type:basic:uint8$id" = external constant i8
-@"reflect/types.type:basic:int16$id" = external constant i8
+@"reflect/types.typeid:basic:uint8" = external constant i8
+@"reflect/types.typeid:basic:int16" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 @"func NeverImplementedMethod()" = external constant i8
 @"Unmatched$interface" = private constant [1 x i8*] [i8* @"func NeverImplementedMethod()"]
@@ -55,7 +55,7 @@ typeswitch.Doubler:
   ret void
 
 typeswitch.notDoubler:
-  %isByte = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.type:basic:uint8$id")
+  %isByte = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.typeid:basic:uint8")
   br i1 %isByte, label %typeswitch.byte, label %typeswitch.notByte
 
 typeswitch.byte:
@@ -66,7 +66,7 @@ typeswitch.byte:
 
 typeswitch.notByte:
   ; this is a type assert that always fails
-  %isInt16 = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.type:basic:int16$id")
+  %isInt16 = call i1 @runtime.typeAssert(i32 %typecode, i8* nonnull @"reflect/types.typeid:basic:int16")
   br i1 %isInt16, label %typeswitch.int16, label %typeswitch.notInt16
 
 typeswitch.int16:

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -5,8 +5,8 @@ target triple = "armv7m-none-eabi"
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = external constant %runtime.typecodeID
-@"reflect/types.type:basic:uint8$id" = external constant i8
-@"reflect/types.type:basic:int16$id" = external constant i8
+@"reflect/types.typeid:basic:uint8" = external constant i8
+@"reflect/types.typeid:basic:int16" = external constant i8
 @"reflect/types.type:basic:int" = external constant %runtime.typecodeID
 @"func NeverImplementedMethod()" = external constant i8
 @"func Double() int" = external constant i8
@@ -93,14 +93,14 @@ define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %parentHandle) {
 define internal i32 @"(Doubler).Double"(i8* %0, i8* %1, i32 %actualType, i8* %parentHandle) unnamed_addr {
 entry:
   switch i32 %actualType, label %default [
-    i32 68, label %"reflect/types.type:named:Number"
+    i32 68, label %"named:Number"
   ]
 
 default:                                          ; preds = %entry
   call void @runtime.nilPanic(i8* undef, i8* undef)
   unreachable
 
-"reflect/types.type:named:Number":                ; preds = %entry
+"named:Number":                                   ; preds = %entry
   %2 = call i32 @"(Number).Double$invoke"(i8* %0, i8* %1)
   ret i32 %2
 }

--- a/transform/wasm-abi.go
+++ b/transform/wasm-abi.go
@@ -73,6 +73,10 @@ func ExternalInt64AsPtr(mod llvm.Module) error {
 		fn.SetName(name + "$i64wrap")
 		externalFnType := llvm.FunctionType(returnType, paramTypes, fnType.IsFunctionVarArg())
 		externalFn := llvm.AddFunction(mod, name, externalFnType)
+		optsize := fn.GetEnumFunctionAttribute(llvm.AttributeKindID("optsize"))
+		if !optsize.IsNil() {
+			fn.AddFunctionAttr(optsize)
+		}
 
 		if fn.IsDeclaration() {
 			// Just a declaration: the definition doesn't exist on the Go side


### PR DESCRIPTION
This PR is a collection of changes with the end goal of moving some work from the serial LTO step to the parallel package build step. This improves compile time slightly (in particular for incremental builds that are largely cached) and is a prerequisite for moving more work towards the parallel package build step in the future.

I originally intended to do this as part of #1612 but couldn't get it to work reliably. Now I see why: many more changes are needed to make it work well.

As part of this change, I also made the following changes:

 - I fixed a possible regression similar to #1765 (second commit).
 - I added alignment to string literals and global variables (third commit). This reduced code size significantly (up to around 2%) so was a surprise find. It also reduces static RAM usage slightly in some cases.