### PR TITLE
machine/feather-nrf52: fix pin definition of uart

### DIFF
--- a/src/machine/board_feather-nrf52840-sense.go
+++ b/src/machine/board_feather-nrf52840-sense.go
@@ -72,8 +72,8 @@ const (
 
 // UART0 pins (logical UART1)
 const (
-	UART_RX_PIN = D0
-	UART_TX_PIN = D1
+	UART_RX_PIN = D1
+	UART_TX_PIN = D0
 )
 
 // I2C pins
@@ -98,4 +98,8 @@ const (
 var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x8088
+)
+
+var (
+	DefaultUART = UART0
 )

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -72,8 +72,8 @@ const (
 
 // UART0 pins (logical UART1)
 const (
-	UART_RX_PIN = D0
-	UART_TX_PIN = D1
+	UART_RX_PIN = D1
+	UART_TX_PIN = D0
 )
 
 // I2C pins
@@ -98,4 +98,8 @@ const (
 var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x802A
+)
+
+var (
+	DefaultUART = UART0
 )


### PR DESCRIPTION
The pin settings for TX and RX of the UART were reversed, which has been corrected.
Also, the DefaultUART setting has been added.


Notes:
The adafruit arduino code does show D0 of feather-nrf52840(-sense) as TX.
D0 of feather-m4 is RX.

Also, considering the position of the D2 pin, the pin definition of feather-nrf52840(-sense) seems to be wrong.
However, perhaps the pin names should be adapted to the Arduino.

https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/master/variants/feather_nrf52840_express/variant.cpp#L29-L30
https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/master/variants/feather_nrf52840_sense/variant.cpp#L29-L30

https://github.com/adafruit/ArduinoCore-samd/blob/master/variants/feather_m4/variant.cpp#L37-L38