### PR TITLE
Target for Arduino Nano w/ new bootloader

### DIFF
--- a/targets/arduino-nano-new.json
+++ b/targets/arduino-nano-new.json
@@ -1,0 +1,4 @@
+{
+	"inherits": ["arduino-nano"],
+	"flash-command": "avrdude -c arduino -p atmega328p -b 115200 -P {port} -U flash:w:{hex}:i"
+}


### PR DESCRIPTION
Since January 2018, Arduino Nanos (and clones) are sold with a new bootloader (see [note](https://www.arduino.cc/en/Guide/ArduinoNano#:~:text=note)), which requires programming at 115200 baud instead of the 57600 baud required by the old one.

This PR adds a target for these new Nanos which simply inherits the "old" target but with a changed baud rate in the flash command.