### PR TITLE
compiler: add nounwind attribute

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 20 // last change: fix export math functions issue
+const Version = 21 // last change: add nounwind attribute
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -814,6 +814,7 @@ func (b *builder) createFunction() {
 		b.addError(b.fn.Pos(), errValue)
 		return
 	}
+	b.addStandardAttributes(b.llvmFn)
 	if !b.info.exported {
 		b.llvmFn.SetVisibility(llvm.HiddenVisibility)
 		b.llvmFn.SetUnnamedAddr(true)

--- a/compiler/goroutine.go
+++ b/compiler/goroutine.go
@@ -176,6 +176,7 @@ func (c *compilerContext) createGoroutineStartWrapper(fn llvm.Value, prefix stri
 		// Create the wrapper.
 		wrapperType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{c.i8ptrType}, false)
 		wrapper = llvm.AddFunction(c.mod, name+"$gowrapper", wrapperType)
+		c.addStandardAttributes(wrapper)
 		wrapper.SetLinkage(llvm.LinkOnceODRLinkage)
 		wrapper.SetUnnamedAddr(true)
 		wrapper.AddAttributeAtIndex(-1, c.ctx.CreateStringAttribute("tinygo-gowrapper", name))
@@ -240,6 +241,7 @@ func (c *compilerContext) createGoroutineStartWrapper(fn llvm.Value, prefix stri
 		// Create the wrapper.
 		wrapperType := llvm.FunctionType(c.ctx.VoidType(), []llvm.Type{c.i8ptrType}, false)
 		wrapper = llvm.AddFunction(c.mod, prefix+".gowrapper", wrapperType)
+		c.addStandardAttributes(wrapper)
 		wrapper.SetLinkage(llvm.LinkOnceODRLinkage)
 		wrapper.SetUnnamedAddr(true)
 		wrapper.AddAttributeAtIndex(-1, c.ctx.CreateStringAttribute("tinygo-gowrapper", ""))

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -489,6 +489,7 @@ func (c *compilerContext) getInterfaceInvokeWrapper(fn *ssa.Function, llvmFn llv
 	paramTypes := append([]llvm.Type{c.i8ptrType}, fnType.ParamTypes()[len(expandedReceiverType):]...)
 	wrapFnType := llvm.FunctionType(fnType.ReturnType(), paramTypes, false)
 	wrapper = llvm.AddFunction(c.mod, wrapperName, wrapFnType)
+	c.addStandardAttributes(wrapper)
 	wrapper.LastParam().SetName("parentHandle")
 
 	wrapper.SetLinkage(llvm.LinkOnceODRLinkage)

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -8,70 +8,82 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden i32 @main.addInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.addInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = add i32 %x, %y
   ret i32 %0
 }
 
-define hidden i1 @main.equalInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.equalInt(i32 %x, i32 %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp eq i32 %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatEQ(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatEQ(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp oeq float %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatNE(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatNE(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp une float %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatLower(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatLower(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp olt float %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatLowerEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatLowerEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp ole float %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatGreater(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatGreater(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp ogt float %x, %y
   ret i1 %0
 }
 
-define hidden i1 @main.floatGreaterEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.floatGreaterEqual(float %x, float %y, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fcmp oge float %x, %y
   ret i1 %0
 }
 
-define hidden float @main.complexReal(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden float @main.complexReal(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret float %x.r
 }
 
-define hidden float @main.complexImag(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden float @main.complexImag(float %x.r, float %x.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret float %x.i
 }
 
-define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fadd float %x.r, %y.r
   %1 = fadd float %x.i, %y.i
@@ -80,7 +92,8 @@ entry:
   ret { float, float } %3
 }
 
-define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fsub float %x.r, %y.r
   %1 = fsub float %x.i, %y.i
@@ -89,7 +102,8 @@ entry:
   ret { float, float } %3
 }
 
-define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = fmul float %x.r, %y.r
   %1 = fmul float %x.i, %y.i
@@ -102,13 +116,17 @@ entry:
   ret { float, float } %7
 }
 
-define hidden void @main.foo(%main.kv* dereferenceable_or_null(4) %a, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.foo(%main.kv* dereferenceable_or_null(4) %a, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   call void @"main.foo$1"(%main.kv.0* null, i8* undef, i8* undef)
   ret void
 }
 
-define hidden void @"main.foo$1"(%main.kv.0* dereferenceable_or_null(1) %b, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @"main.foo$1"(%main.kv.0* dereferenceable_or_null(1) %b, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -11,12 +11,14 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.chanIntSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.chanIntSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
@@ -25,21 +27,22 @@ entry:
   store i32 3, i32* %chan.value, align 4
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  call void @runtime.chanSend(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null)
+  call void @runtime.chanSend(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null) #0
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   ret void
 }
 
 ; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #0
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
 declare void @runtime.chanSend(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*, i8*)
 
 ; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #0
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
 
-define hidden void @main.chanIntRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.chanIntRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
@@ -47,7 +50,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null)
+  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null) #0
   call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
@@ -55,27 +58,30 @@ entry:
 
 declare i1 @runtime.chanRecv(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*, i8*)
 
-define hidden void @main.chanZeroSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.chanZeroSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  call void @runtime.chanSend(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null)
+  call void @runtime.chanSend(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null) #0
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
 }
 
-define hidden void @main.chanZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.chanZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null)
+  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef, i8* null) #0
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
 }
 
-define hidden void @main.selectZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch1, %runtime.channel* dereferenceable_or_null(32) %ch2, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.selectZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch1, %runtime.channel* dereferenceable_or_null(32) %ch2, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
   %select.send.value = alloca i32, align 4
@@ -92,7 +98,7 @@ entry:
   %.repack4 = getelementptr inbounds [2 x %runtime.chanSelectState], [2 x %runtime.chanSelectState]* %select.states.alloca, i32 0, i32 1, i32 1
   store i8* null, i8** %.repack4, align 4
   %select.states = getelementptr inbounds [2 x %runtime.chanSelectState], [2 x %runtime.chanSelectState]* %select.states.alloca, i32 0, i32 0
-  %select.result = call { i32, i1 } @runtime.tryChanSelect(i8* undef, %runtime.chanSelectState* nonnull %select.states, i32 2, i32 2, i8* undef, i8* null)
+  %select.result = call { i32, i1 } @runtime.tryChanSelect(i8* undef, %runtime.chanSelectState* nonnull %select.states, i32 2, i32 2, i8* undef, i8* null) #0
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %select.states.alloca.bitcast)
   %1 = extractvalue { i32, i1 } %select.result, 0
   %2 = icmp eq i32 %1, 0
@@ -111,4 +117,5 @@ select.body:                                      ; preds = %select.next
 
 declare { i32, i1 } @runtime.tryChanSelect(i8*, %runtime.chanSelectState*, i32, i32, i8*, i8*)
 
-attributes #0 = { argmemonly nounwind willreturn }
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind willreturn }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -5,12 +5,14 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden i32 @main.f32tou32(float %v, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.f32tou32(float %v, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -21,22 +23,26 @@ entry:
   ret i32 %0
 }
 
-define hidden float @main.maxu32f(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden float @main.maxu32f(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret float 0x41F0000000000000
 }
 
-define hidden i32 @main.maxu32tof32(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.maxu32tof32(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret i32 -1
 }
 
-define hidden { i32, i32, i32, i32 } @main.inftoi32(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32, i32, i32, i32 } @main.inftoi32(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret { i32, i32, i32, i32 } { i32 -1, i32 0, i32 2147483647, i32 -2147483648 }
 }
 
-define hidden i32 @main.u32tof32tou32(i32 %v, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.u32tof32tou32(i32 %v, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = uitofp i32 %v to float
   %withinmax = fcmp ole float %0, 0x41EFFFFFC0000000
@@ -45,7 +51,8 @@ entry:
   ret i32 %1
 }
 
-define hidden float @main.f32tou32tof32(float %v, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden float @main.f32tou32tof32(float %v, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -57,7 +64,8 @@ entry:
   ret float %1
 }
 
-define hidden i8 @main.f32tou8(float %v, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8 @main.f32tou8(float %v, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 2.550000e+02
@@ -68,7 +76,8 @@ entry:
   ret i8 %0
 }
 
-define hidden i8 @main.f32toi8(float %v, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8 @main.f32toi8(float %v, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %abovemin = fcmp oge float %v, -1.280000e+02
   %belowmax = fcmp ole float %v, 1.270000e+02
@@ -80,3 +89,5 @@ entry:
   %0 = select i1 %inbounds, i8 %normal, i8 %remapped
   ret i8 %0
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -10,24 +10,26 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.foo(i8* %callback.context, i32 %callback.funcptr, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.foo(i8* %callback.context, i32 %callback.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i32 @runtime.getFuncPtr(i8* %callback.context, i32 %callback.funcptr, i8* nonnull @"reflect/types.funcid:func:{basic:int}{}", i8* undef, i8* null)
+  %0 = call i32 @runtime.getFuncPtr(i8* %callback.context, i32 %callback.funcptr, i8* nonnull @"reflect/types.funcid:func:{basic:int}{}", i8* undef, i8* null) #0
   %1 = icmp eq i32 %0, 0
   br i1 %1, label %fpcall.throw, label %fpcall.next
 
 fpcall.throw:                                     ; preds = %entry
-  call void @runtime.nilPanic(i8* undef, i8* null)
+  call void @runtime.nilPanic(i8* undef, i8* null) #0
   unreachable
 
 fpcall.next:                                      ; preds = %entry
   %2 = inttoptr i32 %0 to void (i32, i8*, i8*)*
-  call void %2(i32 3, i8* %callback.context, i8* undef)
+  call void %2(i32 3, i8* %callback.context, i8* undef) #0
   ret void
 }
 
@@ -35,13 +37,17 @@ declare i32 @runtime.getFuncPtr(i8*, i32, i8* dereferenceable_or_null(1), i8*, i
 
 declare void @runtime.nilPanic(i8*, i8*)
 
-define hidden void @main.bar(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.bar(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   call void @main.foo(i8* undef, i32 ptrtoint (%runtime.funcValueWithSignature* @"main.someFunc$withSignature" to i32), i8* undef, i8* undef)
   ret void
 }
 
-define hidden void @main.someFunc(i32 %arg0, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.someFunc(i32 %arg0, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -5,31 +5,35 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden i8* @main.Add32(i8* %p, i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.Add32(i8* %p, i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = getelementptr i8, i8* %p, i32 %len
   ret i8* %0
 }
 
-define hidden i8* @main.Add64(i8* %p, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.Add64(i8* %p, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = trunc i64 %len to i32
   %1 = getelementptr i8, i8* %p, i32 %0
   ret i8* %1
 }
 
-define hidden [4 x i32]* @main.SliceToArray(i32* %s.data, i32 %s.len, i32 %s.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden [4 x i32]* @main.SliceToArray(i32* %s.data, i32 %s.len, i32 %s.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp ult i32 %s.len, 4
   br i1 %0, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.throw:                               ; preds = %entry
-  call void @runtime.sliceToArrayPointerPanic(i8* undef, i8* null)
+  call void @runtime.sliceToArrayPointerPanic(i8* undef, i8* null) #0
   unreachable
 
 slicetoarray.next:                                ; preds = %entry
@@ -39,9 +43,10 @@ slicetoarray.next:                                ; preds = %entry
 
 declare void @runtime.sliceToArrayPointerPanic(i8*, i8*)
 
-define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %makeslice = call i8* @runtime.alloc(i32 24, i8* undef, i8* null)
+  %makeslice = call i8* @runtime.alloc(i32 24, i8* undef, i8* null) #0
   br i1 false, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.throw:                               ; preds = %entry
@@ -52,7 +57,8 @@ slicetoarray.next:                                ; preds = %entry
   ret [4 x i32]* %0
 }
 
-define hidden { i32*, i32, i32 } @main.SliceInt(i32* dereferenceable_or_null(4) %ptr, i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.SliceInt(i32* dereferenceable_or_null(4) %ptr, i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp ugt i32 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -62,7 +68,7 @@ entry:
   br i1 %4, label %unsafe.Slice.throw, label %unsafe.Slice.next
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef, i8* null)
+  call void @runtime.unsafeSlicePanic(i8* undef, i8* null) #0
   unreachable
 
 unsafe.Slice.next:                                ; preds = %entry
@@ -74,7 +80,8 @@ unsafe.Slice.next:                                ; preds = %entry
 
 declare void @runtime.unsafeSlicePanic(i8*, i8*)
 
-define hidden { i8*, i32, i32 } @main.SliceUint16(i8* dereferenceable_or_null(1) %ptr, i16 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i8*, i32, i32 } @main.SliceUint16(i8* dereferenceable_or_null(1) %ptr, i16 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp eq i8* %ptr, null
   %1 = icmp ne i16 %len, 0
@@ -82,7 +89,7 @@ entry:
   br i1 %2, label %unsafe.Slice.throw, label %unsafe.Slice.next
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef, i8* null)
+  call void @runtime.unsafeSlicePanic(i8* undef, i8* null) #0
   unreachable
 
 unsafe.Slice.next:                                ; preds = %entry
@@ -93,7 +100,8 @@ unsafe.Slice.next:                                ; preds = %entry
   ret { i8*, i32, i32 } %6
 }
 
-define hidden { i32*, i32, i32 } @main.SliceUint64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.SliceUint64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp ugt i64 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -103,7 +111,7 @@ entry:
   br i1 %4, label %unsafe.Slice.throw, label %unsafe.Slice.next
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef, i8* null)
+  call void @runtime.unsafeSlicePanic(i8* undef, i8* null) #0
   unreachable
 
 unsafe.Slice.next:                                ; preds = %entry
@@ -114,7 +122,8 @@ unsafe.Slice.next:                                ; preds = %entry
   ret { i32*, i32, i32 } %8
 }
 
-define hidden { i32*, i32, i32 } @main.SliceInt64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.SliceInt64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = icmp ugt i64 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -124,7 +133,7 @@ entry:
   br i1 %4, label %unsafe.Slice.throw, label %unsafe.Slice.next
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef, i8* null)
+  call void @runtime.unsafeSlicePanic(i8* undef, i8* null) #0
   unreachable
 
 unsafe.Slice.next:                                ; preds = %entry
@@ -134,3 +143,5 @@ unsafe.Slice.next:                                ; preds = %entry
   %8 = insertvalue { i32*, i32, i32 } %7, i32 %5, 2
   ret { i32*, i32, i32 } %8
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -11,24 +11,27 @@ target triple = "armv7m-unknown-unknown-eabi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.regularFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.regularFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* undef, i8* undef)
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 %stacksize, i8* undef, i8* null)
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* undef, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 %stacksize, i8* undef, i8* null) #0
   ret void
 }
 
 declare void @main.regularFunction(i32, i8*, i8*)
 
-define linkonce_odr void @"main.regularFunction$gowrapper"(i8* %0) unnamed_addr #0 {
+; Function Attrs: nounwind
+define linkonce_odr void @"main.regularFunction$gowrapper"(i8* %0) unnamed_addr #1 {
 entry:
   %unpack.int = ptrtoint i8* %0 to i32
-  call void @main.regularFunction(i32 %unpack.int, i8* undef, i8* undef)
+  call void @main.regularFunction(i32 %unpack.int, i8* undef, i8* undef) #0
   ret void
 }
 
@@ -36,51 +39,57 @@ declare i32 @"internal/task.getGoroutineStackSize"(i32, i8*, i8*)
 
 declare void @"internal/task.start"(i32, i8*, i32, i8*, i8*)
 
-define hidden void @main.inlineFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.inlineFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* undef, i8* undef)
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 %stacksize, i8* undef, i8* null)
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* undef, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 %stacksize, i8* undef, i8* null) #0
   ret void
 }
 
-define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #1 {
+; Function Attrs: nounwind
+define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #2 {
 entry:
   %unpack.int = ptrtoint i8* %0 to i32
   call void @"main.inlineFunctionGoroutine$1"(i32 %unpack.int, i8* undef, i8* undef)
   ret void
 }
 
-define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null)
+  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null)
+  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
   %4 = bitcast i8* %3 to i8**
   store i8* %n, i8** %4, align 4
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* undef, i8* undef)
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* nonnull %1, i32 %stacksize, i8* undef, i8* null)
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* undef, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* nonnull %1, i32 %stacksize, i8* undef, i8* null) #0
   %5 = load i32, i32* %0, align 4
-  call void @runtime.printint32(i32 %5, i8* undef, i8* null)
+  call void @runtime.printint32(i32 %5, i8* undef, i8* null) #0
   ret void
 }
 
-define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %unpack.ptr = bitcast i8* %context to i32*
   store i32 7, i32* %unpack.ptr, align 4
   ret void
 }
 
