### PR TITLE
atsamd51, atsamd21: fix ADC.Get() value at 8bit and 10bit

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -433,7 +433,18 @@ func (a ADC) Get() uint16 {
 	sam.ADC.CTRLA.ClearBits(sam.ADC_CTRLA_ENABLE)
 	waitADCSync()
 
-	return uint16(val) << 4 // scales from 12 to 16-bit result
+	// scales to 16-bit result
+	switch (sam.ADC.CTRLB.Get() & sam.ADC_CTRLB_RESSEL_Msk) >> sam.ADC_CTRLB_RESSEL_Pos {
+	case sam.ADC_CTRLB_RESSEL_8BIT:
+		val = val << 8
+	case sam.ADC_CTRLB_RESSEL_10BIT:
+		val = val << 6
+	case sam.ADC_CTRLB_RESSEL_16BIT:
+		val = val << 4
+	case sam.ADC_CTRLB_RESSEL_12BIT:
+		val = val << 4
+	}
+	return val
 }
 
 func (a ADC) getADCChannel() uint8 {

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -863,7 +863,18 @@ func (a ADC) Get() uint16 {
 	for bus.SYNCBUSY.HasBits(sam.ADC_SYNCBUSY_ENABLE) {
 	}
 
-	return uint16(val) << 4 // scales from 12 to 16-bit result
+	// scales to 16-bit result
+	switch (bus.CTRLB.Get() & sam.ADC_CTRLB_RESSEL_Msk) >> sam.ADC_CTRLB_RESSEL_Pos {
+	case sam.ADC_CTRLB_RESSEL_8BIT:
+		val = val << 8
+	case sam.ADC_CTRLB_RESSEL_10BIT:
+		val = val << 6
+	case sam.ADC_CTRLB_RESSEL_16BIT:
+		val = val << 4
+	case sam.ADC_CTRLB_RESSEL_12BIT:
+		val = val << 4
+	}
+	return val
 }
 
 func (a ADC) getADCBus() *sam.ADC_Type {


### PR DESCRIPTION
I think they probably wanted to return the same uint16 value for 8bit / 10bit / 12bit.
I felt that the values at 8 bit and 10 bit were different from what I intended, so I fixed them.

before:
```
16 bit ADC : val : 0xFFC0
12 bit ADC : val : 0xFF70
10 bit ADC : val : 0x3FF0
8 bit ADC  : val : 0x0FF0
```

after:
```
16 bit ADC : val : 0xFFC0
12 bit ADC : val : 0xFF70
10 bit ADC : val : 0xFFC0
8 bit ADC  : val : 0xFF00
```

test code:
```go
package main

import (
	"fmt"
	"machine"
	"time"
)

// This example assumes that an analog sensor such as a rotary dial is connected to pin ADC0.
// When the dial is turned past the midway point, the built-in LED will light up.

func main() {
	machine.InitADC()

	led := machine.LED
	led.Configure(machine.PinConfig{Mode: machine.PinOutput})

	sensor := machine.ADC{machine.A0}
	//sensor.Configure(machine.ADCConfig{Resolution: 8})
	//sensor.Configure(machine.ADCConfig{Resolution: 10})
	//sensor.Configure(machine.ADCConfig{Resolution: 12})
	sensor.Configure(machine.ADCConfig{Resolution: 16})

	for {
		val := sensor.Get()
		if val < 0x8000 {
			led.Low()
		} else {
			led.High()
		}
		fmt.Printf("val : 0x%04X\r\n", val)
		time.Sleep(time.Millisecond * 100)
	}
}
```