### PR TITLE
runtime: reset on abort for cortexm

### DIFF
--- a/src/examples/onpanic/onpanic.go
+++ b/src/examples/onpanic/onpanic.go
@@ -1,0 +1,26 @@
+// +build cortexm
+
+package main
+
+import (
+	"device/arm"
+	"runtime"
+	"time"
+)
+
+// This example shows how to reset system on panic.
+// In your application you may: reset, blink an LED to indicate failure, or do something else.
+
+func main() {
+
+	runtime.OnPanic = func() {
+		println("PANIC")
+		time.Sleep(time.Second)
+		arm.SystemReset() // available on cortexm, your system may have to do this differently
+	}
+
+	println("START")
+	time.Sleep(time.Second)
+	panic("AAA!!!111")
+
+}

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -1,5 +1,10 @@
 package runtime
 
+// OnPanic is called during the system panic handling before abort.
+// Note that when this function is called, the program could be in a bad state and
+// heap allocations might be impossible for example.
+var OnPanic func()
+
 // trap is a compiler hint that this function cannot be executed. It is
 // translated into either a trap instruction or a call to abort().
 //export llvm.trap
@@ -10,6 +15,9 @@ func _panic(message interface{}) {
 	printstring("panic: ")
 	printitf(message)
 	printnl()
+	if OnPanic != nil {
+		OnPanic()
+	}
 	abort()
 }
 
@@ -17,6 +25,9 @@ func _panic(message interface{}) {
 func runtimePanic(msg string) {
 	printstring("panic: runtime error: ")
 	println(msg)
+	if OnPanic != nil {
+		OnPanic()
+	}
 	abort()
 }
 

--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -6,16 +6,11 @@ import (
 	"device/arm"
 )
 
-var ResetOnAbort = false
-
 func exit(code int) {
 	abort()
 }
 
 func abort() {
-	if ResetOnAbort {
-		arm.SystemReset()
-	}
 	// lock up forever
 	for {
 		arm.Asm("wfi")

--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -6,11 +6,16 @@ import (
 	"device/arm"
 )
 
+var ResetOnAbort = false
+
 func exit(code int) {
 	abort()
 }
 
 func abort() {
+	if ResetOnAbort {
+		arm.SystemReset()
+	}
 	// lock up forever
 	for {
 		arm.Asm("wfi")


### PR DESCRIPTION
Panics happen. And right now (and still by default after this PR) system just hangs.
Feels like it can be beneficial to let users choose whether to hang or restart the system on panic.

It is not always possible to have easy physical access to embedded devices. Some may have been deployed to run 24/7 at a remote site.

Please suggest better API, this is just some quick attempt to make it useable.

Verified on my Nano RP2040, 24/7 setup, panicking and rebooting on wifinina and lsm6dsox weird situations that hard to catch and debug.