### PR TITLE
main: add -print-allocs flag that lets you print all allocations

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -2,6 +2,7 @@ package compileopts
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -27,6 +28,7 @@ type Options struct {
 	PrintCommands bool
 	Debug         bool
 	PrintSizes    string
+	PrintAllocs   *regexp.Regexp // regexp string
 	PrintStacks   bool
 	Tags          string
 	WasmAbi       string

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -139,6 +139,17 @@ func (c *compilerContext) getFunction(fn *ssa.Function) llvm.Value {
 		for _, attrName := range []string{"noalias", "nonnull"} {
 			llvmFn.AddAttributeAtIndex(0, c.ctx.CreateEnumAttribute(llvm.AttributeKindID(attrName), 0))
 		}
+	case "runtime.sliceAppend":
+		// Appending a slice will only read the to-be-appended slice, it won't
+		// be modified.
+		llvmFn.AddAttributeAtIndex(2, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("nocapture"), 0))
+		llvmFn.AddAttributeAtIndex(2, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("readonly"), 0))
+	case "runtime.sliceCopy":
+		// Copying a slice won't capture any of the parameters.
+		llvmFn.AddAttributeAtIndex(1, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("writeonly"), 0))
+		llvmFn.AddAttributeAtIndex(1, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("nocapture"), 0))
+		llvmFn.AddAttributeAtIndex(2, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("readonly"), 0))
+		llvmFn.AddAttributeAtIndex(2, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("nocapture"), 0))
 	case "runtime.trackPointer":
 		// This function is necessary for tracking pointers on the stack in a
 		// portable way (see gc_stack_portable.go). Indicate to the optimizer

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -60,7 +60,7 @@ entry:
   ret { i32*, i32, i32 } %7
 }
 
-declare { i8*, i32, i32 } @runtime.sliceAppend(i8*, i8*, i32, i32, i32, i32, i8*, i8*)
+declare { i8*, i32, i32 } @runtime.sliceAppend(i8*, i8* nocapture readonly, i32, i32, i32, i32, i8*, i8*)
 
 define hidden { i32*, i32, i32 } @main.sliceAppendSlice(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32* %added.data, i32 %added.len, i32 %added.cap, i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
@@ -85,4 +85,4 @@ entry:
   ret i32 %copy.n
 }
 
-declare i32 @runtime.sliceCopy(i8*, i8*, i32, i32, i32, i8*, i8*)
+declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*, i8*)

--- a/transform/allocs_test.go
+++ b/transform/allocs_test.go
@@ -1,10 +1,12 @@
-package transform
+package transform_test
 
 import (
 	"testing"
+
+	"github.com/tinygo-org/tinygo/transform"
 )
 
 func TestAllocs(t *testing.T) {
 	t.Parallel()
-	testTransform(t, "testdata/allocs", OptimizeAllocs)
+	testTransform(t, "testdata/allocs", transform.OptimizeAllocs)
 }

