### PR TITLE
runtime: remove the asyncScheduler constant

### DIFF
--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -71,8 +71,6 @@ func ticks() timeUnit {
 	return 0
 }
 
-const asyncScheduler = false
-
 func sleepTicks(d timeUnit) {
 	// TODO
 }

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -238,8 +238,6 @@ var (
 
 var timerWakeup volatile.Register8
 
-const asyncScheduler = false
-
 // ticksToNanoseconds converts RTC ticks (at 32768Hz) to nanoseconds.
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	// The following calculation is actually the following, but with both sides

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -227,8 +227,6 @@ var (
 
 var timerWakeup volatile.Register8
 
-const asyncScheduler = false
-
 // ticksToNanoseconds converts RTC ticks (at 32768Hz) to nanoseconds.
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	// The following calculation is actually the following, but with both sides

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -58,8 +58,6 @@ func init() {
 	initUART()
 }
 
-const asyncScheduler = false
-
 const tickNanos = 1024 * 16384 // roughly 16ms in nanoseconds
 
 func ticksToNanoseconds(ticks timeUnit) int64 {

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -27,8 +27,6 @@ func main() {
 	abort()
 }
 
-const asyncScheduler = false
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks)
 }

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -97,8 +97,6 @@ func ticks() timeUnit {
 	return timeUnit(uint64(esp.TIMG0.T0LO.Get()) | uint64(esp.TIMG0.T0HI.Get())<<32)
 }
 
-const asyncScheduler = false
-
 func nanosecondsToTicks(ns int64) timeUnit {
 	// Calculate the number of ticks from the number of nanoseconds. At a 80MHz
 	// APB clock, that's 25 nanoseconds per tick with a timer prescaler of 2:

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -89,8 +89,6 @@ func ticks() timeUnit {
 	return currentTime
 }
 
-const asyncScheduler = false
-
 const tickNanos = 3200 // time.Second / (80MHz / 256)
 
 func ticksToNanoseconds(ticks timeUnit) int64 {

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -100,8 +100,6 @@ func putchar(c byte) {
 	machine.UART0.WriteByte(c)
 }
 
-const asyncScheduler = false
-
 var timerWakeup volatile.Register8
 
 func ticks() timeUnit {

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -112,8 +112,6 @@ func putchar(c byte) {
 	machine.UART0.WriteByte(c)
 }
 
-const asyncScheduler = false
-
 var timerWakeup volatile.Register8
 
 func ticks() timeUnit {

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -10,8 +10,6 @@ import (
 	"unsafe"
 )
 
-const asyncScheduler = false
-
 //go:extern _svectors
 var _svectors [0]byte
 

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -6,8 +6,6 @@ import "unsafe"
 
 type timeUnit int64
 
-const asyncScheduler = false
-
 const (
 	// Handles
 	infoTypeTotalMemorySize = 6          // Total amount of memory available for process.

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -59,8 +59,6 @@ func putchar(c byte) {
 	machine.UART0.WriteByte(c)
 }
 
-const asyncScheduler = false
-
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks()                       // update timestamp

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -232,9 +232,6 @@ func putchar(c byte) {
 	machine.PutcharUART(&machine.UART0, c)
 }
 
-// ???
-const asyncScheduler = false
-
 func abort() {
 	println("!!! ABORT !!!")
 

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -24,8 +24,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -80,8 +80,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initOSC() // configure oscillators
 	initCLK()

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -42,8 +42,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -41,8 +41,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -13,8 +13,6 @@ const (
 
 type arrtype = uint16
 
-const asyncScheduler = false
-
 func putchar(c byte) {
 	machine.UART0.WriteByte(c)
 }

--- a/src/runtime/runtime_stm32l4x2.go
+++ b/src/runtime/runtime_stm32l4x2.go
@@ -66,8 +66,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -42,8 +42,6 @@ const (
 
 type arrtype = uint32
 
-const asyncScheduler = false
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -24,8 +24,6 @@ func main() {
 	abort()
 }
 
-const asyncScheduler = false
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks)
 }

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -123,8 +123,6 @@ func putchar(c byte) {
 	_putchar(int(c))
 }
 
-const asyncScheduler = false
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	// The OS API works in nanoseconds so no conversion necessary.
 	return int64(ticks)

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -40,8 +40,6 @@ func go_scheduler() {
 	scheduler()
 }
 
-const asyncScheduler = true
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	// The JavaScript API works in float64 milliseconds, so convert to
 	// nanoseconds first before converting to a timeUnit (which is a float64),

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -59,10 +59,7 @@ func nanosecondsToTicks(ns int64) timeUnit {
 	return timeUnit(ns)
 }
 
-const (
-	asyncScheduler           = false
-	timePrecisionNanoseconds = 1000 // TODO: how can we determine the appropriate `precision`?
-)
+const timePrecisionNanoseconds = 1000 // TODO: how can we determine the appropriate `precision`?
 
 var (
 	sleepTicksSubscription = __wasi_subscription_t{


### PR DESCRIPTION
There is no reason to specialize this per chip as it is only ever used for JavaScript. Not only that, it is causing confusion and is yet another quirk to learn when porting the runtime to a new microcontroller.