### PR TITLE
builder: simplify running of jobs

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -46,15 +46,14 @@ func (l *Library) Load(target, tmpdir string) (path string, err error) {
 	if err != nil {
 		return "", err
 	}
-	jobs := append([]*compileJob{job}, job.dependencies...)
-	err = runJobs(jobs)
+	err = runJobs(job)
 	return job.result, err
 }
 
 // load returns a compile job to build this library file for the given target
 // and CPU. It may return a dummy compileJob if the library build is already
-// cached. The path is stored as job.result but is only valid if the job and
-// job.dependencies have been run.
+// cached. The path is stored as job.result but is only valid after the job has
+// been run.
 // The provided tmpdir will be used to store intermediary files and possibly the
 // output archive file, it is expected to be removed after use.
 func (l *Library) load(target, cpu, tmpdir string) (job *compileJob, err error) {


### PR DESCRIPTION
Instead of keeping a slice of jobs to run, let the runJobs function
determine which jobs should be run by investigating all dependencies.
This has two benefits:

  - The code is somewhat cleaner, as no 'jobs' slice needs to be
    maintained while constructing the dependency graph.
  - Eventually, some jobs might not be required by any dependency.
    While it's possible to avoid adding them to the slice, the simpler
    solution is to build a new slice from the dependencies which will
    only include required dependencies by design.

---

Note: this is a change that I've made at least twice now, but never in a finished branch yet. So I decided to extract it so that future changes to the builder package will be easier and result in fewer conflicts.