### PR TITLE
internal/task, runtime: add subsections_via_symbols to assembly files…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,9 @@ endif
 	@$(MD5SUM) test.nro
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go
 	@$(MD5SUM) test.hex
+ifneq ($(OS),Windows_NT)
+	$(TINYGO) build -o test.elf -gc=leaking -scheduler=none examples/serial
+endif
 
 
 wasmtest:

--- a/src/internal/task/task_stack_amd64.S
+++ b/src/internal/task/task_stack_amd64.S
@@ -72,3 +72,8 @@ tinygo_swapTask:
 
     // Return into the new task, as if tinygo_swapTask was a regular call.
     ret
+
+#ifdef __MACH__ // Darwin
+// allow these symbols to stripped as dead code
+.subsections_via_symbols
+#endif

--- a/src/runtime/gc_amd64.S
+++ b/src/runtime/gc_amd64.S
@@ -27,3 +27,8 @@ _tinygo_scanCurrentStack:
     // were only pushed to be discoverable by the GC.
     addq $56, %rsp
     retq
+
+#ifdef __MACH__ // Darwin
+// allow these symbols to stripped as dead code
+.subsections_via_symbols
+#endif


### PR DESCRIPTION
… on darwin

This allows the assembly routines in these files to be stripped as dead
code if they're not referenced.  This solves the link issues on MacOS
when the `leaking` garbage collector or the `coroutines` scheduler
are selected.

Fixes #2081