### PR TITLE
cgo: make const parser capable of prefix and infix expressions

### DIFF
--- a/cgo/const.go
+++ b/cgo/const.go
@@ -39,6 +39,7 @@ func init() {
 		token.STRING: parseBasicLit,
 		token.CHAR:   parseBasicLit,
 		token.LPAREN: parseParenExpr,
+		token.SUB:    parseUnaryExpr,
 	}
 }
 
@@ -128,6 +129,17 @@ func parseBinaryExpr(t *tokenizer, left ast.Expr) (ast.Expr, *scanner.Error) {
 	t.Next()
 	right, err := parseConstExpr(t, precedence)
 	expression.Y = right
+	return expression, err
+}
+
+func parseUnaryExpr(t *tokenizer) (ast.Expr, *scanner.Error) {
+	expression := &ast.UnaryExpr{
+		OpPos: t.curPos,
+		Op:    t.curToken,
+	}
+	t.Next()
+	x, err := parseConstExpr(t, precedencePrefix)
+	expression.X = x
 	return expression, err
 }
 

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -44,6 +44,10 @@ func TestParseConst(t *testing.T) {
 		{`(1 - 2) * 3`, `(1 - 2) * 3`},
 		{`1 * 2 - 3`, `1*2 - 3`},
 		{`1 * (2 - 3)`, `1 * (2 - 3)`},
+		// Unary operators.
+		{`-5`, `-5`},
+		{`-5-2`, `-5 - 2`},
+		{`5 - - 2`, `5 - -2`},
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -18,7 +18,7 @@ func TestParseConst(t *testing.T) {
 		{`(5)`, `(5)`},
 		{`(((5)))`, `(5)`},
 		{`)`, `error: 1:1: unexpected token )`},
-		{`5)`, `error: 1:2: unexpected token )`},
+		{`5)`, `error: 1:2: unexpected token ), expected end of expression`},
 		{"  \t)", `error: 1:4: unexpected token )`},
 		{`5.8f`, `5.8`},
 		{`foo`, `C.foo`},
@@ -30,7 +30,7 @@ func TestParseConst(t *testing.T) {
 		{`'a'`, `'a'`},
 		{`0b10`, `0b10`},
 		{`0x1234_5678`, `0x1234_5678`},
-		{`5 5`, `error: 1:3: unexpected token INT`}, // test for a bugfix
+		{`5 5`, `error: 1:3: unexpected token INT, expected end of expression`}, // test for a bugfix
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -31,6 +31,19 @@ func TestParseConst(t *testing.T) {
 		{`0b10`, `0b10`},
 		{`0x1234_5678`, `0x1234_5678`},
 		{`5 5`, `error: 1:3: unexpected token INT, expected end of expression`}, // test for a bugfix
+		// Binary operators.
+		{`5+5`, `5 + 5`},
+		{`5-5`, `5 - 5`},
+		{`5*5`, `5 * 5`},
+		{`5/5`, `5 / 5`},
+		{`5%5`, `5 % 5`},
+		{`(5/5)`, `(5 / 5)`},
+		{`1 - 2`, `1 - 2`},
+		{`1 - 2 + 3`, `1 - 2 + 3`},
+		{`1 - 2 * 3`, `1 - 2*3`},
+		{`(1 - 2) * 3`, `(1 - 2) * 3`},
+		{`1 * 2 - 3`, `1*2 - 3`},
+		{`1 * (2 - 3)`, `1 * (2 - 3)`},
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -1,7 +1,7 @@
 // CGo errors:
 //     testdata/errors.go:4:2: warning: some warning
 //     testdata/errors.go:11:9: error: unknown type name 'someType'
-//     testdata/errors.go:13:23: unexpected token )
+//     testdata/errors.go:13:23: unexpected token ), expected end of expression
 
 // Type checking errors after CGo processing:
 //     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as uint8 value in variable declaration (overflows)

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -6,6 +6,7 @@ int fortytwo(void);
 int mul(int, int);
 #include <string.h>
 #cgo CFLAGS: -DSOME_CONSTANT=17
+#define someDefine -5 + 2 * 7
 */
 import "C"
 
@@ -26,6 +27,7 @@ func main() {
 	println("defined floats:", C.CONST_FLOAT, C.CONST_FLOAT2)
 	println("defined string:", C.CONST_STRING)
 	println("defined char:", C.CONST_CHAR)
+	println("defined expr:", C.someDefine)
 	var ptr C.intPointer
 	var n C.int = 15
 	ptr = C.intPointer(&n)

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -8,6 +8,7 @@ defined ints: 5 5
 defined floats: +5.800000e+000 +5.800000e+000
 defined string: defined string
 defined char: 99
+defined expr: 9
 15: 15
 25: 25
 callback 1: 50


### PR DESCRIPTION
I converted the CGo const parser to a Pratt parser following the book "Writing An Interpreter In Go" by Thorsten Ball. It is now capable of parsing some more numeric constants, see cgo/const_test.go for some expressions that can now be parsed.

We might need to switch to something different eventually. The trouble is that C is much more flexible with constants than Go. For example, the `!x` prefix automatically converts the value `x` to a boolean while Go doesn't do such a thing.

See https://github.com/tinygo-org/bluetooth/pull/65 for an example where this PR would be useful.