### PR TITLE
wasm: add support for the crypto/rand package

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -162,7 +162,7 @@ func runPlatTests(target string, tests []string, t *testing.T) {
 			runTest(name, target, t, nil, nil)
 		})
 	}
-	if target == "wasi" || target == "" {
+	if target == "" || target == "wasi" {
 		t.Run("filesystem.go", func(t *testing.T) {
 			t.Parallel()
 			runTest("filesystem.go", target, t, nil, nil)
@@ -170,6 +170,12 @@ func runPlatTests(target string, tests []string, t *testing.T) {
 		t.Run("env.go", func(t *testing.T) {
 			t.Parallel()
 			runTest("env.go", target, t, []string{"first", "second"}, []string{"ENV1=VALUE1", "ENV2=VALUE2"})
+		})
+	}
+	if target == "" || target == "wasi" || target == "wasm" {
+		t.Run("rand.go", func(t *testing.T) {
+			t.Parallel()
+			runTest("rand.go", target, t, nil, nil)
 		})
 	}
 }

--- a/src/crypto/rand/rand_getentropy.go
+++ b/src/crypto/rand/rand_getentropy.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd wasi
+// +build darwin freebsd tinygo.wasm
 
 // This implementation of crypto/rand uses the getentropy system call (available
 // on both MacOS and WASI) to generate random numbers.

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -285,6 +285,10 @@
 							throw 'trying to exit with code ' + code;
 						}
 					},
+					random_get: (bufPtr, bufLen) => {
+						crypto.getRandomValues(loadSlice(bufPtr, bufLen));
+						return 0;
+					},
 				},
 				env: {
 					// func ticks() float64

--- a/testdata/env.go
+++ b/testdata/env.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/rand"
 	"os"
 )
 
@@ -20,27 +19,5 @@ func main() {
 	println()
 	for _, arg := range os.Args[1:] {
 		println("arg:", arg)
-	}
-
-	// Check for crypto/rand support.
-	checkRand()
-}
-
-func checkRand() {
-	buf := make([]byte, 500)
-	n, err := rand.Read(buf)
-	if n != len(buf) || err != nil {
-		println("could not read random numbers:", err)
-	}
-
-	// Very simple test that random numbers are at least somewhat random.
-	sum := 0
-	for _, b := range buf {
-		sum += int(b)
-	}
-	if sum < 95*len(buf) || sum > 159*len(buf) {
-		println("random numbers don't seem that random, the average byte is", sum/len(buf))
-	} else {
-		println("random number check was successful")
 	}
 }

--- a/testdata/env.txt
+++ b/testdata/env.txt
@@ -3,4 +3,3 @@ ENV2: VALUE2
 
 arg: first
 arg: second
-random number check was successful

--- a/testdata/rand.go
+++ b/testdata/rand.go
@@ -1,0 +1,24 @@
+package main
+
+import "crypto/rand"
+
+// TODO: make this a test in the crypto/rand package.
+
+func main() {
+	buf := make([]byte, 500)
+	n, err := rand.Read(buf)
+	if n != len(buf) || err != nil {
+		println("could not read random numbers:", err)
+	}
+
+	// Very simple test that random numbers are at least somewhat random.
+	sum := 0
+	for _, b := range buf {
+		sum += int(b)
+	}
+	if sum < 95*len(buf) || sum > 159*len(buf) {
+		println("random numbers don't seem that random, the average byte is", sum/len(buf))
+	} else {
+		println("random number check was successful")
+	}
+}

--- a/testdata/rand.txt
+++ b/testdata/rand.txt
@@ -1,0 +1,1 @@
+random number check was successful


### PR DESCRIPTION
This is done via wasi-libc and the WASI interface, for ease of maintenance (only one implementation for both WASI and JS/browsers).