### PR TITLE
Add a stub for os.ReadDir()

### DIFF
--- a/src/os/file_go_116.go
+++ b/src/os/file_go_116.go
@@ -17,6 +17,10 @@ func (f *File) ReadDir(n int) ([]DirEntry, error) {
 	return nil, &PathError{"ReadDir", f.name, ErrNotImplemented}
 }
 
+func ReadDir(name string) ([]DirEntry, error) {
+	return nil, &PathError{"ReadDir", name, ErrNotImplemented}
+}
+
 // The followings are copied from Go 1.16 official implementation:
 // https://github.com/golang/go/blob/go1.16/src/os/file.go
 


### PR DESCRIPTION
This is needed by crypto/x509 in some configuration.
Related to #1888.