### PR TITLE
nrf52840: fix ram size

### DIFF
--- a/targets/circuitplay-bluefruit.ld
+++ b/targets/circuitplay-bluefruit.ld
@@ -2,7 +2,7 @@
 MEMORY
 {
     FLASH_TEXT (rw) : ORIGIN = 0x00000000+0x26000, LENGTH = 0xED000-0x26000 /* SoftDevice S140. See https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/hathach-memory-map. Application starts at 0x26000; user data starts at 0xED000 */
-    RAM (xrw)       : ORIGIN = 0x20004180, LENGTH = 37K
+    RAM (xrw)       : ORIGIN = 0x20004180, LENGTH = 0x20040000-0x20004180
 }
 
 _stack_size = 2K;


### PR DESCRIPTION
Since the nRF52840 has 256KB of RAM, it is necessary to modify the configuration.

https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/hathach-memory-map

> [CFG] SoftDevice config requires more SRAM than provided by the linker.
> App Ram Start must be at least 0x20004180 (provided 0x20003200).
> Please update linker file or re-config SoftDevice.

https://www.nordicsemi.com/-/media/Software-and-other-downloads/Product-Briefs/nRF52840-SoC-product-brief.pdf?la=en&hash=EDF4C48A053E7943AD3C9DD3963B626D768B5885

> nRF52840 Product Brief Version 2.3
> KEY FEATURES
> 64 MHz Arm® Cortex-M4 with FPU
> 1 MB Flash + 256 KB RAM