### PR TITLE
loader: fix true path detection on Windows

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -235,6 +236,9 @@ func (p *Program) getOriginalPath(path string) string {
 		}
 		maybeInTinyGoRoot := false
 		for prefix := range pathsToOverride(needsSyscallPackage(p.config.BuildTags())) {
+			if runtime.GOOS == "windows" {
+				prefix = strings.ReplaceAll(prefix, "/", "\\")
+			}
 			if !strings.HasPrefix(relpath, prefix) {
 				continue
 			}


### PR DESCRIPTION
This is necessary to display error messages on Windows. For example, this command invocation is not correct (esp32 doesn't define `machine.LED`, you need esp32-coreboard-v2 for example):

    tinygo run -target=esp32 examples/blinky1

It results in the following hard-to-read error message:

    # examples/blinky1
    ..\..\..\..\..\AppData\Local\tinygo\goroot-go1.16-24cb853b66a5367bf6d65bc08b2cb665c75bd9971f0be8f8b73f69d1a33e04a1-syscall\src\examples\blinky1\blinky1.go:11:17: LED not declared by package machine

With this commit, this error message becomes much easier to read:

    # examples/blinky1
    C:\Users\Ayke\go\src\github.com\tinygo-org\tinygo\src\examples\blinky1\blinky1.go:11:17: LED not declared by package machine