### PR TITLE
qtpy: add pin for neopixels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-nrf52840  examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=qtpy  				examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=qtpy                examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=teensy40            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -42,7 +42,8 @@ const (
 )
 
 const (
-	LED = D13
+	NEOPIXELS       = D11
+	NEOPIXELS_POWER = D12
 )
 
 // USBCDC pins


### PR DESCRIPTION
This PR adds the neopixels pins and the neopixels power pins to qtpy.
There are no LEDs in qtpy, so I removed them.

https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/qtpy_m0/variant.cpp#L44-L45
https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/qtpy_m0/variant.cpp#L47-L48
https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/qtpy_m0/variant.cpp#L83-L85

Once this PR is merged, the following code will work.
The following code will also create a PR later.

https://github.com/tinygo-org/drivers/commit/7d206bdb93245f10b17aa8f83784af84e7753254