### PR TITLE
runtime (js/wasm): avoid scheduler recursion

### DIFF
--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -116,9 +116,18 @@ func addSleepTask(t *task.Task, duration timeUnit) {
 	*q = t
 }
 
+var schedulerRunning bool
+
 // Run the scheduler until all tasks have finished.
 func scheduler() {
 	// Main scheduler loop.
+	if schedulerDebug {
+		if schedulerRunning {
+			runtimePanic("nested scheduler")
+		}
+
+		schedulerRunning = true
+	}
 	var now timeUnit
 	for !schedulerDone {
 		scheduleLog("")
@@ -143,7 +152,7 @@ func scheduler() {
 			if sleepQueue == nil {
 				if asyncScheduler {
 					// JavaScript is treated specially, see below.
-					return
+					break
 				}
 				waitForEvents()
 				continue
@@ -169,6 +178,9 @@ func scheduler() {
 		// Run the given task.
 		scheduleLogTask("  run:", t)
 		t.Resume()
+	}
+	if schedulerDebug {
+		schedulerRunning = false
 	}
 }
 


### PR DESCRIPTION
The wasm "log" test attaches a callback to a button and then triggers a click event.
The click event then calls back into the WASM module, spawning another copy of the scheduler loop.

This change detects this kind of nesting and will now spawn the event handler but not the scheduler.
A debug assertion has also been added to the scheduler to help track down similar issues in the future.