### PR TITLE
src/testing: stub B.ReportAllocs()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,14 @@ test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
 
 TEST_PACKAGES = \
+	compress/bzip2 \
 	container/heap \
 	container/list \
 	container/ring \
 	crypto/des \
+	crypto/dsa \
 	crypto/md5 \
+	crypto/rc4 \
 	crypto/sha1 \
 	crypto/sha256 \
 	crypto/sha512 \
@@ -199,13 +202,19 @@ TEST_PACKAGES = \
 	encoding/ascii85 \
 	encoding/base32 \
 	encoding/hex \
+	hash \
 	hash/adler32 \
 	hash/fnv \
 	hash/crc64 \
+	html \
+	index/suffixarray \
 	math \
 	math/cmplx \
 	testing \
+	testing/iotest \
 	text/scanner \
+	text/scanner \
+	unicode \
 	unicode/utf8 \
 
 # Test known-working standard library packages.

--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -69,6 +69,12 @@ func (b *B) SetBytes(n int64) {
 	panic("testing: unimplemented: B.SetBytes")
 }
 
+// ReportAllocs enables malloc statistics for this benchmark.
+func (b *B) ReportAllocs() {
+	// Dummy version to allow building e.g. golang.org/crypto/...
+	panic("testing: unimplemented: B.ReportAllocs")
+}
+
 // StartTimer starts timing a test. This function is called automatically
 // before a benchmark starts, but it can also be used to resume timing after
 // a call to StopTimer.


### PR DESCRIPTION
This allows test packages that use this feature in their benchmarks
to build and run (if not the benchmarks themselves).