### PR TITLE
targets/xtensa: revert target specification of esp32

### DIFF
--- a/targets/xtensa.json
+++ b/targets/xtensa.json
@@ -6,6 +6,7 @@
 	"gc": "conservative",
 	"scheduler": "none",
 	"cflags": [
+		"--target=xtensa",
 		"-Werror",
 		"-fshort-enums",
 		"-Wno-macro-redefined",


### PR DESCRIPTION
After the following commit, the build of esp32 fails.
In this PR, the build error will be fixed.

bf9dab36f757eafbf5858784d14e4c0e96fbca9d


before:

```
$ tinygo build -o /tmp/out.uf2 -target esp32-coreboard-v2 -size short examples/blinky1
C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:21:5: error: invalid instruction mnemonic 'rsr.ps'
    rsr.ps a2
    ^~~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:1C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S::3822: :5: error: error: expected comdat type such as 'discard' or 'largest' after protection bitsinvalid instruction mnemonic 'movi'

.section .text.tinygo_startTask,"ax",@progbits
    movi a3, ~(0x00040000)
           ^ ~ ~ ~ 
        C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S : 23 : 5 :       error:        unknown use of instruction mnemonic without a size suffix^

    and a2, a2, a3
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S : 3 : 7^: 
error: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:24expected absolute expression:
5: .type tinygo_startTask, %function
 error:      ^
invalid instruction mnemonic 'wsr.ps'
    wsr.ps a2
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:24: 5 :   ^~~~~~
error: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.Sinvalid instruction mnemonic 'mov.n'
:25    mov.n a6, a2:
5:     ^error: ~~invalid instruction mnemonic 'rsync'~
~
    rsync
 C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S : 25 :^5~~~: ~
error: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:28:5invalid instruction mnemonic 'callx4': 
    callx4 a3
error:     invalid instruction mnemonic 'rsr.windowbase'
^~~    rsr.windowbase a2~
~~
    ^~~~~~~~~C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S~:~28~:~5~: 
error: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:29:5: invalid instruction mnemonic 'call4'
    call4 tinygo_pause
error:     ^invalid instruction mnemonic 'ssl'~
~~~    ssl a2

  C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S : 30^:37~: ~
error: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:30:5: expected comdat type such as 'discard' or 'largest' after protection bits
.section .text.tinygo_swapTask,"ax",@progbitserror: 
 invalid instruction mnemonic 'movi' 
       movi a2, 1
                      ^ ~ ~ ~ 
        C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S^:
31:5: C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:32:error: 7: invalid instruction mnemonic 'sll'
error:     sll a2, a2
   expected absolute expression 
^~.type tinygo_swapTask, %function~

    C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S : 32^:
5: C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:40error: :5: invalid instruction mnemonic 'wsr.windowstart'
error:     wsr.windowstart a2
invalid instruction mnemonic 'entry' 
       entry sp, 32^
~~~ ~ ~ ~ ^~~~~~~~~~
~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:45:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:33:5: error: error: invalid instruction mnemonic 'rsil'
    rsil a4, 3
invalid instruction mnemonic 'rsync'
     rsync
    ^ ~ ~ ~^
~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:50:C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S5:: 36:5: error: error: unknown use of instruction mnemonic without a size suffix
invalid instruction mnemonic 'l32r'    and a12, a12, a12

    l32r sp, 1b
      ^ 
 ^~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:51:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:39:5: error: error: invalid instruction mnemonic 'rotw'
invalid instruction mnemonic 'rsr.ps'    rotw 3

    rsr.ps a2
      ^ ~ ~^~~
~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:52:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:40:5: error: unknown use of instruction mnemonic without a size suffixerror: 
    and a12, a12, a12invalid instruction mnemonic 'movi'

     movi a3, 0x00040000
   ^ 
  ^~~~C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S
:53:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:41:5: error: error: invalid instruction mnemonic 'rotw'
unknown use of instruction mnemonic without a size suffix
    rotw 3
    or a2, a2, a3
      ^ ~ ^~
~
C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:42:C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S5:: 54:5: error: error: invalid instruction mnemonic 'wsr.ps'
    wsr.ps a2
unknown use of instruction mnemonic without a size suffix
      and a12, a12, a12
 ^~~~ ~  ~ 
^
C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:43:5C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S: :55:5: error: error: invalid instruction mnemonic 'rsync'
    rsync
invalid instruction mnemonic 'rotw'
      rotw 3
  ^~ ~~ ~ 
 ^~~~
C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:46:5: C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:56:5: error: error: invalid instruction mnemonic 'movi'
    movi a2, 1unknown use of instruction mnemonic without a size suffix

     and a12, a12, a12
  ^~ ~ ~ 
 ^
C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:4757::55: : error: error: invalid instruction mnemonic 'wsr.cpenable'
invalid instruction mnemonic 'rotw'
    wsr.cpenable a2
    rotw 3
      ^ ~ ~^~~~~~~~
~~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:58:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:48:5: error: error: unknown use of instruction mnemonic without a size suffix
invalid instruction mnemonic 'rsync'    and a12, a12, a12

    rsync
      ^ 
 ^~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:59:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:51:5: error: error: invalid instruction mnemonic 'rotw'
    rotw 4
invalid instruction mnemonic 'call4'
       call4 main
^~~~
    ^~~C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S~:~62
:5: C:\\tinygo\\tinygo\\src\\device\\esp\\esp32.S:57error: :5: invalid instruction mnemonic 'wsr.ps'
error:     wsr.ps a4
 ambiguous instructions require an explicit suffix (could be 'jb', or 'jl') 
      j tinygo_scanstack^
~~~ ~ ~ 
 ^
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:64:5: error: invalid instruction mnemonic 's32i.n'
failed to run tool: clang
    s32i.n a0, sp, 0
    ^~~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:67:5: error: invalid instruction mnemonic 's32i.n'
    s32i.n sp, a3, 0
    ^~~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:70:5: error: invalid instruction mnemonic 'mov.n'
    mov.n sp, a2
    ^~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:75:5: error: invalid instruction mnemonic 'l32i.n'
    l32i.n a0, sp, 0
    ^~~~~~
C:\\tinygo\\tinygo\\src\\internal\\task\\task_stack_esp32.S:79:5: error: invalid instruction mnemonic 'retw.n'
    retw.n
    ^~~~~~
failed to run tool: clang
error: failed to build C:\tinygo\tinygo\src\device\esp\esp32.S: exit status 1

```


after:
```
$ tinygo build -o /tmp/out.uf2 -target esp32-coreboard-v2 -size short examples/blinky1
   code    data     bss |   flash     ram
   2861       0    4136 |    2861    4136
error: ROM segments are non-contiguous: C:\Users\sago3\AppData\Local\Temp\tinygo865807863\main

```