### PR TITLE
os: add FileMode constants from Go 1.16

### DIFF
--- a/src/os/file_go_116.go
+++ b/src/os/file_go_116.go
@@ -83,3 +83,31 @@ func WriteFile(name string, data []byte, perm FileMode) error {
 	}
 	return err
 }
+
+// The defined file mode bits are the most significant bits of the FileMode.
+// The nine least-significant bits are the standard Unix rwxrwxrwx permissions.
+// The values of these bits should be considered part of the public API and
+// may be used in wire protocols or disk representations: they must not be
+// changed, although new bits might be added.
+const (
+	// The single letters are the abbreviations
+	// used by the String method's formatting.
+	ModeDir        = fs.ModeDir        // d: is a directory
+	ModeAppend     = fs.ModeAppend     // a: append-only
+	ModeExclusive  = fs.ModeExclusive  // l: exclusive use
+	ModeTemporary  = fs.ModeTemporary  // T: temporary file; Plan 9 only
+	ModeSymlink    = fs.ModeSymlink    // L: symbolic link
+	ModeDevice     = fs.ModeDevice     // D: device file
+	ModeNamedPipe  = fs.ModeNamedPipe  // p: named pipe (FIFO)
+	ModeSocket     = fs.ModeSocket     // S: Unix domain socket
+	ModeSetuid     = fs.ModeSetuid     // u: setuid
+	ModeSetgid     = fs.ModeSetgid     // g: setgid
+	ModeCharDevice = fs.ModeCharDevice // c: Unix character device, when ModeDevice is set
+	ModeSticky     = fs.ModeSticky     // t: sticky
+	ModeIrregular  = fs.ModeIrregular  // ?: non-regular file; nothing else is known about this file
+
+	// Mask for the type bits. For regular files, none will be set.
+	ModeType = fs.ModeType
+
+	ModePerm = fs.ModePerm // Unix permission bits, 0o777
+)


### PR DESCRIPTION
If you try to build the following code, you will get an error.
In this PR, we will add the constants needed for the above.
It is completely copied from the Go 1.16 source code.

https://github.com/tinygo-org/drivers/pull/265

before:
```
$ tinygo flash --target wioterminal --size short --programmer cmsis-dap ./examples/sdcard/tinyfs/
# github.com/tinygo-org/tinyfs/fatfs
..\..\..\..\pkg\mod\github.com\tinygo-org\tinyfs@v0.0.0-20210514090915-924e60a7bcf8\fatfs\go_fatfs.go:163:11: ModeDir not declared by package os
```