### PR TITLE
cgo: support functions defined in CGo headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,9 +470,9 @@ build/release: tinygo gen-device wasi-libc
 	@mkdir -p build/release/tinygo/lib/nrfx
 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libc
 	@mkdir -p build/release/tinygo/lib/wasi-libc
-	@mkdir -p build/release/tinygo/pkg/armv6m-none-eabi
-	@mkdir -p build/release/tinygo/pkg/armv7m-none-eabi
-	@mkdir -p build/release/tinygo/pkg/armv7em-none-eabi
+	@mkdir -p build/release/tinygo/pkg/armv6m-unknown-unknown-eabi
+	@mkdir -p build/release/tinygo/pkg/armv7m-unknown-unknown-eabi
+	@mkdir -p build/release/tinygo/pkg/armv7em-unknown-unknown-eabi
 	@echo copying source files
 	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
 	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
@@ -491,12 +491,12 @@ build/release: tinygo gen-device wasi-libc
 	@cp -rp lib/wasi-libc/sysroot        build/release/tinygo/lib/wasi-libc/sysroot
 	@cp -rp src                          build/release/tinygo/src
 	@cp -rp targets                      build/release/tinygo/targets
-	./build/tinygo build-library -target=armv6m-none-eabi  -o build/release/tinygo/pkg/armv6m-none-eabi/compiler-rt.a compiler-rt
-	./build/tinygo build-library -target=armv7m-none-eabi  -o build/release/tinygo/pkg/armv7m-none-eabi/compiler-rt.a compiler-rt
-	./build/tinygo build-library -target=armv7em-none-eabi -o build/release/tinygo/pkg/armv7em-none-eabi/compiler-rt.a compiler-rt
-	./build/tinygo build-library -target=armv6m-none-eabi  -o build/release/tinygo/pkg/armv6m-none-eabi/picolibc.a picolibc
-	./build/tinygo build-library -target=armv7m-none-eabi  -o build/release/tinygo/pkg/armv7m-none-eabi/picolibc.a picolibc
-	./build/tinygo build-library -target=armv7em-none-eabi -o build/release/tinygo/pkg/armv7em-none-eabi/picolibc.a picolibc
+	./build/tinygo build-library -target=armv6m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv6m-unknown-unknown-eabi/compiler-rt.a compiler-rt
+	./build/tinygo build-library -target=armv7m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv7m-unknown-unknown-eabi/compiler-rt.a compiler-rt
+	./build/tinygo build-library -target=armv7em-unknown-unknown-eabi -o build/release/tinygo/pkg/armv7em-unknown-unknown-eabi/compiler-rt.a compiler-rt
+	./build/tinygo build-library -target=armv6m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv6m-unknown-unknown-eabi/picolibc.a picolibc
+	./build/tinygo build-library -target=armv7m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv7m-unknown-unknown-eabi/picolibc.a picolibc
+	./build/tinygo build-library -target=armv7em-unknown-unknown-eabi -o build/release/tinygo/pkg/armv7em-unknown-unknown-eabi/picolibc.a picolibc
 
 release: build/release
 	tar -czf build/release.tar.gz -C build/release tinygo

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -28,7 +28,7 @@ func normalizeResult(result string) string {
 }
 
 func TestCGo(t *testing.T) {
-	var cflags = []string{"--target=armv6m-none-eabi"}
+	var cflags = []string{"--target=armv6m-unknown-unknown-eabi"}
 
 	for _, name := range []string{"basic", "errors", "types", "flags", "const"} {
 		name := name // avoid a race condition

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -56,7 +56,7 @@ func TestCGo(t *testing.T) {
 			}
 
 			// Process the AST with CGo.
-			cgoAST, _, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
+			cgoAST, _, _, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags)
 
 			// Check the AST for type errors.
 			var typecheckErrors []error

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -81,7 +81,7 @@ func (p *cgoPackage) parseFragment(fragment string, cflags []string, posFilename
 	defer C.free(unsafe.Pointer(filenameC))
 
 	// fix up error locations
-	fragment = fmt.Sprintf("# %d %#v\n", posLine+1, posFilename) + fragment
+	fragment = fmt.Sprintf("# %d %#v\n", posLine, posFilename) + fragment
 
 	fragmentC := C.CString(fragment)
 	defer C.free(unsafe.Pointer(fragmentC))

--- a/cgo/testdata/basic.out.go
+++ b/cgo/testdata/basic.out.go
@@ -13,14 +13,3 @@ type C.uint32_t = uint32
 type C.uint64_t = uint64
 type C.uint8_t = uint8
 type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16

--- a/cgo/testdata/errors.go
+++ b/cgo/testdata/errors.go
@@ -14,6 +14,9 @@ typedef someType noType; // undefined type
 #define SOME_CONST_2 6) // const not used (so no error)
 #define SOME_CONST_3 1234 // const too large for byte
 */
+//
+//
+// #define SOME_CONST_4 8) // after some empty lines
 import "C"
 
 // Make sure that errors for the following lines won't change with future
@@ -30,4 +33,6 @@ var (
 	_ = C.SOME_CONST_1
 
 	_ byte = C.SOME_CONST_3
+
+	_ = C.SOME_CONST_4
 )

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -2,12 +2,14 @@
 //     testdata/errors.go:4:2: warning: some warning
 //     testdata/errors.go:11:9: error: unknown type name 'someType'
 //     testdata/errors.go:13:23: unexpected token ), expected end of expression
+//     testdata/errors.go:19:26: unexpected token ), expected end of expression
 
 // Type checking errors after CGo processing:
 //     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as uint8 value in variable declaration (overflows)
 //     testdata/errors.go:105: unknown field z in struct literal
 //     testdata/errors.go:108: undeclared name: C.SOME_CONST_1
 //     testdata/errors.go:110: cannot use C.SOME_CONST_3 (untyped int constant 1234) as byte value in variable declaration (overflows)
+//     testdata/errors.go:112: undeclared name: C.SOME_CONST_4
 
 package main
 

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -211,6 +211,8 @@ func (c *Config) CFlags() []string {
 	}
 	// Always emit debug information. It is optionally stripped at link time.
 	cflags = append(cflags, "-g")
+	// Use the same optimization level as TinyGo.
+	cflags = append(cflags, "-O"+c.Options.Opt)
 	return cflags
 }
 

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	TestConfig     TestConfig
 }
 
