### PR TITLE
Clean up -target flag

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -13,7 +13,7 @@ import (
 // uses the currently active GOPATH (from the goenv package) to determine the Go
 // version to use.
 func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
-	spec, err := compileopts.LoadTarget(options.Target)
+	spec, err := compileopts.LoadTarget(options)
 	if err != nil {
 		return nil, err
 	}

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -16,8 +16,11 @@ var (
 )
 
 // Options contains extra options to give to the compiler. These options are
-// usually passed from the command line.
+// usually passed from the command line, but can also be passed in environment
+// variables for example.
 type Options struct {
+	GOOS            string // environment variable
+	GOARCH          string // environment variable
 	Target          string
 	Opt             string
 	GC              string

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -172,7 +172,7 @@ func LoadTarget(target string) (*TargetSpec, error) {
 			"386":   "i386",
 			"amd64": "x86_64",
 			"arm64": "aarch64",
-			"arm":   "thumbv7",
+			"arm":   "armv7",
 		}[goarch]
 		if llvmarch == "" {
 			llvmarch = goarch

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -189,41 +189,16 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 	// Arduino).
 	spec := &TargetSpec{}
 	err := spec.loadFromGivenStr(options.Target)
-	if err == nil {
-		// Successfully loaded this target from a built-in .json file. Make sure
-		// it includes all parents as specified in the "inherits" key.
-		err = spec.resolveInherits()
-		if err != nil {
-			return nil, err
-		}
-		return spec, nil
-	} else if !os.IsNotExist(err) {
-		// Expected a 'file not found' error, got something else. Report it as
-		// an error.
+	if err != nil {
 		return nil, err
-	} else {
-		// Load target from given triple, ignore GOOS/GOARCH environment
-		// variables.
-		tripleSplit := strings.Split(options.Target, "-")
-		if len(tripleSplit) < 3 {
-			return nil, errors.New("expected a full LLVM target or a custom target in -target flag")
-		}
-		goos := tripleSplit[2]
-		if strings.HasPrefix(goos, "darwin") {
-			goos = "darwin"
-		}
-		goarch := map[string]string{ // map from LLVM arch to Go arch
-			"i386":    "386",
-			"i686":    "386",
-			"x86_64":  "amd64",
-			"aarch64": "arm64",
-			"armv7":   "arm",
-		}[tripleSplit[0]]
-		if goarch == "" {
-			goarch = tripleSplit[0]
-		}
-		return defaultTarget(goos, goarch, strings.Join(tripleSplit, "-"))
 	}
+	// Successfully loaded this target from a built-in .json file. Make sure
+	// it includes all parents as specified in the "inherits" key.
+	err = spec.resolveInherits()
+	if err != nil {
+		return nil, err
+	}
+	return spec, nil
 }
 
 // WindowsBuildNotSupportedErr is being thrown, when goos is windows and no target has been specified.

--- a/compileopts/target_test.go
+++ b/compileopts/target_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func TestLoadTarget(t *testing.T) {
-	_, err := LoadTarget("arduino")
+	_, err := LoadTarget(&Options{Target: "arduino"})
 	if err != nil {
 		t.Error("LoadTarget test failed:", err)
 	}
 
-	_, err = LoadTarget("notexist")
+	_, err = LoadTarget(&Options{Target: "notexist"})
 	if err == nil {
 		t.Error("LoadTarget should have failed with non existing target")
 	}

--- a/compileopts/target_test.go
+++ b/compileopts/target_test.go
@@ -1,6 +1,7 @@
 package compileopts
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -16,7 +17,7 @@ func TestLoadTarget(t *testing.T) {
 		t.Error("LoadTarget should have failed with non existing target")
 	}
 
-	if err.Error() != "expected a full LLVM target or a custom target in -target flag" {
+	if !os.IsNotExist(err) {
 		t.Error("LoadTarget failed for wrong reason:", err)
 	}
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -73,12 +73,15 @@ func TestCompiler(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			target, err := compileopts.LoadTarget(targetString)
+			options := &compileopts.Options{
+				Target: targetString,
+			}
+			target, err := compileopts.LoadTarget(options)
 			if err != nil {
 				t.Fatal("failed to load target:", err)
 			}
 			config := &compileopts.Config{
-				Options: &compileopts.Options{},
+				Options: options,
 				Target:  target,
 			}
 			compilerConfig := &Config{

--- a/main.go
+++ b/main.go
@@ -1147,6 +1147,8 @@ func main() {
 	}
 
 	options := &compileopts.Options{
+		GOOS:            goenv.Get("GOOS"),
+		GOARCH:          goenv.Get("GOARCH"),
 		Target:          *target,
 		Opt:             *opt,
 		GC:              *gc,
@@ -1309,7 +1311,7 @@ func main() {
 				continue
 			}
 			path := filepath.Join(dir, entry.Name())
-			spec, err := compileopts.LoadTarget(path)
+			spec, err := compileopts.LoadTarget(&compileopts.Options{Target: path})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "could not list target:", err)
 				os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -1081,7 +1081,7 @@ func main() {
 	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
 	tags := flag.String("tags", "", "a space-separated list of extra build tags")
-	target := flag.String("target", "", "LLVM target | .json file with TargetSpec")
+	target := flag.String("target", "", "chip/board name or JSON target specification file")
 	printSize := flag.String("size", "", "print sizes (none, short, full)")
 	printStacks := flag.Bool("print-stacks", false, "print stack sizes of goroutines")
 	printAllocsString := flag.String("print-allocs", "", "regular expression of functions for which heap allocations should be printed")
@@ -1172,8 +1172,6 @@ func main() {
 	if *printCommands {
 		options.PrintCommands = printCommand
 	}
-
-	os.Setenv("CC", "clang -target="+*target)
 
 	err = options.Verify()
 	if err != nil {

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -140,7 +140,7 @@ func filterIrrelevantIRLines(lines []string) []string {
 // run.
 // If there are any errors, they are reported via the *testing.T instance.
 func compileGoFileForTesting(t *testing.T, filename string) llvm.Module {
-	target, err := compileopts.LoadTarget("i686--linux")
+	target, err := compileopts.LoadTarget(&compileopts.Options{GOOS: "linux", GOARCH: "386"})
 	if err != nil {
 		t.Fatal("failed to load target:", err)
 	}


### PR DESCRIPTION
- fix a bug introduced in #2112
- make sure that this issue is tested for, to prevent re-introducing something like it in the future
- clean up the `-target` flag, use `GOOS`/`GOARCH` environment variables if you want to cross compile (e.g. `GOOS=linux GOARCH=arm tinygo build ...`).