### PR TITLE
scheduler: task.Data made 64bit to avoid overflow

### DIFF
--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -5,7 +5,7 @@ target triple = "armv7m-none-eabi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }
-%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i32, %"internal/task.state" }
+%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.state" }
 %"internal/task.state" = type { i32, i32* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -6,7 +6,7 @@ target triple = "wasm32--wasi"
 %runtime.funcValueWithSignature = type { i32, i8* }
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }
-%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i32, %"internal/task.state" }
+%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.state" }
 %"internal/task.state" = type { i8* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 

--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -13,7 +13,7 @@ type Task struct {
 	Ptr unsafe.Pointer
 
 	// Data is a field which can be used for storing state information.
-	Data uint
+	Data uint64
 
 	// state is the underlying running state of the task.
 	state state

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -88,7 +88,7 @@ func addSleepTask(t *task.Task, duration timeUnit) {
 			panic("runtime: addSleepTask: expected next task to be nil")
 		}
 	}
-	t.Data = uint(duration) // TODO: longer durations
+	t.Data = uint64(duration)
 	now := ticks()
 	if sleepQueue == nil {
 		scheduleLog("  -> sleep new queue")


### PR DESCRIPTION
This is to re-add the change that broke the build to increase size of task.Data (to avoid overflows):
* original add was here: https://github.com/tinygo-org/tinygo/commit/fd8938c6346010979992986b2a1b512449e5c866
* revert was here: https://github.com/tinygo-org/tinygo/commit/ed2db8a26d8b5f3fdb9bf6365002bc6eeb19c758

I can't reproduce locally (make test doesn't break for me), but I believe I've found the cause of the build break, that the compiler test data needs to be updated since the task struct is included in the IR matched against the compiler output.