### PR TITLE
ci: bump Go version in Linux builds to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,12 +391,12 @@ jobs:
           llvm: "11"
   assert-test-linux:
     docker:
-      - image: circleci/golang:1.14-stretch
+      - image: circleci/golang:1.16-buster
     steps:
       - assert-test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.14-stretch
+      - image: circleci/golang:1.16-buster
     steps:
       - build-linux
   build-macos:


### PR DESCRIPTION
Not sure why it was at 1.14. It seems like a better idea to build releases using the latest stable Go version.

This should also fix the CI build failure in #2031.