-// Triple returns the LLVM target triple, like armv6m-none-eabi.
+// Triple returns the LLVM target triple, like armv6m-unknown-unknown-eabi.
 func (c *Config) Triple() string {
 	return c.Target.Triple
 }
@@ -213,6 +213,8 @@ func (c *Config) CFlags() []string {
 	cflags = append(cflags, "-g")
 	// Use the same optimization level as TinyGo.
 	cflags = append(cflags, "-O"+c.Options.Opt)
+	// Set the LLVM target triple.
+	cflags = append(cflags, "--target="+c.Triple())
 	return cflags
 }
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -177,7 +177,10 @@ func LoadTarget(target string) (*TargetSpec, error) {
 		if llvmarch == "" {
 			llvmarch = goarch
 		}
-		target = llvmarch + "--" + llvmos
+		// Target triples (which actually have four components, but are called
+		// triples for historical reasons) have the form:
+		//   arch-vendor-os-environment
+		target = llvmarch + "-unknown-" + llvmos
 		if goarch == "arm" {
 			target += "-gnueabihf"
 		}
@@ -206,14 +209,6 @@ func LoadTarget(target string) (*TargetSpec, error) {
 		tripleSplit := strings.Split(target, "-")
 		if len(tripleSplit) < 3 {
 			return nil, errors.New("expected a full LLVM target or a custom target in -target flag")
-		}
-		if tripleSplit[0] == "arm" {
-			// LLVM and Clang have a different idea of what "arm" means, so
-			// upgrade to a slightly more modern ARM. In fact, when you pass
-			// --target=arm--linux-gnueabihf to Clang, it will convert that
-			// internally to armv7-unknown-linux-gnueabihf. Changing the
-			// architecture to armv7 will keep things consistent.
-			tripleSplit[0] = "armv7"
 		}
 		goos := tripleSplit[2]
 		if strings.HasPrefix(goos, "darwin") {
@@ -250,7 +245,6 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		Scheduler:        "tasks",
 		Linker:           "cc",
 		DefaultStackSize: 1024 * 64, // 64kB
-		CFlags:           []string{"--target=" + triple},
 		GDB:              []string{"gdb"},
 		PortReset:        "false",
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -291,14 +291,14 @@ func CompilePackage(moduleName string, pkg *loader.Package, ssaPkg *ssa.Package,
 	if c.Debug {
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
-				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(), // Error on mismatch
+				llvm.ConstInt(c.ctx.Int32Type(), 2, false).ConstantAsMetadata(), // Warning on mismatch
 				c.ctx.MDString("Debug Info Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 3, false).ConstantAsMetadata(), // DWARF version
 			}),
 		)
 		c.mod.AddNamedMetadataOperand("llvm.module.flags",
 			c.ctx.MDNode([]llvm.Metadata{
-				llvm.ConstInt(c.ctx.Int32Type(), 1, false).ConstantAsMetadata(),
+				llvm.ConstInt(c.ctx.Int32Type(), 7, false).ConstantAsMetadata(), // Max on mismatch
 				c.ctx.MDString("Dwarf Version"),
 				llvm.ConstInt(c.ctx.Int32Type(), 4, false).ConstantAsMetadata(),
 			}),

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'basic.go'
 source_filename = "basic.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %main.kv = type { float }
 %main.kv.0 = type { i8 }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'channel.go'
 source_filename = "channel.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'float.go'
 source_filename = "float.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'func.go'
 source_filename = "func.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %runtime.funcValueWithSignature = type { i32, i8* }
 

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'go1.17.go'
 source_filename = "go1.17.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-target triple = "armv7m-none-eabi"
+target triple = "armv7m-unknown-unknown-eabi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %runtime.funcValueWithSignature = type { i32, i8* }
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'interface.go'
 source_filename = "interface.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID* }
 %runtime.interfaceMethodInfo = type { i8*, i32 }

--- a/compiler/testdata/intrinsics-cortex-m-qemu.ll
+++ b/compiler/testdata/intrinsics-cortex-m-qemu.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-target triple = "armv7m-none-eabi"
+target triple = "armv7m-unknown-unknown-eabi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'pointer.go'
 source_filename = "pointer.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'pragma.go'
 source_filename = "pragma.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 @extern_global = external global [0 x i8], align 1
 @main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'slice.go'
 source_filename = "slice.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'string.go'
 source_filename = "string.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
-target triple = "wasm32--wasi"
+target triple = "wasm32-unknown-wasi"
 
 %runtime._string = type { i8*, i32 }
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -72,6 +72,7 @@ type Package struct {
 	Files      []*ast.File
 	FileHashes map[string][]byte
 	CFlags     []string // CFlags used during CGo preprocessing (only set if CGo is used)
+	CGoHeaders []string // text above 'import "C"' lines
 	Pkg        *types.Package
 	info       types.Info
 }
@@ -397,8 +398,9 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		if p.program.clangHeaders != "" {
 			initialCFlags = append(initialCFlags, "-Xclang", "-internal-isystem", "-Xclang", p.program.clangHeaders)
 		}
-		generated, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, initialCFlags)
+		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, initialCFlags)
 		p.CFlags = append(initialCFlags, cflags...)
+		p.CGoHeaders = headerCode
 		for path, hash := range accessedFiles {
 			p.FileHashes[path] = hash
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -95,13 +95,13 @@ func TestCompiler(t *testing.T) {
 
 	if runtime.GOOS == "linux" {
 		t.Run("X86Linux", func(t *testing.T) {
-			runPlatTests("i386--linux-gnu", tests, t)
+			runPlatTests("i386-unknown-linux", tests, t)
 		})
 		t.Run("ARMLinux", func(t *testing.T) {
-			runPlatTests("arm--linux-gnueabihf", tests, t)
+			runPlatTests("armv7-unknown-linux-gnueabihf", tests, t)
 		})
 		t.Run("ARM64Linux", func(t *testing.T) {
-			runPlatTests("aarch64--linux-gnu", tests, t)
+			runPlatTests("aarch64-unknown-linux", tests, t)
 		})
 		t.Run("WebAssembly", func(t *testing.T) {
 			runPlatTests("wasm", tests, t)

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -1,5 +1,5 @@
 {
-	"llvm-target": "avr-unknown-unknown",
+	"llvm-target": "avr",
 	"build-tags": ["avr", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
@@ -8,7 +8,6 @@
 	"scheduler": "none",
 	"default-stack-size": 256,
 	"cflags": [
-		"--target=avr-unknown-unknown",
 		"-Werror"
 	],
 	"ldflags": [

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -10,7 +10,6 @@
 	"automatic-stack-size": true,
 	"default-stack-size": 2048,
 	"cflags": [
-		"-Oz",
 		"-mthumb",
 		"-Werror",
 		"-fshort-enums",

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -1,7 +1,4 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv6m-none-eabi",
-	"cflags": [
-		"--target=armv6m-none-eabi"
-	]
+	"llvm-target": "armv6m-unknown-unknown-eabi"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -1,7 +1,4 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv6m-none-eabi",
-	"cflags": [
-		"--target=armv6m-none-eabi"
-	]
+	"llvm-target": "armv6m-unknown-unknown-eabi"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -1,7 +1,4 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7m-none-eabi",
-	"cflags": [
-		"--target=armv7m-none-eabi"
-	]
+	"llvm-target": "armv7m-unknown-unknown-eabi"
 }

--- a/targets/cortex-m33.json
+++ b/targets/cortex-m33.json
@@ -1,8 +1,7 @@
 {
     "inherits": ["cortex-m"],
-    "llvm-target": "armv7m-none-eabi",
+    "llvm-target": "armv7m-unknown-unknown-eabi",
     "cflags": [
-        "--target=armv7m-none-eabi",
         "-mfloat-abi=soft"
     ]
 }

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -1,8 +1,7 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"llvm-target": "armv7em-unknown-unknown-eabi",
 	"cflags": [
-		"--target=armv7em-none-eabi",
 		"-mfloat-abi=soft"
 	]
 }

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -1,9 +1,8 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-none-eabi",
+	"llvm-target": "armv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
 	"cflags": [
-		"--target=armv7em-none-eabi",
 		"-mcpu=cortex-m7",
 		"-mfloat-abi=soft"
 	]

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,5 +1,5 @@
 {
-	"llvm-target": "arm4-none-eabi",
+	"llvm-target": "arm4-unknown-unknown-eabi",
 	"cpu": "arm7tdmi",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
@@ -8,7 +8,6 @@
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"cflags": [
-		"--target=arm4-none-eabi",
 		"-mcpu=arm7tdmi",
 		"-Werror",
 		"-fshort-enums",

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -10,7 +10,6 @@
 	"cflags": [
 		"--target=arm4-none-eabi",
 		"-mcpu=arm7tdmi",
-		"-Oz",
 		"-Werror",
 		"-fshort-enums",
 		"-fomit-frame-pointer",

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -7,7 +7,6 @@
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"cflags": [
-		"-Os",
 		"-Werror",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"

--- a/targets/riscv32.json
+++ b/targets/riscv32.json
@@ -3,7 +3,6 @@
 	"llvm-target": "riscv32--none",
 	"build-tags": ["tinygo.riscv32"],
 	"cflags": [
-		"--target=riscv32--none",
 		"-march=rv32imac",
 		"-mabi=ilp32"
 	],

--- a/targets/riscv64.json
+++ b/targets/riscv64.json
@@ -3,7 +3,6 @@
 	"llvm-target": "riscv64--none",
 	"build-tags": ["tinygo.riscv64"],
 	"cflags": [
-		"--target=riscv64--none",
 		"-march=rv64gc",
 		"-mabi=lp64"
 	],

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -1,12 +1,11 @@
 {
-	"llvm-target":   "wasm32--wasi",
+	"llvm-target":   "wasm32-unknown-wasi",
 	"build-tags":    ["tinygo.wasm", "wasi"],
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"cflags": [
-		"--target=wasm32--wasi",
 		"--sysroot={root}/lib/wasi-libc/sysroot"
 	],
 	"ldflags": [

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -7,8 +7,7 @@
 	"libc":          "wasi-libc",
 	"cflags": [
 		"--target=wasm32--wasi",
-		"--sysroot={root}/lib/wasi-libc/sysroot",
-		"-Oz"
+		"--sysroot={root}/lib/wasi-libc/sysroot"
 	],
 	"ldflags": [
 		"--allow-undefined",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,12 +1,11 @@
 {
-	"llvm-target":   "wasm32--wasi",
+	"llvm-target":   "wasm32-unknown-wasi",
 	"build-tags":    ["tinygo.wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"cflags": [
-		"--target=wasm32--wasi",
 		"--sysroot={root}/lib/wasi-libc/sysroot"
 	],
 	"ldflags": [

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -7,8 +7,7 @@
 	"libc":          "wasi-libc",
 	"cflags": [
 		"--target=wasm32--wasi",
-		"--sysroot={root}/lib/wasi-libc/sysroot",
-		"-Oz"
+		"--sysroot={root}/lib/wasi-libc/sysroot"
 	],
 	"ldflags": [
 		"--allow-undefined",

--- a/targets/xtensa.json
+++ b/targets/xtensa.json
@@ -6,7 +6,6 @@
 	"gc": "conservative",
 	"scheduler": "none",
 	"cflags": [
-		"--target=xtensa",
 		"-Werror",
 		"-fshort-enums",
 		"-Wno-macro-redefined",

--- a/targets/xtensa.json
+++ b/targets/xtensa.json
@@ -7,7 +7,6 @@
 	"scheduler": "none",
 	"cflags": [
 		"--target=xtensa",
-		"-Oz",
 		"-Werror",
 		"-fshort-enums",
 		"-Wno-macro-redefined",

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -10,6 +10,7 @@ int mul(int, int);
 */
 import "C"
 
+// int headerfunc(int a) { return a + 1; }
 import "C"
 
 import "unsafe"
@@ -42,6 +43,9 @@ func main() {
 	// variadic functions
 	println("variadic0:", C.variadic0())
 	println("variadic2:", C.variadic2(3, 5))
+
+	// functions in the header C snippet
+	println("headerfunc:", C.headerfunc(5))
 
 	// equivalent types
 	var goInt8 int8 = 5

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -15,6 +15,7 @@ callback 1: 50
 callback 2: 600
 variadic0: 1
 variadic2: 15
+headerfunc: 6
 bool: true true
 float: +3.100000e+000
 double: +3.200000e+000


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/tinygo/issues/2118 and perhaps others.

Not complete. Merging Clang and TinyGo IR introduces some weird side effects which I would like to solve.