### PR TITLE
arm: switch to Thumb instruction set on ARM

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -172,6 +172,7 @@ func LoadTarget(target string) (*TargetSpec, error) {
 			"386":   "i386",
 			"amd64": "x86_64",
 			"arm64": "aarch64",
+			"arm":   "thumbv7",
 		}[goarch]
 		if llvmarch == "" {
 			llvmarch = goarch


### PR DESCRIPTION
This reduces binary size substantially, for two reasons:

  - It switches to a much more modern architecture: ARMv4 vs ARMv7.
  - It switches to Thumb2, which is a lot denser than regular ARM.

Practically all modern and not-so-modern ARM chips support Thumb2, so this seems like a safe change to me.

The size in numbers:

  - Code size for testdata/stdlib.go is reduced by about 35%.
  - Binary size for testdata/stdlib.go (when compiling with -no-debug to strip debug information) is reduced by about 16%.