### PR TITLE
stm32: support SPI on L4 series

### DIFF
--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -13,20 +13,53 @@ const (
 	LED_GREEN   = PB3
 )
 
-// UART pins
 const (
+	// Arduino Pins
+	A0 = PA0
+	A1 = PA1
+	A2 = PA3
+	A3 = PA4
+	A4 = PA5
+	A5 = PA6
+	A6 = PA7
+	A7 = PA2
+
+	D0  = PA10
+	D1  = PA9
+	D2  = PA12
+	D3  = PB0
+	D4  = PB7
+	D5  = PB6
+	D6  = PB1
+	D7  = PC14
+	D8  = PC15
+	D9  = PA8
+	D10 = PA11
+	D11 = PB5
+	D12 = PB4
+	D13 = PB3
+)
+
+const (
+	// UART pins
 	// PA2 and PA15 are connected to the ST-Link Virtual Com Port (VCP)
 	UART_TX_PIN = PA2
 	UART_RX_PIN = PA15
-)
 
-// I2C pins
-const (
+	// I2C pins
 	// With default solder bridge settings:
 	//    PB6 / Arduino D5 / CN3 Pin 8 is SCL
 	//    PB7 / Arduino D4 / CN3 Pin 7 is SDA
 	I2C0_SCL_PIN = PB6
 	I2C0_SDA_PIN = PB7
+
+	// SPI pins
+	SPI1_SCK_PIN = PB3
+	SPI1_SDI_PIN = PB5
+	SPI1_SDO_PIN = PB4
+	SPI0_SCK_PIN = SPI1_SCK_PIN
+	SPI0_SDI_PIN = SPI1_SDI_PIN
+	SPI0_SDO_PIN = SPI1_SDO_PIN
 )
 
 var (
@@ -40,15 +73,20 @@ var (
 		RxAltFuncSelector: 3,
 	}
 	UART1 = &UART0
-)
 
-var (
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{
 		Bus:             stm32.I2C1,
 		AltFuncSelector: 4,
 	}
 	I2C0 = I2C1
+
+	// SPI1 is documented, alias to SPI0 as well
+	SPI1 = &SPI{
+		Bus:             stm32.SPI1,
+		AltFuncSelector: 5,
+	}
+	SPI0 = SPI1
 )
 
 func init() {

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -161,6 +161,10 @@ var (
 	SPI0 = SPI1
 )
 
+func (spi SPI) config8Bits() {
+	// no-op on this series
+}
+
 // Set baud rate for SPI
 func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32

--- a/src/machine/machine_stm32f405.go
+++ b/src/machine/machine_stm32f405.go
@@ -67,6 +67,10 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
+func (spi SPI) config8Bits() {
+	// no-op on this series
+}
+
 func (spi SPI) configurePins(config SPIConfig) {
 	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)

--- a/src/machine/machine_stm32f407.go
+++ b/src/machine/machine_stm32f407.go
@@ -70,6 +70,10 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
+func (spi SPI) config8Bits() {
+	// no-op on this series
+}
+
 // Set baud rate for SPI
 func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -184,6 +184,10 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
+func (spi SPI) config8Bits() {
+	// no-op on this series
+}
+
 // Set baud rate for SPI
 func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-// +build !baremetal stm32,!stm32f7x2,!stm32l5x2,!stm32l4x2 fe310 k210 atmega
+// +build !baremetal stm32,!stm32f7x2,!stm32l5x2 fe310 k210 atmega
 
 package machine
 


### PR DESCRIPTION
Implements: #1785 
Depends on: https://github.com/tinygo-org/stm32-svd/pull/3

Includes fix from @ofauchon / @aykevl to do 8-bit writes to the DR register, even if declared as 16-bit register.

The `getBaudRate` function is not great - cut and paste from other boards with clock-specific magic values.  Will raise a separate PR to have a single implementation of `getBaudRate` for STM32 which accepts the peripheral bus freq as input.