### PR TITLE
loader: fix panic in CGo files with syntax errors

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -386,7 +386,11 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 	}
 
 	// Do CGo processing.
-	if len(p.CgoFiles) != 0 {
+	// This is done when there are any CgoFiles at all. In that case, len(files)
+	// should be non-zero. However, if len(GoFiles) == 0 and len(CgoFiles) == 1
+	// and there is a syntax error in a CGo file, len(files) may be 0. Don't try
+	// to call cgo.Process in that case as it will only cause issues.
+	if len(p.CgoFiles) != 0 && len(files) != 0 {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags()...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)


### PR DESCRIPTION
If all of the Go files presented to the compiler have syntax errors,
cgo.Process gets an empty files slice and will panic:

    panic: runtime error: index out of range [0] with length 0

    goroutine 1 [running]:
    github.com/tinygo-org/tinygo/cgo.Process({0x0, 0x4e8e36, 0x0}, {0xc000024104, 0x18}, 0xc000090fc0, {0xc000899780, 0x7, 0xc00018ce68})
    	/home/ayke/src/github.com/tinygo-org/tinygo/cgo/cgo.go:186 +0x22ee
    github.com/tinygo-org/tinygo/loader.(*Package).parseFiles(0xc0001ccf00)
    	/home/ayke/src/github.com/tinygo-org/tinygo/loader/loader.go:400 +0x51e

This is simple to work around: just don't try to run CGo when there are
no files to process. It just means there are bugs to fix before CGo can
properly run.

(This is perhaps not the nicest solution but certainly the simplest).