### PR TITLE
openocd commands in tinygo command line

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -17,10 +17,18 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if options.OpenOCDCommands != nil {
+		// Override the OpenOCDCommands from the target spec if specified on
+		// the command-line
+		spec.OpenOCDCommands = options.OpenOCDCommands
+	}
+
 	goroot := goenv.Get("GOROOT")
 	if goroot == "" {
 		return nil, errors.New("cannot locate $GOROOT, please set it manually")
 	}
+
 	major, minor, err := goenv.GetGorootVersion(goroot)
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
@@ -28,7 +36,9 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if major != 1 || minor < 13 || minor > 16 {
 		return nil, fmt.Errorf("requires go version 1.13 through 1.16, got go%d.%d", major, minor)
 	}
+
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))
+
 	return &compileopts.Config{
 		Options:        options,
 		Target:         spec,

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -17,24 +17,25 @@ var (
 // Options contains extra options to give to the compiler. These options are
 // usually passed from the command line.
 type Options struct {
-	Target        string
-	Opt           string
-	GC            string
-	PanicStrategy string
-	Scheduler     string
-	PrintIR       bool
-	DumpSSA       bool
-	VerifyIR      bool
-	PrintCommands bool
-	Debug         bool
-	PrintSizes    string
-	PrintAllocs   *regexp.Regexp // regexp string
-	PrintStacks   bool
-	Tags          string
-	WasmAbi       string
-	GlobalValues  map[string]map[string]string // map[pkgpath]map[varname]value
-	TestConfig    TestConfig
-	Programmer    string
+	Target          string
+	Opt             string
+	GC              string
+	PanicStrategy   string
+	Scheduler       string
+	PrintIR         bool
+	DumpSSA         bool
+	VerifyIR        bool
+	PrintCommands   bool
+	Debug           bool
+	PrintSizes      string
+	PrintAllocs     *regexp.Regexp // regexp string
+	PrintStacks     bool
+	Tags            string
+	WasmAbi         string
+	GlobalValues    map[string]map[string]string // map[pkgpath]map[varname]value
+	TestConfig      TestConfig
+	Programmer      string
+	OpenOCDCommands []string
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/main.go
+++ b/main.go
@@ -905,6 +905,7 @@ func main() {
 	printAllocsString := flag.String("print-allocs", "", "regular expression of functions for which heap allocations should be printed")
 	printCommands := flag.Bool("x", false, "Print commands")
 	nodebug := flag.Bool("no-debug", false, "disable DWARF debug symbol generation")
+	ocdCommandsString := flag.String("ocd-commands", "", "OpenOCD commands, overriding target spec (can specify multiple separated by commas)")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
 	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
@@ -943,6 +944,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
 	var printAllocs *regexp.Regexp
 	if *printAllocsString != "" {
 		printAllocs, err = regexp.Compile(*printAllocsString)
@@ -951,24 +953,31 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	var ocdCommands []string
+	if *ocdCommandsString != "" {
+		ocdCommands = strings.Split(*ocdCommandsString, ",")
+	}
+
 	options := &compileopts.Options{
-		Target:        *target,
-		Opt:           *opt,
-		GC:            *gc,
-		PanicStrategy: *panicStrategy,
-		Scheduler:     *scheduler,
-		PrintIR:       *printIR,
-		DumpSSA:       *dumpSSA,
-		VerifyIR:      *verifyIR,
-		Debug:         !*nodebug,
-		PrintSizes:    *printSize,
-		PrintStacks:   *printStacks,
-		PrintAllocs:   printAllocs,
-		PrintCommands: *printCommands,
-		Tags:          *tags,
-		GlobalValues:  globalVarValues,
-		WasmAbi:       *wasmAbi,
-		Programmer:    *programmer,
+		Target:          *target,
+		Opt:             *opt,
+		GC:              *gc,
+		PanicStrategy:   *panicStrategy,
+		Scheduler:       *scheduler,
+		PrintIR:         *printIR,
+		DumpSSA:         *dumpSSA,
+		VerifyIR:        *verifyIR,
+		Debug:           !*nodebug,
+		PrintSizes:      *printSize,
+		PrintStacks:     *printStacks,
+		PrintAllocs:     printAllocs,
+		PrintCommands:   *printCommands,
+		Tags:            *tags,
+		GlobalValues:    globalVarValues,
+		WasmAbi:         *wasmAbi,
+		Programmer:      *programmer,
+		OpenOCDCommands: ocdCommands,
 	}
 
 	os.Setenv("CC", "clang -target="+*target)


### PR DESCRIPTION
Implements #1816 to enable identification of specific ST-LINK devices on tinygo command line.

Because the precise command is specific to the openocd transport in use, this implements as a generic 'openocd command' facility.