### PR TITLE
Fix interp stack overflow with self-referencing data types

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1524,7 +1524,8 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 				return llvm.Value{}, b.makeError(expr.Pos(), fmt.Sprintf("value is too big (%v bytes)", size))
 			}
 			sizeValue := llvm.ConstInt(b.uintptrType, size, false)
-			buf := b.createRuntimeCall("alloc", []llvm.Value{sizeValue}, expr.Comment)
+			nilPtr := llvm.ConstNull(b.i8ptrType)
+			buf := b.createRuntimeCall("alloc", []llvm.Value{sizeValue, nilPtr}, expr.Comment)
 			buf = b.CreateBitCast(buf, llvm.PointerType(typ, 0), "")
 			return buf, nil
 		} else {
@@ -1736,7 +1737,8 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 			return llvm.Value{}, err
 		}
 		sliceSize := b.CreateBinOp(llvm.Mul, elemSizeValue, sliceCapCast, "makeslice.cap")
-		slicePtr := b.createRuntimeCall("alloc", []llvm.Value{sliceSize}, "makeslice.buf")
+		nilPtr := llvm.ConstNull(b.i8ptrType)
+		slicePtr := b.createRuntimeCall("alloc", []llvm.Value{sliceSize, nilPtr}, "makeslice.buf")
 		slicePtr = b.CreateBitCast(slicePtr, llvm.PointerType(llvmElemType, 0), "makeslice.array")
 
 		// Extend or truncate if necessary. This is safe as we've already done

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -54,6 +54,7 @@ func TestCompiler(t *testing.T) {
 		{"channel.go", ""},
 		{"intrinsics.go", "cortex-m-qemu"},
 		{"intrinsics.go", "wasm"},
+		{"gc.go", ""},
 	}
 
 	_, minor, err := goenv.GetGorootVersion(goenv.Get("GOROOT"))

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -217,7 +217,8 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		// This may be hit a variable number of times, so use a heap allocation.
 		size := b.targetData.TypeAllocSize(deferFrameType)
 		sizeValue := llvm.ConstInt(b.uintptrType, size, false)
-		allocCall := b.createRuntimeCall("alloc", []llvm.Value{sizeValue}, "defer.alloc.call")
+		nilPtr := llvm.ConstNull(b.i8ptrType)
+		allocCall := b.createRuntimeCall("alloc", []llvm.Value{sizeValue, nilPtr}, "defer.alloc.call")
 		alloca = b.CreateBitCast(allocCall, llvm.PointerType(deferFrameType, 0), "defer.alloc")
 	}
 	if b.NeedsStackObjects {

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -1,6 +1,11 @@
 package compiler
 
 import (
+	"fmt"
+	"go/token"
+	"go/types"
+	"math/big"
+
 	"github.com/tinygo-org/tinygo/compiler/llvmutil"
 	"tinygo.org/x/go-llvm"
 )
@@ -51,4 +56,200 @@ func (c *compilerContext) makeGlobalArray(buf []byte, name string, elementType l
 	}
 	global.SetInitializer(value)
 	return global
+}
+
+// createObjectLayout returns a LLVM value (of type i8*) that describes where
+// there are pointers in the type t. If all the data fits in a word, it is
+// returned as a word. Otherwise it will store the data in a global.
+//
+// The value contains two pieces of information: the length of the object and
+// which words contain a pointer (indicated by setting the given bit to 1). For
+// arrays, only the element is stored. This works because the GC knows the
+// object size and can therefore know how this value is repeated in the object.
+func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Value {
+	// Use the element type for arrays. This works even for nested arrays.
+	for {
+		kind := t.TypeKind()
+		if kind == llvm.ArrayTypeKind {
+			t = t.ElementType()
+			continue
+		}
+		if kind == llvm.StructTypeKind {
+			fields := t.StructElementTypes()
+			if len(fields) == 1 {
+				t = fields[0]
+				continue
+			}
+		}
+		break
+	}
+
+	// Do a few checks to see whether we need to generate any object layout
+	// information at all.
+	objectSizeBytes := c.targetData.TypeAllocSize(t)
+	pointerSize := c.targetData.TypeAllocSize(c.i8ptrType)
+	pointerAlignment := c.targetData.PrefTypeAlignment(c.i8ptrType)
+	if objectSizeBytes < pointerSize {
+		// Too small to contain a pointer.
+		layout := (uint64(1) << 1) | 1
+		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.i8ptrType)
+	}
+	bitmap := c.getPointerBitmap(t, pos)
+	if bitmap.BitLen() == 0 {
+		// There are no pointers in this type, so we can simplify the layout.
+		// TODO: this can be done in many other cases, e.g. when allocating an
+		// array (like [4][]byte, which repeats a slice 4 times).
+		layout := (uint64(1) << 1) | 1
+		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.i8ptrType)
+	}
+	if objectSizeBytes%uint64(pointerAlignment) != 0 {
+		// This shouldn't happen except for packed structs, which aren't
+		// currently used.
+		c.addError(pos, "internal error: unexpected object size for object with pointer field")
+		return llvm.ConstNull(c.i8ptrType)
+	}
+	objectSizeWords := objectSizeBytes / uint64(pointerAlignment)
+
+	pointerBits := pointerSize * 8
+	var sizeFieldBits uint64
+	switch pointerBits {
+	case 16:
+		sizeFieldBits = 4
+	case 32:
+		sizeFieldBits = 5
+	case 64:
+		sizeFieldBits = 6
+	default:
+		panic("unknown pointer size")
+	}
+	layoutFieldBits := pointerBits - 1 - sizeFieldBits
+
+	// Try to emit the value as an inline integer. This is possible in most
+	// cases.
+	if objectSizeWords < layoutFieldBits {
+		// If it can be stored directly in the pointer value, do so.
+		// The runtime knows that if the least significant bit of the pointer is
+		// set, the pointer contains the value itself.
+		layout := bitmap.Uint64()<<(sizeFieldBits+1) | (objectSizeWords << 1) | 1
+		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.i8ptrType)
+	}
+
+	// Unfortunately, the object layout is too big to fit in a pointer-sized
+	// integer. Store it in a global instead.
+
+	// Try first whether the global already exists. All objects with a
+	// particular name have the same type, so this is possible.
+	globalName := "runtime/gc.layout:" + fmt.Sprintf("%d-%0*x", objectSizeWords, (objectSizeWords+15)/16, bitmap)
+	global := c.mod.NamedGlobal(globalName)
+	if !global.IsNil() {
+		return llvm.ConstBitCast(global, c.i8ptrType)
+	}
+
+	// Create the global initializer.
+	bitmapBytes := make([]byte, int(objectSizeWords+7)/8)
+	copy(bitmapBytes, bitmap.Bytes())
+	var bitmapByteValues []llvm.Value
+	for _, b := range bitmapBytes {
+		bitmapByteValues = append(bitmapByteValues, llvm.ConstInt(c.ctx.Int8Type(), uint64(b), false))
+	}
+	initializer := c.ctx.ConstStruct([]llvm.Value{
+		llvm.ConstInt(c.uintptrType, objectSizeWords, false),
+		llvm.ConstArray(c.ctx.Int8Type(), bitmapByteValues),
+	}, false)
+
+	global = llvm.AddGlobal(c.mod, initializer.Type(), globalName)
+	global.SetInitializer(initializer)
+	global.SetUnnamedAddr(true)
+	global.SetGlobalConstant(true)
+	global.SetLinkage(llvm.LinkOnceODRLinkage)
+	if c.targetData.PrefTypeAlignment(c.uintptrType) < 2 {
+		// AVR doesn't have alignment by default.
+		global.SetAlignment(2)
+	}
+	if c.Debug && pos != token.NoPos {
+		// Creating a fake global so that the value can be inspected in GDB.
+		// For example, the layout for strings.stringFinder (as of Go version
+		// 1.15) has the following type according to GDB:
+		//   type = struct {
+		//       uintptr numBits;
+		//       uint8 data[33];
+		//   }
+		// ...that's sort of a mixed C/Go type, but it is readable. More
+		// importantly, these object layout globals can be read and printed by
+		// GDB which may be useful for debugging.
+		position := c.program.Fset.Position(pos)
+		diglobal := c.dibuilder.CreateGlobalVariableExpression(c.difiles[position.Filename], llvm.DIGlobalVariableExpression{
+			Name: globalName,
+			File: c.getDIFile(position.Filename),
+			Line: position.Line,
+			Type: c.getDIType(types.NewStruct([]*types.Var{
+				types.NewVar(pos, nil, "numBits", types.Typ[types.Uintptr]),
+				types.NewVar(pos, nil, "data", types.NewArray(types.Typ[types.Byte], int64(len(bitmapByteValues)))),
+			}, nil)),
+			LocalToUnit: false,
+			Expr:        c.dibuilder.CreateExpression(nil),
+		})
+		global.AddMetadata(0, diglobal)
+	}
+
+	return llvm.ConstBitCast(global, c.i8ptrType)
+}
+
+// getPointerBitmap scans the given LLVM type for pointers and sets bits in a
+// bigint at the word offset that contains a pointer. This scan is recursive.
+func (c *compilerContext) getPointerBitmap(typ llvm.Type, pos token.Pos) *big.Int {
+	alignment := c.targetData.PrefTypeAlignment(c.i8ptrType)
+	switch typ.TypeKind() {
+	case llvm.IntegerTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind:
+		return big.NewInt(0)
+	case llvm.PointerTypeKind:
+		return big.NewInt(1)
+	case llvm.StructTypeKind:
+		ptrs := big.NewInt(0)
+		if typ.StructName() == "runtime.funcValue" {
+			// Hack: the type runtime.funcValue contains an 'id' field which is
+			// of type uintptr, but before the LowerFuncValues pass it actually
+			// contains a pointer (ptrtoint) to a global. This trips up the
+			// interp package. Therefore, make the id field a pointer for now.
+			typ = c.ctx.StructType([]llvm.Type{c.i8ptrType, c.i8ptrType}, false)
+		}
+		for i, subtyp := range typ.StructElementTypes() {
+			subptrs := c.getPointerBitmap(subtyp, pos)
+			if subptrs.BitLen() == 0 {
+				continue
+			}
+			offset := c.targetData.ElementOffset(typ, i)
+			if offset%uint64(alignment) != 0 {
+				// This error will let the compilation fail, but by continuing
+				// the error can still easily be shown.
+				c.addError(pos, "internal error: allocated struct contains unaligned pointer")
+				continue
+			}
+			subptrs.Lsh(subptrs, uint(offset)/uint(alignment))
+			ptrs.Or(ptrs, subptrs)
+		}
+		return ptrs
+	case llvm.ArrayTypeKind:
+		subtyp := typ.ElementType()
+		subptrs := c.getPointerBitmap(subtyp, pos)
+		ptrs := big.NewInt(0)
+		if subptrs.BitLen() == 0 {
+			return ptrs
+		}
+		elementSize := c.targetData.TypeAllocSize(subtyp)
+		if elementSize%uint64(alignment) != 0 {
+			// This error will let the compilation fail (but continues so that
+			// other errors can be shown).
+			c.addError(pos, "internal error: allocated array contains unaligned pointer")
+			return ptrs
+		}
+		for i := 0; i < typ.ArrayLength(); i++ {
+			ptrs.Lsh(ptrs, uint(elementSize)/uint(alignment))
+			ptrs.Or(ptrs, subptrs)
+		}
+		return ptrs
+	default:
+		// Should not happen.
+		panic("unknown LLVM type")
+	}
 }

