### PR TITLE
Add support for GDB initialization scripts

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -24,6 +24,10 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 		spec.OpenOCDCommands = options.OpenOCDCommands
 	}
 
+	if options.GDBInitPaths != nil {
+		spec.GDBInitPaths = options.GDBInitPaths
+	}
+
 	goroot := goenv.Get("GOROOT")
 	if goroot == "" {
 		return nil, errors.New("cannot locate $GOROOT, please set it manually")

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	GlobalValues    map[string]map[string]string // map[pkgpath]map[varname]value
 	TestConfig      TestConfig
 	Programmer      string
+	GDBInitPaths    []string
 	OpenOCDCommands []string
 	LLVMFeatures    string
 }

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -45,6 +45,7 @@ type TargetSpec struct {
 	Emulator         []string `json:"emulator" override:"copy"` // inherited Emulator must not be append
 	FlashCommand     string   `json:"flash-command"`
 	GDB              []string `json:"gdb"`
+	GDBInitPaths     []string `json:"gdbinit"`
 	PortReset        string   `json:"flash-1200-bps-reset"`
 	SerialPort       []string `json:"serial-port"` // serial port IDs in the form "acm:vid:pid" or "usb:vid:pid"
 	FlashMethod      string   `json:"flash-method"`

--- a/main.go
+++ b/main.go
@@ -578,6 +578,19 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 		for _, cmd := range gdbCommands {
 			params = append(params, "-ex", cmd)
 		}
+		for _, spec := range config.Target.GDBInitPaths {
+			var flag, path string
+			if len(spec) > 1 && spec[0] == '+' {
+				flag = "-x"
+				path = strings.TrimPrefix(spec, "+")
+			} else {
+				flag = "-ix"
+				path = strings.TrimPrefix(spec, "-")
+			}
+			if info, err := os.Stat(path); err == nil && info.Mode().Type() == 0 {
+				params = append(params, flag, path)
+			}
+		}
 		cmd := executeCommand(config.Options, gdb, params...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -1059,6 +1072,22 @@ func parseGoLinkFlag(flagsString string) (map[string]map[string]string, error) {
 	return map[string]map[string]string(globalVarValues), nil
 }
 
+// stringsFlag implements the flag.Value interface, defining a flag that can be
+// provided multiple times on the command-line. Each instance is appended to a
+// slice of strings.
+type stringsFlag []string
+
+func (f stringsFlag) String() string {
+	return "[" + strings.Join(f, ", ") + "]"
+}
+
+func (f *stringsFlag) Set(s string) error {
+	if f != nil {
+		*f = append(*f, s)
+	}
+	return nil
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "No command-line arguments supplied.")
@@ -1066,6 +1095,8 @@ func main() {
 		os.Exit(1)
 	}
 	command := os.Args[1]
+
+	gdbinit := stringsFlag{}
 
 	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, s, z")
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, extalloc, conservative)")
@@ -1084,6 +1115,7 @@ func main() {
 	nodebug := flag.Bool("no-debug", false, "strip debug information")
 	ocdCommandsString := flag.String("ocd-commands", "", "OpenOCD commands, overriding target spec (can specify multiple separated by commas)")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
+	flag.Var(&gdbinit, "gdbinit", "path to GDB init script, use prefix '-'/'+' to exec before/after loading inferior (default before)")
 	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	ldflags := flag.String("ldflags", "", "Go link tool compatible ldflags")
@@ -1157,6 +1189,7 @@ func main() {
 		GlobalValues:    globalVarValues,
 		WasmAbi:         *wasmAbi,
 		Programmer:      *programmer,
+		GDBInitPaths:    gdbinit,
 		OpenOCDCommands: ocdCommands,
 		LLVMFeatures:    *llvmFeatures,
 	}

--- a/main.go
+++ b/main.go
@@ -587,7 +587,7 @@ func FlashGDB(pkgName string, ocdOutput bool, options *compileopts.Options) erro
 				flag = "-ix"
 				path = strings.TrimPrefix(spec, "-")
 			}
-			if info, err := os.Stat(path); err == nil && info.Mode().Type() == 0 {
+			if _, err := os.Stat(path); err == nil {
 				params = append(params, flag, path)
 			}
 		}


### PR DESCRIPTION
These changes add the ability to provide GDB initialization scripts from command-line flags and target JSON files. GDB scripts save a **lot** of time by being able to automatically configure breakpoints, set auto-display expressions, configuring GDB front-end extensions, etc.

The command-line flag is named `-gdbinit` and can be specified multiple times for multiple files. It also accepts an optional single-character prefix, `-` or `+`, that indicates the file should be executed before or after loading the inferior, respectively. These correspond to GDB command-line flags `--init-command, -ix` and `--command, -x`, respectively. If the prefix is not defined, then `-`, or `--init-command, ix`, by default.

The JSON key is also `gdbinit`, of type `[]string`. It follows the same prefix convention as the flag, and if both are provided, the command-line flag takes precedence, overriding the target JSON.