-define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #2 {
+; Function Attrs: nounwind
+define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #3 {
 entry:
   %1 = bitcast i8* %0 to i32*
   %2 = load i32, i32* %1, align 4
@@ -93,9 +102,10 @@ entry:
 
 declare void @runtime.printint32(i32, i8*, i8*)
 
-define hidden void @main.funcGoroutine(i8* %fn.context, void (i32, i8*, i8*)* %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.funcGoroutine(i8* %fn.context, void (i32, i8*, i8*)* %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 12, i8* undef, i8* null)
+  %0 = call i8* @runtime.alloc(i32 12, i8* undef, i8* null) #0
   %1 = bitcast i8* %0 to i32*
   store i32 5, i32* %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4
@@ -104,12 +114,13 @@ entry:
   %4 = getelementptr inbounds i8, i8* %0, i32 8
   %5 = bitcast i8* %4 to void (i32, i8*, i8*)**
   store void (i32, i8*, i8*)* %fn.funcptr, void (i32, i8*, i8*)** %5, align 4
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* undef, i8* undef)
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* nonnull %0, i32 %stacksize, i8* undef, i8* null)
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* undef, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* nonnull %0, i32 %stacksize, i8* undef, i8* null) #0
   ret void
 }
 
-define linkonce_odr void @main.funcGoroutine.gowrapper(i8* %0) unnamed_addr #3 {
+; Function Attrs: nounwind
+define linkonce_odr void @main.funcGoroutine.gowrapper(i8* %0) unnamed_addr #4 {
 entry:
   %1 = bitcast i8* %0 to i32*
   %2 = load i32, i32* %1, align 4
