### PR TITLE
src/reflect: fix type.Size() to account for struct padding

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -554,7 +554,7 @@ func (t rawType) Size() uintptr {
 			return 0
 		}
 		lastField := t.rawField(numField - 1)
-		return lastField.Offset + lastField.Type.Size()
+		return align(lastField.Offset+lastField.Type.Size(), uintptr(t.Align()))
 	default:
 		panic("unimplemented: size of type")
 	}


### PR DESCRIPTION
Fixes #2141