### PR TITLE
build: double timeout period without output for make test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,7 @@ commands:
       - run:
           name: "Test TinyGo"
           command: make test
+          no_output_timeout: 20m
       - run:
           name: "Install fpm"
           command: |


### PR DESCRIPTION
This PR fixes issues with the CircleCI build by doubling the timeout period without output for make test.