### PR TITLE
Add testing.short and t.Parallel()

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -64,6 +64,7 @@ type TB interface {
 	Skipf(format string, args ...interface{})
 	Skipped() bool
 	Helper()
+	Parallel()
 }
 
 var _ TB = (*T)(nil)
@@ -191,6 +192,11 @@ func (c *common) Skipped() bool {
 
 // Helper is not implemented, it is only provided for compatibility.
 func (c *common) Helper() {
+	// Unimplemented.
+}
+
+// Parallel is not implemented, it is only provided for compatibility.
+func (c *common) Parallel() {
 	// Unimplemented.
 }
 

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -19,6 +19,7 @@ import (
 // Testing flags.
 var (
 	flagVerbose bool
+	flagShort   bool
 )
 
 var initRan bool
@@ -31,6 +32,7 @@ func Init() {
 	initRan = true
 
 	flag.BoolVar(&flagVerbose, "test.v", false, "verbose: print additional output")
+	flag.BoolVar(&flagShort, "test.short", false, "short: run smaller test suite to save time")
 }
 
 // common holds the elements common between T and B and
@@ -280,6 +282,11 @@ func (m *M) Run() int {
 		fmt.Println("PASS")
 	}
 	return failures
+}
+
+// Short reports whether the -test.short flag is set.
+func Short() bool {
+	return flagShort
 }
 
 func TestMain(m *M) {


### PR DESCRIPTION
This makes it easier to run standard Go tests unmodified (although many uses of testing.Short() use t.Skip() which is still unimplemented.)

t.Parallel() is just a stub, similar to t.Helper().