### PR TITLE
Proposal to fix #2187 WASI gc=conservative frees data which is still malloc'ed by cgo code 

### DIFF
--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -24,10 +24,10 @@ func wasm_memory_size(index int32) int32
 func wasm_memory_grow(index int32, delta int32) int32
 
 var (
-	heapStart    = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd      = uintptr(wasm_memory_size(0) * wasmPageSize)
-	globalsStart = uintptr(unsafe.Pointer(&globalsStartSymbol))
-	globalsEnd   = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapStart       = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd         = uintptr(wasm_memory_size(0) * wasmPageSize)
+	globalsStart    = uintptr(unsafe.Pointer(&globalsStartSymbol))
+	globalsEnd      = uintptr(unsafe.Pointer(&heapStartSymbol))
 	libcAllocations = make(map[uintptr]uintptr)
 )
 

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -68,6 +68,9 @@ func growHeap() bool {
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
 	memPtr := alloc(size)
+	if memPtr == nil {
+		return memPtr
+	}
 	libcAllocations[uintptr(memPtr)] = size
 	return memPtr
 }


### PR DESCRIPTION
I reported [WASI gc=conservative frees data which is still malloc'ed by cgo code #2187](https://github.com/tinygo-org/tinygo/issues/2187) which describes the issue I was facing. This PR is my proposal to resolve the issue.

Tests are passing except for the arm & aarch64 ones:
exec: "aarch64-linux-gnu-gcc": executable file not found in $PATH
exec: "arm-linux-gnueabihf-gcc": executable file not found in $PATH

I do not have the arm & aarch64 toolchains installed on my system and
could not find any build targets to create them for the tinygo tests,
therefore I skipped them.

Thank you!