### PR TITLE
baremetal,wasm: support command line params and environment variables

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -208,7 +208,7 @@ func mergeDirectory(goroot, tinygoroot, tmpgoroot, importPath string, overrides 
 // with the TinyGo version. This is the case on some targets.
 func needsSyscallPackage(buildTags []string) bool {
 	for _, tag := range buildTags {
-		if tag == "baremetal" || tag == "darwin" || tag == "nintendoswitch" || tag == "wasi" {
+		if tag == "baremetal" || tag == "darwin" || tag == "nintendoswitch" || tag == "tinygo.wasm" {
 			return true
 		}
 	}

--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -1,0 +1,48 @@
+// +build baremetal js
+
+package runtime
+
+// This file is for non-hosted environments, that don't support command line
+// parameters or environment variables. To still be able to run certain tests,
+// command line parameters and environment variables can be passed to the binary
+// by setting the variables `runtime.osArgs` and `runtime.osEnv`, both of which
+// are strings separated by newlines.
+//
+// The primary use case is `tinygo test`, which takes some parameters (such as
+// -test.v).
+
+var env []string
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	return env
+}
+
+var osArgs string
+var osEnv string
+
+func init() {
+	if osArgs != "" {
+		s := osArgs
+		start := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == 0 {
+				args = append(args, s[start:i])
+				start = i + 1
+			}
+		}
+		args = append(args, s[start:])
+	}
+
+	if osEnv != "" {
+		s := osEnv
+		start := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == 0 {
+				env = append(env, s[start:i])
+				start = i + 1
+			}
+		}
+		env = append(env, s[start:])
+	}
+}

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -15,11 +15,6 @@ func _start() {
 	run()
 }
 
-//go:linkname syscall_runtime_envs syscall.runtime_envs
-func syscall_runtime_envs() []string {
-	return nil
-}
-
 var handleEvent func()
 
 //go:linkname setEventHandler syscall/js.setEventHandler

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-// +build baremetal
+// +build baremetal js
 
 package syscall
 
@@ -47,8 +47,24 @@ const (
 	O_CLOEXEC = 0
 )
 
+func runtime_envs() []string
+
 func Getenv(key string) (value string, found bool) {
-	return "", false // stub
+	env := runtime_envs()
+	for _, keyval := range env {
+		// Split at '=' character.
+		var k, v string
+		for i := 0; i < len(keyval); i++ {
+			if keyval[i] == '=' {
+				k = keyval[:i]
+				v = keyval[i+1:]
+			}
+		}
+		if k == key {
+			return v, true
+		}
+	}
+	return "", false
 }
 
 func Open(path string, mode int, perm uint32) (fd int, err error) {

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build baremetal nintendoswitch
+// +build baremetal nintendoswitch js
 
 package syscall
 


### PR DESCRIPTION
This is mainly useful to be able to run `tinygo test`, for example:

    tinygo test -target=cortex-m-qemu -v math

This is not currently supported, but will be in the future.