### PR TITLE
ESP32-C3: implement atomics

### DIFF
--- a/src/device/riscv/riscv.go
+++ b/src/device/riscv/riscv.go
@@ -25,13 +25,14 @@ func AsmFull(asm string, regs map[string]interface{}) uintptr
 func DisableInterrupts() uintptr {
 	// Note: this can be optimized with a CSRRW instruction, which atomically
 	// swaps the value and returns the old value.
-	mask := MIE.Get()
-	MIE.Set(0)
+	mask := MSTATUS.Get()
+	MSTATUS.ClearBits(1 << 3) // clear the MIE bit
 	return mask
 }
 
 // EnableInterrupts enables all interrupts again. The value passed in must be
 // the mask returned by DisableInterrupts.
 func EnableInterrupts(mask uintptr) {
-	MIE.Set(mask)
+	mask &= 1 << 3        // clear all bits except for the MIE bit
+	MSTATUS.SetBits(mask) // set the MIE bit, if it was previously cleared
 }

--- a/src/runtime/arch_tinygoriscv.go
+++ b/src/runtime/arch_tinygoriscv.go
@@ -18,6 +18,53 @@ func getCurrentStackPointer() uintptr {
 // supported RISC-V chips have a single hart, we can simply disable interrupts
 // to get the same behavior.
 
+//export __atomic_load_4
+func __atomic_load_4(ptr *uint32, ordering int32) uint32 {
+	mask := riscv.DisableInterrupts()
+	value := *ptr
+	riscv.EnableInterrupts(mask)
+	return value
+}
+
+//export __atomic_store_4
+func __atomic_store_4(ptr *uint32, value uint32, ordering int32) {
+	mask := riscv.DisableInterrupts()
+	*ptr = value
+	riscv.EnableInterrupts(mask)
+}
+
+//export __atomic_exchange_4
+func __atomic_exchange_4(ptr *uint32, value uint32, ordering int32) uint32 {
+	mask := riscv.DisableInterrupts()
+	oldValue := *ptr
+	*ptr = value
+	riscv.EnableInterrupts(mask)
+	return oldValue
+}
+
+//export __atomic_compare_exchange_4
+func __atomic_compare_exchange_4(ptr, expected *uint32, desired uint32, success_ordering, failure_ordering int32) bool {
+	mask := riscv.DisableInterrupts()
+	oldValue := *ptr
+	success := oldValue == *expected
+	if success {
+		*ptr = desired
+	} else {
+		*expected = oldValue
+	}
+	riscv.EnableInterrupts(mask)
+	return success
+}
+
+//export __atomic_fetch_add_4
+func __atomic_fetch_add_4(ptr *uint32, value uint32, ordering int32) uint32 {
+	mask := riscv.DisableInterrupts()
+	oldValue := *ptr
+	*ptr = oldValue + value
+	riscv.EnableInterrupts(mask)
+	return oldValue
+}
+
 //export __atomic_load_8
 func __atomic_load_8(ptr *uint64, ordering int32) uint64 {
 	mask := riscv.DisableInterrupts()


### PR DESCRIPTION
32-bit atomics need to be implemented for the ESP32-C3 because it lacks the A (atomic) extension. With this commit, flashing ./testdata/atomic.go to the ESP32-C3 works correctly and produces the expected output on the serial console.