### PR TITLE
transform: use IPSCCP pass instead of the constant propagation pass

### DIFF
--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -66,7 +66,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		defer goPasses.Dispose()
 		goPasses.AddGlobalDCEPass()
 		goPasses.AddGlobalOptimizerPass()
-		goPasses.AddConstantPropagationPass()
+		goPasses.AddIPSCCPPass()
 		goPasses.AddAggressiveDCEPass()
 		goPasses.AddFunctionAttrsPass()
 		goPasses.Run(mod)


### PR DESCRIPTION
The constant propagation pass is removed in LLVM 12, so this pass needs
to be replaced anyway. The direct replacement would be the SCCP (sparse
conditional constant propagation) pass, but perhaps a better replacement
is the IPSCCP pass, which is an interprocedural version of the SCCP
pass and propagates constants across function calls if possible.

This is not always a code size reduction, but it appears to reduce code
size in a majority of cases. It certainly reduces code size in almost
all WebAssembly tests I did.