### PR TITLE
machine/arduino_mkrwifi1010: fix pin definition of NINA_RESETN

### DIFF
--- a/src/machine/board_arduino_mkrwifi1010.go
+++ b/src/machine/board_arduino_mkrwifi1010.go
@@ -91,7 +91,7 @@ const (
 	NINA_CS     Pin = PA14
 	NINA_SCK    Pin = PA15
 	NINA_GPIO0  Pin = PA27
-	NINA_RESETN Pin = PA08
+	NINA_RESETN Pin = PB08
 	NINA_ACK    Pin = PA28
 	NINA_TX     Pin = PA22
 	NINA_RX     Pin = PA23


### PR DESCRIPTION
I made a mistake and corrected it.

https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrwifi1010/variant.cpp#L155

refs: #2056 

