### PR TITLE
machine/feather-nrf52840-sense: fix msd-volume-name

### DIFF
--- a/targets/feather-nrf52840-sense.json
+++ b/targets/feather-nrf52840-sense.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "msd-volume-name": "FTHR840BOOT",
+    "msd-volume-name": "FTHRSNSBOOT",
     "msd-firmware-name": "firmware.uf2",
     "uf2-family-id": "0xADA52840",
     "linkerscript": "targets/circuitplay-bluefruit.ld"


### PR DESCRIPTION
The msd-volume-name was changed after updating the firmware.
The problem is that depending on the firmware version, tinygo flash will fail.
However, the tinygo.org documentation says to update to 0.4.1, so I think it's safe to assume.

The following is from feather-nrf52840, but feather-nrf52840-sense is almost the same document.
https://tinygo.org/docs/reference/microcontrollers/feather-nrf52840/


before update:

```
$ cat /media/sago35/FTHR840BOOT/INFO_UF2.TXT 
UF2 Bootloader 0.2.9 lib/nrfx (v1.1.0-1-g096e770) lib/tinyusb (legacy-755-g55874813) s140 6.1.1
Model: Adafruit Feather nRF52840 Express
Board-ID: NRF52-Bluefruit-v0
Bootloader: s140 6.1.1
Date: Feb 22 2019
```

after update: (0.4.1)

```
$ cat /media/sago35/FTHRSNSBOOT/INFO_UF2.TXT 
UF2 Bootloader 0.4.1 lib/nrfx (v2.0.0) lib/tinyusb (0.6.0-272-g4e6aa0d8) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
Model: Adafruit Feather nRF52840 Sense
Board-ID: nRF52840-Feather-Sense
SoftDevice: S140 version 6.1.1
Date: Feb 17 2021
```

after update: (0.6.0)

```
$ cat /media/sago35/FTHRSNSBOOT/INFO_UF2.TXT 
UF2 Bootloader 0.6.0 lib/nrfx (v2.0.0) lib/tinyusb (0.10.1-41-gdf0cda2d) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)
Model: Adafruit Feather nRF52840 Sense
Board-ID: nRF52840-Feather-Sense
SoftDevice: S140 version 6.1.1
Date: Jun 19 2021
```

firmware: 
https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases
