### PR TITLE
machine/arduino_mkrwifi1010: add board definition for Arduino MKR Wifi 1010

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=arduino-nano33      examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=arduino-mkrwifi1010 examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pico                examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nano-33-ble         examples/blinky1

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 68 microcontroller boards are currently supported:
+The following 69 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -69,6 +69,7 @@ The following 68 microcontroller boards are currently supported:
 * [Arduino Mega 1280](https://www.arduino.cc/en/Main/arduinoBoardMega/)
 * [Arduino Mega 2560](https://store.arduino.cc/arduino-mega-2560-rev3)
 * [Arduino MKR1000](https://store.arduino.cc/arduino-mkr1000-wifi)
+* [Arduino MKR WiFi 1010](https://store.arduino.cc/usa/mkr-wifi-1010)
 * [Arduino Nano](https://store.arduino.cc/arduino-nano)
 * [Arduino Nano 33 BLE](https://store.arduino.cc/nano-33-ble)
 * [Arduino Nano 33 BLE Sense](https://store.arduino.cc/nano-33-ble-sense)

--- a/src/machine/board_arduino_mkrwifi1010.go
+++ b/src/machine/board_arduino_mkrwifi1010.go
@@ -1,0 +1,154 @@
+// +build arduino_mkrwifi1010
+
+// This contains the pin mappings for the Arduino MKR WiFi 1010 board.
+//
+// For more information, see: https://store.arduino.cc/usa/mkr-wifi-1010
+//
+package machine
+
+import (
+	"device/sam"
+	"runtime/interrupt"
+)
+
+// used to reset into bootloader
+const RESET_MAGIC_VALUE = 0x07738135
+
+// GPIO Pins
+const (
+	RX0 Pin = PB23 // UART1 RX
+	TX1 Pin = PB22 // UART1 TX
+
+	D0 Pin = PA22 // PWM available
+	D1 Pin = PA23 // PWM available
+	D2 Pin = PA10 // PWM available
+	D3 Pin = PA11 // PWM available
+	D4 Pin = PB10 // PWM available
+	D5 Pin = PB11 // PWM available
+
+	D6  Pin = PA20 // PWM available
+	D7  Pin = PA21 // PWM available
+	D8  Pin = PA16 // PWM available
+	D9  Pin = PA17
+	D10 Pin = PA19 // PWM available
+	D11 Pin = PA08 // SDA
+	D12 Pin = PA09 // PWM available, SCL
+	D13 Pin = PB23 // RX
+	D14 Pin = PB22 // TX
+)
+
+// Analog pins
+const (
+	A0 Pin = PA02 // ADC0/AIN[0]
+	A1 Pin = PB02 // AIN[10]
+	A2 Pin = PB03 // AIN[11]
+	A3 Pin = PA04 // AIN[04]
+	A4 Pin = PA05 // AIN[05]
+	A5 Pin = PA06 // AIN[06]
+	A6 Pin = PA07 // AIN[07]
+)
+
+const (
+	LED = D6
+)
+
+// USBCDC pins
+const (
+	USBCDC_DM_PIN Pin = PA24
+	USBCDC_DP_PIN Pin = PA25
+)
+
+// UART1 pins
+const (
+	UART_TX_PIN Pin = PB22
+	UART_RX_PIN Pin = PB23
+)
+
+// I2C pins
+const (
+	SDA_PIN Pin = D11 // SDA
+	SCL_PIN Pin = D12 // SCL
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN Pin = D9  // SCK: S1
+	SPI0_SDO_PIN Pin = D8  // SDO: S1
+	SPI0_SDI_PIN Pin = D10 // SDI: S1
+)
+
+// I2S pins
+const (
+	I2S_SCK_PIN Pin = PA10
+	I2S_SD_PIN  Pin = PA07
+	I2S_WS_PIN      = NoPin // TODO: figure out what this is on Arduino MKR WiFi 1010.
+)
+
+// NINA-W102 Pins
+const (
+	NINA_SDO    Pin = PA12
+	NINA_SDI    Pin = PA13
+	NINA_CS     Pin = PA14
+	NINA_SCK    Pin = PA15
+	NINA_GPIO0  Pin = PA27
+	NINA_RESETN Pin = PA08
+	NINA_ACK    Pin = PA28
+	NINA_TX     Pin = PA22
+	NINA_RX     Pin = PA23
+)
+
+// UART on the Arduino MKR WiFi 1010.
+var (
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    sam.SERCOM5_USART,
+		SERCOM: 5,
+	}
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(sam.IRQ_SERCOM5, _UART1.handleInterrupt)
+}
+
+// I2C on the Arduino MKR WiFi 1010.
+var (
+	I2C0 = &I2C{
+		Bus:    sam.SERCOM2_I2CM,
+		SERCOM: 2,
+	}
+)
+
+// SPI on the Arduino MKR WiFi 1010.
+var (
+	SPI0 = SPI{
+		Bus:    sam.SERCOM1_SPI,
+		SERCOM: 1,
+	}
+
+	SPI1 = SPI{
+		Bus:    sam.SERCOM4_SPI,
+		SERCOM: 4,
+	}
+	NINA_SPI = SPI1
+)
+
+// I2S on the Arduino MKR WiFi 1010.
+var (
+	I2S0 = I2S{Bus: sam.I2S}
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Arduino MKR WiFi 1010"
+	usb_STRING_MANUFACTURER = "Arduino"
+)
+
+var (
+	usb_VID uint16 = 0x2341
+	usb_PID uint16 = 0x8054
+)
+
+var (
+	DefaultUART = UART1
+)

--- a/targets/arduino-mkrwifi1010.json
+++ b/targets/arduino-mkrwifi1010.json
@@ -1,0 +1,8 @@
+{
+    "inherits": ["atsamd21g18a"],
+    "build-tags": ["arduino_mkrwifi1010"],
+    "serial": "usb",
+    "serial-port": ["acm:2341:8054", "acm:2341:0054"],
+    "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
+    "flash-1200-bps-reset": "true"
+}


### PR DESCRIPTION
Added arduino-mkrwifi1010 (samd21g18) board support.
This board is very similar to arduino-nano33-iot with samd21 + NINA-W102 configuration.
It is also very similar to arduino-mkr1000.
This time, I checked the source code of both while working on it.

* Board
    * Name
        * Arduino MKR WiFi 1010
    * Board developer / designer / manufacturer
        * Arduino
    * schematic
        * https://store.arduino.cc/usa/mkr-wifi-1010
            * https://content.arduino.cc/assets/MKRWiFi1010V2.0_sch.pdf
    * pinout and stuff
        * https://store.arduino.cc/usa/mkr-wifi-1010
            * see `Documentation`
    * URL
        * https://store.arduino.cc/usa/mkr-wifi-1010
    * User manual for the board (if it exists)
        * https://www.arduino.cc/en/Guide/MKRWiFi1010
* Chip
    * chip name
        * samd21g18
    * Clock / ROM / RAM size
        * 48MHz / 256KB / 32KB
    * datasheet URL of the chip
        * https://content.arduino.cc/assets/mkr-microchip_samd21_family_full_datasheet-ds40001882d.pdf
* URL of the source, such as arduino (if it exists)
    * https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrwifi1010/

At least the following examples have been confirmed.
I also checked the SPI with the code I created.

* GPIO: examples/blinky1
* UART: examples/echo
* I2C: drivers/examples/ssd1306/i2c_128x64
* WIFININA: drivers/examples/wifinina/webclient