### PR TITLE
builder: run binaryen after the linker when generating wasm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
           name: "Install binaryen"
           command: |
             wget https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz
-            sudo tar -C /usr/local -xf --strip-components=1 binaryen-version_101-x86_64-linux.tar.gz
+            sudo tar --strip-components=1 -C /usr/local -xf binaryen-version_101-x86_64-linux.tar.gz
   install-xtensa-toolchain:
     parameters:
       variant:
@@ -153,7 +153,7 @@ commands:
                 qemu-user \
                 gcc-avr \
                 avr-libc
-            sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-6-dev
+            sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
       - install-node
       - install-wasmtime
       - install-xtensa-toolchain:
@@ -224,7 +224,7 @@ commands:
                 qemu-user \
                 gcc-avr \
                 avr-libc
-            sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-6-dev
+            sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
       - install-node
       - install-wasmtime
       - install-xtensa-toolchain:
@@ -303,7 +303,7 @@ commands:
             curl https://dl.google.com/go/go1.17.darwin-amd64.tar.gz -o go1.17.darwin-amd64.tar.gz
             sudo tar -C /usr/local -xzf go1.17.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu cmake ninja
       - install-xtensa-toolchain:
           variant: "macos"
       - restore_cache:
@@ -334,8 +334,6 @@ commands:
               # fetch LLVM source
               rm -rf llvm-project
               make llvm-source
-              # install dependencies
-              HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
               # build!
               make llvm-build
               find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,8 +152,13 @@ commands:
                 qemu-system-arm \
                 qemu-user \
                 gcc-avr \
-                avr-libc
+                avr-libc \
+                cmake \
+                ninja-build
             sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
+            # hack ninja to use less jobs
+            echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
+            chmod +x /go/bin/ninja
       - install-node
       - install-wasmtime
       - install-xtensa-toolchain:
@@ -174,11 +179,6 @@ commands:
               # fetch LLVM source
               rm -rf llvm-project
               make llvm-source
-              # install dependencies
-              sudo apt-get install cmake ninja-build
-              # hack ninja to use less jobs
-              echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
-              chmod +x /go/bin/ninja
               # build!
               make ASSERT=1 llvm-build
               find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
@@ -223,8 +223,13 @@ commands:
                 qemu-system-arm \
                 qemu-user \
                 gcc-avr \
-                avr-libc
+                avr-libc \
+                cmake \
+                ninja-build
             sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
+            # hack ninja to use less jobs
+            echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
+            chmod +x /go/bin/ninja
       - install-node
       - install-wasmtime
       - install-xtensa-toolchain:
@@ -245,11 +250,6 @@ commands:
               # fetch LLVM source
               rm -rf llvm-project
               make llvm-source
-              # install dependencies
-              sudo apt-get install cmake ninja-build
-              # hack ninja to use less jobs
-              echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
-              chmod +x /go/bin/ninja
               # build!
               make llvm-build
               find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,8 @@ commands:
                 gcc-avr \
                 avr-libc \
                 cmake \
-                ninja-build
+                ninja-build \
+                python3
             sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
             # hack ninja to use less jobs
             echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja
@@ -225,7 +226,8 @@ commands:
                 gcc-avr \
                 avr-libc \
                 cmake \
-                ninja-build
+                ninja-build \
+                python3
             sudo apt-get install --no-install-recommends libc6-dev-i386 lib32gcc-8-dev
             # hack ninja to use less jobs
             echo -e '#!/bin/sh\n/usr/bin/ninja -j3 "$@"' > /go/bin/ninja

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
           name: "Install binaryen"
           command: |
             wget https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz
-            sudo tar -C /usr/local --strip-components=1 binaryen-version_101-x86_64-linux.tar.gz
+            sudo tar -C /usr/local -xf --strip-components=1 binaryen-version_101-x86_64-linux.tar.gz
   install-xtensa-toolchain:
     parameters:
       variant:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,13 @@ commands:
           command: |
             curl https://wasmtime.dev/install.sh -sSf | bash
             sudo ln -s ~/.wasmtime/bin/wasmtime /usr/local/bin/wasmtime
