### PR TITLE
BlackMagic/BMP Initial support for flashing and debugging

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -285,6 +285,9 @@ func (c *Config) Programmer() (method, openocdInterface string) {
 	case "openocd", "msd", "command":
 		// The -programmer flag only specifies the flash method.
 		return c.Options.Programmer, c.Target.OpenOCDInterface
+	case "bmp":
+		// The -programmer flag only specifies the flash method.
+		return c.Options.Programmer, ""
 	default:
 		// The -programmer flag specifies something else, assume it specifies
 		// the OpenOCD interface name.

--- a/main.go
+++ b/main.go
@@ -288,6 +288,8 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 		fileExt = filepath.Ext(config.Target.FlashFilename)
 	case "openocd":
 		fileExt = ".hex"
+	case "bmp":
+		fileExt = ".elf"
 	case "native":
 		return errors.New("unknown flash method \"native\" - did you miss a -target flag?")
 	default:
@@ -380,6 +382,25 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 				return &commandError{"failed to flash", result.Binary, err}
 			}
 			return nil
+		case "bmp":
+			gdb, err := config.Target.LookupGDB()
+			if err != nil {
+				return err
+			}
+			var bmpGDBPort string
+			bmpGDBPort, _, err = getBMPPorts()
+			if err != nil {
+				return err
+			}
+			args := []string{"-ex", "target extended-remote " + bmpGDBPort, "-ex", "monitor swdp_scan", "-ex", "attach 1", "-ex", "load", filepath.ToSlash(result.Binary)}
+			cmd := executeCommand(config.Options, gdb, args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+			if err != nil {
+				return &commandError{"failed to flash", result.Binary, err}
+			}
+			return nil
 		default:
 			return fmt.Errorf("unknown flash method: %s", flashMethod)
 		}
@@ -434,6 +455,13 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 		switch gdbInterface {
 		case "native":
 			// Run GDB directly.
+		case "bmp":
+			var bmpGDBPort string
+			bmpGDBPort, _, err = getBMPPorts()
+			if err != nil {
+				return err
+			}
+			gdbCommands = append(gdbCommands, "target extended-remote "+bmpGDBPort, "monitor swdp_scan", "compare-sections", "attach 1", "load")
 		case "openocd":
 			gdbCommands = append(gdbCommands, "target extended-remote :3333", "monitor halt", "load", "monitor reset halt")
 
@@ -839,6 +867,35 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 	}
 
 	return "", errors.New("port you specified '" + strings.Join(portCandidates, ",") + "' does not exist, available ports are " + strings.Join(ports, ", "))
+}
+
+// getBMPPorts returns BlackMagicProbe's serial ports if any
+func getBMPPorts() (gdbPort, uartPort string, err error) {
+	var portsList []*enumerator.PortDetails
+	portsList, err = enumerator.GetDetailedPortsList()
+	if err != nil {
+		return "", "", err
+	}
+	var ports []string
+	for _, p := range portsList {
+		if !p.IsUSB {
+			continue
+		}
+		if p.VID != "" && p.PID != "" {
+			vid, vidErr := strconv.ParseUint(p.VID, 16, 16)
+			pid, pidErr := strconv.ParseUint(p.PID, 16, 16)
+			if vidErr == nil && pidErr == nil && vid == 0x1d50 && pid == 0x6018 {
+				ports = append(ports, p.Name)
+			}
+		}
+	}
+	if len(ports) == 2 {
+		return ports[0], ports[1], nil
+	} else if len(ports) == 0 {
+		return "", "", errors.New("no BMP detected")
+	} else {
+		return "", "", fmt.Errorf("expected 2 BMP serial ports, found %d - did you perhaps connect more than one BMP?", len(ports))
+	}
 }
 
 func usage() {


### PR DESCRIPTION
This PR brings  basic support for flashing and debugging with BlackMagic Interface. 
(https://github.com/blacksphere/blackmagic)

You just have to use **-programmer=bmp** to switch to BlackMagic debugger
(Default BMP Debug port is /dev/ttyACM0, but you can change it with **-port /dev/whatever**

How to use it : 
```
# For flashing
tinygo flash -x  -target=bluepill -programmer=bmp blinky1.go

# For debugging 
tinygo gdb -x  -target=bluepill -programmer=bmp blinky1.go
```
At the moment, it was only tested on BluePill targets (stm32f103).


PS: If you don't already know BlackMagic Probe, you should read hackaday.com review: 

https://hackaday.com/2016/12/02/black-magic-probe-the-best-arm-jtag-debugger/

_"...
First off, it’s got a JTAG and a UART serial port in one device. You can flash the target, run your code, use the serial port for printf debugging like you know you want to, and then fall back on full-fledged JTAG-plus-GDB when you need to, all in one dongle. It’s just very convenient.
...
BMP’s killer feature is that it runs a GDB server on the probe. It opens up a virtual serial port that you can connect to directly through GDB on your host computer. No need to hassle around with OpenOCD configurations, or to open up a second window to run [texane]’s marvelous st-util. Just run GDB, "target extended-remote /dev/ttyACM0" and you’re debugging.
"_

