### PR TITLE
ci: bump Xcode version to use macOS 10.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,16 +294,16 @@ commands:
           variant: "macos"
       - restore_cache:
           keys:
-            - go-cache-macos-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
-            - go-cache-macos-v2-{{ checksum "go.mod" }}
+            - go-cache-macos-v3-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+            - go-cache-macos-v3-{{ checksum "go.mod" }}
       - restore_cache:
           keys:
-            - llvm-source-11-macos-v2
+            - llvm-source-11-macos-v3
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-11-macos-v2
+          key: llvm-source-11-macos-v3
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
@@ -311,7 +311,7 @@ commands:
             - llvm-project/llvm/include
       - restore_cache:
           keys:
-            - llvm-build-11-macos-v3
+            - llvm-build-11-macos-v4
       - run:
           name: "Build LLVM"
           command: |
@@ -327,17 +327,17 @@ commands:
               find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
             fi
       - save_cache:
-          key: llvm-build-11-macos-v3
+          key: llvm-build-11-macos-v4
           paths:
             llvm-build
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-macos-v3
+            - wasi-libc-sysroot-macos-v4
       - run:
           name: "Build wasi-libc"
           command: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-macos-v3
+          key: wasi-libc-sysroot-macos-v4
           paths:
             - lib/wasi-libc/sysroot
       - run:
@@ -359,7 +359,7 @@ commands:
             tinygo version
       - run: make smoketest AVR=0
       - save_cache:
-          key: go-cache-macos-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          key: go-cache-macos-v3-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - ~/.cache/go-build
             - /go/pkg/mod
@@ -401,7 +401,7 @@ jobs:
       - build-linux
   build-macos:
     macos:
-      xcode: "10.1.0"
+      xcode: "11.1.0" # macOS 10.14
     steps:
       - build-macos
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -249,6 +249,7 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		PortReset: "false",
 	}
 	if goos == "darwin" {
+		spec.CFlags = append(spec.CFlags, "-isysroot", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")
 		spec.LDFlags = append(spec.LDFlags, "-Wl,-dead_strip")
 	} else {
 		spec.LDFlags = append(spec.LDFlags, "-no-pie", "-Wl,--gc-sections") // WARNING: clang < 5.0 requires -nopie


### PR DESCRIPTION
The CircleCI macOS builds are failing, probably due to the old macOS version that's used. This version (10.13 High Sierra) isn't supported anymore on Homebrew so it seems best to me to simply bump the version.

I picked Xcode 11.1.0 because 10.3.0 is somehow triggering an error while trying to install QEMU (the Python install fails).

Because of this newer Xcode version, I had to add an extra flag (-isysroot) to the default command line for MacOS. The reason is that this newer Xcode version no longer stores header files in /usr/local, an SDK must be specified manually. With this change, the default SDK is used.

