### PR TITLE
feather-stm32f405, feather-rp2040: add I2C pin names

### DIFF
--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -231,6 +231,9 @@ const (
 
 	I2C_SDA_PIN = I2C0_SDA_PIN // default/primary I2C pins
 	I2C_SCL_PIN = I2C0_SCL_PIN //
+
+	SDA_PIN = I2C0_SDA_PIN
+	SCL_PIN = I2C0_SCL_PIN
 )
 
 var (

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -38,6 +38,9 @@ const (
 
 	I2C1_SDA_PIN = GPIO2
 	I2C1_SCL_PIN = GPIO3
+
+	SDA_PIN = I2C1_SDA_PIN
+	SCL_PIN = I2C1_SCL_PIN
 )
 
 // SPI default pins


### PR DESCRIPTION
Added a Pin name to access I2C like other feather boards such as feather-m4.


feather-stm32f405
https://learn.adafruit.com/assets/83680

feather-rp2040
https://learn.adafruit.com/assets/100337