### PR TITLE
ci: fix wasmtime.dev expiry issue by installing ca-certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install \
+                libgnutls30 libssl1.0.2 \
                 gcc-arm-linux-gnueabihf \
                 libc6-dev-armel-cross \
                 gcc-aarch64-linux-gnu \
@@ -205,6 +206,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install \
+                libgnutls30 libssl1.0.2 \
                 gcc-arm-linux-gnueabihf \
                 libc6-dev-armel-cross \
                 gcc-aarch64-linux-gnu \


### PR DESCRIPTION
Hopefully this will fix the CI breakage after curl refuses to download anything from wasmtime.dev (which is signed by Let's Encrypt).