### PR TITLE
 targets: add serial and serial-port key to JSON files for adafruit and seeed

### DIFF
--- a/targets/clue-alpha.json
+++ b/targets/clue-alpha.json
@@ -2,6 +2,7 @@
     "inherits": ["nrf52840"],
     "build-tags": ["clue_alpha","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "serial": "usb",
+    "serial-port": ["acm:239a:8072", "acm:239a:0072", "acm:239a:0071", "acm:239a:8071"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "CLUEBOOT",

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["feather_m0"],
+    "serial": "usb",
+    "serial-port": ["acm:239a:801b", "acm:239a:001b", "acm:239a:800b", "acm:239a:000b", "acm:239a:0015"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-m4-can.json
+++ b/targets/feather-m4-can.json
@@ -2,6 +2,7 @@
     "inherits": ["atsame51j19a"],
     "build-tags": ["feather_m4_can"],
     "serial": "usb",
+    "serial-port": ["acm:239a:80cd", "acm:239a:00cd"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHRCANBOOT",

--- a/targets/feather-m4.json
+++ b/targets/feather-m4.json
@@ -2,6 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["feather_m4"],
     "serial": "usb",
+    "serial-port": ["acm:239a:8022", "acm:239a:0022"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-nrf52840-sense.json
+++ b/targets/feather-nrf52840-sense.json
@@ -2,6 +2,7 @@
     "inherits": ["nrf52840"],
     "build-tags": ["feather_nrf52840_sense","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "serial": "usb",
+    "serial-port": ["acm:239a:8087", "acm:239a:0087", "acm:239a:0088", "acm:239a:8088"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHR840BOOT",

--- a/targets/feather-nrf52840.json
+++ b/targets/feather-nrf52840.json
@@ -2,6 +2,7 @@
     "inherits": ["nrf52840"],
     "build-tags": ["feather_nrf52840","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "serial": "usb",
+    "serial-port": ["acm:239a:8029", "acm:239a:0029", "acm:239a:002a", "acm:239a:802a"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHR840BOOT",

--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -2,6 +2,7 @@
     "inherits": ["atsamd51p20a"],
     "build-tags": ["grandcentral_m4"],
     "serial": "usb",
+    "serial-port": ["acm:239a:8031", "acm:239a:0031", "acm:239a:0032"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["itsybitsy_m0"],
+    "serial": "usb",
+    "serial-port": ["acm:239a:800f", "acm:239a:000f", "acm:239a:8012"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSYBOOT",

--- a/targets/itsybitsy-nrf52840.json
+++ b/targets/itsybitsy-nrf52840.json
@@ -2,6 +2,7 @@
     "inherits": ["nrf52840"],
     "build-tags": ["itsybitsy_nrf52840","nrf52840_reset_uf2", "softdevice", "s140v6"],
     "serial": "usb",
+    "serial-port": ["acm:239A:8052", "acm:239A:0052", "acm:239A:0051", "acm:239A:8051"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSY840BOOT",

--- a/targets/matrixportal-m4.json
+++ b/targets/matrixportal-m4.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd51j19a"],
     "build-tags": ["atsamd51j19a", "matrixportal_m4"],
+    "serial": "usb",
+    "serial-port": ["acm:239a:80c9", "acm:239a:00c9", "acm:239a:80ca"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "MATRIXBOOT",

--- a/targets/metro-m4-airlift.json
+++ b/targets/metro-m4-airlift.json
@@ -2,6 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["metro_m4_airlift"],
     "serial": "usb",
+    "serial-port": ["acm:239A:8037", "acm:239A:0037"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "METROM4BOOT",

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -2,6 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["pygamer"],
     "serial": "usb",
+    "serial-port": ["acm:239a:803d", "acm:239a:003d", "acm:239a:803e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",

--- a/targets/qtpy.json
+++ b/targets/qtpy.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd21e18a"],
     "build-tags": ["qtpy"],
+    "serial": "usb",
+    "serial-port": ["acm:239a:80cb", "acm:239a:00cb", "acm:239a:00cc"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "QTPY_BOOT",

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd21e18a"],
     "build-tags": ["trinket_m0"],
+    "serial": "usb",
+    "serial-port": ["acm:239a:801e", "acm:239a:001e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "TRINKETBOOT",

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -2,6 +2,7 @@
     "inherits": ["atsamd51p19a"],
     "build-tags": ["wioterminal"],
     "serial": "usb",
+    "serial-port": ["acm:2886:002d", "acm:2886:802d"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",

--- a/targets/xiao.json
+++ b/targets/xiao.json
@@ -1,6 +1,8 @@
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["xiao"],
+    "serial": "usb",
+    "serial-port": ["acm:2886:802f", "acm:2886:002f"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",


### PR DESCRIPTION
~Note: #1969 needs to be merged before this PR.~

In this PR, we will add the serial-port key that we added in #1956 for the Adafruit and Seeed boards.

