### PR TITLE
increase stack size for access to sdcard

### DIFF
--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -5,5 +5,6 @@
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",
     "msd-firmware-name": "firmware.uf2",
-    "openocd-interface": "jlink"
+    "openocd-interface": "jlink",
+    "default-stack-size": 2048
 }

--- a/targets/p1am-100.json
+++ b/targets/p1am-100.json
@@ -2,5 +2,6 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "p1am_100"],
     "flash-command": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
-    "flash-1200-bps-reset": "true"
+    "flash-1200-bps-reset": "true",
+    "default-stack-size": 2048
 }

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -4,5 +4,6 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",
-    "msd-firmware-name": "arcade.uf2"
+    "msd-firmware-name": "arcade.uf2",
+    "default-stack-size": 2048
 }

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -4,5 +4,6 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PORTALBOOT",
-    "msd-firmware-name": "firmware.uf2"
+    "msd-firmware-name": "firmware.uf2",
+    "default-stack-size": 2048
 }

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -4,5 +4,6 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",
-    "msd-firmware-name": "firmware.uf2"
+    "msd-firmware-name": "firmware.uf2",
+    "default-stack-size": 2048
 }


### PR DESCRIPTION
I had to change default-stack-size to use drivers/sdcard.
As discussed in the following PR, change the configuration of the board with the built-in sdcard reader.

https://github.com/tinygo-org/drivers/pull/265#issuecomment-851433104