+  install-binaryen:
+    steps:
+      - run:
+          name: "Install binaryen"
+          command: |
+            wget https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-linux.tar.gz
+            sudo tar -C /usr/local --strip-components=1 binaryen-version_101-x86_64-linux.tar.gz
   install-xtensa-toolchain:
     parameters:
       variant:
@@ -103,6 +110,7 @@ commands:
       - install-node
       - install-chrome
       - install-wasmtime
+      - install-binaryen
       - restore_cache:
           keys:
             - go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
@@ -179,6 +187,9 @@ commands:
           key: llvm-build-11-linux-v4-assert
           paths:
             llvm-build
+      - run:
+          name: "Build Binaryen"
+          command: make lib/binaryen/lib/libbinaryen.a
       - run: make ASSERT=1
       - build-wasi-libc
       - run:
@@ -247,6 +258,9 @@ commands:
           key: llvm-build-11-linux-v4-noassert
           paths:
             llvm-build
+      - run:
+          name: "Build Binaryen"
+          command: make lib/binaryen/lib/libbinaryen.a
       - build-wasi-libc
       - run:
           name: "Test TinyGo"
@@ -330,6 +344,9 @@ commands:
           key: llvm-build-11-macos-v5
           paths:
             llvm-build
+      - run:
+          name: "Build Binaryen"
+          command: make lib/binaryen/lib/libbinaryen.a
       - restore_cache:
           keys:
             - wasi-libc-sysroot-macos-v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,4 +25,4 @@
 	url = https://github.com/tinygo-org/stm32-svd
 [submodule "lib/binaryen"]
 	path = lib/binaryen
-	url = git@github.com:WebAssembly/binaryen.git
+	url = https://github.com/WebAssembly/binaryen

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "lib/stm32-svd"]
 	path = lib/stm32-svd
 	url = https://github.com/tinygo-org/stm32-svd
+[submodule "lib/binaryen"]
+	path = lib/binaryen
+	url = git@github.com:WebAssembly/binaryen.git

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ ifneq ("$(wildcard $(LLVM_BUILDDIR)/bin/llvm-config*)","")
     CGO_LDFLAGS+=$(abspath $(LLVM_BUILDDIR))/lib/lib$(LIBCLANG_NAME).a -L$(abspath $(LLVM_BUILDDIR)/lib) $(CLANG_LIBS) $(LLD_LIBS) $(shell $(LLVM_BUILDDIR)/bin/llvm-config --ldflags --libs --system-libs $(LLVM_COMPONENTS)) -lstdc++ $(CGO_LDFLAGS_EXTRA)
 endif
 ifneq ("$(wildcard lib/binaryen/lib/libbinaryen.a)","")
+	CGO_CPPFLAGS+=-I$(abspath lib/binaryen/src/)
 	CGO_LDFLAGS+=$(abspath lib/binaryen/lib/libbinaryen.a)
 endif
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,17 @@ jobs:
         version: '1.17'
     - checkout: self
       fetchDepth: 1
+    - task: Bash@3
+      displayName: Install Dependencies
+      inputs:
+        targetType: inline
+        script: |
+          # install ninja
+          choco install ninja
+          # hack ninja to use fewer jobs
+          echo -e 'C:\\ProgramData\\Chocolatey\\bin\\ninja -j4 %*' > /usr/bin/ninja.bat
+          # install qemu
+          choco install qemu --version=2020.06.12
     - task: Cache@2
       displayName: Cache LLVM source
       inputs:
@@ -37,11 +48,6 @@ jobs:
         script: |
           if [ ! -f llvm-build/lib/liblldELF.a ]
           then
-            # install dependencies
-            choco install ninja
-            # hack ninja to use fewer jobs
-            echo -e 'C:\\ProgramData\\Chocolatey\\bin\\ninja -j4 %*' > /usr/bin/ninja.bat
-            # build!
             make llvm-build
           fi
     - task: Bash@3
@@ -49,11 +55,6 @@ jobs:
       inputs:
         targetType: inline
         script: make lib/binaryen/lib/libbinaryen.a
-    - task: Bash@3
-      displayName: Install QEMU
-      inputs:
-        targetType: inline
-        script: choco install qemu --version=2020.06.12
     - task: CacheBeta@0
       displayName: Cache wasi-libc sysroot
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,11 @@ jobs:
             make llvm-build
           fi
     - task: Bash@3
