### PR TITLE
Tasks scheduler for RISC-V

### DIFF
--- a/src/internal/task/task_stack_tinygoriscv.S
+++ b/src/internal/task/task_stack_tinygoriscv.S
@@ -1,0 +1,69 @@
+.section .text.tinygo_startTask
+.global  tinygo_startTask
+.type    tinygo_startTask, %function
+tinygo_startTask:
+    // Small assembly stub for starting a goroutine. This is already run on the
+    // new stack, with the callee-saved registers already loaded.
+    // Most importantly, s0 contains the pc of the to-be-started function and s1
+    // contains the only argument it is given. Multiple arguments are packed
+    // into one by storing them in a new allocation.
+
+    // Set the first argument of the goroutine start wrapper, which contains all
+    // the arguments.
+    mv    a0, s1
+
+    // Branch to the "goroutine start" function. Use jalr to write the return
+    // address to ra so we'll return here after the goroutine exits.
+    jalr  s0
+
+    // After return, exit this goroutine. This is a tail call.
+    tail  tinygo_pause
+
+.section .text.tinygo_swapTask
+.global  tinygo_swapTask
+.type    tinygo_swapTask, %function
+tinygo_swapTask:
+    // This function gets the following parameters:
+    //   a0 = newStack uintptr
+    //   a1 = oldStack *uintptr
+
+    // Push all callee-saved registers.
+    addi sp, sp, -52
+    sw ra,  48(sp)
+    sw s11, 44(sp)
+    sw s10, 40(sp)
+    sw s9,  36(sp)
+    sw s8,  32(sp)
+    sw s7,  28(sp)
+    sw s6,  24(sp)
+    sw s5,  20(sp)
+    sw s4,  16(sp)
+    sw s3,  12(sp)
+    sw s2,   8(sp)
+    sw s1,   4(sp)
+    sw s0,    (sp)
+
+    // Save the current stack pointer in oldStack.
+    sw sp,  0(a1)
+
+    // Switch to the new stack pointer.
+    mv sp,  a0
+
+    // Pop all saved registers from this new stack.
+    lw ra,  48(sp)
+    lw s11, 44(sp)
+    lw s10, 40(sp)
+    lw s9,  36(sp)
+    lw s8,  32(sp)
+    lw s7,  28(sp)
+    lw s6,  24(sp)
+    lw s5,  20(sp)
+    lw s4,  16(sp)
+    lw s3,  12(sp)
+    lw s2,   8(sp)
+    lw s1,   4(sp)
+    lw s0,    (sp)
+    addi sp, sp, 52
+
+    // Return into the task.
+    ret

--- a/src/internal/task/task_stack_tinygoriscv.go
+++ b/src/internal/task/task_stack_tinygoriscv.go
@@ -1,4 +1,4 @@
-// +build scheduler.tasks,arm,!cortexm,!avr,!xtensa,!tinygo.riscv
+// +build scheduler.tasks,tinygo.riscv
 
 package task
 
@@ -7,17 +7,21 @@ import "unsafe"
 var systemStack uintptr
 
 // calleeSavedRegs is the list of registers that must be saved and restored when
-// switching between tasks. Also see task_stack_arm.S that relies on the exact
-// layout of this struct.
+// switching between tasks. Also see scheduler_riscv.S that relies on the
+// exact layout of this struct.
 type calleeSavedRegs struct {
-	r4  uintptr
-	r5  uintptr
-	r6  uintptr
-	r7  uintptr
-	r8  uintptr
-	r9  uintptr
-	r10 uintptr
-	r11 uintptr
+	s0  uintptr // x8 (fp)
+	s1  uintptr // x9
+	s2  uintptr // x18
+	s3  uintptr // x19
+	s4  uintptr // x20
+	s5  uintptr // x21
+	s6  uintptr // x22
+	s7  uintptr // x23
+	s8  uintptr // x24
+	s9  uintptr // x25
+	s10 uintptr // x26
+	s11 uintptr // x27
 
 	pc uintptr
 }
@@ -30,18 +34,19 @@ func (s *state) archInit(r *calleeSavedRegs, fn uintptr, args unsafe.Pointer) {
 	// Initialize the registers.
 	// These will be popped off of the stack on the first resume of the goroutine.
 
-	// Start the function at tinygo_startTask (defined in src/internal/task/task_stack_arm.S).
-	// This assembly code calls a function (passed in r4) with a single argument
-	// (passed in r5). After the function returns, it calls Pause().
+	// Start the function at tinygo_startTask (defined in src/internal/task/task_stack_riscv.S).
+	// This assembly code calls a function (passed in s0) with a single argument
+	// (passed in s1). After the function returns, it calls Pause().
 	r.pc = uintptr(unsafe.Pointer(&startTask))
 
-	// Pass the function to call in r4.
-	// This function is a compiler-generated wrapper which loads arguments out of a struct pointer.
-	// See createGoroutineStartWrapper (defined in compiler/goroutine.go) for more information.
-	r.r4 = fn
+	// Pass the function to call in s0.
+	// This function is a compiler-generated wrapper which loads arguments out
+	// of a struct pointer. See createGoroutineStartWrapper (defined in
+	// compiler/goroutine.go) for more information.
+	r.s0 = fn
 
-	// Pass the pointer to the arguments struct in r5.
-	r.r5 = uintptr(args)
+	// Pass the pointer to the arguments struct in s1.
+	r.s1 = uintptr(args)
 }
 
 func (s *state) resume() {

--- a/targets/hifive1-qemu.ld
+++ b/targets/hifive1-qemu.ld
@@ -1,11 +1,14 @@
 
 /* memory map:
  * https://github.com/sifive/freedom-e-sdk/blob/v201908-branch/bsp/sifive-hifive1/metal.default.lds
+ * With one change: this linkerscript uses 64K RAM instead of 16K as specified
+ * in metal.default.lds. Not sure why this works, but it works, and it avoids
+ * out-of-memory issues when running tests.
  */
 MEMORY
 {
     FLASH_TEXT (rw) : ORIGIN = 0x20400000, LENGTH = 0x1fc00000
-    RAM (xrw)       : ORIGIN = 0x80000000, LENGTH = 0x4000
+    RAM (xrw)       : ORIGIN = 0x80000000, LENGTH = 64K
 }
 
 _stack_size = 2K;

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -17,6 +17,7 @@
 	],
 	"extra-files": [
 		"src/device/riscv/start.S",
+		"src/internal/task/task_stack_tinygoriscv.S",
 		"src/runtime/gc_riscv.S",
 		"src/device/riscv/handleinterrupt.S"
 	],

--- a/targets/riscv.ld
+++ b/targets/riscv.ld
@@ -58,7 +58,7 @@ SECTIONS
 }
 
 /* For the memory allocator. */
-_heap_start = _ebss;
+_heap_start = ALIGN(_ebss, 16);
 _heap_end = ORIGIN(RAM) + LENGTH(RAM);
 _globals_start = _sdata;
 _globals_end = _ebss;

--- a/targets/riscv32.json
+++ b/targets/riscv32.json
@@ -2,6 +2,8 @@
 	"inherits": ["riscv"],
 	"llvm-target": "riscv32--none",
 	"build-tags": ["tinygo.riscv32"],
+	"scheduler": "tasks",
+	"default-stack-size": 2048,
 	"cflags": [
 		"--target=riscv32--none",
 		"-march=rv32imac",


### PR DESCRIPTION
This is now even more important to support the ESP32-C3.
This PR doesn't add support for the scheduler on the ESP32-C3, that will require some more work. But it is a prerequisite.

Also see #1220 and #963. This is a continuation of #963.