--- a/compiler/llvmutil/wordpack.go
+++ b/compiler/llvmutil/wordpack.go
@@ -97,6 +97,7 @@ func EmitPointerPack(builder llvm.Builder, mod llvm.Module, needsStackObjects bo
 		alloc := mod.NamedFunction("runtime.alloc")
 		packedHeapAlloc := builder.CreateCall(alloc, []llvm.Value{
 			sizeValue,
+			llvm.ConstNull(i8ptrType),
 			llvm.Undef(i8ptrType),            // unused context parameter
 			llvm.ConstPointerNull(i8ptrType), // coroutine handle
 		}, "")

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -6,7 +6,7 @@ target triple = "wasm32-unknown-wasi"
 %main.kv = type { float }
 %main.kv.0 = type { i8 }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -9,7 +9,7 @@ target triple = "wasm32-unknown-wasi"
 %"internal/task.state" = type { i8* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -3,7 +3,7 @@ source_filename = "float.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -8,7 +8,7 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.funcid:func:{basic:int}{}" = external constant i8
 @"main.someFunc$withSignature" = linkonce_odr constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i32, i8*, i8*)* @main.someFunc to i32), i8* @"reflect/types.funcid:func:{basic:int}{}" }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/gc.go
+++ b/compiler/testdata/gc.go
@@ -1,0 +1,72 @@
+package main
+
+var (
+	scalar1 *byte
+	scalar2 *int32
+	scalar3 *int64
+	scalar4 *float32
+
+	array1 *[3]byte
+	array2 *[71]byte
+	array3 *[3]*byte
+
+	struct1 *struct{}
+	struct2 *struct {
+		x int
+		y int
+	}
+	struct3 *struct {
+		x *byte
+		y [60]uintptr
+		z *byte
+	}
+
+	slice1 []byte
+	slice2 []*int
+	slice3 [][]byte
+)
+
+func newScalar() {
+	scalar1 = new(byte)
+	scalar2 = new(int32)
+	scalar3 = new(int64)
+	scalar4 = new(float32)
+}
+
+func newArray() {
+	array1 = new([3]byte)
+	array2 = new([71]byte)
+	array3 = new([3]*byte)
+}
+
+func newStruct() {
+	struct1 = new(struct{})
+	struct2 = new(struct {
+		x int
+		y int
+	})
+	struct3 = new(struct {
+		x *byte
+		y [60]uintptr
+		z *byte
+	})
+}
+
+func newFuncValue() *func() {
+	// On some platforms that use runtime.funcValue ("switch" style) function
+	// values, a func value is allocated as having two pointer words while the
+	// struct looks like {unsafe.Pointer; uintptr}. This is so that the interp
+	// package won't get confused, see getPointerBitmap in compiler/llvm.go for
+	// details.
+	return new(func())
+}
+
+func makeSlice() {
+	slice1 = make([]byte, 5)
+	slice2 = make([]*int, 5)
+	slice3 = make([][]byte, 5)
+}
+
+func makeInterface(v complex128) interface{} {
+	return v // always stored in an allocation
+}

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -1,0 +1,113 @@
+; ModuleID = 'gc.go'
+source_filename = "gc.go"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-wasi"
+
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }
+%runtime.interfaceMethodInfo = type { i8*, i32 }
+%runtime.funcValue = type { i8*, i32 }
+%runtime._interface = type { i32, i8* }
+
+@main.scalar1 = hidden global i8* null, align 4
+@main.scalar2 = hidden global i32* null, align 4
+@main.scalar3 = hidden global i64* null, align 4
+@main.scalar4 = hidden global float* null, align 4
+@main.array1 = hidden global [3 x i8]* null, align 4
+@main.array2 = hidden global [71 x i8]* null, align 4
+@main.array3 = hidden global [3 x i8*]* null, align 4
+@main.struct1 = hidden global {}* null, align 4
+@main.struct2 = hidden global { i32, i32 }* null, align 4
+@main.struct3 = hidden global { i8*, [60 x i32], i8* }* null, align 4
+@main.slice1 = hidden global { i8*, i32, i32 } zeroinitializer, align 8
+@main.slice2 = hidden global { i32**, i32, i32 } zeroinitializer, align 8
+@main.slice3 = hidden global { { i8*, i32, i32 }*, i32, i32 } zeroinitializer, align 8
+@"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c" \00\00\00\00\00\00\01" }
+@"reflect/types.type:basic:complex128" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* null, i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:basic:complex128", i32 0 }
+@"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:complex128", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
+
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
+
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden void @main.newScalar(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %new = call i8* @runtime.alloc(i32 1, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new, i8** @main.scalar1, align 4
+  %new1 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new1, i8** bitcast (i32** @main.scalar2 to i8**), align 4
+  %new2 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new2, i8** bitcast (i64** @main.scalar3 to i8**), align 4
+  %new3 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new3, i8** bitcast (float** @main.scalar4 to i8**), align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden void @main.newArray(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %new = call i8* @runtime.alloc(i32 3, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new, i8** bitcast ([3 x i8]** @main.array1 to i8**), align 4
+  %new1 = call i8* @runtime.alloc(i32 71, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new1, i8** bitcast ([71 x i8]** @main.array2 to i8**), align 4
+  %new2 = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 67 to i8*), i8* undef, i8* null) #0
+  store i8* %new2, i8** bitcast ([3 x i8*]** @main.array3 to i8**), align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden void @main.newStruct(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %new = call i8* @runtime.alloc(i32 0, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new, i8** bitcast ({}** @main.struct1 to i8**), align 4
+  %new1 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %new1, i8** bitcast ({ i32, i32 }** @main.struct2 to i8**), align 4
+  %new2 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-2000000000000001" to i8*), i8* undef, i8* null) #0
+  store i8* %new2, i8** bitcast ({ i8*, [60 x i32], i8* }** @main.struct3 to i8**), align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden %runtime.funcValue* @main.newFuncValue(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %new = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 197 to i8*), i8* undef, i8* null) #0
+  %0 = bitcast i8* %new to %runtime.funcValue*
+  ret %runtime.funcValue* %0
+}
+
+; Function Attrs: nounwind
+define hidden void @main.makeSlice(i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %makeslice = call i8* @runtime.alloc(i32 5, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
+  store i8* %makeslice, i8** getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 0), align 8
+  store i32 5, i32* getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 1), align 4
+  store i32 5, i32* getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 2), align 8
+  %makeslice1 = call i8* @runtime.alloc(i32 20, i8* nonnull inttoptr (i32 67 to i8*), i8* undef, i8* null) #0
+  store i8* %makeslice1, i8** bitcast ({ i32**, i32, i32 }* @main.slice2 to i8**), align 8
+  store i32 5, i32* getelementptr inbounds ({ i32**, i32, i32 }, { i32**, i32, i32 }* @main.slice2, i32 0, i32 1), align 4
+  store i32 5, i32* getelementptr inbounds ({ i32**, i32, i32 }, { i32**, i32, i32 }* @main.slice2, i32 0, i32 2), align 8
+  %makeslice3 = call i8* @runtime.alloc(i32 60, i8* nonnull inttoptr (i32 71 to i8*), i8* undef, i8* null) #0
+  store i8* %makeslice3, i8** bitcast ({ { i8*, i32, i32 }*, i32, i32 }* @main.slice3 to i8**), align 8
+  store i32 5, i32* getelementptr inbounds ({ { i8*, i32, i32 }*, i32, i32 }, { { i8*, i32, i32 }*, i32, i32 }* @main.slice3, i32 0, i32 1), align 4
+  store i32 5, i32* getelementptr inbounds ({ { i8*, i32, i32 }*, i32, i32 }, { { i8*, i32, i32 }*, i32, i32 }* @main.slice3, i32 0, i32 2), align 8
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden %runtime._interface @main.makeInterface(double %v.r, double %v.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef, i8* null) #0
+  %.repack = bitcast i8* %0 to double*
+  store double %v.r, double* %.repack, align 8
+  %.repack1 = getelementptr inbounds i8, i8* %0, i32 8
+  %1 = bitcast i8* %.repack1 to double*
+  store double %v.i, double* %1, align 8
+  %2 = insertvalue %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:complex128" to i32), i8* undef }, i8* %0, 1
+  ret %runtime._interface %2
+}
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -46,7 +46,7 @@ declare void @runtime.sliceToArrayPointerPanic(i8*, i8*)
 ; Function Attrs: nounwind
 define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %makeslice = call i8* @runtime.alloc(i32 24, i8* null, i8* undef, i8* null) #0
+  %makeslice = call i8* @runtime.alloc(i32 24, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   br i1 false, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.throw:                               ; preds = %entry

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -3,7 +3,7 @@ source_filename = "go1.17.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
@@ -46,7 +46,7 @@ declare void @runtime.sliceToArrayPointerPanic(i8*, i8*)
 ; Function Attrs: nounwind
 define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %makeslice = call i8* @runtime.alloc(i32 24, i8* undef, i8* null) #0
+  %makeslice = call i8* @runtime.alloc(i32 24, i8* null, i8* undef, i8* null) #0
   br i1 false, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.throw:                               ; preds = %entry

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -66,7 +66,7 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* null) #0
+  %n = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
   %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef, i8* null) #0

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -11,7 +11,7 @@ target triple = "armv7m-unknown-unknown-eabi"
 
 @"main.startInterfaceMethod$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
