### PR TITLE
wasm: use WASI ABI for exit function

### DIFF
--- a/src/runtime/runtime_wasm.go
+++ b/src/runtime/runtime_wasm.go
@@ -16,6 +16,12 @@ type __wasi_iovec_t struct {
 //export fd_write
 func fd_write(id uint32, iovs *__wasi_iovec_t, iovs_len uint, nwritten *uint) (errno uint)
 
+// See:
+// https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-proc_exitrval-exitcode
+//go:wasm-module wasi_snapshot_preview1
+//export proc_exit
+func proc_exit(exitcode uint32)
+
 func postinit() {}
 
 const (
@@ -47,6 +53,11 @@ func putchar(c byte) {
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
+}
+
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	proc_exit(uint32(code))
 }
 
 // TinyGo does not yet support any form of parallelism on WebAssembly, so these

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -276,6 +276,15 @@
 						mem().setUint32(nwritten_ptr, nwritten, true);
 						return 0;
 					},
+					"proc_exit": (code) => {
+						if (global.process) {
+							// Node.js
+							process.exit(code);
+						} else {
+							// Can't exit in a browser.
+							throw 'trying to exit with code ' + code;
+						}
+					},
 				},
 				env: {
 					// func ticks() float64
@@ -287,17 +296,6 @@
 					"runtime.sleepTicks": (timeout) => {
 						// Do not sleep, only reactivate scheduler after the given timeout.
 						setTimeout(this._inst.exports.go_scheduler, timeout);
-					},
-
-					// func Exit(code int)
-					"syscall.Exit": (code) => {
-						if (global.process) {
-							// Node.js
-							process.exit(code);
-						} else {
-							// Can't exit in a browser.
-							throw 'trying to exit with code ' + code;
-						}
 					},
 
 					// func finalizeRef(v ref)

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -19,4 +19,7 @@ func main() {
 	// package strings
 	fmt.Println("strings.IndexByte:", strings.IndexByte("asdf", 'd'))
 	fmt.Println("strings.Replace:", strings.Replace("An example string", " ", "-", -1))
+
+	// Exit the program normally.
+	os.Exit(0)
 }


### PR DESCRIPTION
This improves compatibility between the regular browser target (`-target=wasm`) and the WASI target (`-target=wasi`). Specifically, it allows running WASI tests like this:

    tinygo test -target=wasi encoding/base32

This fixes https://github.com/tinygo-org/tinygo/issues/1801.