### PR TITLE
Fix maximum slice size

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 15 // last change: add crypto assembly aliases
+const Version = 16 // last change: fix max slice size
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -1439,6 +1439,28 @@ func (b *builder) getValue(expr ssa.Value) llvm.Value {
 	}
 }
 
+// maxSliceSize determines the maximum size a slice of the given element type
+// can be.
+func (c *compilerContext) maxSliceSize(elementType llvm.Type) uint64 {
+	// Calculate ^uintptr(0), which is the max value that fits in uintptr.
+	maxPointerValue := llvm.ConstNot(llvm.ConstInt(c.uintptrType, 0, false)).ZExtValue()
+	// Calculate (^uint(0))/2, which is the max value that fits in an int.
+	maxIntegerValue := llvm.ConstNot(llvm.ConstInt(c.intType, 0, false)).ZExtValue() / 2
+
+	// Determine the maximum allowed size for a slice. The biggest possible
+	// pointer (starting from 0) would be maxPointerValue*sizeof(elementType) so
+	// divide by the element type to get the real maximum size.
+	maxSize := maxPointerValue / c.targetData.TypeAllocSize(elementType)
+
+	// len(slice) is an int. Make sure the length remains small enough to fit in
+	// an int.
+	if maxSize > maxIntegerValue {
+		maxSize = maxIntegerValue
+	}
+
+	return maxSize
+}
+
 // createExpr translates a Go SSA expression to LLVM IR. This can be zero, one,
 // or multiple LLVM IR instructions and/or runtime calls.
 func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
@@ -1652,10 +1674,8 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 		elemSize := b.targetData.TypeAllocSize(llvmElemType)
 		elemSizeValue := llvm.ConstInt(b.uintptrType, elemSize, false)
 
