### PR TITLE
machine/feather-rp2040: add pin name definition for feather

### DIFF
--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -9,6 +9,28 @@ const (
 	xoscFreq = 12 // MHz
 )
 
+// GPIO Pins
+const (
+	D4  = GPIO6
+	D5  = GPIO7
+	D6  = GPIO8
+	D9  = GPIO9
+	D10 = GPIO10
+	D11 = GPIO11
+	D12 = GPIO12
+	D13 = GPIO13
+	D24 = GPIO24
+	D25 = GPIO25
+)
+
+// Analog pins
+const (
+	A0 = GPIO26
+	A1 = GPIO27
+	A2 = GPIO28
+	A3 = GPIO29
+)
+
 // I2C Pins.
 const (
 	I2C0_SDA_PIN = GPIO24


### PR DESCRIPTION
It is better to have a name as feather for better compatibility.
In this PR, the pin name as a feather will be added.

* https://learn.adafruit.com/adafruit-feather-rp2040-pico/pinouts
    * Analog Pins
    * Digital Pins