### PR TITLE
src/runtime: reset heapptr to heapStart after preinit()

### DIFF
--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -52,7 +52,8 @@ func SetFinalizer(obj interface{}, finalizer interface{}) {
 }
 
 func initHeap() {
-	// Nothing to initialize.
+	// preinit() may have moved heapStart; reset heapptr
+	heapptr = heapStart
 }
 
 // setHeapEnd sets a new (larger) heapEnd pointer.


### PR DESCRIPTION
heapptr is assinged to heapStart (which is 0) when it's declared, but preinit()
may have moved the heap somewhere else.  Set heapptr to the proper value
of heapStart when we initialize the heap properly.

This allows the leaking allocator to work on unix.