### PR TITLE
all: add a flag to the command line to select the serial implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=1     examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10040 -serial=none examples/echo
+	@$(MD5SUM) test.hex
 	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/serial
 	@$(MD5SUM) test.nro
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -55,7 +55,7 @@ func (c *Config) GOARCH() string {
 
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
-	tags := append(c.Target.BuildTags, []string{"tinygo", "gc." + c.GC(), "scheduler." + c.Scheduler()}...)
+	tags := append(c.Target.BuildTags, []string{"tinygo", "gc." + c.GC(), "scheduler." + c.Scheduler(), "serial." + c.Serial()}...)
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}
@@ -111,6 +111,18 @@ func (c *Config) Scheduler() string {
 	}
 	// Fall back to coroutines, which are supported everywhere.
 	return "coroutines"
+}
+
+// Serial returns the serial implementation for this build configuration: uart,
+// usb (meaning USB-CDC), or none.
+func (c *Config) Serial() string {
+	if c.Options.Serial != "" {
+		return c.Options.Serial
+	}
+	if c.Target.Serial != "" {
+		return c.Target.Serial
+	}
+	return "none"
 }
 
 // OptLevels returns the optimization level (0-2), size level (0-2), and inliner

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -9,6 +9,7 @@ import (
 var (
 	validGCOptions            = []string{"none", "leaking", "extalloc", "conservative"}
 	validSchedulerOptions     = []string{"none", "tasks", "coroutines"}
+	validSerialOptions        = []string{"none", "uart", "usb"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
 	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
@@ -22,6 +23,7 @@ type Options struct {
 	GC              string
 	PanicStrategy   string
 	Scheduler       string
+	Serial          string
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool
@@ -56,6 +58,15 @@ func (o *Options) Verify() error {
 			return fmt.Errorf(`invalid scheduler option '%s': valid values are %s`,
 				o.Scheduler,
 				strings.Join(validSchedulerOptions, ", "))
+		}
+	}
+
+	if o.Serial != "" {
+		valid := isInArray(validSerialOptions, o.Serial)
+		if !valid {
+			return fmt.Errorf(`invalid serial option '%s': valid values are %s`,
+				o.Serial,
+				strings.Join(validSerialOptions, ", "))
 		}
 	}
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -31,6 +31,7 @@ type TargetSpec struct {
 	BuildTags        []string `json:"build-tags"`
 	GC               string   `json:"gc"`
 	Scheduler        string   `json:"scheduler"`
+	Serial           string   `json:"serial"` // which serial output to use (uart, usb, none)
 	Linker           string   `json:"linker"`
 	RTLib            string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
 	Libc             string   `json:"libc"`

--- a/main.go
+++ b/main.go
@@ -950,6 +950,7 @@ func main() {
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, extalloc, conservative)")
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, coroutines, tasks)")
+	serial := flag.String("serial", "", "which serial output to use (none, uart, usb)")
 	printIR := flag.Bool("printir", false, "print LLVM IR")
 	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
@@ -1022,6 +1023,7 @@ func main() {
 		GC:              *gc,
 		PanicStrategy:   *panicStrategy,
 		Scheduler:       *scheduler,
+		Serial:          *serial,
 		PrintIR:         *printIR,
 		DumpSSA:         *dumpSSA,
 		VerifyIR:        *verifyIR,

--- a/src/machine/board_arduino_mkr1000.go
+++ b/src/machine/board_arduino_mkr1000.go
@@ -47,8 +47,6 @@ const (
 	LED = D6
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN Pin = PA24

--- a/src/machine/board_arduino_zero.go
+++ b/src/machine/board_arduino_zero.go
@@ -35,8 +35,6 @@ const (
 	LED3 Pin = PB03 // RX LED
 )
 
-var Serial = USB
-
 // ADC pins
 const (
 	AREF Pin = PA03

--- a/src/machine/board_atsamd21.go
+++ b/src/machine/board_atsamd21.go
@@ -74,5 +74,3 @@ const (
 	PB30 Pin = 62
 	PB31 Pin = 63
 )
-
-var Serial = USB

--- a/src/machine/board_atsame54-xpro.go
+++ b/src/machine/board_atsame54-xpro.go
@@ -15,8 +15,6 @@ const (
 	BUTTON = PB31
 )
 
-var Serial = USB
-
 const (
 	// https://ww1.microchip.com/downloads/en/DeviceDoc/70005321A.pdf
 

--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -17,7 +17,7 @@ const (
 	BUTTON = PA0
 )
 
-var Serial = UART1
+var DefaultUART = UART1
 
 // UART pins
 const (

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -57,8 +57,6 @@ const (
 	UART_RX_PIN = P0_30 // PORTB
 )
 
-var Serial = USB
-
 // I2C pins
 const (
 	SDA_PIN = P0_05 // I2C0 external

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -104,11 +104,6 @@ const (
 	UART_TX_PIN = D1
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins
 const (
 	SDA_PIN = D20 // I2C0 external

--- a/src/machine/board_esp32-coreboard-v2.go
+++ b/src/machine/board_esp32-coreboard-v2.go
@@ -68,8 +68,6 @@ const (
 	ADC3 Pin = IO39
 )
 
-var Serial = UART0
-
 // UART0 pins
 const (
 	UART_TX_PIN = IO1

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -47,8 +47,6 @@ const (
 	WS2812    = D8
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -40,8 +40,6 @@ const (
 	WS2812 = D8
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -76,11 +76,6 @@ const (
 	UART_TX_PIN = D1
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins
 const (
 	SDA_PIN = D22 // I2C0 external

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -141,7 +141,7 @@ var (
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 )
 
 func initUART() {

--- a/src/machine/board_grandcentral-m4.go
+++ b/src/machine/board_grandcentral-m4.go
@@ -142,8 +142,6 @@ const (
 	WS2812   = NEOPIXEL_PIN
 )
 
-var Serial = USB
-
 // UART pins
 const (
 	UART1_RX_PIN = D0 // (PB25)

--- a/src/machine/board_hifive1b.go
+++ b/src/machine/board_hifive1b.go
@@ -35,7 +35,7 @@ const (
 	LED_BLUE  = P21
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 const (
 	// TODO: figure out the pin numbers for these.

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -37,8 +37,6 @@ const (
 	LED = D13
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -70,11 +70,6 @@ const (
 	UART_TX_PIN = D1
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins
 const (
 	SDA_PIN = D21 // I2C0 external

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -54,7 +54,7 @@ const (
 	I2C0_SDA_PIN = PA10
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 var (
 

--- a/src/machine/board_maixbit.go
+++ b/src/machine/board_maixbit.go
@@ -52,7 +52,7 @@ const (
 	LED_BLUE  = D14
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // Default pins for UARTHS.
 const (

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -41,8 +41,6 @@ const (
 	WS2812 = D40
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_microbit-v2.go
+++ b/src/machine/board_microbit-v2.go
@@ -12,7 +12,7 @@ const (
 	BUTTONB Pin = P11
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins
 const (

--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -12,7 +12,7 @@ const (
 	BUTTONB Pin = 26
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins
 const (

--- a/src/machine/board_nicenano.go
+++ b/src/machine/board_nicenano.go
@@ -54,11 +54,6 @@ const (
 	UART_TX_PIN = P0_08
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins
 const (
 	SDA_PIN = P0_17 // I2C0 external

--- a/src/machine/board_nodemcu.go
+++ b/src/machine/board_nodemcu.go
@@ -20,8 +20,6 @@ const (
 // Onboard blue LED (on the AI-Thinker module).
 const LED = D4
 
-var Serial = UART0
-
 // SPI pins
 const (
 	SPI0_SCK_PIN = D5

--- a/src/machine/board_nrf52840-mdk-usb-dongle.go
+++ b/src/machine/board_nrf52840-mdk-usb-dongle.go
@@ -23,9 +23,6 @@ const (
 	UART_RX_PIN Pin = NoPin
 )
 
-// Serial is the USB device
-var Serial = USB
-
 // I2C pins (unused)
 const (
 	SDA_PIN = NoPin

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -18,9 +18,6 @@ const (
 	UART_RX_PIN Pin = 19
 )
 
-// Serial is the USB device
-var Serial = USB
-
 // I2C pins (unused)
 const (
 	SDA_PIN = NoPin

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -34,7 +34,7 @@ var (
 		Buffer: NewRingBuffer(),
 		Bus:    stm32.USART2,
 	}
-	Serial = UART2
+	DefaultUART = UART2
 )
 
 func init() {

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -38,7 +38,7 @@ var (
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 )
 
 func init() {

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -76,7 +76,7 @@ var (
 		TxAltFuncSelector: 4,
 		RxAltFuncSelector: 4,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -78,7 +78,7 @@ var (
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 3,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 
 	// I2C1 is documented, alias to I2C0 as well
 	I2C1 = &I2C{

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -38,7 +38,7 @@ var (
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 )
 
 const (

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = UART0
+	DefaultUART = UART0
 )
 
 const (

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = UART0
+	DefaultUART = UART0
 )
 
 const (

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -41,7 +41,7 @@ const (
 
 // UART
 var (
-	Serial = UART0
+	DefaultUART = UART0
 )
 
 const (

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -19,7 +19,7 @@ const (
 	LED_BLUE  Pin = 23
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins
 const (

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -23,7 +23,7 @@ const (
 	BUTTON4 Pin = 16
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins for NRF52840-DK
 const (

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -22,7 +22,7 @@ const (
 	BUTTON4 Pin = 25
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins
 const (

--- a/src/machine/board_pca10059.go
+++ b/src/machine/board_pca10059.go
@@ -34,11 +34,6 @@ const (
 	UART_RX_PIN Pin = NoPin
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins (unused)
 const (
 	SDA_PIN = NoPin

--- a/src/machine/board_pinetime-devkit0.go
+++ b/src/machine/board_pinetime-devkit0.go
@@ -17,7 +17,7 @@ const (
 	LED3 = LCD_BACKLIGHT_LOW
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins for PineTime. Note that RX is set to NoPin as RXD is not listed in
 // the PineTime schematic 1.0:

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -67,8 +67,6 @@ const (
 	BUTTON_B_MASK      = 128
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_pygamer.go
+++ b/src/machine/board_pygamer.go
@@ -70,8 +70,6 @@ const (
 	BUTTON_B_MASK      = 128
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -95,8 +95,6 @@ const (
 	LED = D13
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PA24

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -29,7 +29,7 @@ const (
 	BUTTON Pin = 7
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART pins
 const (

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -38,7 +38,7 @@ var (
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
-	Serial = UART1
+	DefaultUART = UART1
 )
 
 // set up RX IRQ handler. Follow similar pattern for other UARTx instances

--- a/src/machine/board_teensy36.go
+++ b/src/machine/board_teensy36.go
@@ -87,6 +87,8 @@ var (
 	TeensyUART5 = UART4
 )
 
+var DefaultUART = UART0
+
 const (
 	defaultUART0RX = D00
 	defaultUART0TX = D01

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -136,9 +136,9 @@ const (
 )
 
 var (
-	Serial = UART1
-	UART1  = &_UART1
-	_UART1 = UART{
+	DefaultUART = UART1
+	UART1       = &_UART1
+	_UART1      = UART{
 		Bus:      nxp.LPUART6,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),

--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -325,8 +325,6 @@ const (
 	OUTPUT_CTR_3V3 = PC15
 )
 
-var Serial = USB
-
 // USBCDC pins
 const (
 	USBCDC_DM_PIN = PIN_USB_DM

--- a/src/machine/board_x9pro.go
+++ b/src/machine/board_x9pro.go
@@ -27,4 +27,4 @@ const (
 
 const HasLowFrequencyCrystal = true
 
-var Serial = UART0
+var DefaultUART = UART0

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -122,7 +122,7 @@ func (i2c *I2C) readByte() byte {
 }
 
 // Always use UART0 as the serial output.
-var Serial = UART0
+var DefaultUART = UART0
 
 // UART
 var (

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -251,6 +251,8 @@ func (p Pin) mux() *volatile.Register32 {
 	}
 }
 
+var DefaultUART = UART0
+
 var (
 	UART0  = &_UART0
 	_UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -139,6 +139,8 @@ func (p Pin) PortMaskClear() (*uint32, uint32) {
 	return &esp.GPIO.GPIO_OUT_W1TC.Reg, 1 << p
 }
 
+var DefaultUART = UART0
+
 // UART0 is a hardware UART that supports both TX and RX.
 var UART0 = &_UART0
 var _UART0 = UART{Buffer: NewRingBuffer()}

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -11,6 +11,12 @@ var (
 	USB   = &UART{100}
 )
 
+// The Serial port always points to the default UART in a simulated environment.
+//
+// TODO: perhaps this should be a special serial object that outputs via WASI
+// stdout calls.
+var Serial = UART0
+
 const (
 	PinInput PinMode = iota
 	PinOutput
@@ -116,12 +122,6 @@ func i2cTransfer(bus uint8, w *byte, wlen int, r *byte, rlen int) int
 
 type UART struct {
 	Bus uint8
-}
-
-type UARTConfig struct {
-	BaudRate uint32
-	TX       Pin
-	RX       Pin
 }
 
 // Configure the UART.

--- a/src/machine/machine_rp2040.go
+++ b/src/machine/machine_rp2040.go
@@ -108,7 +108,7 @@ var (
 	}
 )
 
-var Serial = UART0
+var DefaultUART = UART0
 
 func init() {
 	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)

--- a/src/machine/serial-none.go
+++ b/src/machine/serial-none.go
@@ -1,0 +1,6 @@
+// +build baremetal,serial.none
+
+package machine
+
+// Serial is a null device: writes to it are ignored.
+var Serial = NullSerial{}

--- a/src/machine/serial-uart.go
+++ b/src/machine/serial-uart.go
@@ -1,0 +1,6 @@
+// +build baremetal,serial.uart
+
+package machine
+
+// Serial is implemented via the default (usually the first) UART on the chip.
+var Serial = DefaultUART

--- a/src/machine/serial-usb.go
+++ b/src/machine/serial-usb.go
@@ -1,0 +1,6 @@
+// +build baremetal,serial.usb
+
+package machine
+
+// Serial is implemented via USB (USB-CDC).
+var Serial = USB

--- a/src/machine/serial.go
+++ b/src/machine/serial.go
@@ -1,0 +1,46 @@
+package machine
+
+import "errors"
+
+var errNoByte = errors.New("machine: no byte read")
+
+// UARTConfig is a struct with which a UART (or similar object) can be
+// configured. The baud rate is usually respected, but TX and RX may be ignored
+// depending on the chip and the type of object.
+type UARTConfig struct {
+	BaudRate uint32
+	TX       Pin
+	RX       Pin
+}
+
+// NullSerial is a serial version of /dev/null (or null router): it drops
+// everything that is written to it.
+type NullSerial struct {
+}
+
+// Configure does nothing: the null serial has no configuration.
+func (ns NullSerial) Configure(config UARTConfig) error {
+	return nil
+}
+
+// WriteByte is a no-op: the null serial doesn't write bytes.
+func (ns NullSerial) WriteByte(b byte) error {
+	return nil
+}
+
+// ReadByte always returns an error because there aren't any bytes to read.
+func (ns NullSerial) ReadByte() (byte, error) {
+	return 0, errNoByte
+}
+
+// Buffered returns how many bytes are buffered in the UART. It always returns 0
+// as there are no bytes to read.
+func (ns NullSerial) Buffered() int {
+	return 0
+}
+
+// Write is a no-op: none of the data is being written and it will not return an
+// error.
+func (ns NullSerial) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -23,12 +23,6 @@ const (
 	ParityOdd UARTParity = 2
 )
 
-type UARTConfig struct {
-	BaudRate uint32
-	TX       Pin
-	RX       Pin
-}
-
 // To implement the UART interface for a board, you must declare a concrete type as follows:
 //
 // 		type UART struct {

--- a/targets/arduino-mkr1000.json
+++ b/targets/arduino-mkr1000.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_mkr1000"],
+	"serial": "usb",
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino-zero.json
+++ b/targets/arduino-zero.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_zero"],
+	"serial": "usb",
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }

--- a/targets/atmega1280.json
+++ b/targets/atmega1280.json
@@ -2,6 +2,7 @@
     "inherits": ["avr"],
     "cpu": "atmega1280",
     "build-tags": ["atmega1280", "atmega"],
+    "serial": "uart",
     "cflags": [
         "-mmcu=atmega1280"
     ],

--- a/targets/atmega1284p.json
+++ b/targets/atmega1284p.json
@@ -2,6 +2,7 @@
     "inherits": ["avr"],
     "cpu": "atmega1284p",
     "build-tags": ["atmega1284p", "atmega"],
+    "serial": "uart",
     "cflags": [
         "-mmcu=atmega1284p"
     ],

--- a/targets/atmega2560.json
+++ b/targets/atmega2560.json
@@ -2,6 +2,7 @@
     "inherits": ["avr"],
     "cpu": "atmega2560",
     "build-tags": ["atmega2560", "atmega"],
+    "serial": "uart",
     "cflags": [
         "-mmcu=atmega2560"
     ],

--- a/targets/atmega328p.json
+++ b/targets/atmega328p.json
@@ -2,6 +2,7 @@
 	"inherits": ["avr"],
 	"cpu": "atmega328p",
 	"build-tags": ["atmega328p", "atmega", "avr5"],
+	"serial": "uart",
 	"cflags": [
 		"-mmcu=atmega328p"
 	],

--- a/targets/atsamd21e18a.json
+++ b/targets/atsamd21e18a.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["cortex-m0plus"],
 	"build-tags": ["atsamd21e18a", "atsamd21e18", "atsamd21", "sam"],
+	"serial": "usb",
 	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21e18a.s"

--- a/targets/atsamd21g18a.json
+++ b/targets/atsamd21g18a.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["cortex-m0plus"],
 	"build-tags": ["atsamd21g18a", "atsamd21g18", "atsamd21", "sam"],
+	"serial": "usb",
 	"linkerscript": "targets/atsamd21.ld",
 	"extra-files": [
 		"src/device/sam/atsamd21g18a.s"

--- a/targets/atsame54-xpro.json
+++ b/targets/atsame54-xpro.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsame54p20a"],
     "build-tags": ["atsame54_xpro"],
+    "serial": "usb",
     "flash-method": "openocd",
     "openocd-interface": "cmsis-dap",
     "default-stack-size": 4096

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["cortex-m3"],
 	"build-tags": ["bluepill", "stm32f103", "stm32f1", "stm32"],
+	"serial": "uart",
 	"linkerscript": "targets/stm32.ld",
 	"extra-files": [
 		"src/device/stm32/stm32f103.s"

--- a/targets/circuitplay-bluefruit.json
+++ b/targets/circuitplay-bluefruit.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["circuitplay_bluefruit","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "CPLAYBTBOOT",

--- a/targets/clue-alpha.json
+++ b/targets/clue-alpha.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["clue_alpha","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "CLUEBOOT",

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -3,6 +3,7 @@
 	"cpu": "esp32",
 	"build-tags": ["esp32", "esp"],
 	"scheduler": "tasks",
+	"serial": "uart",
 	"linker": "xtensa-esp32-elf-ld",
 	"default-stack-size": 2048,
 	"cflags": [

--- a/targets/feather-m4-can.json
+++ b/targets/feather-m4-can.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsame51j19a"],
     "build-tags": ["feather_m4_can"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHRCANBOOT",

--- a/targets/feather-m4.json
+++ b/targets/feather-m4.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j19a"],
     "build-tags": ["feather_m4"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-nrf52840.json
+++ b/targets/feather-nrf52840.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["feather_nrf52840","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHR840BOOT",

--- a/targets/feather-stm32f405.json
+++ b/targets/feather-stm32f405.json
@@ -1,6 +1,7 @@
 {
   "inherits": ["cortex-m4"],
   "build-tags": ["feather_stm32f405", "stm32f405", "stm32f4", "stm32"],
+  "serial": "uart",
   "automatic-stack-size": false,
   "default-stack-size": 1024,
   "linkerscript": "targets/stm32f405.ld",

--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51p20a"],
     "build-tags": ["grandcentral_m4"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",

--- a/targets/hifive1-qemu.json
+++ b/targets/hifive1-qemu.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["fe310"],
 	"build-tags": ["hifive1b", "qemu"],
+	"serial": "uart",
 	"linkerscript": "targets/hifive1-qemu.ld",
 	"emulator": ["qemu-system-riscv32", "-machine", "sifive_e", "-nographic", "-kernel"]
 }

--- a/targets/hifive1b.json
+++ b/targets/hifive1b.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["fe310"],
 	"build-tags": ["hifive1b"],
+	"serial": "uart",
 	"linkerscript": "targets/hifive1b.ld",
 	"flash-method": "msd",
 	"msd-volume-name": "HiFive",

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51g19a"],
     "build-tags": ["itsybitsy_m4"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSYM4BOOT",

--- a/targets/itsybitsy-nrf52840.json
+++ b/targets/itsybitsy-nrf52840.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["itsybitsy_nrf52840","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSY840BOOT",

--- a/targets/lgt92.json
+++ b/targets/lgt92.json
@@ -5,6 +5,7 @@
 	"build-tags": [
 		"lgt92"
 	],
+	"serial": "uart",
 	"linkerscript": "targets/stm32l072czt6.ld",
 	"flash-method": "openocd",
 	"openocd-interface": "stlink-v2",

--- a/targets/maixbit.json
+++ b/targets/maixbit.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["k210"],
 	"build-tags": ["maixbit"],
+	"serial": "uart",
 	"linkerscript": "targets/maixbit.ld",
 	"flash-command": "kflash -p {port} --noansi --verbose {bin}"
 }

--- a/targets/metro-m4-airlift.json
+++ b/targets/metro-m4-airlift.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j19a"],
     "build-tags": ["metro_m4_airlift"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "METROM4BOOT",

--- a/targets/microbit-v2.json
+++ b/targets/microbit-v2.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52833"],
 	"build-tags": ["microbit_v2"],
+	"serial": "uart",
 	"flash-method": "msd",
 	"openocd-interface": "cmsis-dap",
 	"msd-volume-name": "MICROBIT",

--- a/targets/microbit.json
+++ b/targets/microbit.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf51"],
 	"build-tags": ["microbit"],
+	"serial": "uart",
 	"flash-method": "msd",
 	"openocd-interface": "cmsis-dap",
 	"msd-volume-name": "MICROBIT",

--- a/targets/nicenano.json
+++ b/targets/nicenano.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["nicenano","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "NICENANO",

--- a/targets/nodemcu.json
+++ b/targets/nodemcu.json
@@ -1,4 +1,5 @@
 {
 	"inherits": ["esp8266"],
-	"build-tags": ["nodemcu"]
+	"build-tags": ["nodemcu"],
+	"serial": "uart"
 }

--- a/targets/nrf52840-mdk-usb-dongle.json
+++ b/targets/nrf52840-mdk-usb-dongle.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["nrf52840"],
     "build-tags": ["nrf52840_mdk_usb_dongle", "nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "MDK-DONGLE",

--- a/targets/nrf52840-mdk.json
+++ b/targets/nrf52840-mdk.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["nrf52840_mdk"],
+	"serial": "usb",
 	"flash-method": "openocd",
 	"openocd-interface": "cmsis-dap"
 }

--- a/targets/nucleo-f103rb.json
+++ b/targets/nucleo-f103rb.json
@@ -1,6 +1,7 @@
 {
   "inherits": ["cortex-m3"],
   "build-tags": ["nucleof103rb", "stm32f103", "stm32f1","stm32"],
+  "serial": "uart",
   "linkerscript": "targets/stm32f103rb.ld",
   "extra-files": [
     "src/device/stm32/stm32f103.s"

--- a/targets/nucleo-f722ze.json
+++ b/targets/nucleo-f722ze.json
@@ -1,6 +1,7 @@
 {
   "inherits": ["cortex-m7"],
   "build-tags": ["nucleof722ze", "stm32f7x2", "stm32f7", "stm32"],
+  "serial": "uart",
   "linkerscript": "targets/stm32f7x2zetx.ld",
   "extra-files": [
     "src/device/stm32/stm32f7x2.s"

--- a/targets/nucleo-l031k6.json
+++ b/targets/nucleo-l031k6.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["cortex-m0"],
     "build-tags": ["nucleol031k6", "stm32l031", "stm32l0x1", "stm32l0", "stm32"],
+    "serial": "uart",
     "linkerscript": "targets/stm32l031k6.ld",
     "extra-files": [
         "src/device/stm32/stm32l0x1.s"

--- a/targets/nucleo-l432kc.json
+++ b/targets/nucleo-l432kc.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["cortex-m4"],
     "build-tags": ["nucleol432kc", "stm32l432", "stm32l4x2", "stm32l4", "stm32"],
+    "serial": "uart",
     "linkerscript": "targets/stm32l4x2.ld",
     "extra-files": [
       "src/device/stm32/stm32l4x2.s"

--- a/targets/nucleo-l552ze.json
+++ b/targets/nucleo-l552ze.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["cortex-m33"],
     "build-tags": ["nucleol552ze", "stm32l552", "stm32l5x2", "stm32l5", "stm32"],
+    "serial": "uart",
     "linkerscript": "targets/stm32l5x2xe.ld",
     "extra-files": [
       "src/device/stm32/stm32l552.s"

--- a/targets/particle-3rd-gen.json
+++ b/targets/particle-3rd-gen.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["particle_3rd_gen"],
+	"serial": "uart",
 	"flash-method": "openocd",
 	"openocd-interface": "cmsis-dap"
 }

--- a/targets/pca10031.json
+++ b/targets/pca10031.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf51"],
 	"build-tags": ["pca10031"],
+	"serial": "uart",
 	"flash-command": "nrfjprog -f nrf51 --sectorerase --program {hex} --reset",
 	"openocd-interface": "cmsis-dap"
 }

--- a/targets/pca10040.json
+++ b/targets/pca10040.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52"],
 	"build-tags": ["pca10040"],
+	"serial": "uart",
 	"flash-method": "openocd",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",

--- a/targets/pca10056.json
+++ b/targets/pca10056.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["pca10056"],
+	"serial": "uart",
 	"flash-method": "command",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"msd-volume-name": "JLINK",

--- a/targets/pca10059.json
+++ b/targets/pca10059.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["pca10059"],
+	"serial": "usb",
 	"linkerscript": "targets/pca10059.ld",
 	"binary-format": "nrf-dfu",
 	"flash-command": "nrfutil dfu usb-serial -pkg {zip} -p {port} -b 115200"

--- a/targets/pico.json
+++ b/targets/pico.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "build-tags": ["pico"],
+    "serial": "uart",
     "linkerscript": "targets/pico.ld",
     "extra-files": [
         "targets/pico_boot_stage2.S"

--- a/targets/pinetime-devkit0.json
+++ b/targets/pinetime-devkit0.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52"],
 	"build-tags": ["pinetime_devkit0"],
+	"serial": "uart",
 	"flash-method": "openocd",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",

--- a/targets/pybadge.json
+++ b/targets/pybadge.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j19a"],
     "build-tags": ["pybadge"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYBADGEBOOT",

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j19a"],
     "build-tags": ["pygamer"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51j20a"],
     "build-tags": ["pyportal"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PORTALBOOT",

--- a/targets/reelboard.json
+++ b/targets/reelboard.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52840"],
 	"build-tags": ["reelboard"],
+	"serial": "uart",
 	"flash-method": "msd",
 	"msd-volume-name": "reel-board",
 	"msd-firmware-name": "firmware.hex",

--- a/targets/stm32f4disco.json
+++ b/targets/stm32f4disco.json
@@ -1,6 +1,7 @@
 {
   "inherits": ["cortex-m4"],
   "build-tags": ["stm32f4disco", "stm32f407", "stm32f4", "stm32"],
+  "serial": "uart",
   "linkerscript": "targets/stm32f407.ld",
   "extra-files": [
     "src/device/stm32/stm32f407.s"

--- a/targets/teensy36.json
+++ b/targets/teensy36.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["cortex-m4"],
 	"build-tags": ["teensy36", "teensy", "mk66f18", "nxp"],
+	"serial": "uart",
 	"linkerscript": "targets/nxpmk66f18.ld",
 	"extra-files": [
 		"src/device/nxp/mk66f18.s",

--- a/targets/teensy40.json
+++ b/targets/teensy40.json
@@ -1,6 +1,7 @@
 {
   "inherits": ["cortex-m7"],
   "build-tags": ["teensy40", "teensy", "mimxrt1062", "nxp"],
+  "serial": "uart",
   "automatic-stack-size": false,
   "default-stack-size": 4096,
   "linkerscript": "targets/mimxrt1062-teensy40.ld",

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -1,6 +1,7 @@
 {
     "inherits": ["atsamd51p19a"],
     "build-tags": ["wioterminal"],
+    "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",

--- a/targets/x9pro.json
+++ b/targets/x9pro.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["nrf52"],
 	"build-tags": ["x9pro"],
+	"serial": "uart",
 	"flash-method": "openocd",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",


### PR DESCRIPTION
This can be very useful for some purposes:

  * It makes it possible to disable the UART in cases where it is not needed or needs to be disabled to conserve power.
  * It makes it possible to disable the serial output to reduce code size, which may be important for some chips. Sometimes, a few kB can be saved this way.
  * It makes it possible to override the default, for example you might want to use an actual UART to debug the USB-CDC implementation.

It also lowers the dependency on having machine.Serial defined, which is often not defined when targeting a chip. Eventually, we might want to make it possible to write `-target=nrf52` or `-target=atmega328p` for example to target the chip itself with no board specific assumptions.

The defaults don't change. I checked this by running `make smoketest XTENSA=0` before and after and comparing the results.