### PR TITLE
Fix testing main packages

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -343,12 +343,11 @@ func (p *Package) Check() error {
 	checker.Importer = p
 
 	packageName := p.ImportPath
-	if p.Name == "main" {
-		// The main package normally has a different import path, such as
-		// "command-line-arguments" or "./testdata/cgo". Therefore, use the name
-		// "main" in such a case: this package isn't imported from anywhere.
-		// This is safe as it isn't possible to import a package with the name
-		// "main".
+	if p == p.program.MainPkg() {
+		if p.Name != "main" {
+			// Sanity check. Should not ever trigger.
+			panic("expected main package to have name 'main'")
+		}
 		packageName = "main"
 	}
 	typesPkg, err := checker.Check(packageName, p.program.fset, p.Files, &p.info)

--- a/main.go
+++ b/main.go
@@ -947,10 +947,11 @@ func main() {
 	wasmAbi := flag.String("wasm-abi", "", "WebAssembly ABI conventions: js (no i64 params) or generic")
 	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
 
-	var flagJSON, flagDeps *bool
+	var flagJSON, flagDeps, flagTest *bool
 	if command == "help" || command == "list" {
 		flagJSON = flag.Bool("json", false, "print data in JSON format")
-		flagDeps = flag.Bool("deps", false, "")
+		flagDeps = flag.Bool("deps", false, "supply -deps flag to go list")
+		flagTest = flag.Bool("test", false, "supply -test flag to go list")
 	}
 	var outpath string
 	if command == "help" || command == "build" || command == "build-library" || command == "test" {
@@ -1199,6 +1200,9 @@ func main() {
 		}
 		if *flagDeps {
 			extraArgs = append(extraArgs, "-deps")
+		}
+		if *flagTest {
+			extraArgs = append(extraArgs, "-test")
 		}
 		cmd, err := loader.List(config, extraArgs, flag.Args())
 		if err != nil {


### PR DESCRIPTION
Reported by @ysoldak.

This PR fixes testing the main package. Before this PR, it would show an internal error like this:

    $ tinygo test -target arduino-nano33 -c ./tinytest/
    error: package github.com/foo/bar/tinytest.test imports main but couldn't find dependency