### PR TITLE
Do not disable interrupts on abort

### DIFF
--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -7,9 +7,6 @@ import (
 )
 
 func abort() {
-	// disable all interrupts
-	arm.DisableInterrupts()
-
 	// lock up forever
 	for {
 		arm.Asm("wfi")


### PR DESCRIPTION
Allows panic messages to be printed fully into serial console.

I've been testing this tiny fix for several days now.
So far panic messages been delivered reliably to serial console w/o any adverse side effects.

Thanks Ayke for the hint where to look.

Fixes #1889 