@@ -119,32 +130,36 @@ entry:
   %6 = getelementptr inbounds i8, i8* %0, i32 8
   %7 = bitcast i8* %6 to void (i32, i8*, i8*)**
   %8 = load void (i32, i8*, i8*)*, void (i32, i8*, i8*)** %7, align 4
-  call void %8(i32 %2, i8* %5, i8* undef)
+  call void %8(i32 %2, i8* %5, i8* undef) #0
   ret void
 }
 
-define hidden void @main.recoverBuiltinGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.recoverBuiltinGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef, i8* null)
+  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef, i8* null) #0
   ret void
 }
 
 declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*, i8*)
 
-define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef, i8* null)
+  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef, i8* null) #0
   ret void
 }
 
 declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*, i8*)
 
-attributes #0 = { "tinygo-gowrapper"="main.regularFunction" }
-attributes #1 = { "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
-attributes #2 = { "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
-attributes #3 = { "tinygo-gowrapper" }
+attributes #0 = { nounwind }
+attributes #1 = { nounwind "tinygo-gowrapper"="main.regularFunction" }
+attributes #2 = { nounwind "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
+attributes #3 = { nounwind "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
+attributes #4 = { nounwind "tinygo-gowrapper" }

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -17,14 +17,16 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.regularFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.regularFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @main.regularFunction to i32), i8* bitcast ({ i32, i8* }* @"main.regularFunctionGoroutine$pack" to i8*), i32 undef, i8* undef, i8* null)
+  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @main.regularFunction to i32), i8* bitcast ({ i32, i8* }* @"main.regularFunctionGoroutine$pack" to i8*), i32 undef, i8* undef, i8* null) #0
   ret void
 }
 
