### PR TITLE
wasm: strip debug info and compress relocations

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -209,9 +209,8 @@ func (c *Config) CFlags() []string {
 		cflags = append(cflags, "-nostdlibinc", "-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "picolibc", "newlib", "libc", "include"))
 		cflags = append(cflags, "-I"+filepath.Join(root, "lib/picolibc-include"))
 	}
-	if c.Debug() {
-		cflags = append(cflags, "-g")
-	}
+	// Always emit debug information. It is optionally stripped at link time.
+	cflags = append(cflags, "-g")
 	return cflags
 }
 
@@ -250,8 +249,9 @@ func (c *Config) VerifyIR() bool {
 	return c.Options.VerifyIR
 }
 
-// Debug returns whether to add debug symbols to the IR, for debugging with GDB
-// and similar.
+// Debug returns whether debug (DWARF) information should be retained by the
+// linker. By default, debug information is retained but it can be removed with
+// the -no-debug flag.
 func (c *Config) Debug() bool {
 	return c.Options.Debug
 }

--- a/main.go
+++ b/main.go
@@ -1019,7 +1019,7 @@ func main() {
 	printStacks := flag.Bool("print-stacks", false, "print stack sizes of goroutines")
 	printAllocsString := flag.String("print-allocs", "", "regular expression of functions for which heap allocations should be printed")
 	printCommands := flag.Bool("x", false, "Print commands")
-	nodebug := flag.Bool("no-debug", false, "disable DWARF debug symbol generation")
+	nodebug := flag.Bool("no-debug", false, "strip debug information")
 	ocdCommandsString := flag.String("ocd-commands", "", "OpenOCD commands, overriding target spec (can specify multiple separated by commas)")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
 	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")


### PR DESCRIPTION
This patch reduces code size significantly by stripping debug
information at the link stage and additionally compressing relocations
(which is only possible when debug information has been stripped).

For example, when compiling testdata/alias.go with -target=wasi, I get
the following results:

```
Previously, without -no-debug: 25326 bytes
Previously, with -no-debug:     5591 bytes
With this patch:                4762 bytes
With this patch and -no-debug:  4747 bytes
```

In other words, by stripping debug information and compressing
relocations by default, the resulting binary is smaller than it would
otherwise be even with -no-debug. Adding -no-debug may give a small
extra reduction in code size, but after this patch it's not very
significant.

This patch currently does not provide a way to opt out of this behavior.
If there is a need, an option can be added at a later time to change
this behavior.

@dkegel-fastly @fgsch because you've been rather involved in WebAssembly lately: what do you think of this change? Is it a good change of defaults?