### PR TITLE
ci: limit test runs of assert-test-linux to two jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,15 +172,16 @@ commands:
           key: llvm-build-11-linux-v2-assert
           paths:
             llvm-build
-      - run: |
-          # Note: -p=2 limits parallelism to two jobs at a time, which is
-          # necessary to keep memory consumption down and avoid OOM (for a
-          # 2CPU/4GB executor).
-          GOFLAGS="-p=2" make ASSERT=1
+      - run: make ASSERT=1
       - build-wasi-libc
       - run:
           name: "Test TinyGo"
           command: make ASSERT=1 test
+          environment:
+            # Note: -p=2 limits parallelism to two jobs at a time, which is
+            # necessary to keep memory consumption down and avoid OOM (for a
+            # 2CPU/4GB executor).
+            GOFLAGS: -p=2
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:


### PR DESCRIPTION
Instead of the regular build, it's the `make test` line that fails due
to OOM. This is because testing means that a lot of test binaries need
to be built while the regular build only needs to link one binary.

This improves https://github.com/tinygo-org/tinygo/pull/1774 and should
hopefully actually fix the OOM errors.