### PR TITLE
syscall: add support for getting uid/gid/pid and related numbers

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 11 // last change: change method name globals
+const Version = 12 // last change: implement syscall.rawSyscallNoError
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -1304,6 +1304,8 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.emitCSROperation(instr)
 		case strings.HasPrefix(name, "syscall.Syscall"):
 			return b.createSyscall(instr)
+		case strings.HasPrefix(name, "syscall.rawSyscallNoError"):
+			return b.createRawSyscallNoError(instr)
 		case strings.HasPrefix(name, "runtime/volatile.Load"):
 			return b.createVolatileLoad(instr)
 		case strings.HasPrefix(name, "runtime/volatile.Store"):

--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -1,6 +1,18 @@
 package os
 
+import "syscall"
+
 type Signal interface {
 	String() string
 	Signal() // to distinguish from other Stringers
+}
+
+// Getpid returns the process id of the caller, or -1 if unavailable.
+func Getpid() int {
+	return syscall.Getpid()
+}
+
+// Getppid returns the process id of the caller's parent, or -1 if unavailable.
+func Getppid() int {
+	return syscall.Getppid()
 }

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -196,8 +196,3 @@ func Readlink(name string) (string, error) {
 func TempDir() string {
 	return "/tmp"
 }
-
-// Getpid is a stub (for now), always returning 1
-func Getpid() int {
-	return 1
-}

--- a/src/os/proc.go
+++ b/src/os/proc.go
@@ -24,3 +24,31 @@ func runtime_args() []string // in package runtime
 func Exit(code int) {
 	syscall.Exit(code)
 }
+
+// Getuid returns the numeric user id of the caller.
+//
+// On non-POSIX systems, it returns -1.
+func Getuid() int {
+	return syscall.Getuid()
+}
+
+// Geteuid returns the numeric effective user id of the caller.
+//
+// On non-POSIX systems, it returns -1.
+func Geteuid() int {
+	return syscall.Geteuid()
+}
+
+// Getgid returns the numeric group id of the caller.
+//
+// On non-POSIX systems, it returns -1.
+func Getgid() int {
+	return syscall.Getgid()
+}
+
+// Getegid returns the numeric effective group id of the caller.
+//
+// On non-POSIX systems, it returns -1.
+func Getegid() int {
+	return syscall.Getegid()
+}

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,0 +1,13 @@
+// +build baremetal wasi wasm
+
+// This file emulates some process-related functions that are only available
+// under a real operating system.
+
+package syscall
+
+func Getuid() int  { return -1 }
+func Geteuid() int { return -1 }
+func Getgid() int  { return -1 }
+func Getegid() int { return -1 }
+func Getpid() int  { return -1 }
+func Getppid() int { return -1 }

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,0 +1,37 @@
+// +build !baremetal,!wasi,!wasm
+
+// This file assumes there is a libc available that runs on a real operating
+// system.
+
+package syscall
+
+func Getuid() int  { return int(libc_getuid()) }
+func Geteuid() int { return int(libc_geteuid()) }
+func Getgid() int  { return int(libc_getgid()) }
+func Getegid() int { return int(libc_getegid()) }
+func Getpid() int  { return int(libc_getpid()) }
+func Getppid() int { return int(libc_getppid()) }
+
+// uid_t getuid(void)
+//export getuid
+func libc_getuid() int32
+
+// gid_t getgid(void)
+//export getgid
+func libc_getgid() int32
+
+// uid_t geteuid(void)
+//export geteuid
+func libc_geteuid() int32
+
+// gid_t getegid(void)
+//export getegid
+func libc_getegid() int32
+
+// gid_t getpid(void)
+//export getpid
+func libc_getpid() int32
+
+// gid_t getppid(void)
+//export getppid
+func libc_getppid() int32

--- a/src/syscall/syscall_baremetal.go
+++ b/src/syscall/syscall_baremetal.go
@@ -98,14 +98,8 @@ type ProcAttr struct {
 type SysProcAttr struct {
 }
 
-func Getegid() int                      { return 1 }
-func Geteuid() int                      { return 1 }
-func Getgid() int                       { return 1 }
 func Getgroups() ([]int, error)         { return []int{1}, nil }
-func Getppid() int                      { return 2 }
-func Getpid() int                       { return 3 }
 func Gettimeofday(tv *Timeval) error    { return ENOSYS }
-func Getuid() int                       { return 1 }
 func Kill(pid int, signum Signal) error { return ENOSYS }
 func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err error) {
 	return 0, ENOSYS

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -62,10 +62,6 @@ func Kill(pid int, sig Signal) (err error) {
 	return ENOSYS // TODO
 }
 
-func Getpid() (pid int) {
-	panic("unimplemented: getpid") // TODO
-}
-
 func Getenv(key string) (value string, found bool) {
 	data := append([]byte(key), 0)
 	raw := libc_getenv(&data[0])

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"syscall"
 )
 
 func main() {
@@ -12,6 +13,14 @@ func main() {
 	fmt.Println("stdin: ", os.Stdin.Name())
 	fmt.Println("stdout:", os.Stdout.Name())
 	fmt.Println("stderr:", os.Stderr.Name())
+
+	// Package syscall, this mostly checks whether the calls don't trigger an error.
+	syscall.Getuid()
+	syscall.Geteuid()
+	syscall.Getgid()
+	syscall.Getegid()
+	syscall.Getpid()
+	syscall.Getppid()
 
 	// package math/rand
 	fmt.Println("pseudorandom number:", rand.Int31())


### PR DESCRIPTION
This is for compatibility with the existing syscall package and in fact
these functions are implemented in the baremetal syscall version. The
numbers will most likely be fake for WebAssembly but that's the job of
wasi-libc to sort out.

I'm not sure how to add tests for these, as they are normally unknown by
definition (unlike command line arguments and environment variables
which can be set by a test program).

See: https://github.com/tinygo-org/tinygo/issues/1886