@@ -32,35 +34,39 @@ declare void @main.regularFunction(i32, i8*, i8*)
 
 declare void @"internal/task.start"(i32, i8*, i32, i8*, i8*)
 
-define hidden void @main.inlineFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.inlineFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @"main.inlineFunctionGoroutine$1" to i32), i8* bitcast ({ i32, i8* }* @"main.inlineFunctionGoroutine$pack" to i8*), i32 undef, i8* undef, i8* null)
+  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @"main.inlineFunctionGoroutine$1" to i32), i8* bitcast ({ i32, i8* }* @"main.inlineFunctionGoroutine$pack" to i8*), i32 undef, i8* undef, i8* null) #0
   ret void
 }
 
-define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.closureFunctionGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null)
+  %n = call i8* @runtime.alloc(i32 4, i8* undef, i8* null) #0
   %0 = bitcast i8* %n to i32*
   store i32 3, i32* %0, align 4
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null)
+  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
   %4 = bitcast i8* %3 to i8**
   store i8* %n, i8** %4, align 4
-  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @"main.closureFunctionGoroutine$1" to i32), i8* nonnull %1, i32 undef, i8* undef, i8* null)
+  call void @"internal/task.start"(i32 ptrtoint (void (i32, i8*, i8*)* @"main.closureFunctionGoroutine$1" to i32), i8* nonnull %1, i32 undef, i8* undef, i8* null) #0
   %5 = load i32, i32* %0, align 4
