### PR TITLE
targets: add DefaultUART to adafruit boards

### DIFF
--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -83,3 +83,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x8045
 )
+
+var (
+	DefaultUART = UART0
+)

--- a/src/machine/board_circuitplay_express_baremetal.go
+++ b/src/machine/board_circuitplay_express_baremetal.go
@@ -47,3 +47,7 @@ var (
 var (
 	I2S0 = I2S{Bus: sam.I2S}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -127,3 +127,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x8072
 )
+
+var (
+	DefaultUART = UART0
+)

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -114,3 +114,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x801B
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -154,3 +154,7 @@ var (
 		Bus: sam.CAN1,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_feather-m4_baremetal.go
+++ b/src/machine/board_feather-m4_baremetal.go
@@ -43,3 +43,7 @@ var (
 		SERCOM: 1,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_grandcentral-m4_baremetal.go
+++ b/src/machine/board_grandcentral-m4_baremetal.go
@@ -65,3 +65,7 @@ var (
 		SERCOM: 2,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -135,3 +135,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x800F
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_itsybitsy-m4_baremetal.go
+++ b/src/machine/board_itsybitsy-m4_baremetal.go
@@ -43,3 +43,7 @@ var (
 		SERCOM: 1,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -93,3 +93,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x8051
 )
+
+var (
+	DefaultUART = UART0
+)

--- a/src/machine/board_matrixportal-m4_baremetal.go
+++ b/src/machine/board_matrixportal-m4_baremetal.go
@@ -50,3 +50,7 @@ var (
 		SERCOM: 0,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_metro-m4-airlift_baremetal.go
+++ b/src/machine/board_metro-m4-airlift_baremetal.go
@@ -52,3 +52,7 @@ var (
 		SERCOM: 1,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_pybadge_baremetal.go
+++ b/src/machine/board_pybadge_baremetal.go
@@ -51,3 +51,7 @@ var (
 		SERCOM: 4,
 	}
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_pyportal_baremetal.go
+++ b/src/machine/board_pyportal_baremetal.go
@@ -36,3 +36,7 @@ var (
 	}
 	NINA_SPI = SPI0
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -119,3 +119,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x80CB
 )
+
+var (
+	DefaultUART = UART1
+)

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -105,3 +105,7 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x801E
 )
+
+var (
+	DefaultUART = UART1
+)


### PR DESCRIPTION
Added the required configuration to #1880 for the adafruit board.

The following boards, which have not been changed in this PR, are already configured.

* feather-nrf52840-sense
* feather-nrf52840
* feather-rp2040
* feather-stm32f405

The recently added mdbt50qrx-uf2 does not have a port and does not need to be configured.
