### PR TITLE
microbit: remove LED constant

### DIFF
--- a/src/machine/board_microbit-v2.go
+++ b/src/machine/board_microbit-v2.go
@@ -5,11 +5,6 @@ package machine
 // The micro:bit does not have a 32kHz crystal on board.
 const HasLowFrequencyCrystal = false
 
-const (
-	LED  = P13
-	LED1 = LED
-)
-
 // Buttons on the micro:bit v2 (A and B)
 const (
 	BUTTON  Pin = BUTTONA


### PR DESCRIPTION
There doesn't appear to be a user-controllable LED outside of the LED
matrix. In fact, the pin assigned for this was P13, which was connected
to the SPI SCK pin.