-  call void @runtime.printint32(i32 %5, i8* undef, i8* null)
+  call void @runtime.printint32(i32 %5, i8* undef, i8* null) #0
   ret void
 }
 
-define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %unpack.ptr = bitcast i8* %context to i32*
   store i32 7, i32* %unpack.ptr, align 4
@@ -69,38 +75,44 @@ entry:
 
 declare void @runtime.printint32(i32, i8*, i8*)
 
-define hidden void @main.funcGoroutine(i8* %fn.context, i32 %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.funcGoroutine(i8* %fn.context, i32 %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i32 @runtime.getFuncPtr(i8* %fn.context, i32 %fn.funcptr, i8* nonnull @"reflect/types.funcid:func:{basic:int}{}", i8* undef, i8* null)
-  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null)
+  %0 = call i32 @runtime.getFuncPtr(i8* %fn.context, i32 %fn.funcptr, i8* nonnull @"reflect/types.funcid:func:{basic:int}{}", i8* undef, i8* null) #0
+  %1 = call i8* @runtime.alloc(i32 8, i8* undef, i8* null) #0
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
   %4 = bitcast i8* %3 to i8**
   store i8* %fn.context, i8** %4, align 4
-  call void @"internal/task.start"(i32 %0, i8* nonnull %1, i32 undef, i8* undef, i8* null)
+  call void @"internal/task.start"(i32 %0, i8* nonnull %1, i32 undef, i8* undef, i8* null) #0
   ret void
 }
 
 declare i32 @runtime.getFuncPtr(i8*, i32, i8* dereferenceable_or_null(1), i8*, i8*)
 
-define hidden void @main.recoverBuiltinGoroutine(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.recoverBuiltinGoroutine(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef, i8* null)
+  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef, i8* null) #0
   ret void
 }
 
 declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*, i8*)
 
