### PR TITLE
testing: add support for the -test.v flag

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -51,6 +51,7 @@ func TestCompiler(t *testing.T) {
 		"stdlib.go",
 		"string.go",
 		"structs.go",
+		"testing.go",
 		"zeroalloc.go",
 	}
 

--- a/testdata/testing.go
+++ b/testdata/testing.go
@@ -1,0 +1,42 @@
+package main
+
+// TODO: also test the verbose version.
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	t.Log("log Foo.a")
+	t.Log("log Foo.b")
+}
+
+func TestBar(t *testing.T) {
+	t.Log("log Bar")
+	t.Log("log g\nh\ni\n")
+	t.Run("Bar1", func(t *testing.T) {})
+	t.Run("Bar2", func(t *testing.T) {
+		t.Log("log Bar2\na\nb\nc")
+		t.Error("failed")
+		t.Log("after failed")
+	})
+	t.Run("Bar3", func(t *testing.T) {})
+	t.Log("log Bar end")
+}
+
+var tests = []testing.InternalTest{
+	{"TestFoo", TestFoo},
+	{"TestBar", TestBar},
+}
+
+var benchmarks = []testing.InternalBenchmark{}
+
+var examples = []testing.InternalExample{}
+
+func main() {
+	m := testing.MainStart(nil, tests, benchmarks, examples)
+	exitcode := m.Run()
+	if exitcode != 0 {
+		println("exitcode:", exitcode)
+	}
+}

--- a/testdata/testing.txt
+++ b/testdata/testing.txt
@@ -1,0 +1,16 @@
+--- FAIL: TestBar
+    log Bar
+    log g
+        h
+        i
+        
+    --- FAIL: TestBar/Bar2
+        log Bar2
+            a
+            b
+            c
+        failed
+        after failed
+    log Bar end
+FAIL
+exitcode: 1


### PR DESCRIPTION
This flag is passed automatically with the (new) -v flag for TinyGo. For example, this prints all the test outputs:

    $ tinygo test -v crypto/md5
    === RUN   TestGolden
    --- PASS: TestGolden
    === RUN   TestGoldenMarshal
    --- PASS: TestGoldenMarshal
    === RUN   TestLarge
    --- PASS: TestLarge
    === RUN   TestBlockGeneric
    --- PASS: TestBlockGeneric
    === RUN   TestLargeHashes
    --- PASS: TestLargeHashes
    PASS
    ok  	crypto/md5	0.002s

This prints just a summary:

    $ tinygo test crypto/md5
    PASS
    ok  	crypto/md5	0.002s

(The superfluous 'PASS' message may be removed in the future).

This is especially useful when testing a large number of packages:

    $ tinygo test crypto/md5 crypto/sha1 crypto/sha256 crypto/sha512
    PASS
    ok  	crypto/md5	0.002s
    PASS
    ok  	crypto/sha1	0.043s
    PASS
    ok  	crypto/sha256	0.002s
    PASS
    ok  	crypto/sha512	0.003s

At the moment, the -test.v flag is not supplied to binaries running in emulation. I intend to fix this after
https://github.com/tinygo-org/tinygo/pull/2038 lands by refactoring `runPackageTest`, `Run`, and `runTestWithConfig` in the main package which al do something similar.