### PR TITLE
teensy40: Enable receive watermark interrupt (Fixes #2092)

### DIFF
--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -88,15 +88,20 @@ const (
 	I2C_SCL_PIN = I2C1_SCL_PIN // D19/A5
 )
 
+// Default peripherals
+var (
+	DefaultUART = UART1
+)
+
 func init() {
 	// register any interrupt handlers for this board's peripherals
-	UART1.Interrupt = interrupt.New(nxp.IRQ_LPUART6, _UART1.handleInterrupt)
-	UART2.Interrupt = interrupt.New(nxp.IRQ_LPUART4, _UART2.handleInterrupt)
-	UART3.Interrupt = interrupt.New(nxp.IRQ_LPUART2, _UART3.handleInterrupt)
-	UART4.Interrupt = interrupt.New(nxp.IRQ_LPUART3, _UART4.handleInterrupt)
-	UART5.Interrupt = interrupt.New(nxp.IRQ_LPUART8, _UART5.handleInterrupt)
-	UART6.Interrupt = interrupt.New(nxp.IRQ_LPUART1, _UART6.handleInterrupt)
-	UART7.Interrupt = interrupt.New(nxp.IRQ_LPUART7, _UART7.handleInterrupt)
+	_UART1.Interrupt = interrupt.New(nxp.IRQ_LPUART6, _UART1.handleInterrupt)
+	_UART2.Interrupt = interrupt.New(nxp.IRQ_LPUART4, _UART2.handleInterrupt)
+	_UART3.Interrupt = interrupt.New(nxp.IRQ_LPUART2, _UART3.handleInterrupt)
+	_UART4.Interrupt = interrupt.New(nxp.IRQ_LPUART3, _UART4.handleInterrupt)
+	_UART5.Interrupt = interrupt.New(nxp.IRQ_LPUART8, _UART5.handleInterrupt)
+	_UART6.Interrupt = interrupt.New(nxp.IRQ_LPUART1, _UART6.handleInterrupt)
+	_UART7.Interrupt = interrupt.New(nxp.IRQ_LPUART7, _UART7.handleInterrupt)
 }
 
 // #=====================================================#
@@ -136,9 +141,8 @@ const (
 )
 
 var (
-	DefaultUART = UART1
-	UART1       = &_UART1
-	_UART1      = UART{
+	UART1  = &_UART1
+	_UART1 = UART{
 		Bus:      nxp.LPUART6,
 		Buffer:   NewRingBuffer(),
 		txBuffer: NewRingBuffer(),

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -45,11 +45,6 @@ func (uart *UART) resetTransmitting() {
 	uart.Bus.GLOBAL.ClearBits(nxp.LPUART_GLOBAL_RST)
 }
 
-func (uart *UART) usesConfig(c UARTConfig) bool {
-	return uart.configured && uart.baud == c.BaudRate &&
-		uart.rx == c.RX && uart.tx == c.TX
-}
-
 // Configure initializes a UART with the given UARTConfig and other default
 // settings.
 func (uart *UART) Configure(config UARTConfig) {
@@ -65,11 +60,6 @@ func (uart *UART) Configure(config UARTConfig) {
 	if config.RX == 0 && config.TX == 0 {
 		config.RX = UART_RX_PIN
 		config.TX = UART_TX_PIN
-	}
-
-	// Do not reconfigure pins and device buffers if duplicate config provided.
-	if uart.usesConfig(config) {
-		return
 	}
 
 	uart.baud = config.BaudRate

--- a/targets/mimxrt1062-teensy40.ld
+++ b/targets/mimxrt1062-teensy40.ld
@@ -8,8 +8,7 @@ MEMORY
 
 ENTRY(Reset_Handler);
 
-_stack_size = 128K;
-_heap_size = 512K;
+_stack_size = 4K;
 
 SECTIONS
 {


### PR DESCRIPTION
This PR fixes a few problems that were apparent while debugging #2092, and it also simplifies the `(*UART).Configure` code a bit.

The most important change was to enable the receive and idle line interrupts (`LPUART_CTRL_RIE`, `LPUART_CTRL_ILIE`) during the config sequence (not sure if/how this was even working before?)

Some smaller periphery updates were also made as they generally improve the Teensy 4 package and do affect the stability/performance of UART:

- Move local registers of `enableDcache(bool)` to package scope (see: `dcacheCcsidr`, `dcacheSets`, and `dcacheWays` in `src/device/nxp/mimxrt1062_mpu.go`)
	- This eliminates a potentially-very-frequent heap allocation, as `enableDcache(bool)` is intended to be called before each DMA beat (I think that's the right term?)
- Reduce TinyGo stack size defined in linker script (`targets/mimxrt1062-teensy40.ld`) from an astronomically unreasonable `128K` to a conventional `4K`.
	- This frees up `124K` of DTCM RAM for application code. Enough said.