### PR TITLE
rp2040: i2c baud rate handling improvements

### DIFF
--- a/src/machine/machine_rp2040_i2c.go
+++ b/src/machine/machine_rp2040_i2c.go
@@ -116,10 +116,10 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 	return i2c.init(config)
 }
 
-// SetBaudrate sets the I2C frequency. It has the side effect of also
+// SetBaudRate sets the I2C frequency. It has the side effect of also
 // enabling the I2C hardware if disabled beforehand.
 //go:inline
-func (i2c *I2C) SetBaudrate(br uint32) error {
+func (i2c *I2C) SetBaudRate(br uint32) error {
 
 	if br == 0 {
 		return ErrInvalidI2CBaudrate
@@ -210,7 +210,7 @@ func (i2c *I2C) init(config I2CConfig) error {
 
 	// Always enable the DREQ signalling -- harmless if DMA isn't listening
 	i2c.Bus.IC_DMA_CR.Set(rp.I2C0_IC_DMA_CR_TDMAE | rp.I2C0_IC_DMA_CR_RDMAE)
-	return i2c.SetBaudrate(config.Frequency)
+	return i2c.SetBaudRate(config.Frequency)
 }
 
 // reset sets I2C register RESET bits in the reset peripheral and then clears them.


### PR DESCRIPTION
Noticed my Nano RP2040 sometimes acts strange, I2C dies, after reset.
(I use ResetOnAbort patch (#2162), so my board restarts on panic w/o power cycling.)

Apparently, it was not re-initialising correctly. Copied baud rate default settings from SPI and it seem to work.
Verified with lsm6dsox IMU over I2C on Nano RP2040.

Also, use recently introduced `CPUFrequency()` instead of hardcoded value.

P.S. On Nano RP2040 one needs to execute following sequence in addition to this fix before configuring I2C, since IMU may turn its I2C off when INT1 pin for some reason reads "high" for a moment.
```
machine.GPIO24.Configure(machine.PinConfig{Mode: machine.PinOutput})
machine.GPIO24.High()
time.Sleep(100 * time.Millisecond)
machine.GPIO24.Low()
```