### PR TITLE
Fix I2c initialization for stm32f1/f4 

### DIFF
--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -204,14 +204,22 @@ func (spi SPI) configurePins(config SPIConfig) {
 // There are 2 I2C interfaces on the STM32F103xx.
 // Since the first interface is named I2C1, both I2C0 and I2C1 refer to I2C1.
 // TODO: implement I2C2.
+
+/*
 var (
 	I2C1 = (*I2C)(unsafe.Pointer(stm32.I2C1))
 	I2C0 = I2C1
 )
+*/
 
 type I2C struct {
 	Bus *stm32.I2C_Type
 }
+
+var (
+	I2C1 = &I2C{Bus: stm32.I2C1}
+	I2C0 = I2C1
+)
 
 func (i2c *I2C) configurePins(config I2CConfig) {
 	if config.SDA == PB9 {

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -205,13 +205,6 @@ func (spi SPI) configurePins(config SPIConfig) {
 // Since the first interface is named I2C1, both I2C0 and I2C1 refer to I2C1.
 // TODO: implement I2C2.
 
-/*
-var (
-	I2C1 = (*I2C)(unsafe.Pointer(stm32.I2C1))
-	I2C0 = I2C1
-)
-*/
-
 type I2C struct {
 	Bus *stm32.I2C_Type
 }


### PR DESCRIPTION
Hi, 

This PR fixes "panic: runtime error: nil pointer dereference" when using i2c on stm32f1/f4. 
Panic rise in i2c Configure function, as i2c.Bus value is nil:

https://github.com/tinygo-org/tinygo/blob/1f73941c43dac9bc91ca651479655fea5c01c538/src/machine/machine_stm32_i2c_reva.go#L120-L124

The fix  was tested on bluepill +  hd44780-I2C Driver. 
