### PR TITLE
atsamd51 atsame5x: change to allow specifying the ADC Bus number

### DIFF
--- a/src/examples/adc/adc.go
+++ b/src/examples/adc/adc.go
@@ -14,7 +14,7 @@ func main() {
 	led := machine.LED
 	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
 
-	sensor := machine.ADC{machine.ADC2}
+	sensor := machine.ADC{Pin: machine.ADC2}
 	sensor.Configure(machine.ADCConfig{})
 
 	for {

--- a/src/machine/adc.go
+++ b/src/machine/adc.go
@@ -9,4 +9,11 @@ type ADCConfig struct {
 	Reference  uint32 // analog reference voltage (AREF) in millivolts
 	Resolution uint32 // number of bits for a single conversion (e.g., 8, 10, 12)
 	Samples    uint32 // number of samples for a single conversion (e.g., 4, 8, 16, 32)
+	Bus        uint8  // bus Number of ADC
 }
+
+const (
+	AdcBusAuto = 0
+	AdcBus0    = 1
+	AdcBus1    = 2
+)

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -44,4 +44,5 @@ func (p Pin) Low() {
 
 type ADC struct {
 	Pin Pin
+	Bus uint8
 }

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -813,6 +813,18 @@ func (a ADC) Configure(config ADCConfig) {
 	}
 
 	a.Pin.Configure(PinConfig{Mode: PinAnalog})
+
+	switch config.Bus {
+	case AdcBusAuto:
+		bus := a.getADCBus()
+		if bus == sam.ADC0 {
+			a.Bus = 0
+		} else {
+			a.Bus = 1
+		}
+	default:
+		a.Bus = config.Bus
+	}
 }
 
 // Get returns the current value of a ADC pin, in the range 0..0xffff.
@@ -876,6 +888,12 @@ func (a ADC) Get() uint16 {
 }
 
 func (a ADC) getADCBus() *sam.ADC_Type {
+	if a.Bus == AdcBus0 {
+		return sam.ADC0
+	} else if a.Bus == AdcBus1 {
+		return sam.ADC1
+	}
+
 	if (a.Pin >= PB04 && a.Pin <= PB07) || (a.Pin >= PC00) {
 		return sam.ADC1
 	}
@@ -887,9 +905,17 @@ func (a ADC) getADCChannel() uint8 {
 	case PA02:
 		return 0
 	case PB08:
-		return 2
+		if a.Bus == AdcBus1 {
+			return 0
+		} else {
+			return 2
+		}
 	case PB09:
-		return 3
+		if a.Bus == AdcBus1 {
+			return 1
+		} else {
+			return 3
+		}
 	case PA04:
 		return 4
 	case PA05:


### PR DESCRIPTION
For PB08 and PB09, and PA08 and PA09, it was not possible to select which ADC instance to use until now.
Since the two ADC instances can be sampled at the same time, we want to be able to select which ADC instance to use.

> https://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D5x_E5x_Family_Data_Sheet_DS60001507G.pdf
> The SAM D5x/E5x has two ADC instances, ADC0 and ADC1.
> The two inputs can be sampled simultaneously, as each ADC includes sample and hold circuits.

|    | ADC0 | ADC1 |
| ---- | - | - |
| PB03 |  15 |  |
| PC00 |     |  10 |
| PC01 |     |  11 |
| PC02 |     |   4 |
| PC03 |     |   5 |
| PA02 |   0 |  |
| PA03 |   1 |  |
| PB04 |     |   6 |
| PB05 |     |   7 |
| PD00 |     |  14 |
| PD01 |     |  15 |
| PB06 |     |   8 |
| PB07 |     |   9 |
| PB08 |   2 |   0 |
| PB09 |   3 |   1 |
| PA04 |   4 |  |
| PA05 |   5 |  |
| PA06 |   6 |  |
| PA07 |   7 |  |
| PA08 |   8 |   2 |
| PA09 |   9 |   3 |
| PA10 |  10 |  |
| PA11 |  11 |  |
| PC30 |     |  12 |
| PC31 |     |  13 |
| PB00 |  12 |  |
| PB01 |  13 |  |
| PB02 |  14 |  |

I tried to change the source code, but there may be a better way.
Also, as I was making changes in src/examples/adc, I ended up with incompatible changes in environments other than atsamx5x.
Would it be better to make sure that all environments except atsamx5x are not incompatible?
