### PR TITLE
Support chained interrupt handlers

### DIFF
--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -41,10 +41,7 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	// type are lowered in the interrupt lowering pass.
 	globalType := b.program.ImportedPackage("runtime/interrupt").Type("handle").Type()
 	globalLLVMType := b.getLLVMType(globalType)
-	globalName := "runtime/interrupt.$interrupt" + strconv.FormatInt(id.Int64(), 10)
-	if global := b.mod.NamedGlobal(globalName); !global.IsNil() {
-		return llvm.Value{}, b.makeError(instr.Pos(), "interrupt redeclared in this program")
-	}
+	globalName := b.fn.Package().Pkg.Path() + "$interrupt" + strconv.FormatInt(id.Int64(), 10)
 	global := llvm.AddGlobal(b.mod, globalLLVMType, globalName)
 	global.SetVisibility(llvm.HiddenVisibility)
 	global.SetGlobalConstant(true)


### PR DESCRIPTION
Multiple calls to interrupt.New are permitted with handlers called sequentially in undefined order.

The implementation works by changing the interrupt 'wrapper' from always being a single call to the actual handler, to being multiple calls to all the handlers in the chain in sequence.

Most of the change is re-arranging the interrupt lowering code such that it's possible to loop over multiple handlers with the same interrupt number when generating the wrapper function.

By way of example, this:
```golang
package main

import (
	"runtime/interrupt"
)

func handler1(interrupt.Interrupt) {
	println("h1")
}

func handler2(interrupt.Interrupt) {
	println("h2")
}

func main() {
	intr1 := interrupt.New(22, handler1)
	intr1.Enable()

	intr2 := interrupt.New(22, handler2)
	intr2.Enable()
}
```

The interrupt handler compiles to this at default optimization level (CAN1_SCE_IRQHandler is interrupt 22 on this device):
```asm
.text:08000d60 <CAN1_SCE_IRQHandler>:
    .text:08000d60 80 b5                            push	{r7, lr}
    .text:08000d62 41 f2 4a 00                      movw	r0, #4170	; 0x104a
    .text:08000d66 02 21                            movs	r1, #2
    .text:08000d68 c0 f6 00 00                      movt	r0, #2048	; 0x800
    .text:08000d6c ff f7 92 fa                      bl	0x08000294 <runtime.printstring>
    .text:08000d70 ff f7 9c fa                      bl	0x080002ac <runtime.printnl>
    .text:08000d74 41 f2 4c 00                      movw	r0, #4172	; 0x104c
    .text:08000d78 02 21                            movs	r1, #2
    .text:08000d7a c0 f6 00 00                      movt	r0, #2048	; 0x800
    .text:08000d7e ff f7 89 fa                      bl	0x08000294 <runtime.printstring>
    .text:08000d82 bd e8 80 40                      ldmia.w	sp!, {r7, lr}
    .text:08000d86 ff f7 91 ba                      b.w	0x080002ac <runtime.printnl>
```
Note the two handlers have both been successfully inlined into the wrapper.  This implementation has minimal or no additional overhead in the output binary (depending on efficient optimization).