+      displayName: Build Binaryen
+      inputs:
+        targetType: inline
+        script: make lib/binaryen/lib/libbinaryen.a
+    - task: Bash@3
       displayName: Install QEMU
       inputs:
         targetType: inline

--- a/builder/binaryen.go
+++ b/builder/binaryen.go
@@ -1,0 +1,39 @@
+package builder
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+// BinaryenConfig is a configuration for binaryen's wasm-opt tool.
+type BinaryenConfig struct {
+	// OptLevel is the optimization level to use.
+	// This must be between 0 (no optimization) and 2 (maximum optimization).
+	OptLevel int
+
+	// ShrinkLevel is the size optimization level to use.
+	// This must be between 0 (no size optimization) and 2 (maximum size optimization).
+	ShrinkLevel int
+
+	// SpecialPasses are special transform/optimization passes to explicitly run before the main optimizer.
+	SpecialPasses []string
+}
+
+func wasmOptCmd(src, dst string, cfg BinaryenConfig) error {
+	args := []string{
+		src,
+		"--output", dst,
+		"--optimize-level", strconv.Itoa(cfg.OptLevel),
+		"--shrink-level", strconv.Itoa(cfg.ShrinkLevel),
+	}
+	for _, pass := range cfg.SpecialPasses {
+		args = append(args, "--"+pass)
+	}
+
+	cmd := exec.Command("wasm-opt", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/builder/build.go
+++ b/builder/build.go
@@ -621,6 +621,30 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 				}
 			}
 
+			// Run wasm-opt if necessary.
+			if config.GOARCH() == "wasm" {
+				var cfg BinaryenConfig
+				switch config.Options.Opt {
+				case "none", "0":
+				case "1":
+					cfg.OptLevel = 1
+				case "2":
+					cfg.OptLevel = 2
+				case "s":
+					cfg.OptLevel = 2
+					cfg.ShrinkLevel = 1
+				case "z":
+					cfg.OptLevel = 2
+					cfg.ShrinkLevel = 2
+				default:
+					return fmt.Errorf("unknown opt level: %q", config.Options.Opt)
+				}
+				err := WasmOpt(executable, executable, cfg)
+				if err != nil {
+					return fmt.Errorf("wasm-opt failed: %w", err)
+				}
+			}
+
 			if config.Options.PrintSizes == "short" || config.Options.PrintSizes == "full" {
 				sizes, err := loadProgramSize(executable)
 				if err != nil {

--- a/builder/tools-builtin.go
+++ b/builder/tools-builtin.go
@@ -5,7 +5,7 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"sync"
 	"unsafe"
 )
@@ -62,7 +62,7 @@ func RunTool(tool string, args ...string) error {
 var wasmOptLock sync.Mutex
 
 func WasmOpt(src, dst string, cfg BinaryenConfig) error {
-	data, err := os.ReadFile(src)
+	data, err := ioutil.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("reading source file: %w", err)
 	}
@@ -72,7 +72,7 @@ func WasmOpt(src, dst string, cfg BinaryenConfig) error {
 		return fmt.Errorf("running wasm-opt: %w", err)
 	}
 
-	err = os.WriteFile(dst, data, 0666)
+	err = ioutil.WriteFile(dst, data, 0666)
 	if err != nil {
 		return fmt.Errorf("writing destination file: %w", err)
 	}

--- a/builder/tools-builtin.go
+++ b/builder/tools-builtin.go
@@ -12,7 +12,6 @@ import (
 
 /*
 #cgo CXXFLAGS: -fno-rtti
-#cgo LDFLAGS: -lbinaryen
 #include <stdbool.h>
 #include <stdlib.h>
 #include <binaryen-c.h>

--- a/builder/tools-external.go
+++ b/builder/tools-external.go
@@ -13,3 +13,7 @@ const hasBuiltinTools = false
 func RunTool(tool string, args ...string) error {
 	return errors.New("cannot run tool: " + tool)
 }
+
+func WasmOpt(src, dst string, cfg BinaryenConfig) error {
+	return wasmOptCmd(src, dst, cfg)
+}


### PR DESCRIPTION
Right now it builds and links.
It needs a lot of cleanup still, and debug symbol support had to be disabled for it to build.
This can use the `wasm-opt` command when dynamically built and `libbinaryen` when built normally.