### PR TITLE
builder: hard code Clang compiler

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -494,7 +494,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		job := &compileJob{
 			description: "compile extra file " + path,
 			run: func(job *compileJob) error {
-				result, err := compileAndCacheCFile(abspath, dir, config.CFlags(), config)
+				result, err := compileAndCacheCFile(abspath, dir, config.CFlags(), config.Options.PrintCommands)
 				job.result = result
 				return err
 			},
@@ -513,7 +513,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 			job := &compileJob{
 				description: "compile CGo file " + abspath,
 				run: func(job *compileJob) error {
-					result, err := compileAndCacheCFile(abspath, dir, pkg.CFlags, config)
+					result, err := compileAndCacheCFile(abspath, dir, pkg.CFlags, config.Options.PrintCommands)
 					job.result = result
 					return err
 				},

--- a/builder/library.go
+++ b/builder/library.go
@@ -136,7 +136,7 @@ func (l *Library) load(target, cpu, tmpdir string) (job *compileJob, err error) 
 				var compileArgs []string
 				compileArgs = append(compileArgs, args...)
 				compileArgs = append(compileArgs, "-o", objpath, srcpath)
-				err := runCCompiler("clang", compileArgs...)
+				err := runCCompiler(compileArgs...)
 				if err != nil {
 					return &commandError{"failed to build", srcpath, err}
 				}

--- a/builder/tools.go
+++ b/builder/tools.go
@@ -9,8 +9,8 @@ import (
 )
 
 // runCCompiler invokes a C compiler with the given arguments.
-func runCCompiler(command string, flags ...string) error {
-	if hasBuiltinTools && command == "clang" {
+func runCCompiler(flags ...string) error {
+	if hasBuiltinTools {
 		// Compile this with the internal Clang compiler.
 		headerPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
 		if headerPath == "" {
@@ -23,17 +23,8 @@ func runCCompiler(command string, flags ...string) error {
 		return cmd.Run()
 	}
 
-	// Running some other compiler. Maybe it has been defined in the
-	// commands map (unlikely).
-	if cmdNames, ok := commands[command]; ok {
-		return execCommand(cmdNames, flags...)
-	}
-
-	// Alternatively, run the compiler directly.
-	cmd := exec.Command(command, flags...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	// Compile this with an external invocation of the Clang compiler.
+	return execCommand(commands["clang"], flags...)
 }
 
 // link invokes a linker with the given name and flags.

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -31,7 +31,6 @@ type TargetSpec struct {
 	BuildTags        []string `json:"build-tags"`
 	GC               string   `json:"gc"`
 	Scheduler        string   `json:"scheduler"`
-	Compiler         string   `json:"compiler"`
 	Linker           string   `json:"linker"`
 	RTLib            string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
 	Libc             string   `json:"libc"`
@@ -244,7 +243,6 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		GOOS:      goos,
 		GOARCH:    goarch,
 		BuildTags: []string{goos, goarch},
-		Compiler:  "clang",
 		Linker:    "cc",
 		CFlags:    []string{"--target=" + triple},
 		GDB:       []string{"gdb"},

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -3,7 +3,6 @@
 	"build-tags": ["avr", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
-	"compiler": "clang",
 	"gc": "conservative",
 	"linker": "avr-gcc",
 	"scheduler": "none",

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -2,7 +2,6 @@
 	"build-tags": ["cortexm", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
-	"compiler": "clang",
 	"gc": "conservative",
 	"scheduler": "tasks",
 	"linker": "ld.lld",

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -4,7 +4,6 @@
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
-	"compiler": "clang",
 	"linker": "ld.lld",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -3,7 +3,6 @@
   "build-tags": ["nintendoswitch", "arm64"],
   "goos": "linux",
   "goarch": "arm64",
-  "compiler": "clang",
   "linker": "ld.lld",
   "rtlib": "compiler-rt",
   "libc": "picolibc",

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -3,7 +3,6 @@
 	"goarch": "arm",
 	"build-tags": ["tinygo.riscv", "baremetal", "linux", "arm"],
 	"gc": "conservative",
-	"compiler": "clang",
 	"linker": "ld.lld",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -3,7 +3,6 @@
 	"build-tags":    ["wasm", "wasi"],
 	"goos":          "linux",
 	"goarch":        "arm",
-	"compiler":      "clang",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"cflags": [

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -3,7 +3,6 @@
 	"build-tags":    ["js", "wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
-	"compiler":      "clang",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"cflags": [

--- a/targets/xtensa.json
+++ b/targets/xtensa.json
@@ -5,7 +5,6 @@
 	"build-tags": ["xtensa", "baremetal", "linux", "arm"],
 	"gc": "conservative",
 	"scheduler": "none",
-	"compiler": "clang",
 	"cflags": [
 		"--target=xtensa",
 		"-Oz",


### PR DESCRIPTION
At the moment, all targets use the Clang compiler to compile C and
assembly files. There is no good reason to make this configurable
anymore and in fact it will make future changes more complicated (and
thus more likely to have bugs). Therefore, I've removed support for
setting the compiler.

Note that the same is not true for the linker. While it makes sense to
standardize on the Clang compiler (because if Clang doesn't support a
target, TinyGo is unlikely to support it either), linkers will remain
configurable for the foreseeable future. One example is Xtensa, which is
supported by the Xtensa LLVM fork but doesn't have support in ld.lld
yet.

I've also fixed a bug in compileAndCacheCFile: it wasn't using the right
CFlags for caching purposes. This could lead to using stale caches. This
commit fixes that too.