### PR TITLE
targets: add openocd configuration for rp2040

### DIFF
--- a/targets/rp2040.json
+++ b/targets/rp2040.json
@@ -9,5 +9,7 @@
     "rp2040-boot-patch": true,
     "extra-files": [
         "src/device/rp/rp2040.s"
-    ]
+    ],
+    "openocd-transport": "swd",
+    "openocd-target": "rp2040"
 }


### PR DESCRIPTION
This PR adds flash and gdb via openocd to the target on rp2040.
For example, in the case of the Raspberry Pi Pico, you can write the following

Now there is no need to press BOOTSEL.

```
$ tinygo flash --target pico --size short --programmer picoprobe examples/blinky1

$ tinygo gdb --target pico --size short --programmer picoprobe examples/blinky1
```