### PR TITLE
Use machine.Serial as the default output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m4-can      examples/caninterrupt
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=arduino-nano33      examples/blinky1
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -9,7 +9,7 @@ import (
 
 // change these to test a different UART or pins if available
 var (
-	uart = machine.UART0
+	uart = machine.Serial
 	tx   = machine.UART_TX_PIN
 	rx   = machine.UART_RX_PIN
 )

--- a/src/machine/board_arduino_mkr1000.go
+++ b/src/machine/board_arduino_mkr1000.go
@@ -47,7 +47,9 @@ const (
 	LED = D6
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN Pin = PA24
 	USBCDC_DP_PIN Pin = PA25

--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -46,7 +46,7 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN Pin = PA24
 	USBCDC_DP_PIN Pin = PA25

--- a/src/machine/board_arduino_nano33_baremetal.go
+++ b/src/machine/board_arduino_nano33_baremetal.go
@@ -9,7 +9,8 @@ import (
 
 // UART1 on the Arduino Nano 33 connects to the onboard NINA-W102 WiFi chip.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM3_USART,
 		SERCOM: 3,
@@ -18,7 +19,8 @@ var (
 
 // UART2 on the Arduino Nano 33 connects to the normal TX/RX pins.
 var (
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART,
 		SERCOM: 5,
@@ -26,8 +28,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM5, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM5, _UART2.handleInterrupt)
 }
 
 // I2C on the Arduino Nano 33.

--- a/src/machine/board_arduino_zero.go
+++ b/src/machine/board_arduino_zero.go
@@ -35,6 +35,8 @@ const (
 	LED3 Pin = PB03 // RX LED
 )
 
+var Serial = USB
+
 // ADC pins
 const (
 	AREF Pin = PA03

--- a/src/machine/board_atsamd21.go
+++ b/src/machine/board_atsamd21.go
@@ -74,3 +74,5 @@ const (
 	PB30 Pin = 62
 	PB31 Pin = 63
 )
+
+var Serial = USB

--- a/src/machine/board_atsame54-xpro.go
+++ b/src/machine/board_atsame54-xpro.go
@@ -240,28 +240,32 @@ var (
 // UART on the SAM E54 Xplained Pro
 var (
 	// Extension Header EXT1
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
 	}
 
 	// Extension Header EXT2
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,
 	}
 
 	// Extension Header EXT3
-	UART3 = UART{
+	UART3  = &_UART3
+	_UART3 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART_INT,
 		SERCOM: 1,
 	}
 
 	// EDBG Virtual COM Port
-	UART4 = UART{
+	UART4  = &_UART4
+	_UART4 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM2_USART_INT,
 		SERCOM: 2,
@@ -269,10 +273,10 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART2.handleInterrupt)
-	UART3.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, UART3.handleInterrupt)
-	UART4.Interrupt = interrupt.New(sam.IRQ_SERCOM2_2, UART4.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, _UART2.handleInterrupt)
+	UART3.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, _UART3.handleInterrupt)
+	UART4.Interrupt = interrupt.New(sam.IRQ_SERCOM2_2, _UART4.handleInterrupt)
 }
 
 // I2C on the SAM E54 Xplained Pro

--- a/src/machine/board_atsame54-xpro.go
+++ b/src/machine/board_atsame54-xpro.go
@@ -15,6 +15,8 @@ const (
 	BUTTON = PB31
 )
 
+var Serial = USB
+
 const (
 	// https://ww1.microchip.com/downloads/en/DeviceDoc/70005321A.pdf
 
@@ -152,7 +154,7 @@ const (
 	PIN_USB_ID      = PC19
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -61,19 +61,21 @@ const (
 var (
 	// USART1 is the first hardware serial port on the STM32.
 	// Both UART0 and UART1 refer to USART1.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART1,
 	}
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART2,
 	}
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART1, UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, UART1.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -50,6 +50,8 @@ const (
 	LED = PC13
 )
 
+var Serial = UART1
+
 // UART pins
 const (
 	UART_TX_PIN     = PA9
@@ -60,22 +62,21 @@ const (
 
 var (
 	// USART1 is the first hardware serial port on the STM32.
-	// Both UART0 and UART1 refer to USART1.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART1,
 	}
-	UART1  = &_UART1
-	_UART1 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART2,
 	}
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART2.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -56,10 +56,7 @@ const (
 	UART_RX_PIN = P0_30 // PORTB
 )
 
-// UART0 is the USB device
-var (
-	UART0 = USB
-)
+var Serial = USB
 
 // I2C pins
 const (

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -58,7 +58,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = &USB
+	UART0 = USB
 )
 
 // I2C pins

--- a/src/machine/board_circuitplay_express_baremetal.go
+++ b/src/machine/board_circuitplay_express_baremetal.go
@@ -9,7 +9,8 @@ import (
 
 // UART1 on the Circuit Playground Express.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM4_USART,
 		SERCOM: 4,
@@ -17,7 +18,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4, _UART1.handleInterrupt)
 }
 
 // I2C on the Circuit Playground Express.

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -105,7 +105,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = &USB
+	UART0 = USB
 )
 
 // I2C pins

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -103,9 +103,9 @@ const (
 	UART_TX_PIN = D1
 )
 
-// UART0 is the USB device
+// Serial is the USB device
 var (
-	UART0 = USB
+	Serial = USB
 )
 
 // I2C pins

--- a/src/machine/board_esp32-coreboard-v2.go
+++ b/src/machine/board_esp32-coreboard-v2.go
@@ -68,6 +68,8 @@ const (
 	ADC3 Pin = IO39
 )
 
+var Serial = UART0
+
 // UART0 pins
 const (
 	UART_TX_PIN = IO1

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -42,7 +42,7 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -56,7 +56,8 @@ const (
 
 // UART1 on the Feather M0.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART,
 		SERCOM: 1,
@@ -64,7 +65,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1, _UART1.handleInterrupt)
 }
 
 // I2C pins

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -46,7 +46,9 @@ const (
 	NEOPIXELS = D8
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -103,13 +103,15 @@ var (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
@@ -117,8 +119,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART2.handleInterrupt)
 
 	// turn on neopixel
 	D7.Configure(PinConfig{Mode: PinOutput})

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -39,7 +39,9 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_feather-m4_baremetal.go
+++ b/src/machine/board_feather-m4_baremetal.go
@@ -8,13 +8,15 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
@@ -22,8 +24,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART2.handleInterrupt)
 }
 
 // I2C on the Feather M4.

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -77,7 +77,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = &USB
+	UART0 = USB
 )
 
 // I2C pins

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -75,9 +75,9 @@ const (
 	UART_TX_PIN = D1
 )
 
-// UART0 is the USB device
+// Serial is the USB device
 var (
-	UART0 = USB
+	Serial = USB
 )
 
 // I2C pins

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -140,7 +140,7 @@ var (
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	UART0 = UART1
+	Serial = UART1
 )
 
 func initUART() {

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -119,19 +119,22 @@ const (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART6,
 		TxAltFuncSelector: AF8_USART4_5_6,
 		RxAltFuncSelector: AF8_USART4_5_6,
 	}
-	UART3 = UART{
+	UART3  = &_UART3
+	_UART3 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: AF7_USART1_2_3,
@@ -141,9 +144,9 @@ var (
 )
 
 func initUART() {
-	UART1.Interrupt = interrupt.New(stm32.IRQ_USART3, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(stm32.IRQ_USART6, UART2.handleInterrupt)
-	UART3.Interrupt = interrupt.New(stm32.IRQ_USART1, UART3.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART3, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(stm32.IRQ_USART6, _UART2.handleInterrupt)
+	UART3.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART3.handleInterrupt)
 }
 
 // -- SPI ----------------------------------------------------------------------

--- a/src/machine/board_grandcentral-m4.go
+++ b/src/machine/board_grandcentral-m4.go
@@ -141,6 +141,8 @@ const (
 	NEOPIXEL = NEOPIXEL_PIN
 )
 
+var Serial = USB
+
 // UART pins
 const (
 	UART1_RX_PIN = D0 // (PB25)

--- a/src/machine/board_grandcentral-m4_baremetal.go
+++ b/src/machine/board_grandcentral-m4_baremetal.go
@@ -8,30 +8,34 @@ import (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, UART2.handleInterrupt)
-	UART3.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, UART3.handleInterrupt)
-	UART4.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART4.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, _UART2.handleInterrupt)
+	UART3.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, _UART3.handleInterrupt)
+	UART4.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, _UART4.handleInterrupt)
 }
 
 // UART on the Grand Central M4
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
 	}
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM4_USART_INT,
 		SERCOM: 4,
 	}
