### PR TITLE
Fix export math functions issue

### DIFF
--- a/compiler/alias.go
+++ b/compiler/alias.go
@@ -75,6 +75,9 @@ var stdlibAliases = map[string]string{
 // createAlias implements the function (in the builder) as a call to the alias
 // function.
 func (b *builder) createAlias(alias llvm.Value) {
+	b.llvmFn.SetVisibility(llvm.HiddenVisibility)
+	b.llvmFn.SetUnnamedAddr(true)
+
 	if b.Debug {
 		if b.fn.Syntax() != nil {
 			// Create debug info file if present.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 19 // last change: fix channel ops with zero values
+const Version = 20 // last change: fix export math functions issue
 
 func init() {
 	llvm.InitializeAllTargets()


### PR DESCRIPTION
This pull request fixes the issue of export math functions.

Issue description:

For a very simple code:

```go
package main
func main() {
	
}
```

Compiling it
```bash
tinygo build -target wasi -gc=leaking -scheduler=none -opt z -o main.wasm main.go
```

Translate wasm to wast with wasm2wat tool in [wabt](https://github.com/WebAssembly/wabt)

```bash
wasm2wat main.wasm
```

You will see the following output:

```
(export "math.Acosh" (func $math.Acosh))
  (export "math.Log" (func $math.Log))
  (export "math.Sqrt" (func $math.Sqrt))
  (export "math.Log1p" (func $math.Log1p))
  (export "math.Frexp" (func $math.Frexp))
  (export "math.Asin" (func $math.Asin))
  (export "math.Acos" (func $math.Acos))
  (export "math.Asinh" (func $math.Asinh))
  (export "math.Atan" (func $math.Atan))
  (export "math.Atan2" (func $math.Atan2))
  (export "math.Atanh" (func $math.Atanh))
  (export "math.Cbrt" (func $math.Cbrt))
  (export "math.Max" (func $math.Max))
  (export "math.Min" (func $math.Min))
  (export "math.Erf" (func $math.Erf))
  (export "math.Exp" (func $math.Exp))
  (export "math.Ldexp" (func $math.Ldexp))
  (export "math.Erfc" (func $math.Erfc))
  (export "math.Exp2" (func $math.Exp2))
  (export "math.Expm1" (func $math.Expm1))
  (export "math.Floor" (func $math.Floor))
  (export "math.Modf" (func $math.Modf))
  (export "math.Ceil" (func $math.Ceil))
  (export "math.Trunc" (func $math.Trunc))
  (export "math.Pow" (func $math.Pow))
  (export "math.Sin" (func $math.Sin))
  (export "math.Hypot" (func $math.Hypot))
  (export "math.Cos" (func $math.Cos))
  (export "math.Mod" (func $math.Mod))
  (export "math.Log10" (func $math.Log10))
  (export "math.Log2" (func $math.Log2))
  (export "math.Remainder" (func $math.Remainder))
  (export "math.Sinh" (func $math.Sinh))
  (export "math.Cosh" (func $math.Cosh))
  (export "math.Tan" (func $math.Tan))
  (export "math.Tanh" (func $math.Tanh))
```

These exported math functions are useless and increase the wasm size.

