### PR TITLE
board/nano-33-ble: pins, blinking leds and serial

### DIFF
--- a/src/machine/board_nano-33-ble.go
+++ b/src/machine/board_nano-33-ble.go
@@ -1,0 +1,100 @@
+// +build nano_33_ble
+
+// This contains the pin mappings for the Arduino Nano 33 BLE [Sense] boards.
+//
+// Flashing the board requires special version of bossac.
+//
+// This executable can be obtained two ways:
+// 1) In Arduino IDE, install support for the board ("Arduino Mbed OS Nano Boards")
+//    Search for "tools/bossac/1.9.1-arduino2/bossac" in Arduino IDEs directory
+// 2) Download https://downloads.arduino.cc/packages/package_index.json
+//    Search for "bossac-1.9.1-arduino2" in that file
+//    Download tarball for your OS and unpack it
+//
+// Once you have the executable, make it accessible in your PATH as "bossac_arduino2".
+//
+// It is possible to replace original bossac with this new one (this only adds support for nrf chip).
+// In that case make "bossac_arduino2" symlink on it, for the board target to be able to find it.
+//
+// For more information, see:
+// - https://store.arduino.cc/arduino-nano-33-ble
+// - https://store.arduino.cc/arduino-nano-33-ble-sense
+//
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// Digital Pins
+const (
+	D2  Pin = P1_11
+	D3  Pin = P1_12
+	D4  Pin = P1_15
+	D5  Pin = P1_13
+	D6  Pin = P1_14
+	D7  Pin = P0_23
+	D8  Pin = P0_21
+	D9  Pin = P0_27
+	D10 Pin = P1_02
+	D11 Pin = P1_01
+	D12 Pin = P1_08
+	D13 Pin = P0_13
+)
+
+// Analog pins
+const (
+	A0 Pin = P0_04
+	A1 Pin = P0_05
+	A2 Pin = P0_30
+	A3 Pin = P0_29
+	A4 Pin = P0_31
+	A5 Pin = P0_02
+	A6 Pin = P0_28
+	A7 Pin = P0_03
+)
+
+// Onboard LEDs
+const (
+	LED         = LED_BUILTIN
+	LED1        = LED_RED
+	LED2        = LED_GREEN
+	LED3        = LED_BLUE
+	LED_BUILTIN = P0_13
+	LED_RED     = P0_24
+	LED_GREEN   = P0_16
+	LED_BLUE    = P0_06
+)
+
+// UART0 pins
+const (
+	UART_RX_PIN = P1_10
+	UART_TX_PIN = P1_03
+)
+
+// Serial is the USB device
+var (
+	Serial = USB
+)
+
+// I2C pins
+const (
+	SDA_PIN = P0_31
+	SCL_PIN = P0_02
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = P0_13
+	SPI0_SDO_PIN = P1_01
+	SPI0_SDI_PIN = P1_08
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Nano 33 BLE"
+	usb_STRING_MANUFACTURER = "Arduino"
+)
+
+var (
+	usb_VID uint16 = 0x2341
+	usb_PID uint16 = 0x805a
+)

--- a/targets/nano-33-ble.json
+++ b/targets/nano-33-ble.json
@@ -1,0 +1,7 @@
+{
+	"inherits": ["nrf52840"],
+	"build-tags": ["nano_33_ble"],
+	"flash-command": "bossac_arduino2 -d -i -e -w -v -R --port={port} {bin}",
+	"flash-1200-bps-reset": "true",
+	"linkerscript": "targets/nano-33-ble.ld"
+}

--- a/targets/nano-33-ble.ld
+++ b/targets/nano-33-ble.ld
@@ -1,0 +1,14 @@
+
+/*
+  See also 
+  https://github.com/arduino/ArduinoCore-mbed/blob/master/variants/ARDUINO_NANO33BLE/linker_script.ld
+*/
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x10000, LENGTH = 0xf0000
+    RAM (rwx)       : ORIGIN = 0x20000000, LENGTH = 0x40000
+}
+
+_stack_size = 4K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
Support Arduino Nano 33 BLE [Sense] boards.

Flashed and verified with `blinky1`, `blinky2` and `echo` examples.

Requires special version of bossac, that can be easily obtained either via Arduino IDE or by simple download.
See comments in the header of the board definition. (thanks @deadprogram for finding the second option!)

~Examples changed a bit, hope that's OK.~