### PR TITLE
docker: apt clean before apt get of llvm to avoid broken packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build/
+llvm-*/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.16 AS tinygo-base
 
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list && \
-    apt-get update && \
+    apt-get update && apt-get clean && \
     apt-get install -y llvm-11-dev libclang-11-dev lld-11 git
 
 COPY . /tinygo


### PR DESCRIPTION
This PR updates the Dockerfile to perform an `apt clean` before the `apt get` of all of the llvm 11 packages to avoid broken packages from the older versions.