### PR TITLE
machine: move PinMode to central location

### DIFF
--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -10,6 +10,11 @@ var (
 	ErrNoPinChangeChannel = errors.New("machine: no channel available for pin interrupt")
 )
 
+// PinMode sets the direction and pull mode of the pin. For example, PinOutput
+// sets the pin as an output and PinInputPullup sets the pin as an input with a
+// pull-up.
+type PinMode uint8
+
 type PinConfig struct {
 	Mode PinMode
 }

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -17,8 +17,6 @@ import (
 	"unsafe"
 )
 
-type PinMode uint8
-
 const (
 	PinAnalog    PinMode = 1
 	PinSERCOM    PinMode = 2

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -20,8 +20,6 @@ func CPUFrequency() uint32 {
 	return 120000000
 }
 
-type PinMode uint8
-
 const (
 	PinAnalog        PinMode = 1
 	PinSERCOM        PinMode = 2

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -8,8 +8,6 @@ import (
 	"unsafe"
 )
 
-type PinMode uint8
-
 const (
 	PinInput PinMode = iota
 	PinInputPullup

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -21,8 +21,6 @@ var (
 	ErrInvalidSPIBus = errors.New("machine: invalid SPI bus")
 )
 
-type PinMode uint8
-
 const (
 	PinOutput PinMode = iota
 	PinInput

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -11,8 +11,6 @@ func CPUFrequency() uint32 {
 	return 80000000 // 80MHz
 }
 
-type PinMode uint8
-
 const (
 	PinOutput PinMode = iota
 	PinInput

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -12,8 +12,6 @@ func CPUFrequency() uint32 {
 	return 16000000
 }
 
-type PinMode uint8
-
 const (
 	PinInput PinMode = iota
 	PinOutput

--- a/src/machine/machine_gameboyadvance.go
+++ b/src/machine/machine_gameboyadvance.go
@@ -30,8 +30,6 @@ const (
 // Make it easier to directly write to I/O RAM.
 var ioram = (*[0x400]volatile.Register8)(unsafe.Pointer(uintptr(0x04000000)))
 
-type PinMode uint8
-
 // Set has not been implemented.
 func (p Pin) Set(value bool) {
 	// do nothing

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -10,8 +10,6 @@ var (
 	UART0 = UART{0}
 )
 
-type PinMode uint8
-
 const (
 	PinInput PinMode = iota
 	PinOutput

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -14,7 +14,6 @@ func CPUFrequency() uint32 {
 	return 390000000
 }
 
-type PinMode uint8
 type fpioaPullMode uint8
 type PinChange uint8
 

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -15,8 +15,6 @@ func CPUFrequency() uint32 {
 	return 600000000
 }
 
-type PinMode uint8
-
 const (
 	// GPIO
 	PinInput PinMode = iota

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -13,8 +13,6 @@ var (
 	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
 )
 
-type PinMode uint8
-
 const (
 	PinInput         PinMode = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 	PinInputPullup   PinMode = PinInput | (nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos)

--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -37,8 +37,6 @@ import (
 	"unsafe"
 )
 
-type PinMode uint8
-
 const (
 	PinInput PinMode = iota
 	PinInputPullUp

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -17,8 +17,6 @@ const (
 	portJ
 )
 
-type PinMode uint8
-
 // Peripheral operations sequence:
 //  1. Enable the clock to the alternate function.
 //  2. Enable clock to corresponding GPIO


### PR DESCRIPTION
It is always implemented exactly the same way (as an uint8) so there is no reason to implement it in each target separately.

This also makes it easier to add some documentation to it.