### PR TITLE
wasi: remove wasm build tag

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -89,7 +89,7 @@ func (c *Config) NeedsStackObjects() bool {
 	switch c.GC() {
 	case "conservative", "extalloc":
 		for _, tag := range c.BuildTags() {
-			if tag == "wasm" {
+			if tag == "tinygo.wasm" {
 				return true
 			}
 		}

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -1,4 +1,4 @@
-// +build arm,!baremetal,!wasm arm,arm7tdmi
+// +build arm,!baremetal,!tinygo.wasm arm,arm7tdmi
 
 package runtime
 

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -1,4 +1,4 @@
-// +build wasm
+// +build tinygo.wasm
 
 package runtime
 

--- a/src/runtime/gc_globals_conservative.go
+++ b/src/runtime/gc_globals_conservative.go
@@ -1,5 +1,5 @@
 // +build gc.conservative gc.extalloc
-// +build baremetal wasm
+// +build baremetal tinygo.wasm
 
 package runtime
 

--- a/src/runtime/gc_globals_precise.go
+++ b/src/runtime/gc_globals_precise.go
@@ -1,5 +1,5 @@
 // +build gc.conservative gc.extalloc
-// +build !baremetal,!wasm
+// +build !baremetal,!tinygo.wasm
 
 package runtime
 

--- a/src/runtime/gc_stack_portable.go
+++ b/src/runtime/gc_stack_portable.go
@@ -1,5 +1,5 @@
 // +build gc.conservative gc.extalloc
-// +build wasm
+// +build tinygo.wasm
 
 package runtime
 

--- a/src/runtime/gc_stack_raw.go
+++ b/src/runtime/gc_stack_raw.go
@@ -1,5 +1,5 @@
 // +build gc.conservative gc.extalloc
-// +build !wasm
+// +build !tinygo.wasm
 
 package runtime
 

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,4 +1,4 @@
-// +build wasm
+// +build tinygo.wasm
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-// +build wasm,wasi
+// +build tinygo.wasm,wasi
 
 package runtime
 

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target":   "wasm32--wasi",
-	"build-tags":    ["wasm", "wasi"],
+	"build-tags":    ["tinygo.wasm", "wasi"],
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,6 +1,6 @@
 {
 	"llvm-target":   "wasm32--wasi",
-	"build-tags":    ["js", "wasm"],
+	"build-tags":    ["tinygo.wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
 	"linker":        "wasm-ld",


### PR DESCRIPTION
The wasm build tag together with GOARCH=arm was causing problems in the internal/cpu package. In general, I think having two architecture build tag will only cause problems (in this case, wasm and arm) so I've removed the wasm build tag and replaced it with tinygo.wasm.

This is similar to the tinygo.riscv build tag, which is used for older Go versions that don't yet have RISC-V support in the standard library (and therefore pretend to be GOARCH=arm instead).

The situation after this PR:

* `-target=wasm` will keep using GOOS=js GOARCH=wasm
* `-target=wasi` already had GOOS=linux GOARCH=arm, but will have the wasm build tag removed for compatibility with the internal/cpu package.

Once WASI gets fully supported by the Go standard library, we can remove this workaround and use GOOS=wasi GOARCH=wasm, which would be the correct way to do this.