### PR TITLE
hifive1b: increase CPU frequency from 16MHz to 320MHz

### DIFF
--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -79,12 +79,12 @@ func handleInterrupt() {
 
 // initPeripherals configures periperhals the way the runtime expects them.
 func initPeripherals() {
-	// Make sure the HFROSC is on
-	sifive.PRCI.HFROSCCFG.SetBits(sifive.PRCI_HFROSCCFG_ENABLE)
-
-	// Run off 16 MHz Crystal for accuracy.
-	sifive.PRCI.PLLCFG.SetBits(sifive.PRCI_PLLCFG_REFSEL | sifive.PRCI_PLLCFG_BYPASS)
-	sifive.PRCI.PLLCFG.SetBits(sifive.PRCI_PLLCFG_SEL)
+	// Configure PLL to output 320MHz.
+	//   R=2:  divide 16MHz to 8MHz
+	//   F=80: multiply 8MHz by 80 to get 640MHz (80/2-1=39)
+	//   Q=2:  divide 640MHz by 2 to get 320MHz
+	// This makes the main CPU run at 320MHz.
+	sifive.PRCI.PLLCFG.Set(sifive.PRCI_PLLCFG_PLLR_R2<<sifive.PRCI_PLLCFG_PLLR_Pos | 39<<sifive.PRCI_PLLCFG_PLLF_Pos | sifive.PRCI_PLLCFG_PLLQ_Q2<<sifive.PRCI_PLLCFG_PLLQ_Pos | sifive.PRCI_PLLCFG_SEL | sifive.PRCI_PLLCFG_REFSEL)
 
 	// Turn off HFROSC to save power
 	sifive.PRCI.HFROSCCFG.ClearBits(sifive.PRCI_HFROSCCFG_ENABLE)


### PR DESCRIPTION
This chip can run so much faster! Let's update the default frequency.

Also, change the UART implementation to be more fexible regarding the clock frequency.