### PR TITLE
main: detect specific serial port IDs based on USB vid/pid

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -45,6 +45,7 @@ type TargetSpec struct {
 	FlashCommand     string   `json:"flash-command"`
 	GDB              []string `json:"gdb"`
 	PortReset        string   `json:"flash-1200-bps-reset"`
+	SerialPort       []string `json:"serial-port"` // serial port IDs in the form "acm:vid:pid" or "usb:vid:pid"
 	FlashMethod      string   `json:"flash-method"`
 	FlashVolume      string   `json:"msd-volume-name"`
 	FlashFilename    string   `json:"msd-firmware-name"`

--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -2,5 +2,6 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_nano33"],
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
+    "serial-port": ["acm:2341:8057", "acm:2341:0057"],
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -6,5 +6,6 @@
 		"-Wl,--defsym=_stack_size=512"
 	],
 	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
+	"serial-port": ["acm:2341:0043", "acm:2341:0001", "acm:2a03:0043", "acm:2341:0243"],
 	"emulator": ["simavr", "-m", "atmega328p", "-f", "16000000"]
 }

--- a/targets/circuitplay-bluefruit.json
+++ b/targets/circuitplay-bluefruit.json
@@ -3,6 +3,7 @@
     "build-tags": ["circuitplay_bluefruit","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
+    "serial-port": ["acm:239a:8045", "acm:239a:45"],
     "msd-volume-name": "CPLAYBTBOOT",
     "msd-firmware-name": "firmware.uf2",
     "uf2-family-id": "0xADA52840",

--- a/targets/circuitplay-express.json
+++ b/targets/circuitplay-express.json
@@ -3,6 +3,7 @@
     "build-tags": ["circuitplay_express"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
+    "serial-port": ["acm:239a:8018", "acm:239a:18"],
     "msd-volume-name": "CPLAYBOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -3,6 +3,7 @@
     "build-tags": ["itsybitsy_m4"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
+    "serial-port": ["acm:239a:802b", "acm:239a:002b"],
     "msd-volume-name": "ITSYM4BOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/nano-33-ble.json
+++ b/targets/nano-33-ble.json
@@ -2,6 +2,7 @@
 	"inherits": ["nrf52840"],
 	"build-tags": ["nano_33_ble"],
 	"flash-command": "bossac_arduino2 -d -i -e -w -v -R --port={port} {bin}",
+	"serial-port": ["acm:2341:805a", "acm:2341:005a"],
 	"flash-1200-bps-reset": "true",
 	"linkerscript": "targets/nano-33-ble.ld"
 }

--- a/targets/pybadge.json
+++ b/targets/pybadge.json
@@ -3,6 +3,7 @@
     "build-tags": ["pybadge"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
+    "serial-port": ["acm:239a:8033", "acm:239a:33"],
     "msd-volume-name": "PYBADGEBOOT",
     "msd-firmware-name": "arcade.uf2"
 }

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -3,6 +3,7 @@
     "build-tags": ["pyportal"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
+    "serial-port": ["acm:239a:8035", "acm:239a:35", "acm:239a:8036"],
     "msd-volume-name": "PORTALBOOT",
     "msd-firmware-name": "firmware.uf2",
     "default-stack-size": 2048


### PR DESCRIPTION
This makes it possible to flash a board even when there are multiple
different kinds of boards attached, e.g. an Arduino Uno and a Circuit
Playground Express. You can find the VID/PID pair in several ways:

 1. By running `lsusb` before and after attaching the board and looking
    at the new USB device.
 2. By grepping for `usb_PID` and `usb_VID` in the TinyGo source code.
 3. By checking the Arduino IDE boards.txt from the vendor.

Note that one board may have multiple VID/PID pairs:

  * The bootloader and main program may have a different PID, so far
    I've seen that the main program generally has the bootloader PID
    with 0x8000 added.
  * The software running on the board may have an erroneous PID, for
    example from a different board. I've seen this happen a few times.
  * A single board may have had some revisions which changed the PID.
    This is particularly true for the Arduino Uno.

As a fallback, if the given VID/PID pair isn't found, the whole set of
serial ports will be used.

There are many boards which I haven't included yet simply because I
couldn't test them.