### PR TITLE
atsamd51: fix PWM support in atsamd51p20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.gba -target=gameboy-advance     examples/gba-display
 	@$(MD5SUM) test.gba
+	$(TINYGO) build -size short -o test.hex -target=grandcentral-m4     examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m4        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m4          examples/blinky1

--- a/src/machine/machine_atsamd51p20.go
+++ b/src/machine/machine_atsamd51p20.go
@@ -11,60 +11,49 @@ import "device/sam"
 
 const HSRAM_SIZE = 0x00040000
 
-// InitPWM initializes the PWM interface.
-func InitPWM() {
-	// turn on timer clocks used for PWM
-	sam.MCLK.APBBMASK.SetBits(sam.MCLK_APBBMASK_TCC0_ | sam.MCLK_APBBMASK_TCC1_)
-	sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TCC2_ | sam.MCLK_APBCMASK_TCC3_)
-	sam.MCLK.APBDMASK.SetBits(sam.MCLK_APBDMASK_TCC4_)
+// This chip has five TCC peripherals, which have PWM as one feature.
+var (
+	TCC0 = (*TCC)(sam.TCC0)
+	TCC1 = (*TCC)(sam.TCC1)
+	TCC2 = (*TCC)(sam.TCC2)
+	TCC3 = (*TCC)(sam.TCC3)
+	TCC4 = (*TCC)(sam.TCC4)
+)
 
-	//use clock generator 0
-	sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC0].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) |
-		sam.GCLK_PCHCTRL_CHEN)
-	sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC2].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) |
-		sam.GCLK_PCHCTRL_CHEN)
-	sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC4].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) |
-		sam.GCLK_PCHCTRL_CHEN)
+func (tcc *TCC) configureClock() {
+	// Turn on timer clocks used for TCC and use generic clock generator 0.
+	switch tcc.timer() {
+	case sam.TCC0:
+		sam.MCLK.APBBMASK.SetBits(sam.MCLK_APBBMASK_TCC0_)
+		sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC0].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) | sam.GCLK_PCHCTRL_CHEN)
+	case sam.TCC1:
+		sam.MCLK.APBBMASK.SetBits(sam.MCLK_APBBMASK_TCC1_)
+		sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC1].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) | sam.GCLK_PCHCTRL_CHEN)
+	case sam.TCC2:
+		sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TCC2_)
+		sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC2].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) | sam.GCLK_PCHCTRL_CHEN)
+	case sam.TCC3:
+		sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TCC3_)
+		sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC3].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) | sam.GCLK_PCHCTRL_CHEN)
+	case sam.TCC4:
+		sam.MCLK.APBDMASK.SetBits(sam.MCLK_APBDMASK_TCC4_)
+		sam.GCLK.PCHCTRL[sam.PCHCTRL_GCLK_TCC4].Set((sam.GCLK_PCHCTRL_GEN_GCLK0 << sam.GCLK_PCHCTRL_GEN_Pos) | sam.GCLK_PCHCTRL_CHEN)
+	}
 }
 
-// getTimer returns the timer to be used for PWM on this pin
-func (pwm PWM) getTimer() *sam.TCC_Type {
-	switch pwm.Pin {
-	case PC18:
-		return sam.TCC0
-	case PC19:
-		return sam.TCC0
-	case PC20:
-		return sam.TCC0
-	case PC21:
-		return sam.TCC0
-	case PD20:
-		return sam.TCC1
-	case PD21:
-		return sam.TCC1
-	case PB18:
-		return sam.TCC1
-	case PB12:
-		return sam.TCC3
-	case PB13:
-		return sam.TCC3
-	case PA15:
-		return sam.TCC2
-	case PC17:
-		return sam.TCC0
-	case PC16:
-		return sam.TCC0
-	case PA14:
-		return sam.TCC2
-	case PB15:
-		return sam.TCC4
-	case PB14:
-		return sam.TCC4
-	case PB20:
-		return sam.TCC1
-	case PB21:
-		return sam.TCC1
+func (tcc *TCC) timerNum() uint8 {
+	switch tcc.timer() {
+	case sam.TCC0:
+		return 0
+	case sam.TCC1:
+		return 1
+	case sam.TCC2:
+		return 2
+	case sam.TCC3:
+		return 3
+	case sam.TCC4:
+		return 4
 	default:
-		return nil // not supported on this pin
+		return 0x0f // should not happen
 	}
 }


### PR DESCRIPTION
This change is related to the following commit / PR.

* 72acda22b0a8d137405e41e9ed54cbfbcce7b26f
* https://github.com/tinygo-org/tinygo/pull/1802

before:
```
sago3@B450GT3 MINGW64 /c/tinygo/tinygo (dev)
$ git rev-parse HEAD
7b761fac7805083dd0263ed376b10e106726ef8f

sago3@B450GT3 MINGW64 /c/tinygo/tinygo (dev)
$ tinygo build -size short -o test.hex -target=grandcentral-m4     examples/blinky1
# machine
..\..\Users\sago3\AppData\Local\tinygo\goroot-go1.16-2c7b295584fef4b6f660ace5f5ad5c3464736a489c31cee94222c4e016a06373-syscall\src\machine\machine_atsamd51p20.go:31:11: undeclared name: PWM
..\..\Users\sago3\AppData\Local\tinygo\goroot-go1.16-2c7b295584fef4b6f660ace5f5ad5c3464736a489c31cee94222c4e016a06373-syscall\src\machine\machine_atsamd51.go:1587:6: tcc.configureClock undefined (type *TCC has no field or method configureClock)
..\..\Users\sago3\AppData\Local\tinygo\goroot-go1.16-2c7b295584fef4b6f660ace5f5ad5c3464736a489c31cee94222c4e016a06373-syscall\src\machine\machine_atsamd51.go:1847:47: tcc.timerNum undefined (type *TCC has no field or method timerNum)

```

after:
```
sago3@B450GT3 MINGW64 /c/tinygo/tinygo (atsamd51p20)
$ git rev-parse HEAD
d9afb666a2a4e5f51c20a6ae904a0e559d3e9ec8

sago3@B450GT3 MINGW64 /c/tinygo/tinygo (atsamd51p20)
$ tinygo build -size short -o test.hex -target=grandcentral-m4     examples/blinky1
   code    data     bss |   flash     ram
   8104      20    6356 |    8124    6376

```