--- a/transform/allocs_test.go
+++ b/transform/allocs_test.go
@@ -1,12 +1,129 @@
 package transform_test
 
 import (
+	"go/token"
+	"go/types"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/compiler"
+	"github.com/tinygo-org/tinygo/loader"
 	"github.com/tinygo-org/tinygo/transform"
+	"tinygo.org/x/go-llvm"
 )
 
 func TestAllocs(t *testing.T) {
 	t.Parallel()
-	testTransform(t, "testdata/allocs", transform.OptimizeAllocs)
+	testTransform(t, "testdata/allocs", func(mod llvm.Module) {
+		transform.OptimizeAllocs(mod, nil, nil)
+	})
+}
+
+type allocsTestOutput struct {
+	filename string
+	line     int
+	msg      string
+}
+
+func (out allocsTestOutput) String() string {
+	return out.filename + ":" + strconv.Itoa(out.line) + ": " + out.msg
+}
+
+// Test with a Go file as input (for more accurate tests).
+func TestAllocs2(t *testing.T) {
+	t.Parallel()
+
+	target, err := compileopts.LoadTarget("i686--linux")
+	if err != nil {
+		t.Fatal("failed to load target:", err)
+	}
+	config := &compileopts.Config{
+		Options: &compileopts.Options{},
+		Target:  target,
+	}
+	compilerConfig := &compiler.Config{
+		Triple:             config.Triple(),
+		GOOS:               config.GOOS(),
+		GOARCH:             config.GOARCH(),
+		CodeModel:          config.CodeModel(),
+		RelocationModel:    config.RelocationModel(),
+		Scheduler:          config.Scheduler(),
+		FuncImplementation: config.FuncImplementation(),
+		AutomaticStackSize: config.AutomaticStackSize(),
+		Debug:              true,
+	}
+	machine, err := compiler.NewTargetMachine(compilerConfig)
+	if err != nil {
+		t.Fatal("failed to create target machine:", err)
+	}
+
+	// Load entire program AST into memory.
+	lprogram, err := loader.Load(config, []string{"./testdata/allocs2.go"}, config.ClangHeaders, types.Config{
+		Sizes: compiler.Sizes(machine),
+	})
+	if err != nil {
+		t.Fatal("failed to create target machine:", err)
+	}
+	err = lprogram.Parse()
+	if err != nil {
+		t.Fatal("could not parse", err)
+	}
+
+	// Compile AST to IR.
+	program := lprogram.LoadSSA()
+	pkg := lprogram.MainPkg()
+	mod, errs := compiler.CompilePackage("allocs2.go", pkg, program.Package(pkg.Pkg), machine, compilerConfig, false)
+	if errs != nil {
+		for _, err := range errs {
+			t.Error(err)
+		}
+		return
+	}
+
+	// Run functionattrs pass, which is necessary for escape analysis.
+	pm := llvm.NewPassManager()
+	defer pm.Dispose()
+	pm.AddInstructionCombiningPass()
+	pm.AddFunctionAttrsPass()
+	pm.Run(mod)
+
+	// Run heap to stack transform.
+	var testOutputs []allocsTestOutput
+	transform.OptimizeAllocs(mod, regexp.MustCompile("."), func(pos token.Position, msg string) {
+		testOutputs = append(testOutputs, allocsTestOutput{
+			filename: filepath.Base(pos.Filename),
+			line:     pos.Line,
+			msg:      msg,
+		})
+	})
+	sort.Slice(testOutputs, func(i, j int) bool {
+		return testOutputs[i].line < testOutputs[j].line
+	})
+	testOutput := ""
+	for _, out := range testOutputs {
+		testOutput += out.String() + "\n"
+	}
+
+	// Load expected test output (the OUT: lines).
+	testInput, err := ioutil.ReadFile("./testdata/allocs2.go")
+	if err != nil {
+		t.Fatal("could not read test input:", err)
+	}
+	var expectedTestOutput string
+	for i, line := range strings.Split(strings.ReplaceAll(string(testInput), "\r\n", "\n"), "\n") {
+		if idx := strings.Index(line, " // OUT: "); idx > 0 {
+			msg := line[idx+len(" // OUT: "):]
+			expectedTestOutput += "allocs2.go:" + strconv.Itoa(i+1) + ": " + msg + "\n"
+		}
+	}
+
+	if testOutput != expectedTestOutput {
+		t.Errorf("output does not match expected output:\n%s", testOutput)
+	}
 }

--- a/transform/func-lowering_test.go
+++ b/transform/func-lowering_test.go
@@ -1,10 +1,12 @@
-package transform
+package transform_test
 
 import (
 	"testing"
+
+	"github.com/tinygo-org/tinygo/transform"
 )
 
 func TestFuncLowering(t *testing.T) {
 	t.Parallel()
-	testTransform(t, "testdata/func-lowering", LowerFuncValues)
+	testTransform(t, "testdata/func-lowering", transform.LowerFuncValues)
 }

--- a/transform/gc_test.go
+++ b/transform/gc_test.go
@@ -1,21 +1,22 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
 func TestAddGlobalsBitmap(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/gc-globals", func(mod llvm.Module) {
-		AddGlobalsBitmap(mod)
+		transform.AddGlobalsBitmap(mod)
 	})
 }
 
 func TestMakeGCStackSlots(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/gc-stackslots", func(mod llvm.Module) {
-		MakeGCStackSlots(mod)
+		transform.MakeGCStackSlots(mod)
 	})
 }

