### PR TITLE
os: don't try to read executable path on baremetal

### DIFF
--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux baremetal
 
 package os
 

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux
+// +build linux,!baremetal
 
 package os
 


### PR DESCRIPTION
Baremetal systems usually pretend to be GOOS=linux, so an extra build tag is needed here.