### PR TITLE
cortexm: add __isr_vector symbol

### DIFF
--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -1103,6 +1103,7 @@ Default_Handler:
 // https://sourceware.org/binutils/docs/as/Section.html#ELF-Version
 .section .isr_vector, "a", %progbits
 .global  __isr_vector
+__isr_vector:
     // Interrupt vector as defined by Cortex-M, starting with the stack top.
     // On reset, SP is initialized with *0x0 and PC is loaded with *0x4, loading
     // _stack_top and Reset_Handler.


### PR DESCRIPTION
This doesn't change the firmware, but it does make the disassembly of the ELF files. Before:

    Disassembly of section .text:

    00000000 <(machine.UART).Write-0x100>:
           0:       20001000        .word   0x20001000
           4:       000009db        .word   0x000009db
           8:       00000f05        .word   0x00000f05
           c:       00000f0b        .word   0x00000f0b
          10:       00000f05        .word   0x00000f05

After:

    Disassembly of section .text:

    00000000 <__isr_vector>:
           0:       20001000        .word   0x20001000
           4:       000009db        .word   0x000009db
           8:       00000f05        .word   0x00000f05
           c:       00000f0b        .word   0x00000f0b
          10:       00000f05        .word   0x00000f05

The difference is that the disassembler will now use a proper symbol name instead of using the closest by symbol (in this case, `(machine.UART).Write)`. This makes the disassembly easier to read.