### PR TITLE
nrf: avoid heap allocations

### DIFF
--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -115,13 +115,14 @@ func (a ADC) Get() uint16 {
 // SPI on the NRF.
 type SPI struct {
 	Bus *nrf.SPIM_Type
+	buf *[1]byte // 1-byte buffer for the Transfer method
 }
 
 // There are 3 SPI interfaces on the NRF528xx.
 var (
-	SPI0 = SPI{Bus: nrf.SPIM0}
-	SPI1 = SPI{Bus: nrf.SPIM1}
-	SPI2 = SPI{Bus: nrf.SPIM2}
+	SPI0 = SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
+	SPI1 = SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
+	SPI2 = SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
 )
 
 // SPIConfig is used to store config info for SPI.
@@ -207,10 +208,10 @@ func (spi SPI) Configure(config SPIConfig) {
 
 // Transfer writes/reads a single byte using the SPI interface.
 func (spi SPI) Transfer(w byte) (byte, error) {
-	var wbuf, rbuf [1]byte
-	wbuf[0] = w
-	err := spi.Tx(wbuf[:], rbuf[:])
-	return rbuf[0], err
+	buf := spi.buf[:]
+	buf[0] = w
+	err := spi.Tx(buf[:], buf[:])
+	return buf[0], err
 }
 
 // Tx handles read/write operation for SPI interface. Since SPI is a syncronous

--- a/src/runtime/runtime_nrf_softdevice.go
+++ b/src/runtime/runtime_nrf_softdevice.go
@@ -10,6 +10,9 @@ import (
 //export sd_app_evt_wait
 func sd_app_evt_wait()
 
+// This is a global variable to avoid a heap allocation in waitForEvents.
+var softdeviceEnabled uint8
+
 func waitForEvents() {
 	// Call into the SoftDevice to sleep. This is necessary here because a
 	// normal wfe will not put the chip in low power mode (it still consumes
@@ -18,10 +21,9 @@ func waitForEvents() {
 
 	// First check whether the SoftDevice is enabled. Unfortunately,
 	// sd_app_evt_wait cannot be called when the SoftDevice is not enabled.
-	var enabled uint8
-	arm.SVCall1(0x12, &enabled) // sd_softdevice_is_enabled
+	arm.SVCall1(0x12, &softdeviceEnabled) // sd_softdevice_is_enabled
 
-	if enabled != 0 {
+	if softdeviceEnabled != 0 {
 		// Now pick the appropriate SVCall number. Hopefully they won't change
 		// in the future with a different SoftDevice version.
 		if nrf.Device == "nrf51" {


### PR DESCRIPTION
This is a PR with two unrelated commits that avoid unnecessary heap allocations.