### PR TITLE
qtpy: fix i2c setting

### DIFF
--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -94,8 +94,8 @@ const (
 // I2C on the QT Py M0.
 var (
 	I2C0 = &I2C{
-		Bus:    sam.SERCOM2_I2CM,
-		SERCOM: 2,
+		Bus:    sam.SERCOM1_I2CM,
+		SERCOM: 1,
 	}
 )
 


### PR DESCRIPTION
Fix QT Py's i2c to SERCOM1.

https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/qtpy_m0/variant.h#L159-L170
