### PR TITLE
Makefile: remove crypto/sha1 from TEST_PACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,6 @@ TEST_PACKAGES = \
 	crypto/dsa \
 	crypto/md5 \
 	crypto/rc4 \
-	crypto/sha1 \
 	crypto/sha256 \
 	crypto/sha512 \
 	encoding \


### PR DESCRIPTION
Due to issue15617_test's use of /x/sys/unix.Mmap, this package
no longer builds and runs out of the box on Mac