@@ -66,10 +66,10 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null) #0
+  %n = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
+  %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
@@ -107,7 +107,7 @@ declare void @runtime.printint32(i32, i8*, i8*)
 ; Function Attrs: nounwind
 define hidden void @main.funcGoroutine(i8* %fn.context, void ()* %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 12, i8* undef, i8* null) #0
+  %0 = call i8* @runtime.alloc(i32 12, i8* null, i8* undef, i8* null) #0
   %1 = bitcast i8* %0 to i32*
   store i32 5, i32* %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4
@@ -163,7 +163,7 @@ declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i
 ; Function Attrs: nounwind
 define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 16, i8* undef, i8* null) #0
+  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef, i8* null) #0
   %1 = bitcast i8* %0 to i8**
   store i8* %itf.value, i8** %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -16,7 +16,7 @@ target triple = "wasm32-unknown-wasi"
 @"main.closureFunctionGoroutine$1$withSignature" = linkonce_odr constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i32, i8*, i8*)* @"main.closureFunctionGoroutine$1" to i32), i8* @"reflect/types.funcid:func:{basic:int}{}" }
 @"main.startInterfaceMethod$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
@@ -51,10 +51,10 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null) #0
+  %n = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
+  %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
@@ -80,7 +80,7 @@ declare void @runtime.printint32(i32, i8*, i8*)
 define hidden void @main.funcGoroutine(i8* %fn.context, i32 %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = call i32 @runtime.getFuncPtr(i8* %fn.context, i32 %fn.funcptr, i8* nonnull @"reflect/types.funcid:func:{basic:int}{}", i8* undef, i8* null) #0
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
+  %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
@@ -119,7 +119,7 @@ declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i
 ; Function Attrs: nounwind
 define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 16, i8* undef, i8* null) #0
+  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef, i8* null) #0
   %1 = bitcast i8* %0 to i8**
   store i8* %itf.value, i8** %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -51,7 +51,7 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* null) #0
