### PR TITLE
Add support Arduino Pro Mini #1401

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following 70 microcontroller boards are currently supported:
 * [Arduino Nano 33 BLE Sense](https://store.arduino.cc/nano-33-ble-sense)
 * [Arduino Nano 33 IoT](https://store.arduino.cc/nano-33-iot)
 * [Arduino Nano RP2040 Connect](https://store.arduino.cc/nano-rp2040-connect)
+* [Arduino Pro Mini](https://www.sparkfun.com/products/11113)
 * [Arduino Uno](https://store.arduino.cc/arduino-uno-rev3)
 * [Arduino Zero](https://store.arduino.cc/usa/arduino-zero)
 * [BBC micro:bit](https://microbit.org/)

--- a/targets/arduino-pro-mini.json
+++ b/targets/arduino-pro-mini.json
@@ -1,0 +1,11 @@
+{
+	"inherits": ["atmega328p"],
+	"build-tags": ["arduino"],
+	"ldflags": [
+		"-Wl,--defsym=_bootloader_size=512",
+		"-Wl,--defsym=_stack_size=512"
+	],
+	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
+	"serial-port": ["acm:2341:0043", "acm:2341:0001", "acm:2a03:0043", "acm:2341:0243"],
+	"emulator": ["simavr", "-m", "atmega328p", "-f", "16000000"]
+}


### PR DESCRIPTION
Pro Mini is basically a Uno with the same pinout on a
smaller board. Especially clones of this board are very
popular because of their low price.

This solves #1401