-		// Calculate (^uintptr(0)) >> 1, which is the max value that fits in
-		// uintptr if uintptr were signed.
-		maxSize := llvm.ConstLShr(llvm.ConstNot(llvm.ConstInt(b.uintptrType, 0, false)), llvm.ConstInt(b.uintptrType, 1, false))
-		if elemSize > maxSize.ZExtValue() {
+		maxSize := b.maxSliceSize(llvmElemType)
+		if elemSize > maxSize {
 			// This seems to be checked by the typechecker already, but let's
 			// check it again just to be sure.
 			return llvm.Value{}, b.makeError(expr.Pos(), fmt.Sprintf("slice element type is too big (%v bytes)", elemSize))
@@ -1664,7 +1684,8 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 		// Bounds checking.
 		lenType := expr.Len.Type().Underlying().(*types.Basic)
 		capType := expr.Cap.Type().Underlying().(*types.Basic)
-		b.createSliceBoundsCheck(maxSize, sliceLen, sliceCap, sliceCap, lenType, capType, capType)
+		maxSizeValue := llvm.ConstInt(b.uintptrType, maxSize, false)
+		b.createSliceBoundsCheck(maxSizeValue, sliceLen, sliceCap, sliceCap, lenType, capType, capType)
 
 		// Allocate the backing array.
 		sliceCapCast, err := b.createConvert(expr.Cap.Type(), types.Typ[types.Uintptr], sliceCap, expr.Pos())

--- a/compiler/testdata/slice.go
+++ b/compiler/testdata/slice.go
@@ -23,3 +23,21 @@ func sliceAppendSlice(ints, added []int) []int {
 func sliceCopy(dst, src []int) int {
 	return copy(dst, src)
 }
+
+// Test bounds checking in *ssa.MakeSlice instruction.
+
+func makeByteSlice(len int) []byte {
+	return make([]byte, len)
+}
+
+func makeInt16Slice(len int) []int16 {
+	return make([]int16, len)
+}
+
+func makeArraySlice(len int) [][3]byte {
+	return make([][3]byte, len) // slice with element size of 3
+}
+
+func makeInt32Slice(len int) []int32 {
+	return make([]int32, len)
+}

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -127,7 +127,7 @@ slice.next:                                       ; preds = %entry
 
 define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
-  %slice.maxcap = icmp slt i32 %len, 0
+  %slice.maxcap = icmp ugt i32 %len, 1431655765
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry
@@ -146,7 +146,7 @@ slice.next:                                       ; preds = %entry
 
 define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
-  %slice.maxcap = icmp slt i32 %len, 0
+  %slice.maxcap = icmp ugt i32 %len, 1073741823
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -86,3 +86,79 @@ entry:
 }
 
 declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*, i8*)
+
+define hidden { i8*, i32, i32 } @main.makeByteSlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %slice.maxcap = icmp slt i32 %len, 0
+  br i1 %slice.maxcap, label %slice.throw, label %slice.next
+
+slice.throw:                                      ; preds = %entry
+  call void @runtime.slicePanic(i8* undef, i8* null)
+  unreachable
+
+slice.next:                                       ; preds = %entry
+  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* undef, i8* null)
+  %0 = insertvalue { i8*, i32, i32 } undef, i8* %makeslice.buf, 0
+  %1 = insertvalue { i8*, i32, i32 } %0, i32 %len, 1
+  %2 = insertvalue { i8*, i32, i32 } %1, i32 %len, 2
+  ret { i8*, i32, i32 } %2
+}
+
+declare void @runtime.slicePanic(i8*, i8*)
+
+define hidden { i16*, i32, i32 } @main.makeInt16Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %slice.maxcap = icmp slt i32 %len, 0
+  br i1 %slice.maxcap, label %slice.throw, label %slice.next
+
+slice.throw:                                      ; preds = %entry
+  call void @runtime.slicePanic(i8* undef, i8* null)
+  unreachable
+
+slice.next:                                       ; preds = %entry
+  %makeslice.cap = shl i32 %len, 1
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.array = bitcast i8* %makeslice.buf to i16*
+  %0 = insertvalue { i16*, i32, i32 } undef, i16* %makeslice.array, 0
+  %1 = insertvalue { i16*, i32, i32 } %0, i32 %len, 1
+  %2 = insertvalue { i16*, i32, i32 } %1, i32 %len, 2
+  ret { i16*, i32, i32 } %2
+}
+
+define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %slice.maxcap = icmp slt i32 %len, 0
+  br i1 %slice.maxcap, label %slice.throw, label %slice.next
+
+slice.throw:                                      ; preds = %entry
+  call void @runtime.slicePanic(i8* undef, i8* null)
+  unreachable
+
+slice.next:                                       ; preds = %entry
+  %makeslice.cap = mul i32 %len, 3
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.array = bitcast i8* %makeslice.buf to [3 x i8]*
+  %0 = insertvalue { [3 x i8]*, i32, i32 } undef, [3 x i8]* %makeslice.array, 0
+  %1 = insertvalue { [3 x i8]*, i32, i32 } %0, i32 %len, 1
+  %2 = insertvalue { [3 x i8]*, i32, i32 } %1, i32 %len, 2
+  ret { [3 x i8]*, i32, i32 } %2
+}
+
+define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  %slice.maxcap = icmp slt i32 %len, 0
+  br i1 %slice.maxcap, label %slice.throw, label %slice.next
+
+slice.throw:                                      ; preds = %entry
+  call void @runtime.slicePanic(i8* undef, i8* null)
+  unreachable
+
+slice.next:                                       ; preds = %entry
+  %makeslice.cap = shl i32 %len, 2
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.array = bitcast i8* %makeslice.buf to i32*
+  %0 = insertvalue { i32*, i32, i32 } undef, i32* %makeslice.array, 0
+  %1 = insertvalue { i32*, i32, i32 } %0, i32 %len, 1
+  %2 = insertvalue { i32*, i32, i32 } %1, i32 %len, 2
+  ret { i32*, i32, i32 } %2
+}


### PR DESCRIPTION
Extracted from #2048. This brings the maximum slice size (in `make([]T, len)`) the same as in upstream Go. I've split this in two commits so that the second commit clearly shows the (small) change in the test output.

This is unlikely to have much (if any) real world impact, but I made the change for consistency.