### PR TITLE
Implement realloc for WASI cgo

### DIFF
--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -84,8 +84,19 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 
 //export realloc
 func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
-	runtimePanic("unimplemented: realloc")
-	return nil
+	newMalloc := libc_malloc(size)
+	newMallocPtr := uintptr(newMalloc)
+	oldPtr := uintptr(ptr)
+
+	var i uintptr
+	for i = 0; i < size; i++ {
+		//unsafe.Add() only available for go>=1.17; can be adjusted later
+		//*(*byte)(unsafe.Add(newMalloc,i)) = *(*byte)(unsafe.Add(ptr,i))
+		*(*byte)(unsafe.Pointer(newMallocPtr + i)) = *(*byte)(unsafe.Pointer(oldPtr + i))
+	}
+
+	libc_free(ptr)
+	return newMalloc
 }
 
 //export posix_memalign

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -84,8 +84,19 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 
 //export realloc
 func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
-	runtimePanic("unimplemented: realloc")
-	return nil
+	newMalloc := libc_malloc(size)
+	newMallocPtr := uintptr(newMalloc)
+	oldPtr := uintptr(ptr)
+
+	var i uintptr;
+	for i=0;i<size;i++ {
+		//unsafe.Add() only available for go>=1.17; can be adjusted later
+		//*(*byte)(unsafe.Add(newMalloc,i)) = *(*byte)(unsafe.Add(ptr,i))
+		*(*byte)(unsafe.Pointer(newMallocPtr + i)) = *(*byte)(unsafe.Pointer(oldPtr + i))
+	}
+
+	libc_free(ptr)
+	return newMalloc
 }
 
 //export posix_memalign


### PR DESCRIPTION
Using wasi-libc from wasi-sdk 12.0 I experienced
a panic because realloc is not implemented yet.
Not sure if the current wasi-libc shipped with tinygo
was patched to avoid realloc, otherwise this
implementation might help to be prepared for newer
versions of wasi-libc.