### PR TITLE
testing: test testing package using `tinygo test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ TEST_PACKAGES = \
 	hash/crc64 \
 	math \
 	math/cmplx \
+	testing \
 	text/scanner \
 	unicode/utf8 \
 
@@ -211,8 +212,6 @@ TEST_PACKAGES = \
 .PHONY: tinygo-test
 tinygo-test:
 	$(TINYGO) test $(TEST_PACKAGES)
-	# until "test testing" passes
-	cd tests/tinygotest && $(TINYGO) test benchmark_test.go
 
 .PHONY: smoketest
 smoketest:

--- a/src/testing/benchmark_test.go
+++ b/src/testing/benchmark_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package testbench
+package testing_test
 
 import (
 	"testing"
@@ -11,8 +11,8 @@ import (
 var buf = make([]byte, 13579)
 
 func NonASCII(b []byte, i int, offset int) int {
-	for i = offset; i < len(b) + offset; i++ {
-		if b[i % len(b)] >= 0x80 {
+	for i = offset; i < len(b)+offset; i++ {
+		if b[i%len(b)] >= 0x80 {
 			break
 		}
 	}


### PR DESCRIPTION
Apparently this already works.