### PR TITLE
docker: use github actions to build/publish tinygo-dev dockerfile

### DIFF
--- a/.github/workflows/build-tinygo-dev-docker.yml
+++ b/.github/workflows/build-tinygo-dev-docker.yml
@@ -1,0 +1,45 @@
+name: CI for tinygo-dev docker container
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GHCR/Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            tinygo/tinygo-dev
+            ghcr.io/${{ github.repository }}/tinygo-dev
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Log in to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR switches to use github actions to build/publish tinygo-dev dockerfile to Docker Hub. This will also stop the docker hub build failure notification.

This is tested and working.

Bonus: also pushes to the Github Container Registry ghcr.io