### PR TITLE
stm32: make SPI CLK fast to fix data issue

### DIFF
--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -55,9 +55,11 @@ const (
 	gpioPullMask     = 0x3
 
 	// OSPEED bitfields.
-	gpioOutputSpeedHigh = 2
-	gpioOutputSpeedLow  = 0
-	gpioOutputSpeedMask = 0x3
+	gpioOutputSpeedVeryHigh = 3
+	gpioOutputSpeedHigh     = 2
+	gpioOutputSpeedMedium   = 1
+	gpioOutputSpeedLow      = 0
+	gpioOutputSpeedMask     = 0x3
 )
 
 // Configure this pin with the given configuration
@@ -120,7 +122,7 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 	// SPI
 	case PinModeSPICLK:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
-		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
+		port.OSPEEDR.ReplaceBits(gpioOutputSpeedHigh, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 	case PinModeSPISDO:


### PR DESCRIPTION
So this was a few days of fun, trying to work out why my logic analyzer and the code didn't agree.

See "STM32F40x and STM32F41x Errata sheet"

> the last bit of the transacted frame
> is not captured when the signal provided by internal feedback loop from the SCK pin
> exceeds a critical delay. The lastly transacted bit of the stored data then keeps the value
> from the pattern received previously

> The main factors contributing to the delay increase are low VDD level, high temperature,
> high SCK pin capacitive load and low SCK I/O output speed. The SPI communication speed
> has no impact.

In essence, the SPI CLK port must be 'fast' or 'very fast' to avoid data corruption on last bit on SDI (at the APB clock speeds we configure).  Two choices are to reduce APB clocks or make the port 'faster', making it faster seems like the best option.  Should not have negative impact on other STM32 boards.

Also finished out the GPIO speed constants.  Using just 'high' because experimentally it sufficient and the errata also indicates either 'high' or 'very high' is OK.