-define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef, i8* null)
+  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef, i8* null) #0
   ret void
 }
 
 declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*, i8*)
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -25,34 +25,40 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden %runtime._interface @main.simpleType(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._interface @main.simpleType(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:int" to i32), i8* null }
 }
 
-define hidden %runtime._interface @main.pointerType(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._interface @main.pointerType(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:basic:int" to i32), i8* null }
 }
 
-define hidden %runtime._interface @main.interfaceType(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._interface @main.interfaceType(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:named:error" to i32), i8* null }
 }
 
-define hidden %runtime._interface @main.anonymousInterfaceType(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._interface @main.anonymousInterfaceType(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" to i32), i8* null }
 }
 
-define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.typeid:basic:int", i8* undef, i8* null)
+  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.typeid:basic:int", i8* undef, i8* null) #0
   br i1 %typecode, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry
@@ -64,9 +70,10 @@ typeassert.next:                                  ; preds = %typeassert.ok, %ent
 
 declare i1 @runtime.typeAssert(i32, i8* dereferenceable_or_null(1), i8*, i8*)
 
-define hidden i1 @main.isError(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.isError(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* undef, i8* null)
+  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* undef, i8* null) #0
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry
@@ -78,9 +85,10 @@ typeassert.next:                                  ; preds = %typeassert.ok, %ent
 
 declare i1 @runtime.interfaceImplements(i32, i8** dereferenceable_or_null(4), i8*, i8*)
 
-define hidden i1 @main.isStringer(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.isStringer(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"reflect/types.interface:interface{String() string}$interface", i32 0, i32 0), i8* undef, i8* null)
+  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"reflect/types.interface:interface{String() string}$interface", i32 0, i32 0), i8* undef, i8* null) #0
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry
@@ -90,12 +98,15 @@ typeassert.next:                                  ; preds = %typeassert.ok, %ent
   ret i1 %0
 }
 
-define hidden %runtime._string @main.callErrorMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._string @main.callErrorMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %invoke.func = call i32 @runtime.interfaceMethod(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Error() string", i8* undef, i8* null)
+  %invoke.func = call i32 @runtime.interfaceMethod(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Error() string", i8* undef, i8* null) #0
   %invoke.func.cast = inttoptr i32 %invoke.func to %runtime._string (i8*, i8*, i8*)*
-  %0 = call %runtime._string %invoke.func.cast(i8* %itf.value, i8* undef, i8* undef)
+  %0 = call %runtime._string %invoke.func.cast(i8* %itf.value, i8* undef, i8* undef) #0
   ret %runtime._string %0
 }
 
 declare i32 @runtime.interfaceMethod(i32, i8** dereferenceable_or_null(4), i8* dereferenceable_or_null(1), i8*, i8*)
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/intrinsics-cortex-m-qemu.ll
+++ b/compiler/testdata/intrinsics-cortex-m-qemu.ll
@@ -5,23 +5,28 @@ target triple = "armv7m-unknown-unknown-eabi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden double @main.mySqrt(double %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden double @main.mySqrt(double %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call double @math.Sqrt(double %x, i8* undef, i8* undef)
+  %0 = call double @math.Sqrt(double %x, i8* undef, i8* undef) #0
   ret double %0
 }
 
 declare double @math.Sqrt(double, i8*, i8*)
 
-define hidden double @main.myTrunc(double %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden double @main.myTrunc(double %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call double @math.Trunc(double %x, i8* undef, i8* undef)
+  %0 = call double @math.Trunc(double %x, i8* undef, i8* undef) #0
   ret double %0
 }
 
 declare double @math.Trunc(double, i8*, i8*)
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -5,27 +5,31 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden double @main.mySqrt(double %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden double @main.mySqrt(double %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = call double @llvm.sqrt.f64(double %x)
   ret double %0
 }
 
 ; Function Attrs: nounwind readnone speculatable willreturn
-declare double @llvm.sqrt.f64(double) #0
+declare double @llvm.sqrt.f64(double) #1
 
-define hidden double @main.myTrunc(double %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden double @main.myTrunc(double %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = call double @llvm.trunc.f64(double %x)
   ret double %0
 }
 
 ; Function Attrs: nounwind readnone speculatable willreturn
-declare double @llvm.trunc.f64(double) #0
+declare double @llvm.trunc.f64(double) #1
 
-attributes #0 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone speculatable willreturn }

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -5,47 +5,57 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden [0 x i32] @main.pointerDerefZero([0 x i32]* %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden [0 x i32] @main.pointerDerefZero([0 x i32]* %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret [0 x i32] zeroinitializer
 }
 
-define hidden i32* @main.pointerCastFromUnsafe(i8* %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32* @main.pointerCastFromUnsafe(i8* %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = bitcast i8* %x to i32*
   ret i32* %0
 }
 
-define hidden i8* @main.pointerCastToUnsafe(i32* dereferenceable_or_null(4) %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.pointerCastToUnsafe(i32* dereferenceable_or_null(4) %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = bitcast i32* %x to i8*
   ret i8* %0
 }
 
-define hidden i8* @main.pointerCastToUnsafeNoop(i8* dereferenceable_or_null(1) %x, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.pointerCastToUnsafeNoop(i8* dereferenceable_or_null(1) %x, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret i8* %x
 }
 
-define hidden i8* @main.pointerUnsafeGEPFixedOffset(i8* dereferenceable_or_null(1) %ptr, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.pointerUnsafeGEPFixedOffset(i8* dereferenceable_or_null(1) %ptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = getelementptr inbounds i8, i8* %ptr, i32 10
   ret i8* %0
 }
 
-define hidden i8* @main.pointerUnsafeGEPByteOffset(i8* dereferenceable_or_null(1) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8* @main.pointerUnsafeGEPByteOffset(i8* dereferenceable_or_null(1) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = getelementptr inbounds i8, i8* %ptr, i32 %offset
   ret i8* %0
 }
 
-define hidden i32* @main.pointerUnsafeGEPIntOffset(i32* dereferenceable_or_null(4) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32* @main.pointerUnsafeGEPIntOffset(i32* dereferenceable_or_null(4) %ptr, i32 %offset, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = getelementptr i32, i32* %ptr, i32 %offset
   ret i32* %0
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -12,48 +12,54 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define void @extern_func() #0 {
+; Function Attrs: nounwind
+define void @extern_func() #1 {
 entry:
   ret void
 }
 
-define hidden void @somepkg.someFunction1(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @somepkg.someFunction1(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
 declare void @somepkg.someFunction2(i8*, i8*)
 
-; Function Attrs: inlinehint
-define hidden void @main.inlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #1 {
+; Function Attrs: inlinehint nounwind
+define hidden void @main.inlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #2 {
 entry:
   ret void
 }
 
-; Function Attrs: noinline
-define hidden void @main.noinlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #2 {
+; Function Attrs: noinline nounwind
+define hidden void @main.noinlineFunc(i8* %context, i8* %parentHandle) unnamed_addr #3 {
 entry:
   ret void
 }
 
-define hidden void @main.functionInSection(i8* %context, i8* %parentHandle) unnamed_addr section ".special_function_section" {
+; Function Attrs: nounwind
+define hidden void @main.functionInSection(i8* %context, i8* %parentHandle) unnamed_addr #0 section ".special_function_section" {
 entry:
   ret void
 }
 
-define void @exportedFunctionInSection() #3 section ".special_function_section" {
+; Function Attrs: nounwind
+define void @exportedFunctionInSection() #4 section ".special_function_section" {
 entry:
   ret void
 }
 
 declare void @main.undefinedFunctionNotInSection(i8*, i8*)
 
-attributes #0 = { "wasm-export-name"="extern_func" }
-attributes #1 = { inlinehint }
-attributes #2 = { noinline }
-attributes #3 = { "wasm-export-name"="exportedFunctionInSection" }
+attributes #0 = { nounwind }
+attributes #1 = { nounwind "wasm-export-name"="extern_func" }
+attributes #2 = { inlinehint nounwind }
+attributes #3 = { noinline nounwind }
+attributes #4 = { nounwind "wasm-export-name"="exportedFunctionInSection" }

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -5,28 +5,32 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden i32 @main.sliceLen(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.sliceLen(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret i32 %ints.len
 }
 
-define hidden i32 @main.sliceCap(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.sliceCap(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret i32 %ints.cap
 }
 
-define hidden i32 @main.sliceElement(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.sliceElement(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %.not = icmp ult i32 %index, %ints.len
   br i1 %.not, label %lookup.next, label %lookup.throw
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(i8* undef, i8* null)
+  call void @runtime.lookupPanic(i8* undef, i8* null) #0
   unreachable
 
 lookup.next:                                      ; preds = %entry
@@ -37,9 +41,10 @@ lookup.next:                                      ; preds = %entry
 
 declare void @runtime.lookupPanic(i8*, i8*)
 
-define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %varargs = call i8* @runtime.alloc(i32 12, i8* undef, i8* null)
+  %varargs = call i8* @runtime.alloc(i32 12, i8* undef, i8* null) #0
   %0 = bitcast i8* %varargs to i32*
   store i32 1, i32* %0, align 4
   %1 = getelementptr inbounds i8, i8* %varargs, i32 4
@@ -49,7 +54,7 @@ entry:
   %4 = bitcast i8* %3 to i32*
   store i32 3, i32* %4, align 4
   %append.srcPtr = bitcast i32* %ints.data to i8*
-  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, i8* undef, i8* null)
+  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, i8* undef, i8* null) #0
   %append.newPtr = extractvalue { i8*, i32, i32 } %append.new, 0
   %append.newBuf = bitcast i8* %append.newPtr to i32*
   %append.newLen = extractvalue { i8*, i32, i32 } %append.new, 1
@@ -62,11 +67,12 @@ entry:
 
 declare { i8*, i32, i32 } @runtime.sliceAppend(i8*, i8* nocapture readonly, i32, i32, i32, i32, i8*, i8*)
 
-define hidden { i32*, i32, i32 } @main.sliceAppendSlice(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32* %added.data, i32 %added.len, i32 %added.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.sliceAppendSlice(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32* %added.data, i32 %added.len, i32 %added.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %append.srcPtr = bitcast i32* %ints.data to i8*
   %append.srcPtr1 = bitcast i32* %added.data to i8*
-  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* %append.srcPtr1, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, i8* undef, i8* null)
+  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* %append.srcPtr1, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, i8* undef, i8* null) #0
   %append.newPtr = extractvalue { i8*, i32, i32 } %append.new, 0
   %append.newBuf = bitcast i8* %append.newPtr to i32*
   %append.newLen = extractvalue { i8*, i32, i32 } %append.new, 1
@@ -77,27 +83,29 @@ entry:
   ret { i32*, i32, i32 } %2
 }
 
-define hidden i32 @main.sliceCopy(i32* %dst.data, i32 %dst.len, i32 %dst.cap, i32* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.sliceCopy(i32* %dst.data, i32 %dst.len, i32 %dst.cap, i32* %src.data, i32 %src.len, i32 %src.cap, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %copy.dstPtr = bitcast i32* %dst.data to i8*
   %copy.srcPtr = bitcast i32* %src.data to i8*
-  %copy.n = call i32 @runtime.sliceCopy(i8* %copy.dstPtr, i8* %copy.srcPtr, i32 %dst.len, i32 %src.len, i32 4, i8* undef, i8* null)
+  %copy.n = call i32 @runtime.sliceCopy(i8* %copy.dstPtr, i8* %copy.srcPtr, i32 %dst.len, i32 %src.len, i32 4, i8* undef, i8* null) #0
   ret i32 %copy.n
 }
 
 declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*, i8*)
 
-define hidden { i8*, i32, i32 } @main.makeByteSlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i8*, i32, i32 } @main.makeByteSlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %slice.maxcap = icmp slt i32 %len, 0
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef, i8* null)
+  call void @runtime.slicePanic(i8* undef, i8* null) #0
   unreachable
 
 slice.next:                                       ; preds = %entry
-  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* undef, i8* null)
+  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* undef, i8* null) #0
   %0 = insertvalue { i8*, i32, i32 } undef, i8* %makeslice.buf, 0
   %1 = insertvalue { i8*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i8*, i32, i32 } %1, i32 %len, 2
@@ -106,18 +114,19 @@ slice.next:                                       ; preds = %entry
 
 declare void @runtime.slicePanic(i8*, i8*)
 
-define hidden { i16*, i32, i32 } @main.makeInt16Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i16*, i32, i32 } @main.makeInt16Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %slice.maxcap = icmp slt i32 %len, 0
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef, i8* null)
+  call void @runtime.slicePanic(i8* undef, i8* null) #0
   unreachable
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 1
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i16*
   %0 = insertvalue { i16*, i32, i32 } undef, i16* %makeslice.array, 0
   %1 = insertvalue { i16*, i32, i32 } %0, i32 %len, 1
@@ -125,18 +134,19 @@ slice.next:                                       ; preds = %entry
   ret { i16*, i32, i32 } %2
 }
 
-define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %slice.maxcap = icmp ugt i32 %len, 1431655765
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef, i8* null)
+  call void @runtime.slicePanic(i8* undef, i8* null) #0
   unreachable
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = mul i32 %len, 3
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to [3 x i8]*
   %0 = insertvalue { [3 x i8]*, i32, i32 } undef, [3 x i8]* %makeslice.array, 0
   %1 = insertvalue { [3 x i8]*, i32, i32 } %0, i32 %len, 1
@@ -144,21 +154,24 @@ slice.next:                                       ; preds = %entry
   ret { [3 x i8]*, i32, i32 } %2
 }
 
-define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %slice.maxcap = icmp ugt i32 %len, 1073741823
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef, i8* null)
+  call void @runtime.slicePanic(i8* undef, i8* null) #0
   unreachable
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 2
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null)
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* undef, i8* null) #0
   %makeslice.array = bitcast i8* %makeslice.buf to i32*
   %0 = insertvalue { i32*, i32, i32 } undef, i32* %makeslice.array, 0
   %1 = insertvalue { i32*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i32*, i32, i32 } %1, i32 %len, 2
   ret { i32*, i32, i32 } %2
 }
