### PR TITLE
transform: work around renamed return type after merging LLVM modules

### DIFF
--- a/transform/interface-lowering.go
+++ b/transform/interface-lowering.go
@@ -578,7 +578,7 @@ func (p *lowerInterfacesPass) getInterfaceMethodFunc(itf *interfaceInfo, signatu
 			paramTypes = append(paramTypes, param.Type())
 		}
 		calledFunctionType := function.Type()
-		sig := llvm.PointerType(llvm.FunctionType(calledFunctionType.ElementType().ReturnType(), paramTypes, false), calledFunctionType.PointerAddressSpace())
+		sig := llvm.PointerType(llvm.FunctionType(returnType, paramTypes, false), calledFunctionType.PointerAddressSpace())
 		if sig != function.Type() {
 			function = p.builder.CreateBitCast(function, sig, "")
 		}


### PR DESCRIPTION
This fix is very similar to https://github.com/tinygo-org/tinygo/pull/1768, but now for the return type. It fixes the issue in https://github.com/tinygo-org/tinygo/issues/1887.

Like #1768, I'm not sure how to test this as it is very specific to certain renames that LLVM does and that don't seem very reproducable.