### PR TITLE
microbit-v2: add support for S113 SoftDevice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,6 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=microbit            examples/microbit-blink
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=microbit-v2         examples/microbit-blink
-	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/pininterrupt
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/serial
@@ -255,6 +253,10 @@ smoketest:
 	$(TINYGO) build -size short -o test.hex -target=microbit            examples/echo
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=microbit-s110v8     examples/echo
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=microbit-v2         examples/microbit-blink
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=microbit-v2-s113v7  examples/microbit-blink
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/runtime/runtime_nrf_softdevice.go
+++ b/src/runtime/runtime_nrf_softdevice.go
@@ -27,7 +27,7 @@ func waitForEvents() {
 		if nrf.DEVICE == "nrf51" {
 			// sd_app_evt_wait: SOC_SVC_BASE_NOT_AVAILABLE + 29
 			arm.SVCall0(0x2B + 29)
-		} else if nrf.DEVICE == "nrf52" || nrf.DEVICE == "nrf52840" {
+		} else if nrf.DEVICE == "nrf52" || nrf.DEVICE == "nrf52840" || nrf.DEVICE == "nrf52833" {
 			// sd_app_evt_wait: SOC_SVC_BASE_NOT_AVAILABLE + 21
 			arm.SVCall0(0x2C + 21)
 		} else {

--- a/targets/microbit-v2-s113v7.json
+++ b/targets/microbit-v2-s113v7.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["microbit-v2", "nrf52833-s113v7"]
+}

--- a/targets/nrf52833-s113v7.json
+++ b/targets/nrf52833-s113v7.json
@@ -1,0 +1,7 @@
+{
+	"build-tags": ["softdevice", "s113v7"],
+	"linkerscript": "targets/nrf52833-s113v7.ld",
+	"ldflags": [
+		"--defsym=__softdevice_stack=0x700"
+	]
+}

--- a/targets/nrf52833-s113v7.ld
+++ b/targets/nrf52833-s113v7.ld
@@ -1,0 +1,14 @@
+
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x00000000 + 0x1C000, LENGTH = 0x80000 - 0x1C000
+    RAM (xrw)       : ORIGIN = 0x20000000 + 0x1e20,  LENGTH = 0x20000 - 0x1e20
+}
+
+_stack_size = 4K + __softdevice_stack;
+
+/* These values are needed for the Nordic SoftDevice. */
+__app_ram_base = ORIGIN(RAM);
+__softdevice_stack = DEFINED(__softdevice_stack) ? __softdevice_stack : 0;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
This currently doesn't work with `tinygo flash` yet (even with `-programmer=openocd`), you can use pyocd instead. For example, from the Bluetooth package:

    tinygo build -o test.hex -target=microbit-v2-s113v7 ./examples/advertisement/
    pyocd flash --target=nrf52 test.hex

I intend to add support for pyocd to work around this issue, so that a simple `tinygo flash` suffices.

If the micro:bit doesn't have the SoftDevice flashed on it, you can restore it by downloading the following file onto it: https://support.microbit.org/support/solutions/articles/19000021613-reset-the-micro-bit-to-factory-defaults