### PR TITLE
Implement reflect.AppendSlice

### DIFF
--- a/src/reflect/sidetables.go
+++ b/src/reflect/sidetables.go
@@ -25,9 +25,9 @@ var arrayTypesSidetable byte
 // table.
 func readStringSidetable(table unsafe.Pointer, index uintptr) string {
 	nameLen, namePtr := readVarint(unsafe.Pointer(uintptr(table) + index))
-	return *(*string)(unsafe.Pointer(&StringHeader{
-		Data: uintptr(namePtr),
-		Len:  nameLen,
+	return *(*string)(unsafe.Pointer(&stringHeader{
+		data: namePtr,
+		len:  nameLen,
 	}))
 }
 

--- a/src/reflect/swapper.go
+++ b/src/reflect/swapper.go
@@ -24,15 +24,15 @@ func Swapper(slice interface{}) func(i, j int) {
 	typ := v.typecode.Elem()
 	size := typ.Size()
 
-	header := (*SliceHeader)(v.value)
+	header := (*sliceHeader)(v.value)
 	tmp := unsafe.Pointer(&make([]byte, size)[0])
 
 	return func(i, j int) {
-		if uint(i) >= uint(header.Len) || uint(j) >= uint(header.Len) {
+		if uint(i) >= uint(header.len) || uint(j) >= uint(header.len) {
 			panic("reflect: slice index out of range")
 		}
-		val1 := unsafe.Pointer(header.Data + uintptr(i)*size)
-		val2 := unsafe.Pointer(header.Data + uintptr(j)*size)
+		val1 := unsafe.Pointer(uintptr(header.data) + uintptr(i)*size)
+		val2 := unsafe.Pointer(uintptr(header.data) + uintptr(j)*size)
 		memcpy(tmp, val1, size)
 		memcpy(val1, val2, size)
 		memcpy(val2, tmp, size)


### PR DESCRIPTION
This implementation basically just calls through to the runtime implementation of the `append` built-in (`runtime.sliceAppend`) with a few extra checks to ensure type safety.

See: https://github.com/tinygo-org/tinygo/issues/1879#issuecomment-844650456