### PR TITLE
Improve/refactor testing of binaries running under qemu-system-*

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -333,9 +333,6 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		}
 	}()
 	err = cmd.Wait()
-	if _, ok := err.(*exec.ExitError); ok && options.Target != "" {
-		err = nil // workaround for QEMU
-	}
 	close(runComplete)
 
 	if ranTooLong {

--- a/src/device/arm/semihosting.go
+++ b/src/device/arm/semihosting.go
@@ -33,28 +33,29 @@ const (
 )
 
 // Special codes for the Angel Semihosting interface.
+// https://www.keil.com/support/man/docs/armcc/armcc_pge1358787050566.htm
 const (
 	// Hardware vector reason codes
-	SemihostingBranchThroughZero = 20000
-	SemihostingUndefinedInstr    = 20001
-	SemihostingSoftwareInterrupt = 20002
-	SemihostingPrefetchAbort     = 20003
-	SemihostingDataAbort         = 20004
-	SemihostingAddressException  = 20005
-	SemihostingIRQ               = 20006
-	SemihostingFIQ               = 20007
+	SemihostingBranchThroughZero = 0x20000
+	SemihostingUndefinedInstr    = 0x20001
+	SemihostingSoftwareInterrupt = 0x20002
+	SemihostingPrefetchAbort     = 0x20003
+	SemihostingDataAbort         = 0x20004
+	SemihostingAddressException  = 0x20005
+	SemihostingIRQ               = 0x20006
+	SemihostingFIQ               = 0x20007
 
 	// Software reason codes
-	SemihostingBreakPoint          = 20020
-	SemihostingWatchPoint          = 20021
-	SemihostingStepComplete        = 20022
-	SemihostingRunTimeErrorUnknown = 20023
-	SemihostingInternalError       = 20024
-	SemihostingUserInterruption    = 20025
-	SemihostingApplicationExit     = 20026
-	SemihostingStackOverflow       = 20027
-	SemihostingDivisionByZero      = 20028
-	SemihostingOSSpecific          = 20029
+	SemihostingBreakPoint          = 0x20020
+	SemihostingWatchPoint          = 0x20021
+	SemihostingStepComplete        = 0x20022
+	SemihostingRunTimeErrorUnknown = 0x20023
+	SemihostingInternalError       = 0x20024
+	SemihostingUserInterruption    = 0x20025
+	SemihostingApplicationExit     = 0x20026
+	SemihostingStackOverflow       = 0x20027
+	SemihostingDivisionByZero      = 0x20028
+	SemihostingOSSpecific          = 0x20029
 )
 
 // Call a semihosting function.

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -48,7 +48,7 @@ func libc_free(ptr unsafe.Pointer) {
 
 //go:linkname syscall_Exit syscall.Exit
 func syscall_Exit(code int) {
-	abort()
+	exit(code)
 }
 
 const baremetal = true

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -75,6 +75,10 @@ func sleepTicks(d timeUnit) {
 	// TODO
 }
 
+func exit(code int) {
+	abort()
+}
+
 func abort() {
 	// TODO
 	for {

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -19,7 +19,7 @@ func postinit() {}
 func main() {
 	preinit()
 	run()
-	abort()
+	exit(0)
 }
 
 func init() {

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -19,7 +19,7 @@ func main() {
 	arm.SCB.CPACR.Set(0) // disable FPU if it is enabled
 	preinit()
 	run()
-	abort()
+	exit(0)
 }
 
 func init() {

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -37,7 +37,7 @@ var _ebss [0]byte
 func main() {
 	preinit()
 	run()
-	abort()
+	exit(0)
 }
 
 func preinit() {
@@ -82,6 +82,10 @@ func sleepTicks(d timeUnit) {
 
 func ticks() timeUnit {
 	return currentTime
+}
+
+func exit(code int) {
+	abort()
 }
 
 func abort() {

--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -6,6 +6,10 @@ import (
 	"device/arm"
 )
 
+func exit(code int) {
+	abort()
+}
+
 func abort() {
 	// lock up forever
 	for {

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -23,8 +23,7 @@ func main() {
 	run()
 
 	// Signal successful exit.
-	arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingApplicationExit)
-	abort()
+	exit(0)
 }
 
 func ticksToNanoseconds(ticks timeUnit) int64 {
@@ -56,8 +55,16 @@ func waitForEvents() {
 }
 
 func abort() {
-	// Signal an abnormal exit.
-	arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingRunTimeErrorUnknown)
+	exit(1)
+}
+
+func exit(code int) {
+	// Exit QEMU.
+	if code == 0 {
+		arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingApplicationExit)
+	} else {
+		arm.SemihostingCall(arm.SemihostingReportException, arm.SemihostingRunTimeErrorUnknown)
+	}
 
 	// Lock up forever (should be unreachable).
 	for {

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -51,7 +51,7 @@ func main() {
 	run()
 
 	// Fallback: if main ever returns, hang the CPU.
-	abort()
+	exit(0)
 }
 
 //go:extern _sbss

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -54,7 +54,7 @@ func main() {
 	run()
 
 	// Fallback: if main ever returns, hang the CPU.
-	abort()
+	exit(0)
 }
 
 func abort() {

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -67,3 +67,7 @@ func sleepTicks(d timeUnit) {
 		// TODO: suspend the CPU to not burn power here unnecessarily.
 	}
 }
+
+func exit(code int) {
+	abort()
+}

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -51,7 +51,7 @@ func main() {
 	run()
 
 	// Fallback: if main ever returns, hang the CPU.
-	abort()
+	exit(0)
 }
 
 //go:extern _sbss
@@ -104,6 +104,10 @@ func sleepTicks(d timeUnit) {
 	sleepUntil := ticks() + d
 	for ticks() < sleepUntil {
 	}
+}
+
+func exit(code int) {
+	abort()
 }
 
 func abort() {

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -42,7 +42,7 @@ func main() {
 	preinit()
 	initPeripherals()
 	run()
-	abort()
+	exit(0)
 }
 
 //go:extern handleInterruptASM

--- a/src/runtime/runtime_fe310_baremetal.go
+++ b/src/runtime/runtime_fe310_baremetal.go
@@ -22,6 +22,10 @@ func nanosecondsToTicks(ns int64) timeUnit {
 	return timeUnit(ns * 64 / 1953125)
 }
 
+func exit(code int) {
+	abort()
+}
+
 func abort() {
 	// lock up forever
 	for {

--- a/src/runtime/runtime_fe310_qemu.go
+++ b/src/runtime/runtime_fe310_qemu.go
@@ -21,6 +21,16 @@ func nanosecondsToTicks(ns int64) timeUnit {
 }
 
 func abort() {
-	// Signal a successful exit.
-	testExit.Set(0x5555)
+	exit(1)
+}
+
+func exit(code int) {
+	if code == 0 {
+		// Signal a successful exit.
+		testExit.Set(0x5555) // FINISHER_PASS
+	} else {
+		// Signal a failure. The exit code is stored in the upper 16 bits of the
+		// 32 bit value.
+		testExit.Set(uint32(code)<<16 | 0x3333) // FINISHER_FAIL
+	}
 }

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -48,7 +48,7 @@ func main() {
 	preinit()
 	initPeripherals()
 	run()
-	abort()
+	exit(0)
 }
 
 func initPLIC() {

--- a/src/runtime/runtime_k210_baremetal.go
+++ b/src/runtime/runtime_k210_baremetal.go
@@ -20,6 +20,10 @@ func nanosecondsToTicks(ns int64) timeUnit {
 	return timeUnit(ns * 39 / 5000)
 }
 
+func exit(code int) {
+	abort()
+}
+
 func abort() {
 	// lock up forever
 	for {

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -43,7 +43,7 @@ func main() {
 	arm.EnableInterrupts(irq)
 
 	run()
-	abort()
+	exit(0)
 }
 
 func getRamSizeConfig(itcmKB, dtcmKB uint32) uint32 {
@@ -125,6 +125,10 @@ func initUART() {
 
 func putchar(c byte) {
 	machine.UART1.WriteByte(c)
+}
+
+func exit(code int) {
+	abort()
 }
 
 func abort() {

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -25,7 +25,7 @@ func main() {
 	systemInit()
 	preinit()
 	run()
-	abort()
+	exit(0)
 }
 
 func init() {

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -58,7 +58,7 @@ func main() {
 	initInternal()
 
 	run()
-	abort()
+	exit(0)
 }
 
 func initSystem() {
@@ -230,6 +230,10 @@ func postinit() {}
 
 func putchar(c byte) {
 	machine.PutcharUART(machine.UART0, c)
+}
+
+func exit(code int) {
+	abort()
 }
 
 func abort() {

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -59,5 +59,5 @@ func postinit() {}
 func main() {
 	preinit()
 	run()
-	abort()
+	exit(0)
 }

--- a/src/runtime/runtime_stm32.go
+++ b/src/runtime/runtime_stm32.go
@@ -12,7 +12,7 @@ func postinit() {}
 func main() {
 	preinit()
 	run()
-	abort()
+	exit(0)
 }
 
 func waitForEvents() {

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -285,7 +285,9 @@ func (m *M) Run() int {
 	if failures > 0 {
 		fmt.Println("FAIL")
 	} else {
-		fmt.Println("PASS")
+		if flagVerbose {
+			fmt.Println("PASS")
+		}
 	}
 	return failures
 }


### PR DESCRIPTION
The first commit fixes the exit code of cortex-m-qemu, hifive1-qemu, and riscv-qemu. The second commit uses this fix to simplify `tinygo test` a bit and improve the output a little bit (removing of a redundant "PASS" line). These two commits could perhaps be squashed but because these changes are somewhat independent I decided to keep them in separate commits.

The `-v` flag feature for emulators is still pending (see #2039), this is just a refactor I'd like to do before getting to the `-v` flag on baremetal and JS.