### PR TITLE
esp32c3: use tasks scheduler by default

### DIFF
--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -2,7 +2,6 @@
 	"inherits": ["riscv32"],
 	"features": ["+c", "+m"],
 	"build-tags": ["esp32c3", "esp"],
-	"scheduler": "none",
 	"serial": "uart",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",


### PR DESCRIPTION
Now that the tasks scheduler has been implemented for 32-bit RISC-V, it can be used for the ESP32-C3.

As an example, the following now works:

    tinygo flash -target=esp32c3 ./testdata/goroutines.go