+
+attributes #0 = { nounwind }

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -9,33 +9,38 @@ target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
-define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden void @main.init(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret void
 }
 
-define hidden %runtime._string @main.someString(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._string @main.someString(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._string { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"main.someString$string", i32 0, i32 0), i32 3 }
 }
 
-define hidden %runtime._string @main.zeroLengthString(i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden %runtime._string @main.zeroLengthString(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._string zeroinitializer
 }
 
-define hidden i32 @main.stringLen(i8* %s.data, i32 %s.len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i32 @main.stringLen(i8* %s.data, i32 %s.len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret i32 %s.len
 }
 
-define hidden i8 @main.stringIndex(i8* %s.data, i32 %s.len, i32 %index, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i8 @main.stringIndex(i8* %s.data, i32 %s.len, i32 %index, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %.not = icmp ult i32 %index, %s.len
   br i1 %.not, label %lookup.next, label %lookup.throw
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(i8* undef, i8* null)
+  call void @runtime.lookupPanic(i8* undef, i8* null) #0
   unreachable
 
 lookup.next:                                      ; preds = %entry
@@ -46,26 +51,31 @@ lookup.next:                                      ; preds = %entry
 
 declare void @runtime.lookupPanic(i8*, i8*)
 
-define hidden i1 @main.stringCompareEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.stringCompareEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null)
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null) #0
   ret i1 %0
 }
 
 declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*, i8*)
 
-define hidden i1 @main.stringCompareUnequal(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.stringCompareUnequal(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null)
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null) #0
   %1 = xor i1 %0, true
   ret i1 %1
 }
 
-define hidden i1 @main.stringCompareLarger(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr {
+; Function Attrs: nounwind
+define hidden i1 @main.stringCompareLarger(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.stringLess(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null)
+  %0 = call i1 @runtime.stringLess(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null) #0
   %1 = xor i1 %0, true
   ret i1 %1
 }
 
 declare i1 @runtime.stringLess(i8*, i32, i8*, i32, i8*, i8*)
+
+attributes #0 = { nounwind }


### PR DESCRIPTION
This attribute is also set by Clang when it compiles C source files (unless `-fexceptions` is set). The advantage is that no unwind tables are emitted on Linux (and perhaps other systems) and therefore binaries are slightly smaller. It also avoids `__aeabi_unwind_cpp_pr0` on ARM when using the musl libc.