### PR TITLE
unix: check for mmap error and act accordingly

### DIFF
--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -16,8 +16,9 @@ func usleep(usec uint) int
 //export malloc
 func malloc(size uintptr) unsafe.Pointer
 
+// void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 //export mmap
-func mmap(addr unsafe.Pointer, length, prot, flags, fd int, offset int) unsafe.Pointer
+func mmap(addr unsafe.Pointer, length uintptr, prot, flags, fd int, offset int) unsafe.Pointer
 
 //export abort
 func abort()


### PR DESCRIPTION
At startup, a large chunk of virtual memory is used up by the heap. This
works fine in emulation (qemu-arm), but doesn't work so well on an
actual Raspberry Pi. Therefore, this commit reduces the requested amount
until a heap size is found that works on the system.

This can certainly be improved, but for now it's an important fix
because it allows TinyGo built binaries to actually run on a Raspberry
Pi with just 1GB RAM. Previously, they would segfault.