### PR TITLE
Add -llvm-features parameter

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -94,6 +94,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		DefaultStackSize:   config.Target.DefaultStackSize,
 		NeedsStackObjects:  config.NeedsStackObjects(),
 		Debug:              config.Debug(),
+		LLVMFeatures:       config.LLVMFeatures(),
 	}
 
 	// Load the target machine, which is the LLVM object that contains all

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -337,6 +337,10 @@ func (c *Config) WasmAbi() string {
 	return c.Target.WasmAbi
 }
 
+func (c *Config) LLVMFeatures() string {
+	return c.Options.LLVMFeatures
+}
+
 type TestConfig struct {
 	CompileTestBinary bool
 	// TODO: Filter the test functions to run, include verbose flag, etc

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	TestConfig      TestConfig
 	Programmer      string
 	OpenOCDCommands []string
+	LLVMFeatures    string
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -59,6 +59,7 @@ type Config struct {
 	DefaultStackSize   uint64
 	NeedsStackObjects  bool
 	Debug              bool // Whether to emit debug information in the LLVM module.
+	LLVMFeatures       string
 }
 
 // compilerContext contains function-independent data that should still be
@@ -185,7 +186,12 @@ func NewTargetMachine(config *Config) (llvm.TargetMachine, error) {
 	if err != nil {
 		return llvm.TargetMachine{}, err
 	}
-	features := strings.Join(config.Features, ",")
+
+	feat := config.Features
+	if len(config.LLVMFeatures) > 0 {
+		feat = append(feat, config.LLVMFeatures)
+	}
+	features := strings.Join(feat, ",")
 
 	var codeModel llvm.CodeModel
 	var relocationModel llvm.RelocMode

--- a/main.go
+++ b/main.go
@@ -911,6 +911,7 @@ func main() {
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	ldflags := flag.String("ldflags", "", "Go link tool compatible ldflags")
 	wasmAbi := flag.String("wasm-abi", "", "WebAssembly ABI conventions: js (no i64 params) or generic")
+	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
 
 	var flagJSON, flagDeps *bool
 	if command == "help" || command == "list" {
@@ -978,6 +979,7 @@ func main() {
 		WasmAbi:         *wasmAbi,
 		Programmer:      *programmer,
 		OpenOCDCommands: ocdCommands,
+		LLVMFeatures:    *llvmFeatures,
 	}
 
 	os.Setenv("CC", "clang -target="+*target)


### PR DESCRIPTION
With this is possible to enable e.g., SIMD in WASM using `-llvm-features +simd128`.  
Multiple features can be specified separated by comma, e.g.,` -llvm-features +simd128,+tail-call`.