### PR TITLE
ci: improve llvm-build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-11-linux-v2-assert
+            - llvm-build-11-linux-v3-assert
       - run:
           name: "Build LLVM"
           command: |
@@ -173,9 +173,10 @@ commands:
               chmod +x /go/bin/ninja
               # build!
               make ASSERT=1 llvm-build
+              find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
             fi
       - save_cache:
-          key: llvm-build-11-linux-v2-assert
+          key: llvm-build-11-linux-v3-assert
           paths:
             llvm-build
       - run: make ASSERT=1
@@ -224,7 +225,7 @@ commands:
       - llvm-source-linux
       - restore_cache:
           keys:
-            - llvm-build-11-linux-v2-noassert
+            - llvm-build-11-linux-v3-noassert
       - run:
           name: "Build LLVM"
           command: |
@@ -240,9 +241,10 @@ commands:
               chmod +x /go/bin/ninja
               # build!
               make llvm-build
+              find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
             fi
       - save_cache:
-          key: llvm-build-11-linux-v2-noassert
+          key: llvm-build-11-linux-v3-noassert
           paths:
             llvm-build
       - build-wasi-libc
@@ -309,7 +311,7 @@ commands:
             - llvm-project/llvm/include
       - restore_cache:
           keys:
-            - llvm-build-11-macos-v2
+            - llvm-build-11-macos-v3
       - run:
           name: "Build LLVM"
           command: |
@@ -322,9 +324,10 @@ commands:
               HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
               # build!
               make llvm-build
+              find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
             fi
       - save_cache:
-          key: llvm-build-11-macos-v2
+          key: llvm-build-11-macos-v3
           paths:
             llvm-build
       - restore_cache:


### PR DESCRIPTION
This PR makes restoring-cache-llvm-build faster.
As described in #1796, the processing time is reduced from 11 sec to 7 sec.

This PR should work fine, but you need to make sure that the CI runs through twice.
Set it to draft PR once until the `2.` is confirmed.

1. Check the behavior without cache in the first CI.
2. Check the next CI to see how it works when cache is present