### PR TITLE
esp32: fix spi extra configuration

### DIFF
--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -384,16 +384,17 @@ func (spi SPI) Configure(config SPIConfig) error {
 	if config.Frequency >= 40e6 {
 		// Delay mode must be set to 0 and SPI_USR_DUMMY_CYCLELEN should be set
 		// to 0 (the default).
+		spi.Bus.USER1.Set(0)
 		userReg |= esp.SPI_USER_USR_DUMMY
 	} else if config.Frequency >= 20e6 {
 		// Nothing to do here, delay mode should be set to 0 according to the
 		// datasheet.
 	} else {
-		// Follow the delay mode as given in table 29 on page 128 of the
+		// Follow the delay mode as given in table 7-3 on page 125 of the
 		// reference manual.
 		// Note that this is only specified for SPI frequency of 10MHz and
 		// below (≤Fapb/8), so 13.3MHz appears to be left unspecified.
-		ctrl2Reg |= delayMode << esp.SPI_CTRL2_MOSI_DELAY_MODE_Pos
+		ctrl2Reg |= delayMode << esp.SPI_CTRL2_MISO_DELAY_MODE_Pos
 	}
 	// Enable full-duplex communication.
 	userReg |= esp.SPI_USER_DOUTDIN


### PR DESCRIPTION
This PR corrects the timing of SCK and SDO.
This PR fixes the problem in #2036.

I am not sure if this change is correct, but I believe it is at this point for the following reasons.
If there is a better way to change it, please let me know.


### 1 ###
USER_USR_DUMMY is not used in espressif/arduino-esp32.
If USER_USR_DUMMY is set, 0x00 will be inserted at the beginning of SPI communication.
This appears to be unnecessary.


### 2 ###
MOSI_DELAY_MODE is also used only in the slave side below.

https://github.com/espressif/arduino-esp32/blob/master/tools/sdk/esp32/include/hal/esp32/include/hal/spi_ll.h#L370-L425

### 3 ###
`table 29 on page 128` is not found.
The following PDF does not appear to require the MOSI_DELAY_MODE setting.

https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf

![image](https://user-images.githubusercontent.com/9251039/133612957-3f1ea8d4-8ae7-4c4a-bc92-f3710ef87ed5.png)


### 4 ###
The actual waveform before and after the modification is shown below.


old w/40e6 Hz - ili9341 did not work
Depending on the USER_USR_DUMMY setting, an extra 0x00 will be output
![image](https://user-images.githubusercontent.com/9251039/133613244-cc015a46-ec36-471e-a65d-b5c6f9df9baf.png)

old w/20e6 Hz - ili9341 worked
![image](https://user-images.githubusercontent.com/9251039/133613284-403380b6-de1a-4da5-b129-e92d573ff15d.png)

old w/4e6 Hz - ili9341 did not work
The timing of SCK and SDO is almost simultaneous due to the MOSI_DELAY setting.
![image](https://user-images.githubusercontent.com/9251039/133613387-3b8b5481-a82a-4237-9410-f44edce1a8b1.png)

new w/40e6 Hz - ili9341 did not work (note-1)
![image](https://user-images.githubusercontent.com/9251039/133613429-4e023994-1909-429f-ab2d-5de30375a6db.png)

new w/20e6 Hz - ili9341 worked
![image](https://user-images.githubusercontent.com/9251039/133613463-b573abfc-3e7a-4c4b-b334-7dcb6a2851a4.png)

new w/4e6 Hz - ili9341 worked
![image](https://user-images.githubusercontent.com/9251039/133613500-32d50630-60ac-440e-bfce-98e593e03f48.png)

note-1:
As a separate issue, I think the CLOCK register setting needs to be fixed. After changing the code a bit, I got the correct waveform output even at 40Mhz. I am going to create another PR.
