### PR TITLE
transform: improve GC stack slot pass to work around a bug

### DIFF
--- a/testdata/goroutines.go
+++ b/testdata/goroutines.go
@@ -76,6 +76,8 @@ func main() {
 	testGoOnBuiltins()
 
 	testCond()
+
+	testIssue1790()
 }
 
 func acquire(m *sync.Mutex) {
@@ -197,4 +199,14 @@ func testCond() {
 	if !ok {
 		panic("missing queued notification")
 	}
+}
+
+var once sync.Once
+
+// This tests a fix for issue 1790:
+// https://github.com/tinygo-org/tinygo/issues/1790
+func testIssue1790() *int {
+	once.Do(func() {})
+	i := 0
+	return &i
 }

--- a/transform/testdata/gc-stackslots.ll
+++ b/transform/testdata/gc-stackslots.ll
@@ -20,6 +20,10 @@ define i8* @needsStackSlots() {
   ; so tracking it is not really necessary.
   %ptr = call i8* @runtime.alloc(i32 4)
   call void @runtime.trackPointer(i8* %ptr)
+  ; Restoring the stack pointer can happen at this position, before the return.
+  ; This avoids issues with tail calls.
+  call void @someArbitraryFunction()
+  %val = load i8, i8* @someGlobal
   ret i8* %ptr
 }
 
@@ -93,5 +97,9 @@ define void @testGEPBitcast() {
   call void @runtime.trackPointer(i8* %arr.bitcast)
   %other = call i8* @runtime.alloc(i32 1)
   call void @runtime.trackPointer(i8* %other)
+  ret void
+}
+
+define void @someArbitraryFunction() {
   ret void
 }

--- a/transform/testdata/gc-stackslots.out.ll
+++ b/transform/testdata/gc-stackslots.out.ll
@@ -26,6 +26,8 @@ define i8* @needsStackSlots() {
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %ptr, i8** %4
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart
+  call void @someArbitraryFunction()
+  %val = load i8, i8* @someGlobal
   ret i8* %ptr
 }
 
@@ -73,8 +75,8 @@ define i8* @fibNext(i8* %x, i8* %y) {
   %out.alloc = call i8* @runtime.alloc(i32 1)
   %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
   store i8* %out.alloc, i8** %4
-  store i8 %out.val, i8* %out.alloc
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart
+  store i8 %out.val, i8* %out.alloc
   ret i8* %out.alloc
 }
 
@@ -133,5 +135,9 @@ define void @testGEPBitcast() {
   %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 3
   store i8* %other, i8** %5
   store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart
+  ret void
+}
+
+define void @someArbitraryFunction() {
   ret void
 }


### PR DESCRIPTION
Bug 1790 ("musttail call must precede a ret with an optional bitcast")
is caused by the GC stack slot pass inserting a store instruction
between a musttail call and a return instruction. This is not allowed in
LLVM IR.

One solution would be to remove the musttail. That would probably work,
but 1) the go-llvm API doesn't support this and 2) this might have
unforeseen consequences. What I've done in this commit is to move the
store instruction to a position earlier in the basic block, just after
the last access to the GC stack slot alloca.

Thanks to @fgsch for a very small repro, which I've used as a regression
test.

fixes #1790 