### PR TITLE
ci: run stdlib tests for other architectures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,7 @@ commands:
             ln -s ~/lib/tinygo/bin/tinygo /go/bin/tinygo
             tinygo version
       - run: make smoketest
+      - run: make tinygo-test-all
   build-macos:
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,21 @@ TEST_PACKAGES = \
 # Test known-working standard library packages.
 # TODO: parallelize, and only show failing tests (no implied -v flag).
 .PHONY: tinygo-test
-tinygo-test:
-	$(TINYGO) test $(TEST_PACKAGES)
+tinygo-test: tinygo-test-amd64
+
+# Test all architectures (not just the host architecture).
+.PHONY: tinygo-test-all tinygo-test-386 tinygo-test-arm tinygo-test-arm64 tinygo-test-wasi
+tinygo-test-all: tinygo-test-amd64 tinygo-test-386 tinygo-test-arm tinygo-test-arm64 tinygo-test-wasi
+tinygo-test-amd64:
+	GOARCH=amd64 $(TINYGO) test $(TEST_PACKAGES)
+tinygo-test-386:
+	GOARCH=386 $(TINYGO) test $(TEST_PACKAGES)
+tinygo-test-arm:
+	GOARCH=arm $(TINYGO) test $(TEST_PACKAGES)
+tinygo-test-arm64:
+	GOARCH=arm64 $(TINYGO) test $(TEST_PACKAGES)
+tinygo-test-wasi:
+	$(TINYGO) test -target=wasi $(TEST_PACKAGES)
 
 .PHONY: smoketest
 smoketest:


### PR DESCRIPTION
Currently this runs the tests for amd64, 386, arm, arm64, and wasi. I
tried adding wasm and a baremetal target (such as riscv-qemu) but they
don't pass the tests yet and should be fixed in the future. At least
this change should make sure that existing tests continue to pass on a
variety of architectures.

Depends on #2030 for 386 and wasm fixes, so marked as draft until then.