### PR TITLE
machine: support Pin.Get() function when the pin is configured as output

### DIFF
--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -33,7 +33,8 @@ func (p Pin) Set(high bool) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when configured as an input or as
+// an output.
 func (p Pin) Get() bool {
 	return (sam.PORT.IN0.Get()>>uint8(p))&1 > 0
 }

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -49,7 +49,8 @@ func (p Pin) Set(high bool) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when configured as an input or as
+// an output.
 func (p Pin) Get() bool {
 	if p < 32 {
 		return (sam.PORT.IN0.Get()>>uint8(p))&1 > 0

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -542,7 +542,8 @@ func (p Pin) Set(high bool) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when configured as an input or as
+// an output.
 func (p Pin) Get() bool {
 	group, pin_in_group := p.getPinGrouping()
 	return (sam.PORT.GROUP[group].IN.Get()>>pin_in_group)&1 > 0

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -63,7 +63,8 @@ func (p Pin) Configure(config PinConfig) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input or as an output.
 func (p Pin) Get() bool {
 	port, mask := p.getPortMask()
 	// As noted above, the PINx register is always two registers below the PORTx

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -159,7 +159,7 @@ func (p Pin) portMaskClear() (*volatile.Register32, uint32) {
 }
 
 // Get returns the current value of a GPIO pin when the pin is configured as an
-// input.
+// input or as an output.
 func (p Pin) Get() bool {
 	if p < 32 {
 		return esp.GPIO.IN.Get()&(1<<p) != 0

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -106,7 +106,7 @@ func (p Pin) Configure(config PinConfig) {
 }
 
 // Get returns the current value of a GPIO pin when the pin is configured as an
-// input.
+// input or as an output.
 func (p Pin) Get() bool {
 	// See this document for details
 	// https://www.espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -44,7 +44,8 @@ func (p Pin) Set(high bool) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input or as an output.
 func (p Pin) Get() bool {
 	val := sifive.GPIO0.VALUE.Get() & (1 << uint8(p))
 	return (val > 0)

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -17,7 +17,7 @@ const (
 	PinInput         PinMode = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 	PinInputPullup   PinMode = PinInput | (nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos)
 	PinInputPulldown PinMode = PinInput | (nrf.GPIO_PIN_CNF_PULL_Pulldown << nrf.GPIO_PIN_CNF_PULL_Pos)
-	PinOutput        PinMode = (nrf.GPIO_PIN_CNF_DIR_Output << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Disconnect << nrf.GPIO_PIN_CNF_INPUT_Pos)
+	PinOutput        PinMode = (nrf.GPIO_PIN_CNF_DIR_Output << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 )
 
 type PinChange uint8
@@ -64,7 +64,8 @@ func (p Pin) PortMaskClear() (*uint32, uint32) {
 	return &port.OUTCLR.Reg, 1 << pin
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input or as an output.
 func (p Pin) Get() bool {
 	port, pin := p.getPortPin()
 	return (port.IN.Get()>>pin)&1 != 0

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -51,7 +51,8 @@ func (p Pin) Set(high bool) {
 	}
 }
 
-// Get returns the current value of a GPIO pin.
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input or as an output.
 func (p Pin) Get() bool {
 	port := p.getPort()
 	pin := uint8(p) % 16


### PR DESCRIPTION
To my surprise, this is supported on all the devices I could test so therefore it makes sense to change the API to allow this.

Tested on all the devices that have a changed comment. Unfortunately I could not test on the NXP chips (because I don't have them) and on the RP2040 (because my Pico somehow doesn't show up when I try to flash it).

I only needed to change the nrf series to enable the pin input when it is configured as an output.