+  %n = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
   %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef, i8* null) #0

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -22,7 +22,7 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.interface:interface{String() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.String() string"]
 @"reflect/types.typeid:basic:int" = external constant i8
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/intrinsics-cortex-m-qemu.ll
+++ b/compiler/testdata/intrinsics-cortex-m-qemu.ll
@@ -3,7 +3,7 @@ source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-unknown-unknown-eabi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -3,7 +3,7 @@ source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -3,7 +3,7 @@ source_filename = "pointer.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -10,7 +10,7 @@ target triple = "wasm32-unknown-wasi"
 @undefinedGlobalNotInSection = external global i32, align 4
 @main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -44,7 +44,7 @@ declare void @runtime.lookupPanic(i8*, i8*)
 ; Function Attrs: nounwind
 define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %varargs = call i8* @runtime.alloc(i32 12, i8* null, i8* undef, i8* null) #0
+  %varargs = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %0 = bitcast i8* %varargs to i32*
   store i32 1, i32* %0, align 4
   %1 = getelementptr inbounds i8, i8* %varargs, i32 4
@@ -105,7 +105,7 @@ slice.throw:                                      ; preds = %entry
   unreachable
 
 slice.next:                                       ; preds = %entry
-  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* null, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %0 = insertvalue { i8*, i32, i32 } undef, i8* %makeslice.buf, 0
   %1 = insertvalue { i8*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i8*, i32, i32 } %1, i32 %len, 2
@@ -126,7 +126,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 1
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i16*
   %0 = insertvalue { i16*, i32, i32 } undef, i16* %makeslice.array, 0
   %1 = insertvalue { i16*, i32, i32 } %0, i32 %len, 1
@@ -146,7 +146,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = mul i32 %len, 3
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to [3 x i8]*
   %0 = insertvalue { [3 x i8]*, i32, i32 } undef, [3 x i8]* %makeslice.array, 0
   %1 = insertvalue { [3 x i8]*, i32, i32 } %0, i32 %len, 1
@@ -166,7 +166,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 2
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i32*
   %0 = insertvalue { i32*, i32, i32 } undef, i32* %makeslice.array, 0
   %1 = insertvalue { i32*, i32, i32 } %0, i32 %len, 1

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -3,7 +3,7 @@ source_filename = "slice.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
@@ -44,7 +44,7 @@ declare void @runtime.lookupPanic(i8*, i8*)
 ; Function Attrs: nounwind
 define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %varargs = call i8* @runtime.alloc(i32 12, i8* undef, i8* null) #0
+  %varargs = call i8* @runtime.alloc(i32 12, i8* null, i8* undef, i8* null) #0
   %0 = bitcast i8* %varargs to i32*
   store i32 1, i32* %0, align 4
   %1 = getelementptr inbounds i8, i8* %varargs, i32 4
@@ -105,7 +105,7 @@ slice.throw:                                      ; preds = %entry
   unreachable
 
 slice.next:                                       ; preds = %entry
-  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* null, i8* undef, i8* null) #0
   %0 = insertvalue { i8*, i32, i32 } undef, i8* %makeslice.buf, 0
   %1 = insertvalue { i8*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i8*, i32, i32 } %1, i32 %len, 2
@@ -126,7 +126,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 1
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i16*
   %0 = insertvalue { i16*, i32, i32 } undef, i16* %makeslice.array, 0
   %1 = insertvalue { i16*, i32, i32 } %0, i32 %len, 1
@@ -146,7 +146,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = mul i32 %len, 3
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to [3 x i8]*
   %0 = insertvalue { [3 x i8]*, i32, i32 } undef, [3 x i8]* %makeslice.array, 0
   %1 = insertvalue { [3 x i8]*, i32, i32 } %0, i32 %len, 1
@@ -166,7 +166,7 @@ slice.throw:                                      ; preds = %entry
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 2
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* null, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i32*
   %0 = insertvalue { i32*, i32, i32 } undef, i32* %makeslice.array, 0
   %1 = insertvalue { i32*, i32, i32 } %0, i32 %len, 1

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -7,7 +7,7 @@ target triple = "wasm32-unknown-wasi"
 
 @"main.someString$string" = internal unnamed_addr constant [3 x i8] c"foo", align 1
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -17,6 +17,7 @@ func TestInterp(t *testing.T) {
 		"consteval",
 		"interface",
 		"revert",
+		"alloc",
 	} {
 		name := name // make tc local to this closure
 		t.Run(name, func(t *testing.T) {

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -234,11 +234,15 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				// Get the requested memory size to be allocated.
 				size := operands[1].Uint()
 
+				// Get the object layout, if it is available.
+				llvmLayoutType := r.getLLVMTypeFromLayout(operands[2])
+
 				// Create the object.
 				alloc := object{
-					globalName: r.pkgName + "$alloc",
-					buffer:     newRawValue(uint32(size)),
-					size:       uint32(size),
+					globalName:     r.pkgName + "$alloc",
+					llvmLayoutType: llvmLayoutType,
+					buffer:         newRawValue(uint32(size)),
+					size:           uint32(size),
 				}
 				index := len(r.objects)
 				r.objects = append(r.objects, alloc)

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -985,12 +985,9 @@ func (v *rawValue) set(llvmValue llvm.Value, r *runner) {
 		case llvm.GetElementPtr:
 			ptr := llvmValue.Operand(0)
 			index := llvmValue.Operand(1)
-			if checks && index.IsAConstantInt().IsNil() || index.ZExtValue() != 0 {
-				panic("expected first index of const gep to be i32 0")
-			}
 			numOperands := llvmValue.OperandsCount()
 			elementType := ptr.Type().ElementType()
-			totalOffset := uint64(0)
+			totalOffset := r.targetData.TypeAllocSize(elementType) * index.ZExtValue()
 			for i := 2; i < numOperands; i++ {
 				indexValue := llvmValue.Operand(i)
 				if checks && indexValue.IsAConstantInt().IsNil() {

--- a/interp/testdata/alloc.ll
+++ b/interp/testdata/alloc.ll
@@ -1,0 +1,53 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32--wasi"
+
+@"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c" \00\00\00\00\00\00\01" }
+@pointerFree12 = global i8* null
+@pointerFree7 = global i8* null
+@pointerFree3 = global i8* null
+@pointerFree0 = global i8* null
+@layout1 = global i8* null
+@layout2 = global i8* null
+@layout3 = global i8* null
+@layout4 = global i8* null
+@bigobj1 = global i8* null
+
+declare i8* @runtime.alloc(i32, i8*) unnamed_addr
+
+define void @runtime.initAll() unnamed_addr {
+  call void @main.init()
+  ret void
+}
+
+define internal void @main.init() unnamed_addr {
+  ; Object that's word-aligned.
+  %pointerFree12 = call i8* @runtime.alloc(i32 12, i8* inttoptr (i32 3 to i8*))
+  store i8* %pointerFree12, i8** @pointerFree12
+  ; Object larger than a word but not word-aligned.
+  %pointerFree7 = call i8* @runtime.alloc(i32 7, i8* inttoptr (i32 3 to i8*))
+  store i8* %pointerFree7, i8** @pointerFree7
+  ; Object smaller than a word (and of course not word-aligned).
+  %pointerFree3 = call i8* @runtime.alloc(i32 3, i8* inttoptr (i32 3 to i8*))
+  store i8* %pointerFree3, i8** @pointerFree3
+  ; Zero-sized object.
+  %pointerFree0 = call i8* @runtime.alloc(i32 0, i8* inttoptr (i32 3 to i8*))
+  store i8* %pointerFree0, i8** @pointerFree0
+
+  ; Object made out of 3 pointers.
+  %layout1 = call i8* @runtime.alloc(i32 12, i8* inttoptr (i32 67 to i8*))
+  store i8* %layout1, i8** @layout1
+  ; Array (or slice) of 5 slices.
+  %layout2 = call i8* @runtime.alloc(i32 60, i8* inttoptr (i32 71 to i8*))
+  store i8* %layout2, i8** @layout2
+  ; Oddly shaped object, using all bits in the layout integer.
+  %layout3 = call i8* @runtime.alloc(i32 104, i8* inttoptr (i32 2467830261 to i8*))
+  store i8* %layout3, i8** @layout3
+  ; ...repeated.
+  %layout4 = call i8* @runtime.alloc(i32 312, i8* inttoptr (i32 2467830261 to i8*))
+  store i8* %layout4, i8** @layout4
+
+  ; Large object that needs to be stored in a separate global.
+  %bigobj1 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-2000000000000001" to i8*))
+  store i8* %bigobj1, i8** @bigobj1
+  ret void
+}

--- a/interp/testdata/alloc.out.ll
+++ b/interp/testdata/alloc.out.ll
@@ -1,0 +1,25 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32--wasi"
+
+@pointerFree12 = local_unnamed_addr global i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"main$alloc", i32 0, i32 0)
+@pointerFree7 = local_unnamed_addr global i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"main$alloc.1", i32 0, i32 0)
+@pointerFree3 = local_unnamed_addr global i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"main$alloc.2", i32 0, i32 0)
+@pointerFree0 = local_unnamed_addr global i8* getelementptr inbounds ([0 x i8], [0 x i8]* @"main$alloc.3", i32 0, i32 0)
+@layout1 = local_unnamed_addr global i8* bitcast ([3 x i8*]* @"main$alloc.4" to i8*)
+@layout2 = local_unnamed_addr global i8* bitcast ([5 x { i8*, i32, i32 }]* @"main$alloc.5" to i8*)
+@layout3 = local_unnamed_addr global i8* bitcast ({ i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }* @"main$alloc.6" to i8*)
+@layout4 = local_unnamed_addr global i8* bitcast ([3 x { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }]* @"main$alloc.7" to i8*)
+@bigobj1 = local_unnamed_addr global i8* bitcast ({ i8*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i8* }* @"main$alloc.8" to i8*)
+@"main$alloc" = internal global [12 x i8] zeroinitializer, align 4
+@"main$alloc.1" = internal global [7 x i8] zeroinitializer, align 4
+@"main$alloc.2" = internal global [3 x i8] zeroinitializer, align 4
+@"main$alloc.3" = internal global [0 x i8] zeroinitializer, align 4
+@"main$alloc.4" = internal global [3 x i8*] zeroinitializer, align 4
+@"main$alloc.5" = internal global [5 x { i8*, i32, i32 }] zeroinitializer, align 4
+@"main$alloc.6" = internal global { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* } zeroinitializer, align 4
+@"main$alloc.7" = internal global [3 x { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }] zeroinitializer, align 4
+@"main$alloc.8" = internal global { i8*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i8* } zeroinitializer, align 4
+
+define void @runtime.initAll() unnamed_addr {
+  ret void
+}

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -21,7 +21,7 @@ entry:
   store i64 %value1, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0), align 8
   %value2 = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0), align 8
   store i64 %value2, i64* @main.nonConst2, align 8
-  call void @modifyExternal(i32* getelementptr inbounds ([8 x { i16, i32 }], [8 x { i16, i32 }]* @main.someArray, i32 0, i32 3, i32 1))
+  call void @modifyExternal(i32* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ([8 x { i16, i32 }]* @main.someArray to i8*), i32 28) to i32*))
   call void @modifyExternal(i32* bitcast ([1 x i16*]* @main.exportedValue to i32*))
   store i16 5, i16* @main.exposedValue1, align 2
   call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))

