### PR TITLE
compiler: fix equally named structs in different scopes

### DIFF
--- a/compiler/testdata/basic.go
+++ b/compiler/testdata/basic.go
@@ -55,3 +55,18 @@ func complexMul(x, y complex64) complex64 {
 }
 
 // TODO: complexDiv (requires runtime call)
+
+// A type 'kv' also exists in function foo. Test that these two types don't
+// conflict with each other.
+type kv struct {
+	v float32
+}
+
+func foo(a *kv) {
+	// Define a new 'kv' type.
+	type kv struct {
+		v byte
+	}
+	// Use this type.
+	func(b *kv) {}(nil)
+}

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -3,6 +3,9 @@ source_filename = "basic.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32--wasi"
 
+%main.kv = type { float }
+%main.kv.0 = type { i8 }
+
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
 define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
@@ -97,4 +100,15 @@ entry:
   %6 = insertvalue { float, float } undef, float %2, 0
   %7 = insertvalue { float, float } %6, float %5, 1
   ret { float, float } %7
+}
+
+define hidden void @main.foo(%main.kv* dereferenceable_or_null(4) %a, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  call void @"main.foo$1"(%main.kv.0* null, i8* undef, i8* undef)
+  ret void
+}
+
+define hidden void @"main.foo$1"(%main.kv.0* dereferenceable_or_null(1) %b, i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  ret void
 }


### PR DESCRIPTION
For example, in this code:

    type kv struct {
           v float32
    }

    func foo(a *kv) {
           type kv struct {
                   v byte
           }
    }

Both `kv` types would be given the same LLVM type, even though they are different types! This is fixed by only creating a LLVM type once per Go type (types.Type).

As an added bonus, this change gives a performance improvement of about 0.4%. Not that much, but certainly not nothing for such a small change.