### PR TITLE
ci: improve llvm-source cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,14 +68,17 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-11-v1
+            - llvm-source-11-v2
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-11-v1
+          key: llvm-source-11-v2
           paths:
-            - llvm-project
+            - llvm-project/clang/lib/Headers
+            - llvm-project/clang/include
+            - llvm-project/lld/include
+            - llvm-project/llvm/include
   build-wasi-libc:
     steps:
       - restore_cache:
@@ -160,6 +163,9 @@ commands:
           command: |
             if [ ! -f llvm-build/lib/liblldELF.a ]
             then
+              # fetch LLVM source
+              rm -rf llvm-project
+              make llvm-source
               # install dependencies
               sudo apt-get install cmake ninja-build
               # hack ninja to use less jobs
@@ -224,6 +230,9 @@ commands:
           command: |
             if [ ! -f llvm-build/lib/liblldELF.a ]
             then
+              # fetch LLVM source
+              rm -rf llvm-project
+              make llvm-source
               # install dependencies
               sudo apt-get install cmake ninja-build
               # hack ninja to use less jobs
@@ -287,14 +296,17 @@ commands:
             - go-cache-macos-v2-{{ checksum "go.mod" }}
       - restore_cache:
           keys:
-            - llvm-source-11-macos-v1
+            - llvm-source-11-macos-v2
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-11-macos-v1
+          key: llvm-source-11-macos-v2
           paths:
-            - llvm-project
+            - llvm-project/clang/lib/Headers
+            - llvm-project/clang/include
+            - llvm-project/lld/include
+            - llvm-project/llvm/include
       - restore_cache:
           keys:
             - llvm-build-11-macos-v2
@@ -303,6 +315,9 @@ commands:
           command: |
             if [ ! -f llvm-build/lib/liblldELF.a ]
             then
+              # fetch LLVM source
+              rm -rf llvm-project
+              make llvm-source
               # install dependencies
               HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
               # build!

--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,9 @@ gen-device-stm32: build/gen-device-svd
 
 
 # Get LLVM sources.
-$(LLVM_PROJECTDIR)/README.md:
+$(LLVM_PROJECTDIR)/llvm:
 	git clone -b xtensa_release_11.0.0 --depth=1 https://github.com/tinygo-org/llvm-project $(LLVM_PROJECTDIR)
-llvm-source: $(LLVM_PROJECTDIR)/README.md
+llvm-source: $(LLVM_PROJECTDIR)/llvm
 
 # Configure LLVM.
 TINYGO_SOURCE_DIR=$(shell pwd)


### PR DESCRIPTION
This PR makes restoring-cache-llvm-source faster.
As described in #1796, the processing time is reduced from 21 sec to 1 sec.

Instead, if the make llvm-build is needed, it needs to be downloaded again with make llvm-source.
However, the only case where this will increase processing time is when doing llvm-build, so only the first time.