### PR TITLE
targets: add serial key to JSON files for newly added boards

### DIFF
--- a/src/machine/board_nano-33-ble.go
+++ b/src/machine/board_nano-33-ble.go
@@ -70,11 +70,6 @@ const (
 	UART_TX_PIN = P1_03
 )
 
-// Serial is the USB device
-var (
-	Serial = USB
-)
-
 // I2C pins
 const (
 	SDA_PIN = P0_31

--- a/targets/feather-rp2040.json
+++ b/targets/feather-rp2040.json
@@ -2,6 +2,7 @@
     "inherits": [
         "rp2040"
     ],
+    "serial": "uart",
     "build-tags": ["feather_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",
     "extra-files": [

--- a/targets/nano-33-ble.json
+++ b/targets/nano-33-ble.json
@@ -3,6 +3,7 @@
 	"build-tags": ["nano_33_ble", "nrf52840_reset_bossa"],
 	"flash-command": "bossac_arduino2 -d -i -e -w -v -R --port={port} {bin}",
 	"serial-port": ["acm:2341:805a", "acm:2341:005a"],
+	"serial": "usb",
 	"flash-1200-bps-reset": "true",
 	"linkerscript": "targets/nano-33-ble.ld"
 }

--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -2,6 +2,7 @@
     "inherits": [
         "rp2040"
     ],
+    "serial": "uart",
     "build-tags": ["nano_rp2040"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [


### PR DESCRIPTION
This PR corrects the omission of the `serial` key in target JSON files for newly added rp2040 boards and also nano-33-ble board.