### PR TITLE
ci: drop support for Go 1.13 and 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,24 +365,12 @@ commands:
             - /go/pkg/mod
 
 jobs:
-  test-llvm10-go113:
-    docker:
-      - image: circleci/golang:1.13-buster
-    steps:
-      - test-linux:
-          llvm: "10"
-  test-llvm10-go114:
-    docker:
-      - image: circleci/golang:1.14-buster
-    steps:
-      - test-linux:
-          llvm: "10"
-  test-llvm11-go115:
+  test-llvm10-go115:
     docker:
       - image: circleci/golang:1.15-buster
     steps:
       - test-linux:
-          llvm: "11"
+          llvm: "10"
   test-llvm11-go116:
     docker:
       - image: circleci/golang:1.16-buster
@@ -391,12 +379,12 @@ jobs:
           llvm: "11"
   assert-test-linux:
     docker:
-      - image: circleci/golang:1.14-stretch
+      - image: circleci/golang:1.16-stretch
     steps:
       - assert-test-linux
   build-linux:
     docker:
-      - image: circleci/golang:1.14-stretch
+      - image: circleci/golang:1.16-stretch
     steps:
       - build-linux
   build-macos:
@@ -410,9 +398,7 @@ jobs:
 workflows:
   test-all:
     jobs:
-      - test-llvm10-go113
-      - test-llvm10-go114
-      - test-llvm11-go115
+      - test-llvm10-go115
       - test-llvm11-go116
       - build-linux
       - build-macos

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,7 +23,7 @@ different guide:
 LLVM, Clang and LLD are quite light on dependencies, requiring only standard
 build tools to be built. Go is of course necessary to build TinyGo itself.
 
-  * Go (1.13+)
+  * Go (1.15+)
   * Standard build tools (gcc/clang)
   * git
   * CMake

