### PR TITLE
ci: changed to generate only files that exist in targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,22 +120,22 @@ gen-device-avr:
 	@GO111MODULE=off $(GO) fmt ./src/device/avr
 
 build/gen-device-svd: ./tools/gen-device-svd/*.go
-	$(GO) build -o $@ ./tools/gen-device-svd/
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -o $@ ./tools/gen-device-svd/
 
 gen-device-esp: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif-Community -interrupts=software lib/cmsis-svd/data/Espressif-Community/ src/device/esp/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif-Community -only-used -interrupts=software lib/cmsis-svd/data/Espressif-Community/ src/device/esp/
 	GO111MODULE=off $(GO) fmt ./src/device/esp
 
 gen-device-nrf: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/NordicSemiconductor/nrfx/tree/master/mdk lib/nrfx/mdk/ src/device/nrf/
+	./build/gen-device-svd -source=https://github.com/NordicSemiconductor/nrfx/tree/master/mdk -only-used lib/nrfx/mdk/ src/device/nrf/
 	GO111MODULE=off $(GO) fmt ./src/device/nrf
 
 gen-device-nxp: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/NXP lib/cmsis-svd/data/NXP/ src/device/nxp/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/NXP -only-used lib/cmsis-svd/data/NXP/ src/device/nxp/
 	GO111MODULE=off $(GO) fmt ./src/device/nxp
 
 gen-device-sam: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Atmel lib/cmsis-svd/data/Atmel/ src/device/sam/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Atmel -only-used lib/cmsis-svd/data/Atmel/ src/device/sam/
 	GO111MODULE=off $(GO) fmt ./src/device/sam
 
 gen-device-sifive: build/gen-device-svd
@@ -143,11 +143,11 @@ gen-device-sifive: build/gen-device-svd
 	GO111MODULE=off $(GO) fmt ./src/device/sifive
 
 gen-device-kendryte: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Kendryte-Community -interrupts=software lib/cmsis-svd/data/Kendryte-Community/ src/device/kendryte/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Kendryte-Community -only-used -interrupts=software lib/cmsis-svd/data/Kendryte-Community/ src/device/kendryte/
 	GO111MODULE=off $(GO) fmt ./src/device/kendryte
 
 gen-device-stm32: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/tinygo-org/stm32-svd lib/stm32-svd/svd src/device/stm32/
+	./build/gen-device-svd -source=https://github.com/tinygo-org/stm32-svd -only-used lib/stm32-svd/svd src/device/stm32/
 	GO111MODULE=off $(GO) fmt ./src/device/stm32
 
 


### PR DESCRIPTION
This PR will speed up `make gen-device` .
Reduce the number of targets for SVD parsing by using the same buildTag that can be obtained from tinygo targets.

This will allow CI to run faster.
Also, the size of the release version will be a little smaller.
(Actually, I think it will be almost the same size because of compression)

Instead, if you want to use a new chip, you need to add the buildTag to targets/*.json first, and then run `make gen-device` again.

after:
```
$ make build/gen-device-svd && time make gen-device -j 3

real    0m2.320s
user    0m11.424s
sys     0m1.329s

$ du -sk ./src/device/
27912   ./src/device/
```

before:
```
$ make build/gen-device-svd && time make gen-device -j 3                                                                                                                                                         

real    0m25.431s
user    1m26.611s
sys     0m8.942s

$ du -sk ./src/device/
207712  ./src/device/
```