--- a/transform/globals_test.go
+++ b/transform/globals_test.go
@@ -1,14 +1,15 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
 func TestApplyFunctionSections(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/globals-function-sections", func(mod llvm.Module) {
-		ApplyFunctionSections(mod)
+		transform.ApplyFunctionSections(mod)
 	})
 }

--- a/transform/goroutine_test.go
+++ b/transform/goroutine_test.go
@@ -1,14 +1,16 @@
-package transform
+package transform_test
 
 import (
 	"testing"
+
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
 func TestGoroutineLowering(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/coroutines", func(mod llvm.Module) {
-		err := LowerCoroutines(mod, false)
+		err := transform.LowerCoroutines(mod, false)
 		if err != nil {
 			panic(err)
 		}

--- a/transform/interface-lowering_test.go
+++ b/transform/interface-lowering_test.go
@@ -1,15 +1,16 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
 func TestInterfaceLowering(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/interface", func(mod llvm.Module) {
-		err := LowerInterfaces(mod, 0)
+		err := transform.LowerInterfaces(mod, 0)
 		if err != nil {
 			t.Error(err)
 		}

--- a/transform/interrupt_test.go
+++ b/transform/interrupt_test.go
@@ -1,8 +1,9 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -11,7 +12,7 @@ func TestInterruptLowering(t *testing.T) {
 	for _, subtest := range []string{"avr", "cortexm"} {
 		t.Run(subtest, func(t *testing.T) {
 			testTransform(t, "testdata/interrupt-"+subtest, func(mod llvm.Module) {
-				errs := LowerInterrupts(mod, 0)
+				errs := transform.LowerInterrupts(mod, 0)
 				if len(errs) != 0 {
 					t.Fail()
 					for _, err := range errs {

--- a/transform/maps_test.go
+++ b/transform/maps_test.go
@@ -1,8 +1,9 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -10,7 +11,7 @@ func TestOptimizeMaps(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/maps", func(mod llvm.Module) {
 		// Run optimization pass.
-		OptimizeMaps(mod)
+		transform.OptimizeMaps(mod)
 
 		// Run an optimization pass, to clean up the result.
 		// This shows that all code related to the map is really eliminated.

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -3,6 +3,8 @@ package transform
 import (
 	"errors"
 	"fmt"
+	"go/token"
+	"os"
 
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/compiler/ircheck"
@@ -65,7 +67,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		OptimizeMaps(mod)
 		OptimizeStringToBytes(mod)
 		OptimizeReflectImplements(mod)
-		OptimizeAllocs(mod)
+		OptimizeAllocs(mod, nil, nil)
 		err := LowerInterfaces(mod, sizeLevel)
 		if err != nil {
 			return []error{err}
@@ -86,7 +88,9 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		goPasses.Run(mod)
 
 		// Run TinyGo-specific interprocedural optimizations.
-		OptimizeAllocs(mod)
+		OptimizeAllocs(mod, config.Options.PrintAllocs, func(pos token.Position, msg string) {
+			fmt.Fprintln(os.Stderr, pos.String()+": "+msg)
+		})
 		OptimizeStringToBytes(mod)
 		OptimizeStringEqual(mod)
 

--- a/transform/panic_test.go
+++ b/transform/panic_test.go
@@ -1,10 +1,12 @@
-package transform
+package transform_test
 
 import (
 	"testing"
+
+	"github.com/tinygo-org/tinygo/transform"
 )
 
 func TestReplacePanicsWithTrap(t *testing.T) {
 	t.Parallel()
-	testTransform(t, "testdata/panic", ReplacePanicsWithTrap)
+	testTransform(t, "testdata/panic", transform.ReplacePanicsWithTrap)
 }

--- a/transform/rtcalls_test.go
+++ b/transform/rtcalls_test.go
@@ -1,8 +1,9 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -10,7 +11,7 @@ func TestOptimizeStringToBytes(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/stringtobytes", func(mod llvm.Module) {
 		// Run optimization pass.
-		OptimizeStringToBytes(mod)
+		transform.OptimizeStringToBytes(mod)
 	})
 }
 
@@ -18,7 +19,7 @@ func TestOptimizeStringEqual(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/stringequal", func(mod llvm.Module) {
 		// Run optimization pass.
-		OptimizeStringEqual(mod)
+		transform.OptimizeStringEqual(mod)
 	})
 }
 
@@ -26,6 +27,6 @@ func TestOptimizeReflectImplements(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/reflect-implements", func(mod llvm.Module) {
 		// Run optimization pass.
-		OptimizeReflectImplements(mod)
+		transform.OptimizeReflectImplements(mod)
 	})
 }

--- a/transform/stacksize_test.go
+++ b/transform/stacksize_test.go
@@ -1,9 +1,10 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -11,7 +12,7 @@ func TestCreateStackSizeLoads(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/stacksize", func(mod llvm.Module) {
 		// Run optimization pass.
-		CreateStackSizeLoads(mod, &compileopts.Config{
+		transform.CreateStackSizeLoads(mod, &compileopts.Config{
 			Target: &compileopts.TargetSpec{
 				DefaultStackSize: 1024,
 			},

--- a/transform/testdata/allocs2.go
+++ b/transform/testdata/allocs2.go
@@ -22,6 +22,13 @@ func main() {
 
 	s4 := make([]byte, 300) // OUT: object allocated on the heap: object size 300 exceeds maximum stack allocation size 256
 	readByteSlice(s4)
+
+	s5 := make([]int, 4) // OUT: object allocated on the heap: escapes at line 27
+	s5 = append(s5, 5)
+
+	s6 := make([]int, 3)
+	s7 := []int{1, 2, 3}
+	copySlice(s6, s7)
 }
 
 func derefInt(x *int) int {
@@ -45,3 +52,7 @@ func returnIntSlice(s []int) []int {
 }
 
 func getUnknownNumber() int
+
+func copySlice(out, in []int) {
+	copy(out, in)
+}

--- a/transform/testdata/allocs2.go
+++ b/transform/testdata/allocs2.go
@@ -1,0 +1,47 @@
+package main
+
+func main() {
+	n1 := 5
+	derefInt(&n1)
+
+	// This should eventually be modified to not escape.
+	n2 := 6 // OUT: object allocated on the heap: escapes at line 9
+	returnIntPtr(&n2)
+
+	s1 := make([]int, 3)
+	readIntSlice(s1)
+
+	s2 := [3]int{}
+	readIntSlice(s2[:])
+
+	// This should also be modified to not escape.
+	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 19
+	returnIntSlice(s3)
+
+	_ = make([]int, getUnknownNumber()) // OUT: object allocated on the heap: size is not constant
+
+	s4 := make([]byte, 300) // OUT: object allocated on the heap: object size 300 exceeds maximum stack allocation size 256
+	readByteSlice(s4)
+}
+
+func derefInt(x *int) int {
+	return *x
+}
+
+func returnIntPtr(x *int) *int {
+	return x
+}
+
+func readIntSlice(s []int) int {
+	return s[1]
+}
+
+func readByteSlice(s []byte) byte {
+	return s[1]
+}
+
+func returnIntSlice(s []int) []int {
+	return s
+}
+
+func getUnknownNumber() int

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -1,4 +1,4 @@
-package transform
+package transform_test
 
 // This file defines some helper functions for testing transforms.
 

--- a/transform/wasm-abi_test.go
+++ b/transform/wasm-abi_test.go
@@ -1,8 +1,9 @@
-package transform
+package transform_test
 
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -10,7 +11,7 @@ func TestWasmABI(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/wasm-abi", func(mod llvm.Module) {
 		// Run ABI change pass.
-		err := ExternalInt64AsPtr(mod)
+		err := transform.ExternalInt64AsPtr(mod)
 		if err != nil {
 			t.Errorf("failed to change wasm ABI: %v", err)
 		}


### PR DESCRIPTION
This flag, if set, is a regexp for function names. If there are heap
allocations in the matching function names, these heap allocations will
be printed with an explanation why the heap allocation exists (and why
the object can't be stack allocated).

TODO: write tests.