--- a/interp/testdata/consteval.ll
+++ b/interp/testdata/consteval.ll
@@ -3,6 +3,8 @@ target triple = "x86_64--linux"
 
 @intToPtrResult = global i8 0
 @ptrToIntResult = global i8 0
+@someArray = internal global {i16, i8, i8} zeroinitializer
+@someArrayPointer = global i8* zeroinitializer
 
 define void @runtime.initAll() {
   call void @main.init()
@@ -12,6 +14,7 @@ define void @runtime.initAll() {
 define internal void @main.init() {
   call void @testIntToPtr()
   call void @testPtrToInt()
+  call void @testConstGEP()
   ret void
 }
 
@@ -38,5 +41,10 @@ a:
 b:
   ; should be reached
   store i8 2, i8* @ptrToIntResult
+  ret void
+}
+
+define internal void @testConstGEP() {
+  store i8* getelementptr inbounds (i8, i8* bitcast ({i16, i8, i8}* @someArray to i8*), i32 2), i8** @someArrayPointer
   ret void
 }

--- a/interp/testdata/consteval.out.ll
+++ b/interp/testdata/consteval.out.ll
@@ -3,6 +3,8 @@ target triple = "x86_64--linux"
 
 @intToPtrResult = local_unnamed_addr global i8 2
 @ptrToIntResult = local_unnamed_addr global i8 2
+@someArray = internal global { i16, i8, i8 } zeroinitializer
+@someArrayPointer = local_unnamed_addr global i8* getelementptr inbounds ({ i16, i8, i8 }, { i16, i8, i8 }* @someArray, i64 0, i32 1)
 
 define void @runtime.initAll() local_unnamed_addr {
   ret void

--- a/interp/testdata/slice-copy.ll
+++ b/interp/testdata/slice-copy.ll
@@ -10,7 +10,7 @@ target triple = "x86_64--linux"
 
 declare i64 @runtime.sliceCopy(i8* %dst, i8* %src, i64 %dstLen, i64 %srcLen, i64 %elemSize) unnamed_addr
 
-declare i8* @runtime.alloc(i64) unnamed_addr
+declare i8* @runtime.alloc(i64, i8*) unnamed_addr
 
 declare void @runtime.printuint8(i8)
 
@@ -52,7 +52,7 @@ entry:
   ;     uint8SliceDst = make([]uint8, len(uint8SliceSrc))
   %uint8SliceSrc = load { i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceSrc
   %uint8SliceSrc.len = extractvalue { i8*, i64, i64 } %uint8SliceSrc, 1
-  %uint8SliceDst.buf = call i8* @runtime.alloc(i64 %uint8SliceSrc.len)
+  %uint8SliceDst.buf = call i8* @runtime.alloc(i64 %uint8SliceSrc.len, i8* null)
   %0 = insertvalue { i8*, i64, i64 } undef, i8* %uint8SliceDst.buf, 0
   %1 = insertvalue { i8*, i64, i64 } %0, i64 %uint8SliceSrc.len, 1
   %2 = insertvalue { i8*, i64, i64 } %1, i64 %uint8SliceSrc.len, 2
@@ -68,7 +68,7 @@ entry:
   %int16SliceSrc = load { i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceSrc
   %int16SliceSrc.len = extractvalue { i16*, i64, i64 } %int16SliceSrc, 1
   %int16SliceSrc.len.bytes = mul i64 %int16SliceSrc.len, 2
-  %int16SliceDst.buf.raw = call i8* @runtime.alloc(i64 %int16SliceSrc.len.bytes)
+  %int16SliceDst.buf.raw = call i8* @runtime.alloc(i64 %int16SliceSrc.len.bytes, i8* null)
   %int16SliceDst.buf = bitcast i8* %int16SliceDst.buf.raw to i16*
   %3 = insertvalue { i16*, i64, i64 } undef, i16* %int16SliceDst.buf, 0
   %4 = insertvalue { i16*, i64, i64 } %3, i64 %int16SliceSrc.len, 1

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -729,7 +729,7 @@ func Zero(typ Type) Value {
 func New(typ Type) Value {
 	return Value{
 		typecode: PtrTo(typ).(rawType),
-		value:    alloc(typ.Size()),
+		value:    alloc(typ.Size(), nil),
 		flags:    valueFlagExported,
 	}
 }
@@ -778,7 +778,7 @@ func (e *ValueError) Error() string {
 func memcpy(dst, src unsafe.Pointer, size uintptr)
 
 //go:linkname alloc runtime.alloc
-func alloc(size uintptr) unsafe.Pointer
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
 
 //go:linkname sliceAppend runtime.sliceAppend
 func sliceAppend(srcBuf, elemsBuf unsafe.Pointer, srcLen, srcCap, elemsLen uintptr, elemSize uintptr) (unsafe.Pointer, uintptr, uintptr)

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -66,7 +66,7 @@ func growHeap() bool {
 
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
-	return alloc(size)
+	return alloc(size, nil)
 }
 
 //export free
@@ -79,7 +79,7 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 	// Note: we could be even more correct here and check that nmemb * size
 	// doesn't overflow. However the current implementation should normally work
 	// fine.
-	return alloc(nmemb * size)
+	return alloc(nmemb*size, nil)
 }
 
 //export realloc

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -38,7 +38,7 @@ func growHeap() bool {
 
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
-	return alloc(size)
+	return alloc(size, nil)
 }
 
 //export free

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -133,7 +133,7 @@ func chanMake(elementSize uintptr, bufSize uintptr) *channel {
 	return &channel{
 		elementSize: elementSize,
 		bufSize:     bufSize,
-		buf:         alloc(elementSize * bufSize),
+		buf:         alloc(elementSize*bufSize, nil),
 	}
 }
 

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -263,7 +263,7 @@ func calculateHeapAddresses() {
 // alloc tries to find some free space on the heap, possibly doing a garbage
 // collection cycle if needed. If no space is free, it panics.
 //go:noinline
-func alloc(size uintptr) unsafe.Pointer {
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	if size == 0 {
 		return unsafe.Pointer(&zeroSizedAlloc)
 	}

--- a/src/runtime/gc_extalloc.go
+++ b/src/runtime/gc_extalloc.go
@@ -527,7 +527,7 @@ var zeroSizedAlloc uint8
 // alloc tries to find some free space on the heap, possibly doing a garbage
 // collection cycle if needed. If no space is free, it panics.
 //go:noinline
-func alloc(size uintptr) unsafe.Pointer {
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	if size == 0 {
 		return unsafe.Pointer(&zeroSizedAlloc)
 	}

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -13,7 +13,7 @@ import (
 // Ever-incrementing pointer: no memory is freed.
 var heapptr = heapStart
 
-func alloc(size uintptr) unsafe.Pointer {
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	// TODO: this can be optimized by not casting between pointers and ints so
 	// much. And by using platform-native data types (e.g. *uint8 for 8-bit
 	// systems).

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-func alloc(size uintptr) unsafe.Pointer
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
 
 func free(ptr unsafe.Pointer) {
 	// Nothing to free when nothing gets allocated.

--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -69,7 +69,7 @@ func hashmapMake(keySize, valueSize uint8, sizeHint uintptr) *hashmap {
 		bucketBits++
 	}
 	bucketBufSize := unsafe.Sizeof(hashmapBucket{}) + uintptr(keySize)*8 + uintptr(valueSize)*8
-	buckets := alloc(bucketBufSize * (1 << bucketBits))
+	buckets := alloc(bucketBufSize*(1<<bucketBits), nil)
 	return &hashmap{
 		buckets:    buckets,
 		keySize:    keySize,
@@ -157,7 +157,7 @@ func hashmapSet(m *hashmap, key unsafe.Pointer, value unsafe.Pointer, hash uint3
 // value into the bucket, and returns a pointer to this bucket.
 func hashmapInsertIntoNewBucket(m *hashmap, key, value unsafe.Pointer, tophash uint8) *hashmapBucket {
 	bucketBufSize := unsafe.Sizeof(hashmapBucket{}) + uintptr(m.keySize)*8 + uintptr(m.valueSize)*8
-	bucketBuf := alloc(bucketBufSize)
+	bucketBuf := alloc(bucketBufSize, nil)
 	// Insert into the first slot, which is empty as it has just been allocated.
 	slotKeyOffset := unsafe.Sizeof(hashmapBucket{})
 	slotKey := unsafe.Pointer(uintptr(bucketBuf) + slotKeyOffset)

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -27,7 +27,7 @@ func sliceAppend(srcBuf, elemsBuf unsafe.Pointer, srcLen, srcCap, elemsLen uintp
 			// programs).
 			srcCap *= 2
 		}
-		buf := alloc(srcCap * elemSize)
+		buf := alloc(srcCap*elemSize, nil)
 
 		// Copy the old slice to the new slice.
 		if srcLen != 0 {

--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -57,7 +57,7 @@ func stringConcat(x, y _string) _string {
 		return x
 	} else {
 		length := x.length + y.length
-		buf := alloc(length)
+		buf := alloc(length, nil)
 		memcpy(buf, unsafe.Pointer(x.ptr), x.length)
 		memcpy(unsafe.Pointer(uintptr(buf)+x.length), unsafe.Pointer(y.ptr), y.length)
 		return _string{ptr: (*byte)(buf), length: length}
@@ -70,7 +70,7 @@ func stringFromBytes(x struct {
 	len uintptr
 	cap uintptr
 }) _string {
-	buf := alloc(x.len)
+	buf := alloc(x.len, nil)
 	memcpy(buf, unsafe.Pointer(x.ptr), x.len)
 	return _string{ptr: (*byte)(buf), length: x.len}
 }
@@ -81,7 +81,7 @@ func stringToBytes(x _string) (slice struct {
 	len uintptr
 	cap uintptr
 }) {
-	buf := alloc(x.length)
+	buf := alloc(x.length, nil)
 	memcpy(buf, unsafe.Pointer(x.ptr), x.length)
 	slice.ptr = (*byte)(buf)
 	slice.len = x.length
@@ -98,7 +98,7 @@ func stringFromRunes(runeSlice []rune) (s _string) {
 	}
 
 	// Allocate memory for the string.
-	s.ptr = (*byte)(alloc(s.length))
+	s.ptr = (*byte)(alloc(s.length, nil))
 
 	// Encode runes to UTF-8 and store the resulting bytes in the string.
 	index := uintptr(0)

--- a/testdata/init.go
+++ b/testdata/init.go
@@ -44,7 +44,52 @@ var (
 	uint8SliceDst []uint8
 	intSliceSrc   = []int16{5, 123, 1024}
 	intSliceDst   []int16
+
+	someList    *linkedList
+	someBigList *bigLinkedList
 )
+
+type linkedList struct {
+	prev *linkedList
+	next *linkedList
+	v    int // arbitrary value (don't care)
+}
+
+func init() {
+	someList = &linkedList{
+		v: -1,
+	}
+	for i := 0; i < 3; i++ {
+		prev := someList
+		someList = &linkedList{
+			v:    i,
+			prev: prev,
+		}
+		prev.next = someList
+	}
+}
+
+type bigLinkedList struct {
+	prev *bigLinkedList
+	next *bigLinkedList
+	v    int
+	buf  [100]*int
+}
+
+func init() {
+	// Create a circular reference.
+	someBigList = &bigLinkedList{
+		v: -1,
+	}
+	for i := 0; i < 3; i++ {
+		prev := someBigList
+		someBigList = &bigLinkedList{
+			v:    i,
+			prev: prev,
+		}
+		prev.next = someBigList
+	}
+}
 
 func init() {
 	uint8SliceDst = make([]uint8, len(uint8SliceSrc))

--- a/transform/allocs.go
+++ b/transform/allocs.go
@@ -70,7 +70,7 @@ func OptimizeAllocs(mod llvm.Module, printAllocs *regexp.Regexp, logger func(tok
 		}
 
 		// In general the pattern is:
-		//     %0 = call i8* @runtime.alloc(i32 %size)
+		//     %0 = call i8* @runtime.alloc(i32 %size, i8* null)
 		//     %1 = bitcast i8* %0 to type*
 		//     (use %1 only)
 		// But the bitcast might sometimes be dropped when allocating an *i8.

--- a/transform/coroutines.go
+++ b/transform/coroutines.go
@@ -627,7 +627,7 @@ func (async *asyncFunc) hasValueStoreReturn() bool {
 func (c *coroutineLoweringPass) heapAlloc(t llvm.Type, name string) llvm.Value {
 	sizeT := c.alloc.FirstParam().Type()
 	size := llvm.ConstInt(sizeT, c.target.TypeAllocSize(t), false)
-	return c.builder.CreateCall(c.alloc, []llvm.Value{size, llvm.Undef(c.i8ptr), llvm.Undef(c.i8ptr)}, name)
+	return c.builder.CreateCall(c.alloc, []llvm.Value{size, llvm.ConstNull(c.i8ptr), llvm.Undef(c.i8ptr), llvm.Undef(c.i8ptr)}, name)
 }
 
 // lowerFuncFast lowers an async function that has no suspend points.
@@ -798,7 +798,7 @@ func (c *coroutineLoweringPass) lowerFuncCoro(fn *asyncFunc) {
 	// %coro.size = call i32 @llvm.coro.size.i32()
 	coroSize := c.builder.CreateCall(c.coroSize, []llvm.Value{}, "coro.size")
 	// %coro.alloc = call i8* runtime.alloc(i32 %coro.size)
-	coroAlloc := c.builder.CreateCall(c.alloc, []llvm.Value{coroSize, llvm.Undef(c.i8ptr), llvm.Undef(c.i8ptr)}, "coro.alloc")
+	coroAlloc := c.builder.CreateCall(c.alloc, []llvm.Value{coroSize, llvm.ConstNull(c.i8ptr), llvm.Undef(c.i8ptr), llvm.Undef(c.i8ptr)}, "coro.alloc")
 	// %coro.state = call noalias i8* @llvm.coro.begin(token %coro.id, i8* %coro.alloc)
 	coroState := c.builder.CreateCall(c.coroBegin, []llvm.Value{coroId, coroAlloc}, "coro.state")
 	c.track(coroState)

--- a/transform/testdata/allocs.ll
+++ b/transform/testdata/allocs.ll
@@ -3,11 +3,11 @@ target triple = "armv7m-none-eabi"
 
 @runtime.zeroSizedAlloc = internal global i8 0, align 1
 
-declare nonnull i8* @runtime.alloc(i32)
+declare nonnull i8* @runtime.alloc(i32, i8*)
 
 ; Test allocating a single int (i32) that should be allocated on the stack.
 define void @testInt() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2
   ret void
@@ -16,7 +16,7 @@ define void @testInt() {
 ; Test allocating an array of 3 i16 values that should be allocated on the
 ; stack.
 define i16 @testArray() {
-  %1 = call i8* @runtime.alloc(i32 6)
+  %1 = call i8* @runtime.alloc(i32 6, i8* null)
   %2 = bitcast i8* %1 to i16*
   %3 = getelementptr i16, i16* %2, i32 1
   store i16 5, i16* %3
@@ -28,14 +28,14 @@ define i16 @testArray() {
 ; Call a function that will let the pointer escape, so the heap-to-stack
 ; transform shouldn't be applied.
 define void @testEscapingCall() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @escapeIntPtr(i32* %2)
   ret void
 }
 
 define void @testEscapingCall2() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @escapeIntPtrSometimes(i32* %2, i32* %2)
   ret void
@@ -43,7 +43,7 @@ define void @testEscapingCall2() {
 
 ; Call a function that doesn't let the pointer escape.
 define void @testNonEscapingCall() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @noescapeIntPtr(i32* %2)
   ret void
@@ -51,7 +51,7 @@ define void @testNonEscapingCall() {
 
 ; Return the allocated value, which lets it escape.
 define i32* @testEscapingReturn() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   ret i32* %2
 }
@@ -61,7 +61,7 @@ define void @testNonEscapingLoop() {
 entry:
   br label %loop
 loop:
-  %0 = call i8* @runtime.alloc(i32 4)
+  %0 = call i8* @runtime.alloc(i32 4, i8* null)
   %1 = bitcast i8* %0 to i32*
   %2 = call i32* @noescapeIntPtr(i32* %1)
   %3 = icmp eq i32* null, %2
@@ -72,7 +72,7 @@ end:
 
 ; Test a zero-sized allocation.
 define void @testZeroSizedAlloc() {
-  %1 = call i8* @runtime.alloc(i32 0)
+  %1 = call i8* @runtime.alloc(i32 0, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @noescapeIntPtr(i32* %2)
   ret void

--- a/transform/testdata/allocs.out.ll
+++ b/transform/testdata/allocs.out.ll
@@ -3,7 +3,7 @@ target triple = "armv7m-none-eabi"
 
 @runtime.zeroSizedAlloc = internal global i8 0, align 1
 
-declare nonnull i8* @runtime.alloc(i32)
+declare nonnull i8* @runtime.alloc(i32, i8*)
 
 define void @testInt() {
   %stackalloc.alloca = alloca [1 x i32], align 4
@@ -25,14 +25,14 @@ define i16 @testArray() {
 }
 
 define void @testEscapingCall() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @escapeIntPtr(i32* %2)
   ret void
 }
 
 define void @testEscapingCall2() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   %3 = call i32* @escapeIntPtrSometimes(i32* %2, i32* %2)
   ret void
@@ -47,7 +47,7 @@ define void @testNonEscapingCall() {
 }
 
 define i32* @testEscapingReturn() {
-  %1 = call i8* @runtime.alloc(i32 4)
+  %1 = call i8* @runtime.alloc(i32 4, i8* null)
   %2 = bitcast i8* %1 to i32*
   ret i32* %2
 }

--- a/transform/testdata/coroutines.ll
+++ b/transform/testdata/coroutines.ll
@@ -9,7 +9,7 @@ declare void @"internal/task.Pause"(i8*, i8*)
 
 declare void @runtime.scheduler(i8*, i8*)
 
-declare i8* @runtime.alloc(i32, i8*, i8*)
+declare i8* @runtime.alloc(i32, i8*, i8*, i8*)
 declare void @runtime.free(i8*, i8*, i8*)
 
 declare %"internal/task.Task"* @"internal/task.Current"(i8*, i8*)

--- a/transform/testdata/coroutines.out.ll
+++ b/transform/testdata/coroutines.out.ll
@@ -10,7 +10,7 @@ declare void @"internal/task.Pause"(i8*, i8*)
 
 declare void @runtime.scheduler(i8*, i8*)
 
-declare i8* @runtime.alloc(i32, i8*, i8*)
+declare i8* @runtime.alloc(i32, i8*, i8*, i8*)
 
 declare void @runtime.free(i8*, i8*, i8*)
 
@@ -66,7 +66,7 @@ entry:
 define void @ditchTail(i32 %0, i64 %1, i8* %2, i8* %parentHandle) {
 entry:
   %task.current = bitcast i8* %parentHandle to %"internal/task.Task"*
-  %ret.ditch = call i8* @runtime.alloc(i32 4, i8* undef, i8* undef)
+  %ret.ditch = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* undef)
   call void @"(*internal/task.Task).setReturnPtr"(%"internal/task.Task"* %task.current, i8* %ret.ditch, i8* undef, i8* undef)
   %3 = call i32 @delayedValue(i32 %0, i64 %1, i8* undef, i8* %parentHandle)
   ret void
@@ -85,7 +85,7 @@ entry:
   %ret.ptr = call i8* @"(*internal/task.Task).getReturnPtr"(%"internal/task.Task"* %task.current, i8* undef, i8* undef)
   %ret.ptr.bitcast = bitcast i8* %ret.ptr to i32*
   store i32 %0, i32* %ret.ptr.bitcast, align 4
-  %ret.alternate = call i8* @runtime.alloc(i32 4, i8* undef, i8* undef)
+  %ret.alternate = call i8* @runtime.alloc(i32 4, i8* null, i8* undef, i8* undef)
   call void @"(*internal/task.Task).setReturnPtr"(%"internal/task.Task"* %task.current, i8* %ret.alternate, i8* undef, i8* undef)
   %4 = call i32 @delayedValue(i32 %1, i64 %2, i8* undef, i8* %parentHandle)
   ret i32 undef
@@ -96,7 +96,7 @@ entry:
   %call.return = alloca i32, align 4
   %coro.id = call token @llvm.coro.id(i32 0, i8* null, i8* null, i8* null)
   %coro.size = call i32 @llvm.coro.size.i32()
-  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* undef, i8* undef)
+  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* null, i8* undef, i8* undef)
   %coro.state = call i8* @llvm.coro.begin(token %coro.id, i8* %coro.alloc)
   %task.current2 = bitcast i8* %parentHandle to %"internal/task.Task"*
   %task.state.parent = call i8* @"(*internal/task.Task).setState"(%"internal/task.Task"* %task.current2, i8* %coro.state, i8* undef, i8* undef)
@@ -143,7 +143,7 @@ entry:
   %a = alloca i8, align 1
   %coro.id = call token @llvm.coro.id(i32 0, i8* null, i8* null, i8* null)
   %coro.size = call i32 @llvm.coro.size.i32()
-  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* undef, i8* undef)
+  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* null, i8* undef, i8* undef)
   %coro.state = call i8* @llvm.coro.begin(token %coro.id, i8* %coro.alloc)
   %task.current = bitcast i8* %parentHandle to %"internal/task.Task"*
   %task.state.parent = call i8* @"(*internal/task.Task).setState"(%"internal/task.Task"* %task.current, i8* %coro.state, i8* undef, i8* undef)
@@ -180,7 +180,7 @@ entry:
   %a = alloca i8, align 1
   %coro.id = call token @llvm.coro.id(i32 0, i8* null, i8* null, i8* null)
   %coro.size = call i32 @llvm.coro.size.i32()
-  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* undef, i8* undef)
+  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* null, i8* undef, i8* undef)
   %coro.state = call i8* @llvm.coro.begin(token %coro.id, i8* %coro.alloc)
   %task.current = bitcast i8* %parentHandle to %"internal/task.Task"*
   %task.state.parent = call i8* @"(*internal/task.Task).setState"(%"internal/task.Task"* %task.current, i8* %coro.state, i8* undef, i8* undef)
@@ -225,7 +225,7 @@ define i8 @usePtr(i8* %0, i8* %1, i8* %parentHandle) {
 entry:
   %coro.id = call token @llvm.coro.id(i32 0, i8* null, i8* null, i8* null)
   %coro.size = call i32 @llvm.coro.size.i32()
-  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* undef, i8* undef)
+  %coro.alloc = call i8* @runtime.alloc(i32 %coro.size, i8* null, i8* undef, i8* undef)
   %coro.state = call i8* @llvm.coro.begin(token %coro.id, i8* %coro.alloc)
   %task.current = bitcast i8* %parentHandle to %"internal/task.Task"*
   %task.state.parent = call i8* @"(*internal/task.Task).setState"(%"internal/task.Task"* %task.current, i8* %coro.state, i8* undef, i8* undef)

--- a/transform/testdata/gc-stackslots.out.ll
+++ b/transform/testdata/gc-stackslots.out.ll
@@ -8,7 +8,7 @@ target triple = "wasm32-unknown-unknown-wasm"
 
 declare void @runtime.trackPointer(i8* nocapture readonly)
 
-declare noalias nonnull i8* @runtime.alloc(i32)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*)
 
 define i8* @getPointer() {
   ret i8* @someGlobal
@@ -22,7 +22,7 @@ define i8* @needsStackSlots() {
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
   %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
   store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %ptr = call i8* @runtime.alloc(i32 4)
+  %ptr = call i8* @runtime.alloc(i32 4, i8* null)
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %ptr, i8** %4, align 4
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
@@ -49,7 +49,7 @@ define i8* @needsStackSlots2() {
   %ptr2 = getelementptr i8, i8* @someGlobal, i32 0
   %7 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 5
   store i8* %ptr2, i8** %7, align 4
-  %unused = call i8* @runtime.alloc(i32 4)
+  %unused = call i8* @runtime.alloc(i32 4, i8* null)
   %8 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 6
   store i8* %unused, i8** %8, align 4
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
@@ -72,7 +72,7 @@ define i8* @fibNext(i8* %x, i8* %y) {
   %x.val = load i8, i8* %x, align 1
   %y.val = load i8, i8* %y, align 1
   %out.val = add i8 %x.val, %y.val
-  %out.alloc = call i8* @runtime.alloc(i32 1)
+  %out.alloc = call i8* @runtime.alloc(i32 1, i8* null)
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %out.alloc, i8** %4, align 4
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
@@ -89,10 +89,10 @@ entry:
   store %runtime.stackChainObject* %0, %runtime.stackChainObject** %1, align 4
   %2 = bitcast { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject to %runtime.stackChainObject*
   store %runtime.stackChainObject* %2, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %entry.x = call i8* @runtime.alloc(i32 1)
+  %entry.x = call i8* @runtime.alloc(i32 1, i8* null)
   %3 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %entry.x, i8** %3, align 4
-  %entry.y = call i8* @runtime.alloc(i32 1)
+  %entry.y = call i8* @runtime.alloc(i32 1, i8* null)
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 3
   store i8* %entry.y, i8** %4, align 4
   store i8 1, i8* %entry.y, align 1
@@ -131,7 +131,7 @@ define void @testGEPBitcast() {
   %arr.bitcast = getelementptr [32 x i8], [32 x i8]* %arr, i32 0, i32 0
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %arr.bitcast, i8** %4, align 4
-  %other = call i8* @runtime.alloc(i32 1)
+  %other = call i8* @runtime.alloc(i32 1, i8* null)
   %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 3
   store i8* %other, i8** %5, align 4
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -41,6 +41,12 @@ func testTransform(t *testing.T, pathPrefix string, transform func(mod llvm.Modu
 	// Perform the transform.
 	transform(mod)
 
+	// Check for any incorrect IR.
+	err = llvm.VerifyModule(mod, llvm.PrintMessageAction)
+	if err != nil {
+		t.Fatal("IR verification failed")
+	}
+
 	// Get the output from the test and filter some irrelevant lines.
 	actual := mod.String()
 	actual = actual[strings.Index(actual, "\ntarget datalayout = ")+1:]


### PR DESCRIPTION
This PR partially fixes https://github.com/tinygo-org/tinygo/issues/1848. It's relatively big: it adds object layout information to the IR which is normally optimized away but is used by the interp package to avoid problematic cases like linked list, tree structures, etc.

It also improves https://github.com/tinygo-org/tinygo/issues/1306 and https://github.com/tinygo-org/tinygo/issues/1830 but doesn't yet fix them. Somehow they're still failing.