### PR TITLE
machine/feather-nrf52840-sense: add board definition for Adafruit Feather nRF52840 Sense

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-nrf52840  	examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-nrf52840-sense examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-nrf52840  examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=qtpy                examples/serial

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 67 microcontroller boards are currently supported:
+The following 68 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -52,6 +52,7 @@ The following 67 microcontroller boards are currently supported:
 * [Adafruit Feather M4](https://www.adafruit.com/product/3857)
 * [Adafruit Feather M4 CAN](https://www.adafruit.com/product/4759)
 * [Adafruit Feather nRF52840 Express](https://www.adafruit.com/product/4062)
+* [Adafruit Feather nRF52840 Sense](https://www.adafruit.com/product/4516)
 * [Adafruit Feather RP2040](https://www.adafruit.com/product/4884)
 * [Adafruit Feather STM32F405 Express](https://www.adafruit.com/product/4382)
 * [Adafruit Grand Central M4](https://www.adafruit.com/product/4064)

--- a/src/machine/board_feather-nrf52840-sense.go
+++ b/src/machine/board_feather-nrf52840-sense.go
@@ -1,0 +1,101 @@
+// +build feather_nrf52840_sense
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// GPIO Pins
+const (
+	D0  = P0_25 // UART TX
+	D1  = P0_24 // UART RX
+	D2  = P0_10 // NFC2
+	D3  = P1_11
+	D4  = P1_10 // LED2
+	D5  = P1_08
+	D6  = P0_07
+	D7  = P1_02 // Button
+	D8  = P0_16 // NeoPixel
+	D9  = P0_26
+	D10 = P0_27
+	D11 = P0_06
+	D12 = P0_08
+	D13 = P1_09 // LED1
+	D14 = P0_04 // A0
+	D15 = P0_05 // A1
+	D16 = P0_30 // A2
+	D17 = P0_28 // A3
+	D18 = P0_02 // A4
+	D19 = P0_03 // A5
+	D20 = P0_29 // Battery
+	D21 = P0_31 // AREF
+	D22 = P0_12 // I2C SDA
+	D23 = P0_11 // I2C SCL
+	D24 = P0_15 // SPI MISO
+	D25 = P0_13 // SPI MOSI
+	D26 = P0_14 // SPI SCK
+	D27 = P0_19 // QSPI CLK
+	D28 = P0_20 // QSPI CS
+	D29 = P0_17 // QSPI Data 0
+	D30 = P0_22 // QSPI Data 1
+	D31 = P0_23 // QSPI Data 2
+	D32 = P0_21 // QSPI Data 3
+	D33 = P0_09 // NFC1 (test point on bottom of board)
+)
+
+// Analog Pins
+const (
+	A0 = D14
+	A1 = D15
+	A2 = D16
+	A3 = D17
+	A4 = D18
+	A5 = D19
+	A6 = D20 // Battery
+	A7 = D21 // ARef
+)
+
+const (
+	LED      = D13
+	LED1     = LED
+	LED2     = D4
+	NEOPIXEL = D8
+	WS2812   = D8
+	BUTTON   = D7
+
+	QSPI_SCK   = D27
+	QSPI_CS    = D28
+	QSPI_DATA0 = D29
+	QSPI_DATA1 = D30
+	QSPI_DATA2 = D31
+	QSPI_DATA3 = D32
+)
+
+// UART0 pins (logical UART1)
+const (
+	UART_RX_PIN = D0
+	UART_TX_PIN = D1
+)
+
+// I2C pins
+const (
+	SDA_PIN = D22 // I2C0 external
+	SCL_PIN = D23 // I2C0 external
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = D26 // SCK
+	SPI0_SDO_PIN = D25 // SDO
+	SPI0_SDI_PIN = D24 // SDI
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Feather nRF52840 Express"
+	usb_STRING_MANUFACTURER = "Adafruit Industries LLC"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8088
+)

--- a/targets/feather-nrf52840-sense.json
+++ b/targets/feather-nrf52840-sense.json
@@ -1,0 +1,11 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["feather_nrf52840_sense","nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "msd-volume-name": "FTHR840BOOT",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
Added `feather-nrf52840-sense` (nrf52840) board support.

This board is almost the same as feather-nrf52840, but some of the LED pins have been changed.
It also has a number of sensors on board, including the APDS9960.
The defferences are as follows

* board
    * Some of the pins have been changed.
    * USB VID/PID
