### PR TITLE
compiler: only check for default stack size with tasks scheduler

### DIFF
--- a/compiler/goroutine.go
+++ b/compiler/goroutine.go
@@ -34,7 +34,7 @@ func (b *builder) createGoInstruction(funcPtr llvm.Value, params []llvm.Value, p
 		} else {
 			// The stack size is fixed at compile time. By emitting it here as a
 			// constant, it can be optimized.
-			if b.DefaultStackSize == 0 {
+			if b.Scheduler == "tasks" && b.DefaultStackSize == 0 {
 				b.addError(pos, "default stack size for goroutines is not set")
 			}
 			stackSize = llvm.ConstInt(b.uintptrType, b.DefaultStackSize, false)


### PR DESCRIPTION
With `-scheduler=none`, there are no goroutines so there is no stack size anywhere. Therefore, don't check whether the default stack size is set.