### PR TITLE
cortexm: bump default stack size to 2048 bytes

### DIFF
--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -8,7 +8,7 @@
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"automatic-stack-size": true,
-	"default-stack-size": 1024,
+	"default-stack-size": 2048,
 	"cflags": [
 		"-Oz",
 		"-mthumb",

--- a/targets/feather-stm32f405.json
+++ b/targets/feather-stm32f405.json
@@ -2,7 +2,6 @@
   "inherits": ["cortex-m4"],
   "build-tags": ["feather_stm32f405", "stm32f405", "stm32f4", "stm32"],
   "automatic-stack-size": false,
-  "default-stack-size": 1024,
   "linkerscript": "targets/stm32f405.ld",
   "extra-files": [
     "src/device/stm32/stm32f405.s"

--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -5,6 +5,5 @@
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",
     "msd-firmware-name": "firmware.uf2",
-    "openocd-interface": "jlink",
-    "default-stack-size": 2048
+    "openocd-interface": "jlink"
 }

--- a/targets/p1am-100.json
+++ b/targets/p1am-100.json
@@ -2,6 +2,5 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["sam", "atsamd21g18a", "p1am_100"],
     "flash-command": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
-    "flash-1200-bps-reset": "true",
-    "default-stack-size": 2048
+    "flash-1200-bps-reset": "true"
 }

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -4,6 +4,5 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",
-    "msd-firmware-name": "arcade.uf2",
-    "default-stack-size": 2048
+    "msd-firmware-name": "arcade.uf2"
 }

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -4,6 +4,5 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PORTALBOOT",
-    "msd-firmware-name": "firmware.uf2",
-    "default-stack-size": 2048
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -4,6 +4,5 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",
-    "msd-firmware-name": "firmware.uf2",
-    "default-stack-size": 2048
+    "msd-firmware-name": "firmware.uf2"
 }


### PR DESCRIPTION
Previously it was 1024 bytes, which occasionally ran into a stack overflow. I hope that 2048 bytes will be enough for most purposes.

I've also removed some 2048-byte stack size settings in JSON files, which are unnecessary now that the parent (cortex-m.json) sets them.

Also see https://github.com/tinygo-org/tinygo/pull/1920, which does this for a limited number of boards.