### PR TITLE
Added realloc implementation to GCs

### DIFF
--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -84,8 +84,7 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 
 //export realloc
 func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
-	runtimePanic("unimplemented: realloc")
-	return nil
+	return realloc(ptr, size)
 }
 
 //export posix_memalign

--- a/src/runtime/gc_extalloc.go
+++ b/src/runtime/gc_extalloc.go
@@ -630,6 +630,10 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	}
 }
 
+func realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
+	runtimePanic("unimplemented: gc_extalloc.realloc")
+}
+
 func free(ptr unsafe.Pointer) {
 	// Currently unimplemented due to bugs in coroutine lowering.
 }

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -35,6 +35,18 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	return unsafe.Pointer(addr)
 }
 
+func realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
+	newAlloc := alloc(size, nil)
+	if ptr == nil {
+		return newAlloc
+	}
+	// according to POSIX everything beyond the previous pointer's
+	// size will have indeterminate values so we can just copy garbage
+	memcpy(newAlloc, ptr, size)
+
+	return newAlloc
+}
+
 func free(ptr unsafe.Pointer) {
 	// Memory is never freed.
 }

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -12,6 +12,8 @@ import (
 
 func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
 
+func realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer
+
 func free(ptr unsafe.Pointer) {
 	// Nothing to free when nothing gets allocated.
 }


### PR DESCRIPTION
 When using the latest wasi-libc I experienced a panic on an attempt to call realloc. My first attempt to add it to arch_tinygowasm.go was not good (PR #2194) for obvious reasons. 
So here is another suggestion.    

Somehow I got motivated to help. Please stop me, if it is more annoying than helping.
