### PR TITLE
compiler: add support for recursive function types

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -23,7 +23,7 @@ import (
 // Version of the compiler pacakge. Must be incremented each time the compiler
 // package changes in a way that affects the generated LLVM module.
 // This version is independent of the TinyGo version number.
-const Version = 22 // last change: check for divide by zero
+const Version = 23 // last change: fix recursive function types
 
 func init() {
 	llvm.InitializeAllTargets()
@@ -76,6 +76,7 @@ type compilerContext struct {
 	targetData       llvm.TargetData
 	intType          llvm.Type
 	i8ptrType        llvm.Type // for convenience
+	rawVoidFuncType  llvm.Type // for convenience
 	funcPtrAddrSpace int
 	uintptrType      llvm.Type
 	program          *ssa.Program
@@ -121,6 +122,7 @@ func newCompilerContext(moduleName string, machine llvm.TargetMachine, config *C
 	dummyFuncType := llvm.FunctionType(c.ctx.VoidType(), nil, false)
 	dummyFunc := llvm.AddFunction(c.mod, "tinygo.dummy", dummyFuncType)
 	c.funcPtrAddrSpace = dummyFunc.Type().PointerAddressSpace()
+	c.rawVoidFuncType = dummyFunc.Type()
 	dummyFunc.EraseFromParentAsFunction()
 
 	return c

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -103,7 +103,7 @@ entry:
 declare void @runtime.printint32(i32, i8*, i8*)
 
 ; Function Attrs: nounwind
-define hidden void @main.funcGoroutine(i8* %fn.context, void (i32, i8*, i8*)* %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
+define hidden void @main.funcGoroutine(i8* %fn.context, void ()* %fn.funcptr, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %0 = call i8* @runtime.alloc(i32 12, i8* undef, i8* null) #0
   %1 = bitcast i8* %0 to i32*
@@ -112,8 +112,8 @@ entry:
   %3 = bitcast i8* %2 to i8**
   store i8* %fn.context, i8** %3, align 4
   %4 = getelementptr inbounds i8, i8* %0, i32 8
-  %5 = bitcast i8* %4 to void (i32, i8*, i8*)**
-  store void (i32, i8*, i8*)* %fn.funcptr, void (i32, i8*, i8*)** %5, align 4
+  %5 = bitcast i8* %4 to void ()**
+  store void ()* %fn.funcptr, void ()** %5, align 4
   %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* undef, i8* undef) #0
   call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* nonnull %0, i32 %stacksize, i8* undef, i8* null) #0
   ret void

--- a/testdata/calls.go
+++ b/testdata/calls.go
@@ -228,3 +228,7 @@ type issue1304 struct {
 func (x issue1304) call() {
 	// nothing to do
 }
+
+type recursiveFuncType func(recursiveFuncType)
+
+var recursiveFunction recursiveFuncType


### PR DESCRIPTION
This adds support for a construct like this:

    type foo func(fn foo)

Unfortunately, LLVM cannot create function pointers that look like this.
LLVM only supports named types for structs (not for pointers) and thus
can't add a pointer to a function type of the same type to a parameter
of that function type.

The fix is simple: cast all function pointers to a void function, in
LLVM IR:

    void ()*

Raw function pointers are cast to this type before storing, and cast
back to the regular function type before calling. This means that
function parameters will never refer to its own type because raw
function types are fixed at that one type.

Somehow, this does have an effect on binary size in some cases. The
effect is small and goes both ways. On top of that, there is work
underway in LLVM which would make all pointer types opaque (without a
pointee type). This would make this whole commit useless and therefore
should fix any size increases that might happen.
https://llvm.org/docs/OpaquePointers.html