### PR TITLE
esp32c3 interrupt implementation 

### DIFF
--- a/src/device/esp/esp32c3.S
+++ b/src/device/esp/esp32c3.S
@@ -47,3 +47,21 @@ call_start_cpu0:
     // (It appears that the linker relaxes this jump and instead inserts the
     // _start function right after here).
     j _start
+
+.section .text.exception_vectors
+.global _vector_table
+.type _vector_table,@function
+
+_vector_table:
+
+    .option push
+    .option norvc
+
+    .rept 32
+    j handleInterruptASM            /* interrupt handler */
+    .endr
+
+    .option pop
+
+.size _vector_table, .-_vector_table
+

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -10,91 +10,40 @@ import (
 	"unsafe"
 )
 
-const (
-	// Each module of the ESP32C3 uses different interrupt registers.
-	// Below is the list of modules used from machine package to initialize interrupt handler
-	GPIO HandlerID = iota
-	UART0
-	UART1
-	USB
-	I2C0
-	I2S1
-	TIMG0
-	TIMG1
-	UHCI0
-	RMT
-	SPI1
-	SPI2
-	TWAI
-	RNG
-	WIFI
-	BT
-	WIFI_BT_COMMON
-	BT_BASEBAND
-	BT_LC
-	RSA
-	AES
-	SHA
-	HMAC
-	DS
-	GDMA
-	SYSTIMER
-	SARADC
-)
-
-var (
-	ErrInterruptNotImplemented = errors.New("interrupt number is not implemented")
-)
-
-type HandlerID int
-
+// Enable register CPU interrupt with interrupt.Interrupt.
+// The ESP32-C3 has 31 CPU independent interrupts.
+// The Interrupt.New(x, f) (x = [1..31]) attaches CPU interrupt to function f.
+// Caller must map the selected interrupt using following sequence (for example using id 5):
+//
+//    // map interrupt 5 to my XXXX module
+//    esp.INTERRUPT_CORE0.XXXX_INTERRUPT_PRO_MAP.Set( 5 )
+//    _ = Interrupt.New(5, func(interrupt.Interrupt) {
+//        ...
+//    }).Enable()
 func (i Interrupt) Enable() error {
+	if i.num < 1 && i.num > 31 {
+		return errors.New("interrupt for ESP32-C3 must be in range of 1 through 31")
+	}
 	mask := riscv.DisableInterrupts()
 	defer riscv.EnableInterrupts(mask)
 
-	// map mapRegister to CPU interrupt
-	intr, err := HandlerID(i.num).set()
-	if err != nil {
-		return err
-	}
+	// enable CPU interrupt number i.num
+	esp.INTERRUPT_CORE0.CPU_INT_ENABLE.SetBits(1 << i.num)
 
-	esp.INTERRUPT_CORE0.CPU_INT_ENABLE.SetBits(1 << intr)
-	esp.INTERRUPT_CORE0.CPU_INT_TYPE.SetBits(1 << intr)
-	// Set threshold to 5
-	reg := (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0)) + uintptr(intr)*4)))
+	// Set pulse interrupt type (rising edge detection)
+	esp.INTERRUPT_CORE0.CPU_INT_TYPE.SetBits(1 << i.num)
+
+	// Set default threshold to 5
+	reg := (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0)) + uintptr(i.num)*4)))
 	reg.Set(5)
 
-	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(1 << intr)
-	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(1 << intr)
+	// Reset interrupt before reenabling
+	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(1 << i.num)
+	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(1 << i.num)
 
+	// we must wait for any pending write operations to complete
 	riscv.Asm("fence")
 	return nil
-}
-
-var (
-	interruptMap = map[int][]HandlerID{
-		1: {GPIO},
-		2: {UART0},
-		3: {UART1},
-	}
-)
-
-// set will update and return module's CPU interrupt
-// IMPORTANT: must match interruptMap
-func (h HandlerID) set() (int, error) {
-	switch h {
-	case GPIO:
-		esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(1)
-		return 1, nil
-	case UART0:
-		esp.INTERRUPT_CORE0.UART_INTR_MAP.Set(2)
-		return 2, nil
-	case UART1:
-		esp.INTERRUPT_CORE0.UART1_INTR_MAP.Set(3)
-		return 3, nil
-	default:
-		return -1, ErrInterruptNotImplemented
-	}
 }
 
 //export handleInterrupt