--- a/builder/config.go
+++ b/builder/config.go
@@ -33,8 +33,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 13 || minor > 16 {
-		return nil, fmt.Errorf("requires go version 1.13 through 1.16, got go%d.%d", major, minor)
+	if major != 1 || minor < 15 || minor > 16 {
+		return nil, fmt.Errorf("requires go version 1.15 through 1.16, got go%d.%d", major, minor)
 	}
 
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tinygo-org/tinygo
 
-go 1.13
+go 1.15
 
 require (
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/tinygo-org/tinygo/builder"
 	"github.com/tinygo-org/tinygo/compileopts"
-	"github.com/tinygo-org/tinygo/goenv"
 )
 
 const TESTDATA = "testdata"
@@ -95,21 +94,9 @@ func TestCompiler(t *testing.T) {
 		t.Run("ARM64Linux", func(t *testing.T) {
 			runPlatTests("aarch64--linux-gnu", tests, t)
 		})
-		goVersion, err := goenv.GorootVersionString(goenv.Get("GOROOT"))
-		if err != nil {
-			t.Error("could not get Go version:", err)
-			return
-		}
-		minorVersion := strings.Split(goVersion, ".")[1]
-		if minorVersion != "13" {
-			// WebAssembly tests fail on Go 1.13, so skip them there. Versions
-			// below that are also not supported but still seem to pass, so
-			// include them in the tests for now.
-			t.Run("WebAssembly", func(t *testing.T) {
-				runPlatTests("wasm", tests, t)
-			})
-		}
-
+		t.Run("WebAssembly", func(t *testing.T) {
+			runPlatTests("wasm", tests, t)
+		})
 		t.Run("WASI", func(t *testing.T) {
 			runPlatTests("wasi", tests, t)
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -210,16 +210,7 @@ func runTestWithConfig(name, target string, t *testing.T, options compileopts.Op
 	}
 
 	// Create a temporary directory for test output files.
-	tmpdir, err := ioutil.TempDir("", "tinygo-test")
-	if err != nil {
-		t.Fatal("could not create temporary directory:", err)
-	}
-	defer func() {
-		rerr := os.RemoveAll(tmpdir)
-		if rerr != nil {
-			t.Errorf("failed to remove temporary directory %q: %s", tmpdir, rerr.Error())
-		}
-	}()
+	tmpdir := t.TempDir()
 
 	// Determine whether we're on a system that supports environment variables
 	// and command line parameters (operating systems, WASI) or not (baremetal,

--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -11,8 +11,7 @@ func TestChan(t *testing.T) {
 
 	t.Parallel()
 
-	wasmTmpDir, server, cleanup := startServer(t)
-	defer cleanup()
+	wasmTmpDir, server := startServer(t)
 
 	err := run("tinygo build -o " + wasmTmpDir + "/chan.wasm -target wasm testdata/chan.go")
 	if err != nil {

--- a/tests/wasm/event_test.go
+++ b/tests/wasm/event_test.go
@@ -11,8 +11,7 @@ func TestEvent(t *testing.T) {
 
 	t.Parallel()
 
-	wasmTmpDir, server, cleanup := startServer(t)
-	defer cleanup()
+	wasmTmpDir, server := startServer(t)
 
 	err := run("tinygo build -o " + wasmTmpDir + "/event.wasm -target wasm testdata/event.go")
 	if err != nil {

--- a/tests/wasm/event_test.go
+++ b/tests/wasm/event_test.go
@@ -1,5 +1,3 @@
-// +build go1.14
-
 package wasm
 
 import (

--- a/tests/wasm/fmt_test.go
+++ b/tests/wasm/fmt_test.go
@@ -1,13 +1,4 @@
-// +build go1.14
-
 package wasm
-
-// NOTE: this should work in go1.13 but panics with:
-// panic: syscall/js: call of Value.Get on string
-// which is coming from here: https://github.com/golang/go/blob/release-branch.go1.13/src/syscall/js/js.go#L252
-// But I'm not sure how import "fmt" results in this.
-// To reproduce, install Go 1.13.x and change the build tag above
-// to go1.13 and run this test.
 
 import (
 	"testing"

--- a/tests/wasm/fmt_test.go
+++ b/tests/wasm/fmt_test.go
@@ -11,8 +11,7 @@ func TestFmt(t *testing.T) {
 
 	t.Parallel()
 
-	wasmTmpDir, server, cleanup := startServer(t)
-	defer cleanup()
+	wasmTmpDir, server := startServer(t)
 
 	err := run("tinygo build -o " + wasmTmpDir + "/fmt.wasm -target wasm testdata/fmt.go")
 	if err != nil {

--- a/tests/wasm/fmtprint_test.go
+++ b/tests/wasm/fmtprint_test.go
@@ -11,8 +11,7 @@ func TestFmtprint(t *testing.T) {
 
 	t.Parallel()
 
-	wasmTmpDir, server, cleanup := startServer(t)
-	defer cleanup()
+	wasmTmpDir, server := startServer(t)
 
 	err := run("tinygo build -o " + wasmTmpDir + "/fmtprint.wasm -target wasm testdata/fmtprint.go")
 	if err != nil {

--- a/tests/wasm/fmtprint_test.go
+++ b/tests/wasm/fmtprint_test.go
@@ -1,5 +1,3 @@
-// +build go1.14
-
 package wasm
 
 import (

--- a/tests/wasm/log_test.go
+++ b/tests/wasm/log_test.go
@@ -11,8 +11,7 @@ func TestLog(t *testing.T) {
 
 	t.Parallel()
 
-	wasmTmpDir, server, cleanup := startServer(t)
-	defer cleanup()
+	wasmTmpDir, server := startServer(t)
 
 	err := run("tinygo build -o " + wasmTmpDir + "/log.wasm -target wasm testdata/log.go")
 	if err != nil {

--- a/tests/wasm/log_test.go
+++ b/tests/wasm/log_test.go
@@ -1,5 +1,3 @@
-// +build go1.14
-
 package wasm
 
 import (


### PR DESCRIPTION
They aren't supported anymore in CI, and because untested code is broken code, let's remove support for these Go versions altogether.

This should address the recent CI failures.