### PR TITLE
main: don't consider compile-only tests as failing

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func Test(pkgName string, options *compileopts.Options, testCompileOnly bool, ou
 		return false, err
 	}
 
-	var passed bool
+	passed := true
 	err = builder.Build(pkgName, outpath, config, func(result builder.BuildResult) error {
 		if testCompileOnly || outpath != "" {
 			// Write test binary to the specified file name.


### PR DESCRIPTION
Previously a command like the following would incorrectly print FAIL:

    tinygo test -c math

This commit fixes this issue by defaulting to a passing test (the test is marked as passed if it isn't run).
Thanks to @ysoldak for finding this bug!