### PR TITLE
board: add support for MDBT50Q-RX with TinyUF2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 69 microcontroller boards are currently supported:
+The following 70 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -102,6 +102,7 @@ The following 69 microcontroller boards are currently supported:
 * [PJRC Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
 * [ProductivityOpen P1AM-100](https://facts-engineering.github.io/modules/P1AM-100/P1AM-100.html)
 * [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
+* [Raytac MDBT50Q-RX Dongle (with TinyUF2 bootloader)](https://www.adafruit.com/product/5199)
 * [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html)
 * [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
 * [Seeed Sipeed MAix BiT](https://www.seeedstudio.com/Sipeed-MAix-BiT-for-RISC-V-AI-IoT-p-2872.html)

--- a/src/machine/board_mdbt50qrx.go
+++ b/src/machine/board_mdbt50qrx.go
@@ -1,0 +1,40 @@
+// +build mdbt50qrx
+
+package machine
+
+const HasLowFrequencyCrystal = false
+
+// GPIO Pins
+const (
+	D0 = P1_13 // LED1
+	D1 = P1_11 // LED2 (not populated by default)
+	D2 = P0_15 // Button
+)
+
+const (
+	LED = D0
+)
+
+// MDBT50Q-RX dongle does not have pins broken out for the peripherals below,
+// however the machine_nrf*.go implementations of I2C/SPI/etc expect the pin
+// constants to be defined, so we are defining them all as 0
+const (
+	UART_TX_PIN  = 0
+	UART_RX_PIN  = 0
+	SDA_PIN      = 0
+	SCL_PIN      = 0
+	SPI0_SCK_PIN = 0
+	SPI0_SDO_PIN = 0
+	SPI0_SDI_PIN = 0
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Raytac MDBT50Q - RX"
+	usb_STRING_MANUFACTURER = "Raytac Corporation"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x810B
+)

--- a/targets/mdbt50qrx-uf2.json
+++ b/targets/mdbt50qrx-uf2.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["nrf52840"],
+    "build-tags": ["mdbt50qrx", "nrf52840_reset_uf2", "softdevice", "s140v6"],
+    "serial": "usb",
+    "flash-1200-bps-reset": "true",
+    "flash-method": "msd",
+    "serial-port": ["acm:239a:801b", "acm:239a:010b", "acm:239a:810c"],
+    "msd-volume-name": "MDBT50QBOOT",
+    "msd-firmware-name": "firmware.uf2",
+    "uf2-family-id": "0xADA52840",
+    "linkerscript": "targets/circuitplay-bluefruit.ld"
+}


### PR DESCRIPTION
Adds support for https://www.adafruit.com/product/5199