### PR TITLE
machine: avoid heap allocations in USB code

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -2298,7 +2298,7 @@ func handleStandardSetup(setup usbSetup) bool {
 func cdcSetup(setup usbSetup) bool {
 	if setup.bmRequestType == usb_REQUEST_DEVICETOHOST_CLASS_INTERFACE {
 		if setup.bRequest == usb_CDC_GET_LINE_CODING {
-			b := make([]byte, 7)
+			var b [cdcLineInfoSize]byte
 			b[0] = byte(usbLineInfo.dwDTERate)
 			b[1] = byte(usbLineInfo.dwDTERate >> 8)
 			b[2] = byte(usbLineInfo.dwDTERate >> 16)
@@ -2307,14 +2307,18 @@ func cdcSetup(setup usbSetup) bool {
 			b[5] = byte(usbLineInfo.bParityType)
 			b[6] = byte(usbLineInfo.bDataBits)
 
-			sendUSBPacket(0, b)
+			sendUSBPacket(0, b[:])
 			return true
 		}
 	}
 
 	if setup.bmRequestType == usb_REQUEST_HOSTTODEVICE_CLASS_INTERFACE {
 		if setup.bRequest == usb_CDC_SET_LINE_CODING {
-			b := receiveUSBControlPacket()
+			b, err := receiveUSBControlPacket()
+			if err != nil {
+				return false
+			}
+
 			usbLineInfo.dwDTERate = uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
 			usbLineInfo.bCharFormat = b[4]
 			usbLineInfo.bParityType = b[5]
@@ -2361,7 +2365,9 @@ func sendUSBPacket(ep uint32, data []byte) {
 	usbEndpointDescriptors[ep].DeviceDescBank[1].PCKSIZE.SetBits(uint32((len(data) & usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask) << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos))
 }
 
-func receiveUSBControlPacket() []byte {
+func receiveUSBControlPacket() ([cdcLineInfoSize]byte, error) {
+	var b [cdcLineInfoSize]byte
+
 	// address
 	usbEndpointDescriptors[0].DeviceDescBank[0].ADDR.Set(uint32(uintptr(unsafe.Pointer(&udd_ep_out_cache_buffer[0]))))
 
@@ -2376,7 +2382,7 @@ func receiveUSBControlPacket() []byte {
 	for (getEPSTATUS(0) & sam.USB_DEVICE_EPSTATUS_BK0RDY) == 0 {
 		timeout--
 		if timeout == 0 {
-			return []byte{}
+			return b, errUSBCDCReadTimeout
 		}
 	}
 
@@ -2385,7 +2391,7 @@ func receiveUSBControlPacket() []byte {
 	for (getEPINTFLAG(0) & sam.USB_DEVICE_EPINTFLAG_TRCPT0) == 0 {
 		timeout--
 		if timeout == 0 {
-			return []byte{}
+			return b, errUSBCDCReadTimeout
 		}
 	}
 
@@ -2393,10 +2399,13 @@ func receiveUSBControlPacket() []byte {
 	bytesread := uint32((usbEndpointDescriptors[0].DeviceDescBank[0].PCKSIZE.Get() >>
 		usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos) & usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask)
 
-	data := make([]byte, bytesread)
-	copy(data, udd_ep_out_cache_buffer[0][:])
+	if bytesread != cdcLineInfoSize {
+		return b, errUSBCDCBytesRead
+	}
 
-	return data
+	copy(b[:7], udd_ep_out_cache_buffer[0][:7])
+
+	return b, nil
 }
 
 func handleEndpoint(ep uint32) {

--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -445,7 +445,7 @@ func handleStandardSetup(setup usbSetup) bool {
 func cdcSetup(setup usbSetup) bool {
 	if setup.bmRequestType == usb_REQUEST_DEVICETOHOST_CLASS_INTERFACE {
 		if setup.bRequest == usb_CDC_GET_LINE_CODING {
-			b := make([]byte, 7)
+			var b [cdcLineInfoSize]byte
 			b[0] = byte(usbLineInfo.dwDTERate)
 			b[1] = byte(usbLineInfo.dwDTERate >> 8)
 			b[2] = byte(usbLineInfo.dwDTERate >> 16)
@@ -454,7 +454,7 @@ func cdcSetup(setup usbSetup) bool {
 			b[5] = byte(usbLineInfo.bParityType)
 			b[6] = byte(usbLineInfo.bDataBits)
 
-			sendUSBPacket(0, b)
+			sendUSBPacket(0, b[:])
 			return true
 		}
 	}

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -43,8 +43,8 @@ func NewDeviceDescriptor(class, subClass, proto, packetSize0 uint8, vid, pid, ve
 }
 
 // Bytes returns DeviceDescriptor data
-func (d DeviceDescriptor) Bytes() []byte {
-	b := make([]byte, deviceDescriptorSize)
+func (d DeviceDescriptor) Bytes() [deviceDescriptorSize]byte {
+	var b [deviceDescriptorSize]byte
 	b[0] = byte(d.bLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.bcdUSB)
@@ -91,8 +91,8 @@ func NewConfigDescriptor(totalLength uint16, interfaces uint8) ConfigDescriptor 
 }
 
 // Bytes returns ConfigDescriptor data.
-func (d ConfigDescriptor) Bytes() []byte {
-	b := make([]byte, configDescriptorSize)
+func (d ConfigDescriptor) Bytes() [configDescriptorSize]byte {
+	var b [configDescriptorSize]byte
 	b[0] = byte(d.bLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.wTotalLength)
@@ -131,8 +131,8 @@ func NewInterfaceDescriptor(n, numEndpoints, class, subClass, protocol uint8) In
 }
 
 // Bytes returns InterfaceDescriptor data.
-func (d InterfaceDescriptor) Bytes() []byte {
-	b := make([]byte, interfaceDescriptorSize)
+func (d InterfaceDescriptor) Bytes() [interfaceDescriptorSize]byte {
+	var b [interfaceDescriptorSize]byte
 	b[0] = byte(d.bLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.bInterfaceNumber)
@@ -167,8 +167,8 @@ func NewEndpointDescriptor(addr, attr uint8, packetSize uint16, interval uint8) 
 }
 
 // Bytes returns EndpointDescriptor data.
-func (d EndpointDescriptor) Bytes() []byte {
-	b := make([]byte, endpointDescriptorSize)
+func (d EndpointDescriptor) Bytes() [endpointDescriptorSize]byte {
+	var b [endpointDescriptorSize]byte
 	b[0] = byte(d.bLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.bEndpointAddress)
@@ -205,8 +205,8 @@ func NewIADDescriptor(firstInterface, count, class, subClass, protocol uint8) IA
 }
 
 // Bytes returns IADDescriptor data.
-func (d IADDescriptor) Bytes() []byte {
-	b := make([]byte, iadDescriptorSize)
+func (d IADDescriptor) Bytes() [iadDescriptorSize]byte {
+	var b [iadDescriptorSize]byte
 	b[0] = byte(d.bLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.bFirstInterface)
@@ -235,8 +235,8 @@ func NewCDCCSInterfaceDescriptor(subtype, d0, d1 uint8) CDCCSInterfaceDescriptor
 }
 
 // Bytes returns CDCCSInterfaceDescriptor data.
-func (d CDCCSInterfaceDescriptor) Bytes() []byte {
-	b := make([]byte, cdcCSInterfaceDescriptorSize)
+func (d CDCCSInterfaceDescriptor) Bytes() [cdcCSInterfaceDescriptorSize]byte {
+	var b [cdcCSInterfaceDescriptorSize]byte
 	b[0] = byte(d.len)
 	b[1] = byte(d.dtype)
 	b[2] = byte(d.subtype)
@@ -262,8 +262,8 @@ func NewCMFunctionalDescriptor(subtype, d0, d1 uint8) CMFunctionalDescriptor {
 }
 
 // Bytes returns the CMFunctionalDescriptor data.
-func (d CMFunctionalDescriptor) Bytes() []byte {
-	b := make([]byte, cmFunctionalDescriptorSize)
+func (d CMFunctionalDescriptor) Bytes() [cmFunctionalDescriptorSize]byte {
+	var b [cmFunctionalDescriptorSize]byte
 	b[0] = byte(d.bFunctionLength)
 	b[1] = byte(d.bDescriptorType)
 	b[2] = byte(d.bDescriptorSubtype)
@@ -288,8 +288,8 @@ func NewACMFunctionalDescriptor(subtype, d0 uint8) ACMFunctionalDescriptor {
 }
 
 // Bytes returns the ACMFunctionalDescriptor data.
-func (d ACMFunctionalDescriptor) Bytes() []byte {
-	b := make([]byte, acmFunctionalDescriptorSize)
+func (d ACMFunctionalDescriptor) Bytes() [acmFunctionalDescriptorSize]byte {
+	var b [acmFunctionalDescriptorSize]byte
 	b[0] = byte(d.len)
 	b[1] = byte(d.dtype)
 	b[2] = byte(d.subtype)
@@ -351,19 +351,51 @@ const cdcSize = iadDescriptorSize +
 	endpointDescriptorSize
 
 // Bytes returns CDCDescriptor data.
-func (d CDCDescriptor) Bytes() []byte {
-	var buf []byte
-	buf = append(buf, d.iad.Bytes()...)
-	buf = append(buf, d.cif.Bytes()...)
-	buf = append(buf, d.header.Bytes()...)
-	buf = append(buf, d.controlManagement.Bytes()...)
-	buf = append(buf, d.functionalDescriptor.Bytes()...)
-	buf = append(buf, d.callManagement.Bytes()...)
-	buf = append(buf, d.cifin.Bytes()...)
-	buf = append(buf, d.dif.Bytes()...)
-	buf = append(buf, d.out.Bytes()...)
-	buf = append(buf, d.in.Bytes()...)
-	return buf
+func (d CDCDescriptor) Bytes() [cdcSize]byte {
+	var b [cdcSize]byte
+	offset := 0
+
+	iad := d.iad.Bytes()
+	copy(b[offset:], iad[:])
+	offset += len(iad)
+
+	cif := d.cif.Bytes()
+	copy(b[offset:], cif[:])
+	offset += len(cif)
+
+	header := d.header.Bytes()
+	copy(b[offset:], header[:])
+	offset += len(header)
+
+	controlManagement := d.controlManagement.Bytes()
+	copy(b[offset:], controlManagement[:])
+	offset += len(controlManagement)
+
+	functionalDescriptor := d.functionalDescriptor.Bytes()
+	copy(b[offset:], functionalDescriptor[:])
+	offset += len(functionalDescriptor)
+
+	callManagement := d.callManagement.Bytes()
+	copy(b[offset:], callManagement[:])
+	offset += len(callManagement)
+
+	cifin := d.cifin.Bytes()
+	copy(b[offset:], cifin[:])
+	offset += len(cifin)
+
+	dif := d.dif.Bytes()
+	copy(b[offset:], dif[:])
+	offset += len(dif)
+
+	out := d.out.Bytes()
+	copy(b[offset:], out[:])
+	offset += len(out)
+
+	in := d.in.Bytes()
+	copy(b[offset:], in[:])
+	offset += len(in)
+
+	return b
 }
 
 // MSCDescriptor is not used yet.
@@ -633,7 +665,8 @@ func sendDescriptor(setup usbSetup) {
 		if setup.wLength < deviceDescriptorSize {
 			l = int(setup.wLength)
 		}
-		sendUSBPacket(0, dd.Bytes()[:l])
+		buf := dd.Bytes()
+		sendUSBPacket(0, buf[:l])
 		return
 
 	case usb_STRING_DESCRIPTOR_TYPE:
@@ -669,7 +702,8 @@ func sendConfiguration(setup usbSetup) {
 	if setup.wLength == 9 {
 		sz := uint16(configDescriptorSize + cdcSize)
 		config := NewConfigDescriptor(sz, 2)
-		sendUSBPacket(0, config.Bytes())
+		configBuf := config.Bytes()
+		sendUSBPacket(0, configBuf[:])
 	} else {
 		iad := NewIADDescriptor(0, 2, usb_CDC_COMMUNICATION_INTERFACE_CLASS, usb_CDC_ABSTRACT_CONTROL_MODEL, 0)
 
@@ -705,10 +739,12 @@ func sendConfiguration(setup usbSetup) {
 		sz := uint16(configDescriptorSize + cdcSize)
 		config := NewConfigDescriptor(sz, 2)
 
-		buf := make([]byte, 0, sz)
-		buf = append(buf, config.Bytes()...)
-		buf = append(buf, cdc.Bytes()...)
+		configBuf := config.Bytes()
+		cdcBuf := cdc.Bytes()
+		var buf [configDescriptorSize + cdcSize]byte
+		copy(buf[0:], configBuf[:])
+		copy(buf[configDescriptorSize:], cdcBuf[:])
 
-		sendUSBPacket(0, buf)
+		sendUSBPacket(0, buf[:])
 	}
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -12,6 +12,8 @@ const deviceDescriptorSize = 18
 var (
 	errUSBCDCBufferEmpty      = errors.New("USB-CDC buffer empty")
 	errUSBCDCWriteByteTimeout = errors.New("USB-CDC write byte timeout")
+	errUSBCDCReadTimeout      = errors.New("USB-CDC read timeout")
+	errUSBCDCBytesRead        = errors.New("USB-CDC invalid number of bytes read")
 )
 
 // DeviceDescriptor implements the USB standard device descriptor.
@@ -404,6 +406,8 @@ type MSCDescriptor struct {
 	in  EndpointDescriptor
 	out EndpointDescriptor
 }
+
+const cdcLineInfoSize = 7
 
 type cdcLineInfo struct {
 	dwDTERate   uint32


### PR DESCRIPTION
This commit replaces most heap allocations in USB related code with stack allocations. This is important for several reasons:

  - It avoids running the GC unnecessarily.
  - It reduces code size by 400-464 bytes.
  - USB code might be called from interrupt handlers. The heap may be in an inconsistent state when that happens if main thread code also performs heap allocations.

The last one is by far the most important one: not doing heap allocations in interrupts is critical for correctness. But the code size reduction alone should be worth it.

There are two heap allocations in USB related code left: in the function `receiveUSBControlPacket` (SAMD21 and SAMD51). This heap allocation must also be removed because it runs in an interrupt, but I've left that for a future change.

---

This PR is made easy by the change in #1821, which provides a convenient way of showing all heap allocations in the code or in a single package (in this case, the machine package).
Eventually this USB code will likely be replaced by the new USB stack that's being written by @ardnew but it's a relatively simple improvement until that work is complete.

@deadprogram can you maybe take a look at `receiveUSBControlPacket`? I see that the callers only use the first 7 bytes, so it should be relatively simple to replace with a `[7]byte` but I'm not sure what to do with `bytesread`.