### PR TITLE
main: escape commands while printing them with the -x flag

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -547,8 +547,8 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 				}
 				ldflags = append(ldflags, dependency.result)
 			}
-			if config.Options.PrintCommands {
-				fmt.Printf("%s %s\n", config.Target.Linker, strings.Join(ldflags, " "))
+			if config.Options.PrintCommands != nil {
+				config.Options.PrintCommands(config.Target.Linker, ldflags...)
 			}
 			err = link(config.Target.Linker, ldflags...)
 			if err != nil {

--- a/builder/cc.go
+++ b/builder/cc.go
@@ -56,7 +56,7 @@ import (
 //   depfile but without invalidating its name. For this reason, the depfile is
 //   written on each new compilation (even when it seems unnecessary). However, it
 //   could in rare cases lead to a stale file fetched from the cache.
-func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands bool) (string, error) {
+func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands func(string, ...string)) (string, error) {
 	// Hash input file.
 	fileHash, err := hashFile(abspath)
 	if err != nil {
@@ -128,8 +128,8 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 		// flags (for the assembler) is a compiler error.
 		flags = append(flags, "-Qunused-arguments")
 	}
-	if printCommands {
-		fmt.Printf("clang %s\n", strings.Join(flags, " "))
+	if printCommands != nil {
+		printCommands("clang", flags...)
 	}
 	err = runCCompiler(flags...)
 	if err != nil {

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -25,7 +25,7 @@ type Options struct {
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool
-	PrintCommands   bool
+	PrintCommands   func(cmd string, args ...string)
 	Debug           bool
 	PrintSizes      string
 	PrintAllocs     *regexp.Regexp // regexp string


### PR DESCRIPTION
This should make issues such as the one in https://github.com/tinygo-org/tinygo/issues/1910 more obvious.