### PR TITLE
Make WifiNINA work on Arduino Nano RP2040 Connect board

### DIFF
--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -68,6 +68,10 @@ const (
 	SPI1_SDI_PIN Pin = GPIO22
 )
 
+var (
+	NINA_SPI = SPI1
+)
+
 // NINA-W102 Pins
 const (
 	NINA_SCK Pin = GPIO14
@@ -76,7 +80,7 @@ const (
 
 	NINA_CS     Pin = GPIO9
 	NINA_ACK    Pin = GPIO10
-	NINA_GPIO0  Pin = GPIO0
+	NINA_GPIO0  Pin = GPIO2
 	NINA_RESETN Pin = GPIO3
 
 	NINA_TX Pin = GPIO9


### PR DESCRIPTION
My board came with wifinina chip flashed with nina-fw 1.4.5 and http[s] did not work.
That was fixed by updating wifinina to 1.4.8.
https://github.com/arduino/nina-fw/releases

I did use hack-arduino-app-by-replacing-latest-known-version-bin-with-new-one method (replaced 1.4.5 with 1.4.8 binary) and flashed with official Arduino app. The other method described in the following page might also work. Mind the pre-compiled passthrough bin is for Nano 33 IoT board though.
https://github.com/tinygo-org/drivers/tree/dev/wifinina