@@ -125,13 +74,7 @@ func handleInterrupt() {
 		riscv.MSTATUS.SetBits(0x8)
 
 		// Call registered interrupt handler(s)
-		if vector, ok := interruptMap[int(interruptNumber)]; ok {
-			for _, handlerID := range vector {
-				callInterruptHandler(int(handlerID))
-			}
-		} else {
-			println("unhandled CPU interrupt", interruptNumber)
-		}
+		callInterruptHandler(int(interruptNumber))
 
 		// disable CPU interrupts
 		riscv.MSTATUS.ClearBits(0x8)

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -100,7 +100,6 @@ func handleInterrupt() {
 }
 
 func handleException(mcause uintptr) {
-	// TODO need to get location of actual MEPC from the stack stash created in src/device/riscv/handleinterrupt.S
 	println("*** Exception:     pc:", riscv.MEPC.Get())
 	println("*** Exception:   code:", uint32(mcause&0x1f))
 	println("*** Exception: mcause:", mcause)

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -112,7 +112,7 @@ func handleInterrupt() {
 		esp.INTERRUPT_CORE0.CPU_INT_ENABLE.ClearBits(interruptBit)
 
 		// reset pending status interrupt
-		if esp.INTERRUPT_CORE0.CPU_INT_TYPE.Get()&(interruptBit) != 0 {
+		if esp.INTERRUPT_CORE0.CPU_INT_TYPE.Get()&interruptBit != 0 {
 			// this is edge type interrupt
 			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(interruptBit)
 			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(interruptBit)

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -156,7 +156,6 @@ func handleInterrupt() {
 	}
 }
 
-//export handleException
 func handleException(mcause uintptr) {
 	// TODO need to get location of actual MEPC from the stack stash created in src/device/riscv/handleinterrupt.S
 	println("*** Exception:     pc:", riscv.MEPC.Get())

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -11,7 +11,9 @@ import (
 )
 
 const (
-	LEDC HandlerID = iota
+	// Each module of the ESP32C3 uses different interrupt registers.
+	// Below is the list of modules used from machine package to initialize interrupt handler
+	GPIO HandlerID = iota
 	UART0
 	UART1
 	USB
@@ -21,8 +23,8 @@ const (
 	TIMG1
 	UHCI0
 	RMT
-	SPI  //SPI1
-	SPI2 //SPI2
+	SPI1
+	SPI2
 	TWAI
 	RNG
 	WIFI
@@ -38,12 +40,10 @@ const (
 	GDMA
 	SYSTIMER
 	SARADC
-	GPIO
 )
 
 var (
 	ErrInterruptNotImplemented = errors.New("interrupt number is not implemented")
-	ErrMissingMapRegister      = errors.New("interrupt map register is missing")
 )
 
 type HandlerID int
@@ -104,7 +104,6 @@ func getHandlerIDsForInterrupt(interrupt int) []HandlerID {
 		return []HandlerID{UART1}
 	default:
 		return []HandlerID{
-			LEDC,
 			USB,
 			I2C0,
 			I2S1,
@@ -112,8 +111,8 @@ func getHandlerIDsForInterrupt(interrupt int) []HandlerID {
 			TIMG1,
 			UHCI0,
 			RMT,
-			SPI,  //SPI1
-			SPI2, //SPI2
+			SPI1,
+			SPI2,
 			TWAI,
 			RNG,
 			WIFI,

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -1,0 +1,223 @@
+// +build esp32c3
+
+package interrupt
+
+import (
+	"device/esp"
+	"device/riscv"
+	"errors"
+	"runtime/volatile"
+	"unsafe"
+)
+
+const (
+	LEDC HandlerID = iota
+	UART0
+	UART1
+	USB
+	I2C0
+	I2S1
+	TIMG0
+	TIMG1
+	UHCI0
+	RMT
+	SPI  //SPI1
+	SPI2 //SPI2
+	TWAI
+	RNG
+	WIFI
+	BT
+	WIFI_BT_COMMON
+	BT_BASEBAND
+	BT_LC
+	RSA
+	AES
+	SHA
+	HMAC
+	DS
+	GDMA
+	SYSTIMER
+	SARADC
+	GPIO
+)
+
+var (
+	ErrInterruptNotImplemented = errors.New("interrupt number is not implemented")
+	ErrMissingMapRegister      = errors.New("interrupt map register is missing")
+)
+
+type HandlerID int
+
+func Init() {
+	mie := riscv.DisableInterrupts()
+
+	// Reset all interrupt source priorities to zero.
+	priReg := &esp.INTERRUPT_CORE0.CPU_INT_PRI_1
+	for i := 0; i < 31; i++ {
+		priReg.Set(0)
+		priReg = (*volatile.Register32)(unsafe.Pointer(uintptr(unsafe.Pointer(priReg)) + uintptr(4)))
+	}
+
+	// default threshold for interrupts is 5
+	esp.INTERRUPT_CORE0.CPU_INT_THRESH.Set(5)
+
+	// Set the interrupt address.
+	// Set MODE field to 1 - a vector base address (only supported by ESP32C3)
+	// Note that this address must be aligned to 256 bytes.
+	riscv.MTVEC.Set((uintptr(unsafe.Pointer(&_vector_table))) | 1)
+
+	riscv.EnableInterrupts(mie)
+}
+
+func (i Interrupt) Enable() error {
+	mask := riscv.DisableInterrupts()
+	defer riscv.EnableInterrupts(mask)
+
+	intr := getInterruptForHandlerID(HandlerID(i.num))
+
+	// map mapRegister to intr
+	if err := HandlerID(i.num).set(intr); err != nil {
+		return err
+	}
+
+	esp.INTERRUPT_CORE0.CPU_INT_ENABLE.SetBits(1 << intr)
+	esp.INTERRUPT_CORE0.CPU_INT_TYPE.SetBits(1 << intr)
+	// Set threshold to 5
+	reg := (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0)) + uintptr(intr)*4)))
+	reg.Set(5)
+
+	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(1 << intr)
+	esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(1 << intr)
+
+	riscv.Asm("fence")
+	return nil
+}
+
+// getHandlerIDsForInterrupt return registered codes for interrupt
+func getHandlerIDsForInterrupt(interrupt int) []HandlerID {
+	switch interrupt {
+	case 1:
+		return []HandlerID{GPIO}
+	case 2:
+		return []HandlerID{UART0}
+	case 3:
+		return []HandlerID{UART1}
+	default:
+		return []HandlerID{
+			LEDC,
+			USB,
+			I2C0,
+			I2S1,
+			TIMG0,
+			TIMG1,
+			UHCI0,
+			RMT,
+			SPI,  //SPI1
+			SPI2, //SPI2
+			TWAI,
+			RNG,
+			WIFI,
+			BT,
+			WIFI_BT_COMMON,
+			BT_BASEBAND,
+			BT_LC,
+			RSA,
+			AES,
+			SHA,
+			HMAC,
+			DS,
+			GDMA,
+			SYSTIMER,
+			SARADC,
+		}
+	}
+}
+
+// getInterruptForHandlerID return registered codes for interrupt
+func getInterruptForHandlerID(ID HandlerID) int {
+	switch ID {
+	case GPIO:
+		return 1
+	case UART0:
+		return 2
+	case UART1:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (h HandlerID) set(interrupt int) error {
+	switch h {
+	case UART0:
+		esp.INTERRUPT_CORE0.UART_INTR_MAP.Set(uint32(interrupt))
+	case UART1:
+		esp.INTERRUPT_CORE0.UART1_INTR_MAP.Set(uint32(interrupt))
+	case GPIO:
+		esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(uint32(interrupt))
+	default:
+		return ErrInterruptNotImplemented
+	}
+	return nil
+}
+
+//go:extern _vector_table
+var _vector_table [0]uintptr
+
+//export handleInterrupt
+func handleInterrupt() {
+	cause := riscv.MCAUSE.Get()
+	interruptNumber := uint32(cause & 0x1f)
+
+	if cause&(1<<31) != 0 && interruptNumber > 0 {
+		// disable this interrupt
+		interruptBit := uint32(1 << interruptNumber)
+		esp.INTERRUPT_CORE0.CPU_INT_ENABLE.ClearBits(interruptBit)
+
+		// reset this interrupt
+		if esp.INTERRUPT_CORE0.CPU_INT_TYPE.Get()&(interruptBit) != 0 {
+			// this is edge type interrupt
+			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(interruptBit)
+			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(interruptBit)
+		} else {
+			// this is level type interrupt
+			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.ClearBits(interruptBit)
+		}
+
+		// enable CPU interrupts
+		riscv.MSTATUS.SetBits(0x8)
+
+		// Call the interrupt handler, if any is registered for this code.
+		for _, id := range getHandlerIDsForInterrupt(int(interruptNumber)) {
+			callInterruptHandler(int(id))
+		}
+
+		// disable CPU interrupts
+		riscv.MSTATUS.ClearBits(0x8)
+
+		// enable this interrupt
+		esp.INTERRUPT_CORE0.CPU_INT_ENABLE.SetBits(interruptBit)
+
+		// enable CPU interrupts
+		riscv.MSTATUS.SetBits(0x8)
+
+	} else {
+		// Topmost bit is clear, so it is an exception of some sort.
+		// We could implement support for unsupported instructions here (such as
+		// misaligned loads). However, for now we'll just print a fatal error.
+		handleException(interruptNumber)
+	}
+}
+
+//export handleException
+func handleException(code uint32) {
+	println("*** Exception: code:", code)
+	for {
+		riscv.Asm("wfi")
+	}
+}
+
+// callInterruptHandler is a compiler-generated function that calls the
+// appropriate interrupt handler for the given interrupt ID.
+//go:linkname callInterruptHandler runtime.callInterruptHandler
+func callInterruptHandler(id int)

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -52,10 +52,9 @@ func (i Interrupt) Enable() error {
 	mask := riscv.DisableInterrupts()
 	defer riscv.EnableInterrupts(mask)
 
-	intr := getInterruptForHandlerID(HandlerID(i.num))
-
-	// map mapRegister to intr
-	if err := HandlerID(i.num).set(intr); err != nil {
+	// map mapRegister to CPU interrupt
+	intr, err := HandlerID(i.num).set()
+	if err != nil {
 		return err
 	}
 
@@ -72,84 +71,47 @@ func (i Interrupt) Enable() error {
 	return nil
 }
 
-// getHandlerIDsForInterrupt return registered codes for interrupt
-func getHandlerIDsForInterrupt(interrupt int) []HandlerID {
-	switch interrupt {
-	case 1:
-		return []HandlerID{GPIO}
-	case 2:
-		return []HandlerID{UART0}
-	case 3:
-		return []HandlerID{UART1}
-	default:
-		return []HandlerID{
-			USB,
-			I2C0,
-			I2S1,
-			TIMG0,
-			TIMG1,
-			UHCI0,
-			RMT,
-			SPI1,
-			SPI2,
-			TWAI,
-			RNG,
-			WIFI,
-			BT,
-			WIFI_BT_COMMON,
-			BT_BASEBAND,
-			BT_LC,
-			RSA,
-			AES,
-			SHA,
-			HMAC,
-			DS,
-			GDMA,
-			SYSTIMER,
-			SARADC,
-		}
+var (
+	interruptMap = map[int][]HandlerID{
+		1: {GPIO},
+		2: {UART0},
+		3: {UART1},
 	}
-}
+)
 
-// getInterruptForHandlerID return registered codes for interrupt
-func getInterruptForHandlerID(ID HandlerID) int {
-	switch ID {
-	case GPIO:
-		return 1
-	case UART0:
-		return 2
-	case UART1:
-		return 3
-	default:
-		return 4
-	}
-}
-
-func (h HandlerID) set(interrupt int) error {
+// set will update and return module's CPU interrupt
+// IMPORTANT: must match interruptMap
+func (h HandlerID) set() (int, error) {
 	switch h {
-	case UART0:
-		esp.INTERRUPT_CORE0.UART_INTR_MAP.Set(uint32(interrupt))
-	case UART1:
-		esp.INTERRUPT_CORE0.UART1_INTR_MAP.Set(uint32(interrupt))
 	case GPIO:
-		esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(uint32(interrupt))
+		esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(1)
+		return 1, nil
+	case UART0:
+		esp.INTERRUPT_CORE0.UART_INTR_MAP.Set(2)
+		return 2, nil
+	case UART1:
+		esp.INTERRUPT_CORE0.UART1_INTR_MAP.Set(3)
+		return 3, nil
 	default:
-		return ErrInterruptNotImplemented
+		return -1, ErrInterruptNotImplemented
 	}
-	return nil
 }
 
 //export handleInterrupt
 func handleInterrupt() {
-	cause := riscv.MCAUSE.Get()
-	interruptNumber := uint32(cause & 0x1f)
+	mcause := riscv.MCAUSE.Get()
+	exception := mcause&(1<<31) == 0
+	interruptNumber := uint32(mcause & 0x1f)
 
-	if cause&(1<<31) != 0 && interruptNumber > 0 {
-		// disable this interrupt
+	if !exception && interruptNumber > 0 {
+		// save mepc, which could be overwritten by another CPU interrupt
+		mepc := riscv.MEPC.Get()
+
+		// disable interrupt
 		interruptBit := uint32(1 << interruptNumber)
 		esp.INTERRUPT_CORE0.CPU_INT_ENABLE.ClearBits(interruptBit)
 
-		// reset this interrupt
+		// reset pending status interrupt
 		if esp.INTERRUPT_CORE0.CPU_INT_TYPE.Get()&(interruptBit) != 0 {
 			// this is edge type interrupt
 			esp.INTERRUPT_CORE0.CPU_INT_CLEAR.SetBits(interruptBit)
@@ -162,31 +124,44 @@ func handleInterrupt() {
 		// enable CPU interrupts
 		riscv.MSTATUS.SetBits(0x8)
 
-		// Call the interrupt handler, if any is registered for this code.
-		for _, id := range getHandlerIDsForInterrupt(int(interruptNumber)) {
-			callInterruptHandler(int(id))
+		// Call registered interrupt handler(s)
+		if vector, ok := interruptMap[int(interruptNumber)]; ok {
+			for _, handlerID := range vector {
+				callInterruptHandler(int(handlerID))
+			}
+		} else {
+			println("unhandled CPU interrupt", interruptNumber)
 		}
 
 		// disable CPU interrupts
 		riscv.MSTATUS.ClearBits(0x8)
 
+		// mpie must be set to 1 to resume interrupts after 'MRET'
+		riscv.MSTATUS.SetBits(0x80)
+
+		// restore MEPC
+		riscv.MEPC.Set(mepc)
+
 		// enable this interrupt
 		esp.INTERRUPT_CORE0.CPU_INT_ENABLE.SetBits(interruptBit)
 
-		// enable CPU interrupts
-		riscv.MSTATUS.SetBits(0x8)
-
+		// do not enable CPU interrupts now
+		// the 'MRET' in src/device/riscv/handleinterrupt.S will copies the state of MPIE back into MIE, and subsequently clears MPIE.
+		// riscv.MSTATUS.SetBits(0x8)
 	} else {
 		// Topmost bit is clear, so it is an exception of some sort.
 		// We could implement support for unsupported instructions here (such as
 		// misaligned loads). However, for now we'll just print a fatal error.
-		handleException(interruptNumber)
+		handleException(mcause)
 	}
 }
 
 //export handleException
-func handleException(code uint32) {
-	println("*** Exception: code:", code)
+func handleException(mcause uintptr) {
+	// TODO need to get location of actual MEPC from the stack stash created in src/device/riscv/handleinterrupt.S
+	println("*** Exception:     pc:", riscv.MEPC.Get())
+	println("*** Exception:   code:", uint32(mcause&0x1f))
+	println("*** Exception: mcause:", mcause)
 	for {
 		riscv.Asm("wfi")
 	}

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -48,27 +48,6 @@ var (
 
 type HandlerID int
 
-func Init() {
-	mie := riscv.DisableInterrupts()
-
-	// Reset all interrupt source priorities to zero.
-	priReg := &esp.INTERRUPT_CORE0.CPU_INT_PRI_1
-	for i := 0; i < 31; i++ {
-		priReg.Set(0)
-		priReg = (*volatile.Register32)(unsafe.Pointer(uintptr(unsafe.Pointer(priReg)) + uintptr(4)))
-	}
-
-	// default threshold for interrupts is 5
-	esp.INTERRUPT_CORE0.CPU_INT_THRESH.Set(5)
-
-	// Set the interrupt address.
-	// Set MODE field to 1 - a vector base address (only supported by ESP32C3)
-	// Note that this address must be aligned to 256 bytes.
-	riscv.MTVEC.Set((uintptr(unsafe.Pointer(&_vector_table))) | 1)
-
-	riscv.EnableInterrupts(mie)
-}
-
 func (i Interrupt) Enable() error {
 	mask := riscv.DisableInterrupts()
 	defer riscv.EnableInterrupts(mask)
@@ -159,9 +138,6 @@ func (h HandlerID) set(interrupt int) error {
 	}
 	return nil
 }
-
-//go:extern _vector_table
-var _vector_table [0]uintptr
 
 //export handleInterrupt
 func handleInterrupt() {

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -69,7 +69,7 @@ func abort() {
 	}
 }
 
-// Init initialize the interrupt controller and called from runtime once.
+// interruptInit initialize the interrupt controller and called from runtime once.
 func interruptInit() {
 	mie := riscv.DisableInterrupts()
 

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"device/esp"
 	"device/riscv"
+	"runtime/interrupt"
 )
 
 // This is the function called on startup after the flash (IROM/DROM) is
@@ -46,6 +47,9 @@ func main() {
 	esp.SYSTEM.CPU_PER_CONF.Set(esp.SYSTEM_CPU_PER_CONF_CPU_WAIT_MODE_FORCE_ON | esp.SYSTEM_CPU_PER_CONF_PLL_FREQ_SEL | 1<<esp.SYSTEM_CPU_PER_CONF_CPUPERIOD_SEL_Pos)
 
 	clearbss()
+
+	// Configure interrupt handler
+	interrupt.Init()
 
 	// Initialize main system timer used for time.Now.
 	initTimer()

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -14,6 +14,7 @@
 	"serial-port": ["acm:303a:1001"],
 	"openocd-interface": "esp_usb_jtag",
 	"openocd-target": "esp32c3",
-	"openocd-commands": ["gdb_memory_map disable"]
+	"openocd-commands": ["gdb_memory_map disable"],
+	"gdb": ["riscv32-esp-elf-gdb"]
 }
 

--- a/targets/esp32c3.ld
+++ b/targets/esp32c3.ld
@@ -146,6 +146,9 @@ SECTIONS
      */
     .text : ALIGN(4)
     {
+        . = ALIGN (256);
+        *(.text.exception_vectors)
+        . = ALIGN (4);
         *(.text .text.*)
         *(.wifislpiram .wifislpiram.*)
     } >IROM


### PR DESCRIPTION
@aykevl this is only interrupt implementation for esp32c3.
No exported APIs except enum values of `HandlerID` type to initialize chip's modules.
Tested with pin src/examples/pininterrupt/pininterrupt.go (not checked in)