### PR TITLE
nrf52840: add support for flashing with the BOSSA tool

### DIFF
--- a/src/machine/machine_nrf52840_usb_reset_bossa.go
+++ b/src/machine/machine_nrf52840_usb_reset_bossa.go
@@ -1,0 +1,26 @@
+// +build nrf52840,nrf52840_reset_bossa
+
+package machine
+
+import (
+	"device/arm"
+	"device/nrf"
+)
+
+const DFU_MAGIC_SERIAL_ONLY_RESET = 0xb0
+
+// checkShouldReset is called by the USB-CDC implementation to check whether to
+// reset into the bootloader/OTA and if so, resets the chip appropriately.
+func checkShouldReset() {
+	if usbLineInfo.dwDTERate == 1200 && usbLineInfo.lineState&usb_CDC_LINESTATE_DTR == 0 {
+		EnterSerialBootloader()
+	}
+}
+
+// EnterSerialBootloader resets the chip into the serial bootloader. After
+// reset, it can be flashed using serial/nrfutil.
+func EnterSerialBootloader() {
+	arm.DisableInterrupts()
+	nrf.POWER.GPREGRET.Set(DFU_MAGIC_SERIAL_ONLY_RESET)
+	arm.SystemReset()
+}

--- a/src/machine/machine_nrf52840_usb_reset_none.go
+++ b/src/machine/machine_nrf52840_usb_reset_none.go
@@ -1,4 +1,4 @@
-// +build nrf52840,!nrf52840_reset_uf2
+// +build nrf52840,!nrf52840_reset_uf2,!nrf52840_reset_bossa
 
 package machine
 

--- a/targets/nano-33-ble.json
+++ b/targets/nano-33-ble.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["nrf52840"],
-	"build-tags": ["nano_33_ble"],
+	"build-tags": ["nano_33_ble", "nrf52840_reset_bossa"],
 	"flash-command": "bossac_arduino2 -d -i -e -w -v -R --port={port} {bin}",
 	"flash-1200-bps-reset": "true",
 	"linkerscript": "targets/nano-33-ble.ld"


### PR DESCRIPTION
This only works with a custom bossac build from Arduino, not with the upstream version. It avoids needing the manual "double tap" to enter bootloader mode before flashing firmware.

Untested. Can somebody with an Arduino Nano 33 BLE please test this PR?