### PR TITLE
board: add M5Stack Core2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,8 @@ ifneq ($(XTENSA), 0)
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=nodemcu             examples/blinky1
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target m5stack-core2       examples/serial
+	@$(MD5SUM) test.bin
 endif
 	$(TINYGO) build -size short -o test.bin -target=esp32c3           	examples/serial
 	@$(MD5SUM) test.bin

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 70 microcontroller boards are currently supported:
+The following 71 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -84,6 +84,7 @@ The following 70 microcontroller boards are currently supported:
 * [ESP32](https://www.espressif.com/en/products/socs/esp32)
 * [ESP8266](https://www.espressif.com/en/products/socs/esp8266)
 * [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
+* [M5Stack Core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit)
 * [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
 * [Makerdiary nRF52840-MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)
 * [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/productdetails/atsame54-xpro)

--- a/src/machine/board_m5stack_core2.go
+++ b/src/machine/board_m5stack_core2.go
@@ -1,0 +1,115 @@
+// +build m5stack_core2
+
+package machine
+
+const (
+	//     GND      | ADC       G35
+	//     GND      | ADC       G36
+	//     GND      | RST       EN
+	// G23 MOSI     | DAC       G25
+	// G38 MISO     | DAC       G26
+	// G18 SCK      | 3.3V
+	// G3  RXD0     | TXD0      G1
+	// G13 RXD2     | TXD2      G14
+	// G21 intSDA   | intSC     G22
+	// G32 PA_SDA   | PA_SCL     G33
+	// G27 GPIO     | GPIO      G19
+	// G2  I2S_DOUT | I2S_LRCKC G0
+	//     N/C      | PDM_DAT   G34
+	//     N/C      | 5V
+	//     N/C      | BAT
+
+	IO0  Pin = 0
+	IO1  Pin = 1 // U0TXD
+	IO2  Pin = 2
+	IO3  Pin = 3 // U0RXD
+	IO4  Pin = 4
+	IO5  Pin = 5
+	IO6  Pin = 6  // SD_CLK
+	IO7  Pin = 7  // SD_DATA0
+	IO8  Pin = 8  // SD_DATA1
+	IO9  Pin = 9  // SD_DATA2
+	IO10 Pin = 10 // SD_DATA3
+	IO11 Pin = 11 // SD_CMD
+	IO12 Pin = 12
+	IO13 Pin = 13 // U0RXD
+	IO14 Pin = 14 // U1TXD
+	IO15 Pin = 15
+	IO16 Pin = 16
+	IO17 Pin = 17
+	IO18 Pin = 18 // SPI0_SCK
+	IO19 Pin = 19
+	IO21 Pin = 21 // SDA0
+	IO22 Pin = 22 // SCL0
+	IO23 Pin = 23 // SPI0_SDO
+	IO25 Pin = 25
+	IO26 Pin = 26
+	IO27 Pin = 27
+	IO32 Pin = 32 // SDA1
+	IO33 Pin = 33 // SCL1
+	IO34 Pin = 34
+	IO35 Pin = 35 // ADC1
+	IO36 Pin = 36 // ADC2
+	IO38 Pin = 38 // SPI0_SDI
+	IO39 Pin = 39
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = IO18
+	SPI0_SDO_PIN = IO23
+	SPI0_SDI_PIN = IO38
+	SPI0_CS0_PIN = IO5
+
+	// LCD (ILI9342C)
+	LCD_SCK_PIN = SPI0_SCK_PIN
+	LCD_SDO_PIN = SPI0_SDO_PIN
+	LCD_SDI_PIN = SPI0_SDI_PIN
+	LCD_SS_PIN  = SPI0_CS0_PIN
+	LCD_DC_PIN  = IO15
+
+	// SD CARD
+	SDCARD_SCK_PIN = SPI0_SCK_PIN
+	SDCARD_SDO_PIN = SPI0_SDO_PIN
+	SDCARD_SDI_PIN = SPI0_SDI_PIN
+	SDCARD_SS_PIN  = IO4
+)
+
+// I2C pins
+const (
+	// Internal I2C (AXP192 / FT6336U / BM8563 / MPU6886)
+	SDA0_PIN = IO21
+	SCL0_PIN = IO22
+
+	// External I2C (PORT A)
+	SDA1_PIN = IO32
+	SCL1_PIN = IO33
+
+	SDA_PIN = SDA1_PIN
+	SCL_PIN = SCL1_PIN
+)
+
+// ADC pins
+const (
+	ADC1 Pin = IO35
+	ADC2 Pin = IO36
+)
+
+// DAC pins
+const (
+	DAC1 Pin = IO25
+	DAC2 Pin = IO26
+)
+
+// UART pins
+const (
+	// UART0 (CP2104)
+	UART0_TX_PIN = IO1
+	UART0_RX_PIN = IO3
+
+	UART1_TX_PIN = IO14
+	UART1_RX_PIN = IO13
+
+	UART_TX_PIN = UART0_TX_PIN
+	UART_RX_PIN = UART0_RX_PIN
+)

--- a/targets/m5stack-core2.json
+++ b/targets/m5stack-core2.json
@@ -1,0 +1,5 @@
+{
+	"inherits": ["esp32"],
+	"build-tags": ["m5stack_core2"],
+	"serial-port": ["acm:10c4:ea60"]
+}


### PR DESCRIPTION
This PR adds M5Stack Core2 support.

The LEDs are on-board, but can be controlled by operating the AXP192 through an I2C connection.
For this reason, smoketest uses examples/serial instead of examples/blinky1.
The LCD also requires AXP192 to operate, so some PR must be added to display the screen.
In my environment, I am able to display the LCD, so I will create the PRs little by little.

* Board
    * Name
        * M5Stack Core2
    * Board developer / designer / manufacturer
        * M5Stack
    * schematic
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/CORE2_V1.0_SCH.pdf
    * pinout and stuff
        * https://docs.m5stack.com/en/core/core2
    * URL
        * https://docs.m5stack.com/en/core/core2
        * https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit
        * https://github.com/m5stack/M5Core2
    * User manual for the board (if it exists)
        * (none)
* Chip
    * chip name
        * ESP32 D0WDQ6-V3 (dual core Xtensa 32-bit)
    * Clock / ROM / RAM size
        * 240Mhz / 16MB / 8MB
    * datasheet URL of the chip
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/esp32_datasheet_en.pdf
* URL of the source, such as arduino (if it exists)
    * https://github.com/espressif/arduino-esp32/blob/master/variants/m5stack_core2/pins_arduino.h