-	UART3 = UART{
+	UART3  = &_UART3
+	_UART3 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART_INT,
 		SERCOM: 1,
 	}
-	UART4 = UART{
+	UART4  = &_UART4
+	_UART4 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,

--- a/src/machine/board_hifive1b.go
+++ b/src/machine/board_hifive1b.go
@@ -35,6 +35,8 @@ const (
 	LED_BLUE  = P21
 )
 
+var Serial = UART0
+
 const (
 	// TODO: figure out the pin numbers for these.
 	UART_TX_PIN = D1

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -56,7 +56,8 @@ const (
 
 // UART1 on the ItsyBitsy M0.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART,
 		SERCOM: 1,
@@ -64,7 +65,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1, _UART1.handleInterrupt)
 }
 
 // I2C pins

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -42,7 +42,7 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -37,7 +37,9 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_itsybitsy-m4_baremetal.go
+++ b/src/machine/board_itsybitsy-m4_baremetal.go
@@ -8,13 +8,15 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM3_USART_INT,
 		SERCOM: 3,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
@@ -22,8 +24,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART2.handleInterrupt)
 }
 
 // I2C on the ItsyBitsy M4.

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -70,9 +70,9 @@ const (
 	UART_TX_PIN = D1
 )
 
-// UART0 is the USB device
+// Serial is the USB device
 var (
-	UART0 = USB
+	Serial = USB
 )
 
 // I2C pins

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -72,7 +72,7 @@ const (
 
 // UART0 is the USB device
 var (
-	UART0 = &USB
+	UART0 = USB
 )
 
 // I2C pins

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -54,6 +54,8 @@ const (
 	I2C0_SDA_PIN = PA10
 )
 
+var Serial = UART0
+
 var (
 
 	// Console UART (LPUSART1)

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -57,7 +57,8 @@ const (
 var (
 
 	// Console UART (LPUSART1)
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.LPUART1,
 		TxAltFuncSelector: 6,
@@ -65,7 +66,8 @@ var (
 	}
 
 	// Gps UART
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: 0,
@@ -88,6 +90,6 @@ var (
 
 func init() {
 	// Enable UARTs Interrupts
-	UART0.Interrupt = interrupt.New(stm32.IRQ_AES_RNG_LPUART1, UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(stm32.IRQ_USART1, UART1.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_AES_RNG_LPUART1, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART1.handleInterrupt)
 }

--- a/src/machine/board_maixbit.go
+++ b/src/machine/board_maixbit.go
@@ -52,6 +52,8 @@ const (
 	LED_BLUE  = D14
 )
 
+var Serial = UART0
+
 // Default pins for UARTHS.
 const (
 	UART_TX_PIN = D5

--- a/src/machine/board_matrixportal-m4_baremetal.go
+++ b/src/machine/board_matrixportal-m4_baremetal.go
@@ -9,13 +9,15 @@ import (
 
 // UART on the MatrixPortal M4
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART_INT,
 		SERCOM: 1,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM4_USART_INT,
 		SERCOM: 4,
@@ -23,8 +25,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1_1, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM4_1, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM1_1, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM4_1, _UART2.handleInterrupt)
 }
 
 // I2C on the MatrixPortal M4

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -40,7 +40,9 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_metro-m4-airlift_baremetal.go
+++ b/src/machine/board_metro-m4-airlift_baremetal.go
@@ -8,13 +8,15 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM3_USART_INT,
 		SERCOM: 3,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
@@ -22,8 +24,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM3_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART2.handleInterrupt)
 }
 
 // I2C on the Metro M4.

--- a/src/machine/board_microbit-v2.go
+++ b/src/machine/board_microbit-v2.go
@@ -12,6 +12,8 @@ const (
 	BUTTONB Pin = P11
 )
 
+var Serial = UART0
+
 // UART pins
 const (
 	UART_TX_PIN Pin = P34

--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -12,6 +12,8 @@ const (
 	BUTTONB Pin = 26
 )
 
+var Serial = UART0
+
 // UART pins
 const (
 	UART_TX_PIN Pin = 24

--- a/src/machine/board_nicenano.go
+++ b/src/machine/board_nicenano.go
@@ -54,9 +54,9 @@ const (
 	UART_TX_PIN = P0_08
 )
 
-// UART0 is the USB device
+// Serial is the USB device
 var (
-	UART0 = USB
+	Serial = USB
 )
 
 // I2C pins

--- a/src/machine/board_nodemcu.go
+++ b/src/machine/board_nodemcu.go
@@ -20,6 +20,8 @@ const (
 // Onboard blue LED (on the AI-Thinker module).
 const LED = D4
 
+var Serial = UART0
+
 // SPI pins
 const (
 	SPI0_SCK_PIN = D5

--- a/src/machine/board_nrf52840-mdk-usb-dongle.go
+++ b/src/machine/board_nrf52840-mdk-usb-dongle.go
@@ -23,10 +23,8 @@ const (
 	UART_RX_PIN Pin = NoPin
 )
 
-// UART0 is the USB device
-var (
-	UART0 = USB
-)
+// Serial is the USB device
+var Serial = USB
 
 // I2C pins (unused)
 const (

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -18,10 +18,8 @@ const (
 	UART_RX_PIN Pin = 19
 )
 
-// UART0 is the USB device
-var (
-	UART0 = USB
-)
+// Serial is the USB device
+var Serial = USB
 
 // I2C pins (unused)
 const (

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -99,17 +99,16 @@ const (
 var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
-	// Both UART0 and UART1 refer to USART2.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART2,
 	}
-	UART2 = UART0
+	Serial = UART2
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
+	UART2.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART2.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -100,15 +100,16 @@ var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to USART2.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART2,
 	}
-	UART2 = &UART0
+	UART2 = UART0
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -32,17 +32,18 @@ var (
 	// USART3 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to USART2.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	UART1 = &UART0
+	UART1 = UART0
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART3, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART3, _UART0.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -31,19 +31,18 @@ const (
 var (
 	// USART3 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
-	// Both UART0 and UART1 refer to USART2.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	UART1 = UART0
+	Serial = UART1
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART3, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART3, _UART1.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -63,15 +63,14 @@ const (
 var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
-	// Both UART0 and UART1 refer to USART2.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 4,
 		RxAltFuncSelector: 4,
 	}
-	UART1 = UART0
+	Serial = UART1
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{
@@ -89,5 +88,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
 }

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -64,13 +64,14 @@ var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to USART2.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 4,
 		RxAltFuncSelector: 4,
 	}
-	UART1 = &UART0
+	UART1 = UART0
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{
@@ -88,5 +89,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
 }

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -66,13 +66,14 @@ var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to USART2.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 3,
 	}
-	UART1 = &UART0
+	UART1 = UART0
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{
@@ -90,5 +91,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
 }

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -65,15 +65,14 @@ const (
 var (
 	// USART2 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
-	// Both UART0 and UART1 refer to USART2.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 3,
 	}
-	UART1 = UART0
+	Serial = UART1
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{
@@ -91,5 +90,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
 }

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -32,13 +32,14 @@ var (
 	// LPUART1 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	// Both UART0 and UART1 refer to LPUART1.
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.LPUART1,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	UART1 = &UART0
+	UART1 = UART0
 )
 
 const (
@@ -56,5 +57,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_LPUART1, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_LPUART1, _UART0.handleInterrupt)
 }

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -31,15 +31,14 @@ const (
 var (
 	// LPUART1 is the hardware serial port connected to the onboard ST-LINK
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
-	// Both UART0 and UART1 refer to LPUART1.
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.LPUART1,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	UART1 = UART0
+	Serial = UART1
 )
 
 const (
@@ -57,5 +56,5 @@ var (
 )
 
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_LPUART1, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_LPUART1, _UART1.handleInterrupt)
 }

--- a/src/machine/board_p1am-100.go
+++ b/src/machine/board_p1am-100.go
@@ -66,7 +66,7 @@ const (
 	BASE_ENABLE_PIN       Pin = PB09
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN          Pin = PA24
 	USBCDC_DP_PIN          Pin = PA25

--- a/src/machine/board_p1am-100_baremetal.go
+++ b/src/machine/board_p1am-100_baremetal.go
@@ -9,7 +9,8 @@ import (
 
 // UART1 on the P1AM-100 connects to the normal TX/RX pins.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM3_USART,
 		SERCOM: 5,
@@ -17,7 +18,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5, _UART1.handleInterrupt)
 }
 
 // I2C on the P1AM-100.

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -41,8 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
-	UART0  = NRF_UART0
+	Serial = UART0
 )
 
 const (

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = &USB
+	Serial = USB
 	UART0  = NRF_UART0
 )
 

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -41,8 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
-	UART0  = NRF_UART0
+	Serial = UART0
 )
 
 const (

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = &USB
+	Serial = USB
 	UART0  = NRF_UART0
 )
 

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -41,8 +41,7 @@ const (
 
 // UART
 var (
-	Serial = USB
-	UART0  = NRF_UART0
+	Serial = UART0
 )
 
 const (

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = &USB
+	Serial = USB
 	UART0  = NRF_UART0
 )
 

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -19,6 +19,8 @@ const (
 	LED_BLUE  Pin = 23
 )
 
+var Serial = UART0
+
 // UART pins
 const (
 	UART_TX_PIN Pin = 9

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -23,6 +23,8 @@ const (
 	BUTTON4 Pin = 16
 )
 
+var Serial = UART0
+
 // UART pins for NRF52840-DK
 const (
 	UART_TX_PIN Pin = 6

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -22,6 +22,8 @@ const (
 	BUTTON4 Pin = 25
 )
 
+var Serial = UART0
+
 // UART pins
 const (
 	UART_TX_PIN Pin = 6

--- a/src/machine/board_pca10056_baremetal.go
+++ b/src/machine/board_pca10056_baremetal.go
@@ -1,8 +1,0 @@
-// +build nrf52840,pca10056
-
-package machine
-
-// UART0 is the NRF UART
-var (
-	UART0 = NRF_UART0
-)

--- a/src/machine/board_pca10059.go
+++ b/src/machine/board_pca10059.go
@@ -34,9 +34,9 @@ const (
 	UART_RX_PIN Pin = NoPin
 )
 
-// UART0 is the USB device
+// Serial is the USB device
 var (
-	UART0 = USB
+	Serial = USB
 )
 
 // I2C pins (unused)

--- a/src/machine/board_pinetime-devkit0.go
+++ b/src/machine/board_pinetime-devkit0.go
@@ -17,6 +17,8 @@ const (
 	LED3 = LCD_BACKLIGHT_LOW
 )
 
+var Serial = UART0
+
 // UART pins for PineTime. Note that RX is set to NoPin as RXD is not listed in
 // the PineTime schematic 1.0:
 // http://files.pine64.org/doc/PineTime/PineTime%20Port%20Assignment%20rev1.0.pdf

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -66,7 +66,9 @@ const (
 	BUTTON_B_MASK      = 128
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_pybadge_baremetal.go
+++ b/src/machine/board_pybadge_baremetal.go
@@ -8,13 +8,15 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM5_USART_INT,
 		SERCOM: 5,
 	}
 
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART_INT,
 		SERCOM: 0,
@@ -22,8 +24,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM0_2, _UART2.handleInterrupt)
 }
 
 // I2C on the ItsyBitsy M4.

--- a/src/machine/board_pygamer.go
+++ b/src/machine/board_pygamer.go
@@ -69,7 +69,9 @@ const (
 	BUTTON_B_MASK      = 128
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -94,7 +94,9 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_pyportal_baremetal.go
+++ b/src/machine/board_pyportal_baremetal.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM4_USART_INT,
 		SERCOM: 4,
@@ -16,7 +17,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4_2, _UART1.handleInterrupt)
 }
 
 // I2C on the PyPortal.

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -45,7 +45,7 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -59,7 +59,8 @@ const (
 
 // UART1 on the QT Py M0.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART,
 		SERCOM: 0,
@@ -67,7 +68,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0, _UART1.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -29,6 +29,8 @@ const (
 	BUTTON Pin = 7
 )
 
+var Serial = UART0
+
 // UART pins
 const (
 	UART_TX_PIN Pin = 6

--- a/src/machine/board_reelboard_baremetal.go
+++ b/src/machine/board_reelboard_baremetal.go
@@ -1,8 +1,0 @@
-// +build nrf52840,reelboard
-
-package machine
-
-// UART0 is the NRF UART
-var (
-	UART0 = NRF_UART0
-)

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -27,18 +27,19 @@ const (
 )
 
 var (
-	UART0 = UART{
+	UART0  = &_UART0
+	_UART0 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	UART1 = &UART0
+	UART1 = UART0
 )
 
 // set up RX IRQ handler. Follow similar pattern for other UARTx instances
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, UART0.handleInterrupt)
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -27,19 +27,19 @@ const (
 )
 
 var (
-	UART0  = &_UART0
-	_UART0 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer:            NewRingBuffer(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	UART1 = UART0
+	Serial = UART1
 )
 
 // set up RX IRQ handler. Follow similar pattern for other UARTx instances
 func init() {
-	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_teensy36.go
+++ b/src/machine/board_teensy36.go
@@ -80,11 +80,11 @@ const (
 )
 
 var (
-	TeensyUART1 = &UART0
-	TeensyUART2 = &UART1
-	TeensyUART3 = &UART2
-	TeensyUART4 = &UART3
-	TeensyUART5 = &UART4
+	TeensyUART1 = UART0
+	TeensyUART2 = UART1
+	TeensyUART3 = UART2
+	TeensyUART4 = UART3
+	TeensyUART5 = UART4
 )
 
 const (

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -90,13 +90,13 @@ const (
 
 func init() {
 	// register any interrupt handlers for this board's peripherals
-	UART1.Interrupt = interrupt.New(nxp.IRQ_LPUART6, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(nxp.IRQ_LPUART4, UART2.handleInterrupt)
-	UART3.Interrupt = interrupt.New(nxp.IRQ_LPUART2, UART3.handleInterrupt)
-	UART4.Interrupt = interrupt.New(nxp.IRQ_LPUART3, UART4.handleInterrupt)
-	UART5.Interrupt = interrupt.New(nxp.IRQ_LPUART8, UART5.handleInterrupt)
-	UART6.Interrupt = interrupt.New(nxp.IRQ_LPUART1, UART6.handleInterrupt)
-	UART7.Interrupt = interrupt.New(nxp.IRQ_LPUART7, UART7.handleInterrupt)
+	UART1.Interrupt = interrupt.New(nxp.IRQ_LPUART6, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(nxp.IRQ_LPUART4, _UART2.handleInterrupt)
+	UART3.Interrupt = interrupt.New(nxp.IRQ_LPUART2, _UART3.handleInterrupt)
+	UART4.Interrupt = interrupt.New(nxp.IRQ_LPUART3, _UART4.handleInterrupt)
+	UART5.Interrupt = interrupt.New(nxp.IRQ_LPUART8, _UART5.handleInterrupt)
+	UART6.Interrupt = interrupt.New(nxp.IRQ_LPUART1, _UART6.handleInterrupt)
+	UART7.Interrupt = interrupt.New(nxp.IRQ_LPUART7, _UART7.handleInterrupt)
 }
 
 // #=====================================================#
@@ -136,8 +136,9 @@ const (
 )
 
 var (
-	UART0 = &UART1 // alias UART0 to UART1
-	UART1 = UART{
+	UART0  = UART1 // alias UART0 to UART1
+	UART1  = &_UART1
+	_UART1 = UART{
 		Bus:      nxp.LPUART6,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -150,7 +151,8 @@ var (
 			sel: &nxp.IOMUXC.LPUART6_TX_SELECT_INPUT,
 		},
 	}
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Bus:      nxp.LPUART4,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -163,7 +165,8 @@ var (
 			sel: &nxp.IOMUXC.LPUART4_TX_SELECT_INPUT,
 		},
 	}
-	UART3 = UART{
+	UART3  = &_UART3
+	_UART3 = UART{
 		Bus:      nxp.LPUART2,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -176,7 +179,8 @@ var (
 			sel: &nxp.IOMUXC.LPUART2_TX_SELECT_INPUT,
 		},
 	}
-	UART4 = UART{
+	UART4  = &_UART4
+	_UART4 = UART{
 		Bus:      nxp.LPUART3,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -189,7 +193,8 @@ var (
 			sel: &nxp.IOMUXC.LPUART3_TX_SELECT_INPUT,
 		},
 	}
-	UART5 = UART{
+	UART5  = &_UART5
+	_UART5 = UART{
 		Bus:      nxp.LPUART8,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -202,7 +207,8 @@ var (
 			sel: &nxp.IOMUXC.LPUART8_TX_SELECT_INPUT,
 		},
 	}
-	UART6 = UART{
+	UART6  = &_UART6
+	_UART6 = UART{
 		Bus:      nxp.LPUART1,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),
@@ -210,7 +216,8 @@ var (
 		//   RX: D24 (PA12 [AD_B0_12])
 		//   TX: D25 (PA13 [AD_B0_13])
 	}
-	UART7 = UART{
+	UART7  = &_UART7
+	_UART7 = UART{
 		Bus:      nxp.LPUART7,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -136,7 +136,7 @@ const (
 )
 
 var (
-	UART0  = UART1 // alias UART0 to UART1
+	Serial = UART1
 	UART1  = &_UART1
 	_UART1 = UART{
 		Bus:      nxp.LPUART6,

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -33,7 +33,7 @@ const (
 	LED = D13
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -47,7 +47,8 @@ const (
 
 // UART1 on the Trinket M0.
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM0_USART,
 		SERCOM: 0,
@@ -55,7 +56,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM0, _UART1.handleInterrupt)
 }
 
 // SPI pins

--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -325,7 +325,9 @@ const (
 	OUTPUT_CTR_3V3 = PC15
 )
 
-// UART0 aka USBCDC pins
+var Serial = USB
+
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PIN_USB_DM
 	USBCDC_DP_PIN = PIN_USB_DP

--- a/src/machine/board_wioterminal_baremetal.go
+++ b/src/machine/board_wioterminal_baremetal.go
@@ -8,14 +8,16 @@ import (
 )
 
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM2_USART_INT,
 		SERCOM: 2,
 	}
 
 	// RTL8720D
-	UART2 = UART{
+	UART2  = &_UART2
+	_UART2 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM1_USART_INT,
 		SERCOM: 1,
@@ -23,8 +25,8 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM2_2, UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, UART2.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM2_2, _UART1.handleInterrupt)
+	UART2.Interrupt = interrupt.New(sam.IRQ_SERCOM1_2, _UART2.handleInterrupt)
 }
 
 // I2C on the Wio Terminal

--- a/src/machine/board_x9pro.go
+++ b/src/machine/board_x9pro.go
@@ -26,3 +26,5 @@ const (
 )
 
 const HasLowFrequencyCrystal = true
+
+var Serial = UART0

--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -48,7 +48,7 @@ const (
 	LED3    = LED_TXL
 )
 
-// UART0 aka USBCDC pins
+// USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24
 	USBCDC_DP_PIN = PA25

--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -62,7 +62,8 @@ const (
 
 // UART1 on the Xiao
 var (
-	UART1 = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Buffer: NewRingBuffer(),
 		Bus:    sam.SERCOM4_USART,
 		SERCOM: 4,
@@ -70,7 +71,7 @@ var (
 )
 
 func init() {
-	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4, UART1.handleInterrupt)
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM4, _UART1.handleInterrupt)
 }
 
 // I2C pins

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -124,7 +124,8 @@ func (i2c *I2C) readByte() byte {
 // UART
 var (
 	// UART0 is the hardware serial port on the AVR.
-	UART0 = UART{Buffer: NewRingBuffer()}
+	UART0  = &_UART0
+	_UART0 = UART{Buffer: NewRingBuffer()}
 )
 
 // UART on the AVR.
@@ -133,7 +134,7 @@ type UART struct {
 }
 
 // Configure the UART on the AVR. Defaults to 9600 baud on Arduino.
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	if config.BaudRate == 0 {
 		config.BaudRate = 9600
 	}
@@ -165,7 +166,7 @@ func (uart UART) Configure(config UARTConfig) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart UART) WriteByte(c byte) error {
+func (uart *UART) WriteByte(c byte) error {
 	// Wait until UART buffer is not busy.
 	for !avr.UCSR0A.HasBits(avr.UCSR0A_UDRE0) {
 	}

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -121,6 +121,9 @@ func (i2c *I2C) readByte() byte {
 	return byte(avr.TWDR.Get())
 }
 
+// Always use UART0 as the serial output.
+var Serial = UART0
+
 // UART
 var (
 	// UART0 is the hardware serial port on the AVR.

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -506,7 +506,7 @@ type UART struct {
 
 var (
 	// UART0 is actually a USB CDC interface.
-	UART0 = USBCDC{Buffer: NewRingBuffer()}
+	UART0 = &USBCDC{Buffer: NewRingBuffer()}
 )
 
 const (
@@ -1788,7 +1788,7 @@ func (usbcdc *USBCDC) Flush() error {
 
 			// send data by setting bank ready
 			setEPSTATUSSET(usb_CDC_ENDPOINT_IN, sam.USB_DEVICE_EPSTATUSSET_BK1RDY)
-			UART0.sent = true
+			usbcdc.sent = true
 		}
 	}
 	return nil
@@ -1802,10 +1802,10 @@ func (usbcdc *USBCDC) WriteByte(c byte) error {
 		for {
 			mask := interrupt.Disable()
 
-			idx := UART0.TxIdx.Get()
+			idx := usbcdc.TxIdx.Get()
 			if (idx & usbcdcTxSizeMask) < usbcdcTxSizeMask {
 				udd_ep_in_cache_buffer[usb_CDC_ENDPOINT_IN][idx] = c
-				UART0.TxIdx.Set(idx + 1)
+				usbcdc.TxIdx.Set(idx + 1)
 				ok = true
 			}
 
@@ -1813,26 +1813,26 @@ func (usbcdc *USBCDC) WriteByte(c byte) error {
 
 			if ok {
 				break
-			} else if usbcdcTxMaxRetriesAllowed < UART0.waitTxcRetryCount {
+			} else if usbcdcTxMaxRetriesAllowed < usbcdc.waitTxcRetryCount {
 				mask := interrupt.Disable()
-				UART0.waitTxc = false
-				UART0.waitTxcRetryCount = 0
-				UART0.TxIdx.Set(0)
+				usbcdc.waitTxc = false
+				usbcdc.waitTxcRetryCount = 0
+				usbcdc.TxIdx.Set(0)
 				usbLineInfo.lineState = 0
 				interrupt.Restore(mask)
 				break
 			} else {
 				mask := interrupt.Disable()
-				if UART0.sent {
-					if UART0.waitTxc {
+				if usbcdc.sent {
+					if usbcdc.waitTxc {
 						if (getEPINTFLAG(usb_CDC_ENDPOINT_IN) & sam.USB_DEVICE_EPINTFLAG_TRCPT1) != 0 {
 							setEPSTATUSCLR(usb_CDC_ENDPOINT_IN, sam.USB_DEVICE_EPSTATUSCLR_BK1RDY)
 							setEPINTFLAG(usb_CDC_ENDPOINT_IN, sam.USB_DEVICE_EPINTFLAG_TRCPT1)
-							UART0.waitTxc = false
-							UART0.Flush()
+							usbcdc.waitTxc = false
+							usbcdc.Flush()
 						}
 					} else {
-						UART0.Flush()
+						usbcdc.Flush()
 					}
 				}
 				interrupt.Restore(mask)
@@ -1843,11 +1843,11 @@ func (usbcdc *USBCDC) WriteByte(c byte) error {
 	return nil
 }
 
-func (usbcdc USBCDC) DTR() bool {
+func (usbcdc *USBCDC) DTR() bool {
 	return (usbLineInfo.lineState & usb_CDC_LINESTATE_DTR) > 0
 }
 
-func (usbcdc USBCDC) RTS() bool {
+func (usbcdc *USBCDC) RTS() bool {
 	return (usbLineInfo.lineState & usb_CDC_LINESTATE_RTS) > 0
 }
 
@@ -1882,7 +1882,7 @@ var (
 )
 
 // Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-func (usbcdc USBCDC) Configure(config UARTConfig) {
+func (usbcdc *USBCDC) Configure(config UARTConfig) {
 	// reset USB interface
 	sam.USB_DEVICE.CTRLA.SetBits(sam.USB_DEVICE_CTRLA_SWRST)
 	for sam.USB_DEVICE.SYNCBUSY.HasBits(sam.USB_DEVICE_SYNCBUSY_SWRST) ||

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -505,8 +505,7 @@ type UART struct {
 }
 
 var (
-	// UART0 is actually a USB CDC interface.
-	UART0 = &USBCDC{Buffer: NewRingBuffer()}
+	USB = &USBCDC{Buffer: NewRingBuffer()}
 )
 
 const (
@@ -1985,7 +1984,7 @@ func handleUSB(intr interrupt.Interrupt) {
 
 	// Start of frame
 	if (flags & sam.USB_DEVICE_INTFLAG_SOF) > 0 {
-		UART0.Flush()
+		USB.Flush()
 		// if you want to blink LED showing traffic, this would be the place...
 	}
 
@@ -2045,7 +2044,7 @@ func handleUSB(intr interrupt.Interrupt) {
 				setEPINTFLAG(i, sam.USB_DEVICE_EPINTFLAG_TRCPT1)
 
 				if i == usb_CDC_ENDPOINT_IN {
-					UART0.waitTxc = false
+					USB.waitTxc = false
 				}
 			}
 		}
@@ -2359,7 +2358,7 @@ func handleEndpoint(ep uint32) {
 
 	// move to ring buffer
 	for i := 0; i < count; i++ {
-		UART0.Receive(byte((udd_ep_out_cache_buffer[ep][i] & 0xFF)))
+		USB.Receive(byte((udd_ep_out_cache_buffer[ep][i] & 0xFF)))
 	}
 
 	// set byte count to zero

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -515,7 +515,7 @@ const (
 )
 
 // Configure the UART.
-func (uart UART) Configure(config UARTConfig) error {
+func (uart *UART) Configure(config UARTConfig) error {
 	// Default baud rate to 115200.
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
@@ -614,7 +614,7 @@ func (uart UART) Configure(config UARTConfig) error {
 }
 
 // SetBaudRate sets the communication speed for the UART.
-func (uart UART) SetBaudRate(br uint32) {
+func (uart *UART) SetBaudRate(br uint32) {
 	// Asynchronous fractional mode (Table 24-2 in datasheet)
 	//   BAUD = fref / (sampleRateValue * fbaud)
 	// (multiply by 8, to calculate fractional piece)
@@ -628,7 +628,7 @@ func (uart UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart UART) WriteByte(c byte) error {
+func (uart *UART) WriteByte(c byte) error {
 	// wait until ready to receive
 	for !uart.Bus.INTFLAG.HasBits(sam.SERCOM_USART_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -951,8 +951,8 @@ type UART struct {
 }
 
 var (
-	// UART0 is actually a USB CDC interface.
-	UART0 = &USBCDC{Buffer: NewRingBuffer()}
+	// USB is a USB CDC interface.
+	USB = &USBCDC{Buffer: NewRingBuffer()}
 )
 
 const (
@@ -2193,7 +2193,7 @@ func handleUSBIRQ(interrupt.Interrupt) {
 
 	// Start of frame
 	if (flags & sam.USB_DEVICE_INTFLAG_SOF) > 0 {
-		UART0.Flush()
+		USB.Flush()
 		// if you want to blink LED showing traffic, this would be the place...
 	}
 
@@ -2253,7 +2253,7 @@ func handleUSBIRQ(interrupt.Interrupt) {
 				setEPINTFLAG(i, sam.USB_DEVICE_ENDPOINT_EPINTFLAG_TRCPT1)
 
 				if i == usb_CDC_ENDPOINT_IN {
-					UART0.waitTxc = false
+					USB.waitTxc = false
 				}
 			}
 		}
@@ -2567,7 +2567,7 @@ func handleEndpoint(ep uint32) {
 
 	// move to ring buffer
 	for i := 0; i < count; i++ {
-		UART0.Receive(byte((udd_ep_out_cache_buffer[ep][i] & 0xFF)))
+		USB.Receive(byte((udd_ep_out_cache_buffer[ep][i] & 0xFF)))
 	}
 
 	// set byte count to zero

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -961,7 +961,7 @@ const (
 )
 
 // Configure the UART.
-func (uart UART) Configure(config UARTConfig) error {
+func (uart *UART) Configure(config UARTConfig) error {
 	// Default baud rate to 115200.
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
@@ -1064,7 +1064,7 @@ func (uart UART) Configure(config UARTConfig) error {
 }
 
 // SetBaudRate sets the communication speed for the UART.
-func (uart UART) SetBaudRate(br uint32) {
+func (uart *UART) SetBaudRate(br uint32) {
 	// Asynchronous fractional mode (Table 24-2 in datasheet)
 	//   BAUD = fref / (sampleRateValue * fbaud)
 	// (multiply by 8, to calculate fractional piece)
@@ -1078,7 +1078,7 @@ func (uart UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart UART) WriteByte(c byte) error {
+func (uart *UART) WriteByte(c byte) error {
 	// wait until ready to receive
 	for !uart.Bus.INTFLAG.HasBits(sam.SERCOM_USART_INT_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -252,9 +252,12 @@ func (p Pin) mux() *volatile.Register32 {
 }
 
 var (
-	UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
-	UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
-	UART2 = UART{Bus: esp.UART2, Buffer: NewRingBuffer()}
+	UART0  = &_UART0
+	_UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
+	UART1  = &_UART1
+	_UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	UART2  = &_UART2
+	_UART2 = UART{Bus: esp.UART2, Buffer: NewRingBuffer()}
 )
 
 type UART struct {
@@ -262,14 +265,14 @@ type UART struct {
 	Buffer *RingBuffer
 }
 
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
 	}
 	uart.Bus.CLKDIV.Set(peripheralClock / config.BaudRate)
 }
 
-func (uart UART) WriteByte(b byte) error {
+func (uart *UART) WriteByte(b byte) error {
 	for (uart.Bus.STATUS.Get()>>16)&0xff >= 128 {
 		// Read UART_TXFIFO_CNT from the status register, which indicates how
 		// many bytes there are in the transmit buffer. Wait until there are

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -140,7 +140,8 @@ func (p Pin) PortMaskClear() (*uint32, uint32) {
 }
 
 // UART0 is a hardware UART that supports both TX and RX.
-var UART0 = UART{Buffer: NewRingBuffer()}
+var UART0 = &_UART0
+var _UART0 = UART{Buffer: NewRingBuffer()}
 
 type UART struct {
 	Buffer *RingBuffer
@@ -148,7 +149,7 @@ type UART struct {
 
 // Configure the UART baud rate. TX and RX pins are fixed by the hardware so
 // cannot be modified and will be ignored.
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
 	}
@@ -157,7 +158,7 @@ func (uart UART) Configure(config UARTConfig) {
 
 // WriteByte writes a single byte to the output buffer. Note that the hardware
 // includes a buffer of 128 bytes which will be used first.
-func (uart UART) WriteByte(c byte) error {
+func (uart *UART) WriteByte(c byte) error {
 	for (esp.UART0.UART_STATUS.Get()>>16)&0xff >= 128 {
 		// Wait until the TX buffer has room.
 	}

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -56,17 +56,18 @@ type UART struct {
 }
 
 var (
-	UART0 = UART{Bus: sifive.UART0, Buffer: NewRingBuffer()}
+	UART0  = &_UART0
+	_UART0 = UART{Bus: sifive.UART0, Buffer: NewRingBuffer()}
 )
 
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	// Assuming a 16Mhz Crystal (which is Y1 on the HiFive1), the divisor for a
 	// 115200 baud rate is 138.
 	sifive.UART0.DIV.Set(138)
 	sifive.UART0.TXCTRL.Set(sifive.UART_TXCTRL_ENABLE)
 	sifive.UART0.RXCTRL.Set(sifive.UART_RXCTRL_ENABLE)
 	sifive.UART0.IE.Set(sifive.UART_IE_RXWM) // enable the receive interrupt (only)
-	intr := interrupt.New(sifive.IRQ_UART0, UART0.handleInterrupt)
+	intr := interrupt.New(sifive.IRQ_UART0, _UART0.handleInterrupt)
 	intr.SetPriority(5)
 	intr.Enable()
 }
@@ -83,7 +84,7 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart UART) WriteByte(c byte) {
+func (uart *UART) WriteByte(c byte) {
 	for sifive.UART0.TXDATA.Get()&sifive.UART_TXDATA_FULL != 0 {
 	}
 

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -8,6 +8,7 @@ var (
 	SPI0  = SPI{0}
 	I2C0  = &I2C{0}
 	UART0 = &UART{0}
+	USB   = &UART{100}
 )
 
 const (

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -7,7 +7,7 @@ package machine
 var (
 	SPI0  = SPI{0}
 	I2C0  = &I2C{0}
-	UART0 = UART{0}
+	UART0 = &UART{0}
 )
 
 const (
@@ -124,34 +124,34 @@ type UARTConfig struct {
 }
 
 // Configure the UART.
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	uartConfigure(uart.Bus, config.TX, config.RX)
 }
 
 // Read from the UART.
-func (uart UART) Read(data []byte) (n int, err error) {
+func (uart *UART) Read(data []byte) (n int, err error) {
 	return uartRead(uart.Bus, &data[0], len(data)), nil
 }
 
 // Write to the UART.
-func (uart UART) Write(data []byte) (n int, err error) {
+func (uart *UART) Write(data []byte) (n int, err error) {
 	return uartWrite(uart.Bus, &data[0], len(data)), nil
 }
 
 // Buffered returns the number of bytes currently stored in the RX buffer.
-func (uart UART) Buffered() int {
+func (uart *UART) Buffered() int {
 	return 0
 }
 
 // ReadByte reads a single byte from the UART.
-func (uart UART) ReadByte() (byte, error) {
+func (uart *UART) ReadByte() (byte, error) {
 	var b byte
 	uartRead(uart.Bus, &b, 1)
 	return b, nil
 }
 
 // WriteByte writes a single byte to the UART.
-func (uart UART) WriteByte(b byte) error {
+func (uart *UART) WriteByte(b byte) error {
 	uartWrite(uart.Bus, &b, 1)
 	return nil
 }

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -338,10 +338,11 @@ type UART struct {
 }
 
 var (
-	UART0 = UART{Bus: kendryte.UARTHS, Buffer: NewRingBuffer()}
+	UART0  = &_UART0
+	_UART0 = UART{Bus: kendryte.UARTHS, Buffer: NewRingBuffer()}
 )
 
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 
 	// Use default baudrate  if not set.
 	if config.BaudRate == 0 {
@@ -366,7 +367,7 @@ func (uart UART) Configure(config UARTConfig) {
 	// Enable interrupts on receive.
 	uart.Bus.IE.Set(kendryte.UARTHS_IE_RXWM)
 
-	intr := interrupt.New(kendryte.IRQ_UARTHS, UART0.handleInterrupt)
+	intr := interrupt.New(kendryte.IRQ_UARTHS, _UART0.handleInterrupt)
 	intr.SetPriority(5)
 	intr.Enable()
 }
@@ -383,7 +384,7 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart UART) WriteByte(c byte) {
+func (uart *UART) WriteByte(c byte) {
 	for uart.Bus.TXDATA.Get()&kendryte.UARTHS_TXDATA_FULL != 0 {
 	}
 

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -137,12 +137,13 @@ type UART struct {
 
 // UART
 var (
-	// NRF_UART0 is the hardware UART on the NRF SoC.
-	NRF_UART0 = UART{Buffer: NewRingBuffer()}
+	// UART0 is the hardware UART on the NRF SoC.
+	_NRF_UART0 = UART{Buffer: NewRingBuffer()}
+	NRF_UART0  = &_NRF_UART0
 )
 
 // Configure the UART.
-func (uart UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) {
 	// Default baud rate to 115200.
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
@@ -164,13 +165,13 @@ func (uart UART) Configure(config UARTConfig) {
 	nrf.UART0.INTENSET.Set(nrf.UART_INTENSET_RXDRDY_Msk)
 
 	// Enable RX IRQ.
-	intr := interrupt.New(nrf.IRQ_UART0, NRF_UART0.handleInterrupt)
+	intr := interrupt.New(nrf.IRQ_UART0, _NRF_UART0.handleInterrupt)
 	intr.SetPriority(0xc0) // low priority
 	intr.Enable()
 }
 
 // SetBaudRate sets the communication speed for the UART.
-func (uart UART) SetBaudRate(br uint32) {
+func (uart *UART) SetBaudRate(br uint32) {
 	// Magic: calculate 'baudrate' register from the input number.
 	// Every value listed in the datasheet will be converted to the
 	// correct register value, except for 192600. I suspect the value
@@ -185,7 +186,7 @@ func (uart UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart UART) WriteByte(c byte) error {
+func (uart *UART) WriteByte(c byte) error {
 	nrf.UART0.EVENTS_TXDRDY.Set(0)
 	nrf.UART0.TXD.Set(uint32(c))
 	for nrf.UART0.EVENTS_TXDRDY.Get() == 0 {

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -138,8 +138,8 @@ type UART struct {
 // UART
 var (
 	// UART0 is the hardware UART on the NRF SoC.
-	_NRF_UART0 = UART{Buffer: NewRingBuffer()}
-	NRF_UART0  = &_NRF_UART0
+	_UART0 = UART{Buffer: NewRingBuffer()}
+	UART0  = &_UART0
 )
 
 // Configure the UART.
@@ -165,7 +165,7 @@ func (uart *UART) Configure(config UARTConfig) {
 	nrf.UART0.INTENSET.Set(nrf.UART_INTENSET_RXDRDY_Msk)
 
 	// Enable RX IRQ.
-	intr := interrupt.New(nrf.IRQ_UART0, _NRF_UART0.handleInterrupt)
+	intr := interrupt.New(nrf.IRQ_UART0, _UART0.handleInterrupt)
 	intr.SetPriority(0xc0) // low priority
 	intr.Enable()
 }

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -19,7 +19,7 @@ func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	return nrf.GPIO, uint32(p)
 }
 
-func (uart UART) setPins(tx, rx Pin) {
+func (uart *UART) setPins(tx, rx Pin) {
 	nrf.UART0.PSELTXD.Set(uint32(tx))
 	nrf.UART0.PSELRXD.Set(uint32(rx))
 }

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -6,10 +6,6 @@ import (
 	"device/nrf"
 )
 
-var (
-	UART0 = NRF_UART0
-)
-
 func CPUFrequency() uint32 {
 	return 16000000
 }

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -51,7 +51,7 @@ func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	return nrf.P0, uint32(p)
 }
 
-func (uart UART) setPins(tx, rx Pin) {
+func (uart *UART) setPins(tx, rx Pin) {
 	nrf.UART0.PSELTXD.Set(uint32(tx))
 	nrf.UART0.PSELRXD.Set(uint32(rx))
 }

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -42,10 +42,6 @@ const (
 	P0_31 Pin = 31
 )
 
-var (
-	UART0 = NRF_UART0
-)
-
 // Get peripheral and pin number for this GPIO pin.
 func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	return nrf.P0, uint32(p)

--- a/src/machine/machine_nrf52833.go
+++ b/src/machine/machine_nrf52833.go
@@ -58,10 +58,6 @@ const (
 	P1_15 Pin = 47
 )
 
-var (
-	UART0 = NRF_UART0
-)
-
 // Get peripheral and pin number for this GPIO pin.
 func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	if p >= 32 {

--- a/src/machine/machine_nrf52833.go
+++ b/src/machine/machine_nrf52833.go
@@ -71,7 +71,7 @@ func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	}
 }
 
-func (uart UART) setPins(tx, rx Pin) {
+func (uart *UART) setPins(tx, rx Pin) {
 	nrf.UART0.PSEL.TXD.Set(uint32(tx))
 	nrf.UART0.PSEL.RXD.Set(uint32(rx))
 }

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -67,7 +67,7 @@ func (p Pin) getPortPin() (*nrf.GPIO_Type, uint32) {
 	}
 }
 
-func (uart UART) setPins(tx, rx Pin) {
+func (uart *UART) setPins(tx, rx Pin) {
 	nrf.UART0.PSEL.TXD.Set(uint32(tx))
 	nrf.UART0.PSEL.RXD.Set(uint32(rx))
 }

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -101,18 +101,25 @@ type UART struct {
 	Interrupt    interrupt.Interrupt
 }
 
-var UART0 = UART{UART_Type: nxp.UART0, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART0, DefaultRX: defaultUART0RX, DefaultTX: defaultUART0TX}
-var UART1 = UART{UART_Type: nxp.UART1, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART1, DefaultRX: defaultUART1RX, DefaultTX: defaultUART1TX}
-var UART2 = UART{UART_Type: nxp.UART2, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART2, DefaultRX: defaultUART2RX, DefaultTX: defaultUART2TX}
-var UART3 = UART{UART_Type: nxp.UART3, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART3, DefaultRX: defaultUART3RX, DefaultTX: defaultUART3TX}
-var UART4 = UART{UART_Type: nxp.UART4, SCGC: &nxp.SIM.SCGC1, SCGCMask: nxp.SIM_SCGC1_UART4, DefaultRX: defaultUART4RX, DefaultTX: defaultUART4TX}
+var (
+	UART0  = &_UART0
+	UART1  = &_UART1
+	UART2  = &_UART2
+	UART3  = &_UART3
+	UART4  = &_UART4
+	_UART0 = UART{UART_Type: nxp.UART0, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART0, DefaultRX: defaultUART0RX, DefaultTX: defaultUART0TX}
+	_UART1 = UART{UART_Type: nxp.UART1, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART1, DefaultRX: defaultUART1RX, DefaultTX: defaultUART1TX}
+	_UART2 = UART{UART_Type: nxp.UART2, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART2, DefaultRX: defaultUART2RX, DefaultTX: defaultUART2TX}
+	_UART3 = UART{UART_Type: nxp.UART3, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART3, DefaultRX: defaultUART3RX, DefaultTX: defaultUART3TX}
+	_UART4 = UART{UART_Type: nxp.UART4, SCGC: &nxp.SIM.SCGC1, SCGCMask: nxp.SIM_SCGC1_UART4, DefaultRX: defaultUART4RX, DefaultTX: defaultUART4TX}
+)
 
 func init() {
-	UART0.Interrupt = interrupt.New(nxp.IRQ_UART0_RX_TX, UART0.handleStatusInterrupt)
-	UART1.Interrupt = interrupt.New(nxp.IRQ_UART1_RX_TX, UART1.handleStatusInterrupt)
-	UART2.Interrupt = interrupt.New(nxp.IRQ_UART2_RX_TX, UART2.handleStatusInterrupt)
-	UART3.Interrupt = interrupt.New(nxp.IRQ_UART3_RX_TX, UART3.handleStatusInterrupt)
-	UART4.Interrupt = interrupt.New(nxp.IRQ_UART4_RX_TX, UART4.handleStatusInterrupt)
+	UART0.Interrupt = interrupt.New(nxp.IRQ_UART0_RX_TX, _UART0.handleStatusInterrupt)
+	UART1.Interrupt = interrupt.New(nxp.IRQ_UART1_RX_TX, _UART1.handleStatusInterrupt)
+	UART2.Interrupt = interrupt.New(nxp.IRQ_UART2_RX_TX, _UART2.handleStatusInterrupt)
+	UART3.Interrupt = interrupt.New(nxp.IRQ_UART3_RX_TX, _UART3.handleStatusInterrupt)
+	UART4.Interrupt = interrupt.New(nxp.IRQ_UART4_RX_TX, _UART4.handleStatusInterrupt)
 }
 
 // Configure the UART.

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -144,14 +144,14 @@ func (p Pin) enableClock() {
 //---------- UART related types and code
 
 // Configure the UART.
-func (uart UART) configurePins(config UARTConfig) {
+func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
 	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
 	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed
-func (uart UART) getBaudRateDivisor(baudRate uint32) uint32 {
+func (uart *UART) getBaudRateDivisor(baudRate uint32) uint32 {
 	var clock, rate uint32
 	switch uart.Bus {
 	case stm32.LPUART1:

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -27,7 +27,7 @@ type UARTConfig struct {
 //
 
 // Read from the RX buffer.
-func (uart UART) Read(data []byte) (n int, err error) {
+func (uart *UART) Read(data []byte) (n int, err error) {
 	// check if RX buffer is empty
 	size := uart.Buffered()
 	if size == 0 {
@@ -49,7 +49,7 @@ func (uart UART) Read(data []byte) (n int, err error) {
 }
 
 // Write data to the UART.
-func (uart UART) Write(data []byte) (n int, err error) {
+func (uart *UART) Write(data []byte) (n int, err error) {
 	for _, v := range data {
 		uart.WriteByte(v)
 	}
@@ -58,7 +58,7 @@ func (uart UART) Write(data []byte) (n int, err error) {
 
 // ReadByte reads a single byte from the RX buffer.
 // If there is no data in the buffer, returns an error.
-func (uart UART) ReadByte() (byte, error) {
+func (uart *UART) ReadByte() (byte, error) {
 	// check if RX buffer is empty
 	buf, ok := uart.Buffer.Get()
 	if !ok {
@@ -68,12 +68,12 @@ func (uart UART) ReadByte() (byte, error) {
 }
 
 // Buffered returns the number of bytes currently stored in the RX buffer.
-func (uart UART) Buffered() int {
+func (uart *UART) Buffered() int {
 	return int(uart.Buffer.Used())
 }
 
 // Receive handles adding data to the UART's data buffer.
 // Usually called by the IRQ handler for a machine.
-func (uart UART) Receive(data byte) {
+func (uart *UART) Receive(data byte) {
 	uart.Buffer.Put(data)
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -604,7 +604,7 @@ func newUSBSetup(data []byte) usbSetup {
 //
 
 // Read from the RX buffer.
-func (usbcdc USBCDC) Read(data []byte) (n int, err error) {
+func (usbcdc *USBCDC) Read(data []byte) (n int, err error) {
 	// check if RX buffer is empty
 	size := usbcdc.Buffered()
 	if size == 0 {
@@ -626,7 +626,7 @@ func (usbcdc USBCDC) Read(data []byte) (n int, err error) {
 }
 
 // Write data to the USBCDC.
-func (usbcdc USBCDC) Write(data []byte) (n int, err error) {
+func (usbcdc *USBCDC) Write(data []byte) (n int, err error) {
 	for _, v := range data {
 		usbcdc.WriteByte(v)
 	}
@@ -635,7 +635,7 @@ func (usbcdc USBCDC) Write(data []byte) (n int, err error) {
 
 // ReadByte reads a single byte from the RX buffer.
 // If there is no data in the buffer, returns an error.
-func (usbcdc USBCDC) ReadByte() (byte, error) {
+func (usbcdc *USBCDC) ReadByte() (byte, error) {
 	// check if RX buffer is empty
 	buf, ok := usbcdc.Buffer.Get()
 	if !ok {
@@ -645,13 +645,13 @@ func (usbcdc USBCDC) ReadByte() (byte, error) {
 }
 
 // Buffered returns the number of bytes currently stored in the RX buffer.
-func (usbcdc USBCDC) Buffered() int {
+func (usbcdc *USBCDC) Buffered() int {
 	return int(usbcdc.Buffer.Used())
 }
 
 // Receive handles adding data to the UART's data buffer.
 // Usually called by the IRQ handler for a machine.
-func (usbcdc USBCDC) Receive(data byte) {
+func (usbcdc *USBCDC) Receive(data byte) {
 	usbcdc.Buffer.Put(data)
 }
 

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -8,11 +8,11 @@ import (
 )
 
 func initUART() {
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 // Sleep for a given period. The period is defined by the WDT peripheral, and is

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -30,11 +30,11 @@ func init() {
 	initADCClock()
 
 	// connect to USB CDC interface
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initClocks() {

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -30,11 +30,11 @@ func init() {
 	initADCClock()
 
 	// connect to USB CDC interface
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initClocks() {

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -14,7 +14,7 @@ type timeUnit int64
 var currentTime timeUnit
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func postinit() {}
@@ -53,7 +53,7 @@ func main() {
 	preinit()
 
 	// Initialize UART.
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	// Configure timer 0 in timer group 0, for timekeeping.
 	//   EN:       Enable the timer.

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -14,7 +14,7 @@ type timeUnit int64
 var currentTime timeUnit = 0
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 // Write to the internal control bus (using I2C?).
@@ -37,7 +37,7 @@ func main() {
 	rom_i2c_writeReg(103, 4, 2, 145)
 
 	// Initialize UART.
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	// Initialize timer. Bits:
 	//  ENABLE:   timer enable

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -93,11 +93,11 @@ func initPeripherals() {
 	sifive.RTC.RTCCFG.Set(sifive.RTC_RTCCFG_ENALWAYS)
 
 	// Configure the UART.
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 var timerWakeup volatile.Register8

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -105,11 +105,11 @@ func initPeripherals() {
 	// Enable FPIOA peripheral.
 	kendryte.SYSCTL.CLK_EN_PERI.SetBits(kendryte.SYSCTL_CLK_EN_PERI_FPIOA_CLK_EN)
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 var timerWakeup volatile.Register8

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -29,7 +29,7 @@ func main() {
 }
 
 func init() {
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 	initLFCLK()
 	initRTC()
 }
@@ -64,7 +64,7 @@ func initRTC() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func sleepTicks(d timeUnit) {

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -229,7 +229,7 @@ func initInternal() {
 func postinit() {}
 
 func putchar(c byte) {
-	machine.PutcharUART(&machine.UART0, c)
+	machine.PutcharUART(machine.UART0, c)
 }
 
 func abort() {
@@ -256,9 +256,9 @@ func abort() {
 		// keep polling some communication while in fault
 		// mode, so we don't completely die.
 		// machine.PollUSB(&machine.USB0)
-		machine.PollUART(&machine.UART0)
-		machine.PollUART(&machine.UART1)
-		machine.PollUART(&machine.UART2)
+		machine.PollUART(machine.UART0)
+		machine.PollUART(machine.UART1)
+		machine.PollUART(machine.UART2)
 	}
 }
 

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -33,7 +33,7 @@ func init() {
 		Device:         stm32.TIM3,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB1ENR,
@@ -43,7 +43,7 @@ func init() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 // initCLK sets clock to 72MHz using HSE 8MHz crystal w/ PLL X 9 (8MHz x 9 = 72MHz).

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -181,10 +181,10 @@ func initCLK() {
 
 func initCOM() {
 	if machine.NUM_UART_INTERFACES > 0 {
-		machine.UART0.Configure(machine.UARTConfig{})
+		machine.Serial.Configure(machine.UARTConfig{})
 	}
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -51,7 +51,7 @@ func init() {
 		Device:         stm32.TIM3,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB1ENR,
@@ -61,7 +61,7 @@ func init() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initCLK() {

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -50,7 +50,7 @@ func init() {
 		Device:         stm32.TIM3,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB1ENR,
@@ -60,7 +60,7 @@ func init() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initCLK() {

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -14,7 +14,7 @@ const (
 type arrtype = uint16
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initCLK() {

--- a/src/runtime/runtime_stm32l0x1.go
+++ b/src/runtime/runtime_stm32l0x1.go
@@ -34,7 +34,7 @@ func init() {
 		Device:         stm32.TIM22,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB2ENR,

--- a/src/runtime/runtime_stm32l0x2.go
+++ b/src/runtime/runtime_stm32l0x2.go
@@ -34,7 +34,7 @@ func init() {
 		Device:         stm32.TIM3,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB1ENR,

--- a/src/runtime/runtime_stm32l4x2.go
+++ b/src/runtime/runtime_stm32l4x2.go
@@ -75,7 +75,7 @@ func init() {
 		Device:         stm32.TIM15,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB2ENR,
@@ -85,7 +85,7 @@ func init() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initCLK() {

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -51,7 +51,7 @@ func init() {
 		Device:         stm32.TIM15,
 	})
 
-	machine.UART0.Configure(machine.UARTConfig{})
+	machine.Serial.Configure(machine.UARTConfig{})
 
 	initTickTimer(&timerInfo{
 		EnableRegister: &stm32.RCC.APB2ENR,
@@ -61,7 +61,7 @@ func init() {
 }
 
 func putchar(c byte) {
-	machine.UART0.WriteByte(c)
+	machine.Serial.WriteByte(c)
 }
 
 func initCLK() {


### PR DESCRIPTION
Previously, the machine.UART0 object had two meanings:

  - it was the first UART on the chip
  - it was the default output for println

These two meanings conflict, and resulted in workarounds like:

  - Defining UART0 to refer to the USB-CDC interface (atsamd21,
    atsamd51, nrf52840), even though that clearly isn't an UART.
  - Defining NRF_UART0 to avoid a conflict with UART0 (which was
    redefined as a USB-CDC interface).
  - Defining aliases like UART0 = UART1, which refer to the same
    hardware peripheral (stm32).

This PR changes this to use a new machine.Serial object for the
default serial port. It might refer to the first or second UART
depending on the board, or even to the USB-CDC interface. Also, UART0
now really refers to the first UART on the chip, no longer to a USB-CDC
interface.

To make that work, I also made both the `machine.USBCDC` and the `machine.UART` pointer receivers so that these objects can more easily be assigned to different variables without copying.