### PR TITLE
compiler: check for errors

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -298,7 +298,7 @@ func CompilePackage(moduleName string, pkg *loader.Package, ssaPkg *ssa.Package,
 		c.dibuilder.Finalize()
 	}
 
-	return c.mod, nil
+	return c.mod, c.diagnostics
 }
 
 // getLLVMRuntimeType obtains a named type from the runtime package and returns

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -84,9 +84,14 @@ func TestCompiler(t *testing.T) {
 			mod, errs := CompilePackage(testCase, pkg, program.Package(pkg.Pkg), machine, compilerConfig, false)
 			if errs != nil {
 				for _, err := range errs {
-					t.Log("error:", err)
+					t.Error(err)
 				}
 				return
+			}
+
+			err = llvm.VerifyModule(mod, llvm.PrintMessageAction)
+			if err != nil {
+				t.Error(err)
 			}
 
 			// Optimize IR a little.


### PR DESCRIPTION
Some errors were generated but never returned or never checked in the test function. That's a problem. Therefore this commit fixes this oversight (by me).