### PR TITLE
cgo: don't normalize CGo tests anymore

### DIFF
--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -12,7 +12,6 @@ import (
 	"go/types"
 	"io/ioutil"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -25,14 +24,6 @@ var flagUpdate = flag.Bool("update", false, "Update images based on test output.
 // platforms and Go versions.
 func normalizeResult(result string) string {
 	actual := strings.ReplaceAll(result, "\r\n", "\n")
-
-	// Make sure all functions are wrapped, even those that would otherwise be
-	// single-line functions. This is necessary because Go 1.14 changed the way
-	// such functions are wrapped and it's important to have consistent test
-	// results.
-	re := regexp.MustCompile(`func \((.+)\)( .*?) +{ (.+) }`)
-	actual = re.ReplaceAllString(actual, "func ($1)$2 {\n\t$3\n}")
-
 	return actual
 }
 

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -67,9 +67,7 @@ type C.union3_t = C.union_1
 type C.union_nested_t = C.union_3
 type C.unionarray_t = struct{ arr [10]C.uchar }
 
-func (s *C.struct_4) bitfield_a() C.uchar {
-	return s.__bitfield_1 & 0x1f
-}
+func (s *C.struct_4) bitfield_a() C.uchar { return s.__bitfield_1 & 0x1f }
 func (s *C.struct_4) set_bitfield_a(value C.uchar) {
 	s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0
 }
@@ -105,15 +103,9 @@ type C.struct_type1 struct {
 }
 type C.struct_type2 struct{ _type C.int }
 
-func (union *C.union_1) unionfield_i() *C.int {
-	return (*C.int)(unsafe.Pointer(&union.$union))
-}
-func (union *C.union_1) unionfield_d() *float64 {
-	return (*float64)(unsafe.Pointer(&union.$union))
-}
-func (union *C.union_1) unionfield_s() *C.short {
-	return (*C.short)(unsafe.Pointer(&union.$union))
-}
+func (union *C.union_1) unionfield_i() *C.int   { return (*C.int)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_1) unionfield_d() *float64 { return (*float64)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_1) unionfield_s() *C.short { return (*C.short)(unsafe.Pointer(&union.$union)) }
 
 type C.union_1 struct{ $union uint64 }
 
@@ -138,9 +130,7 @@ func (union *C.union_3) unionfield_thing() *C.union3_t {
 
 type C.union_3 struct{ $union [2]uint64 }
 
-func (union *C.union_union2d) unionfield_i() *C.int {
-	return (*C.int)(unsafe.Pointer(&union.$union))
-}
+func (union *C.union_union2d) unionfield_i() *C.int { return (*C.int)(unsafe.Pointer(&union.$union)) }
 func (union *C.union_union2d) unionfield_d() *[2]float64 {
 	return (*[2]float64)(unsafe.Pointer(&union.$union))
 }


### PR DESCRIPTION
Normalization was required because previously we supported Go 1.13 and Go 1.14 at the same time. Now we've dropped support for both so this normalization is not necessary anymore.

CGo support remains the same. It's just the test outputs that aren't normalized anymore.

(This is just to remove some cruft to keep the code base clean)