### PR TITLE
compiler: add support for the go keyword on interface methods

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1342,9 +1342,9 @@ func (b *builder) createBuiltin(argTypes []types.Type, argValues []llvm.Value, c
 //
 // This is also where compiler intrinsics are implemented.
 func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) {
-	if instr.IsInvoke() {
-		fnCast, args := b.getInvokeCall(instr)
-		return b.createCall(fnCast, args, ""), nil
+	var params []llvm.Value
+	for _, param := range instr.Args {
+		params = append(params, b.getValue(param))
 	}
 
 	// Try to call the function directly for trivially static calls.
@@ -1415,12 +1415,20 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 	} else if call, ok := instr.Value.(*ssa.Builtin); ok {
 		// Builtin function (append, close, delete, etc.).)
 		var argTypes []types.Type
-		var argValues []llvm.Value
 		for _, arg := range instr.Args {
 			argTypes = append(argTypes, arg.Type())
-			argValues = append(argValues, b.getValue(arg))
 		}
-		return b.createBuiltin(argTypes, argValues, call.Name(), instr.Pos())
+		return b.createBuiltin(argTypes, params, call.Name(), instr.Pos())
+	} else if instr.IsInvoke() {
+		// Interface method call (aka invoke call).
+		itf := b.getValue(instr.Value) // interface value (runtime._interface)
+		typecode := b.CreateExtractValue(itf, 0, "invoke.func.typecode")
+		value := b.CreateExtractValue(itf, 1, "invoke.func.value") // receiver
+		// Prefix the params with receiver value and suffix with typecode.
+		params = append([]llvm.Value{value}, params...)
+		params = append(params, typecode)
+		callee = b.getInvokeFunction(instr)
+		context = llvm.Undef(b.i8ptrType)
 	} else {
 		// Function pointer.
 		value := b.getValue(instr.Value)
@@ -1428,11 +1436,6 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 		// extract the function pointer and context first from the func value.
 		callee, context = b.decodeFuncValue(value, instr.Value.Type().Underlying().(*types.Signature))
 		b.createNilCheck(instr.Value, callee, "fpcall")
-	}
-
-	var params []llvm.Value
-	for _, param := range instr.Args {
-		params = append(params, b.getValue(param))
 	}
 
 	if !exported {

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -331,10 +331,10 @@ func (b *builder) createRunDefers() {
 				//Pass context
 				forwardParams = append(forwardParams, context)
 			} else {
-				// Isolate the typecode.
-				typecode := forwardParams[0]
-				forwardParams = forwardParams[1:]
-				fnPtr = b.getInvokePtr(callback, typecode)
+				// Move typecode from the start to the end of the list of
+				// parameters.
+				forwardParams = append(forwardParams[1:], forwardParams[0])
+				fnPtr = b.getInvokeFunction(callback)
 
 				// Add the context parameter. An interface call cannot also be a
 				// closure but we have to supply the parameter anyway for platforms

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -9,6 +9,8 @@ target triple = "armv7m-unknown-unknown-eabi"
 %"internal/task.state" = type { i32, i32* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
+@"main.startInterfaceMethod$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
+
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
 ; Function Attrs: nounwind
@@ -158,8 +160,50 @@ entry:
 
 declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*, i8*)
 
+; Function Attrs: nounwind
+define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %0 = call i8* @runtime.alloc(i32 16, i8* undef, i8* null) #0
+  %1 = bitcast i8* %0 to i8**
+  store i8* %itf.value, i8** %1, align 4
+  %2 = getelementptr inbounds i8, i8* %0, i32 4
+  %.repack = bitcast i8* %2 to i8**
+  store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"main.startInterfaceMethod$string", i32 0, i32 0), i8** %.repack, align 4
+  %.repack1 = getelementptr inbounds i8, i8* %0, i32 8
+  %3 = bitcast i8* %.repack1 to i32*
+  store i32 4, i32* %3, align 4
+  %4 = getelementptr inbounds i8, i8* %0, i32 12
+  %5 = bitcast i8* %4 to i32*
+  store i32 %itf.typecode, i32* %5, align 4
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), i8* undef, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), i8* nonnull %0, i32 %stacksize, i8* undef, i8* null) #0
+  ret void
+}
+
+declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8*, i8*, i32, i32, i8*, i8*) #5
+
+; Function Attrs: nounwind
+define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(i8* %0) unnamed_addr #6 {
+entry:
+  %1 = bitcast i8* %0 to i8**
+  %2 = load i8*, i8** %1, align 4
+  %3 = getelementptr inbounds i8, i8* %0, i32 4
+  %4 = bitcast i8* %3 to i8**
+  %5 = load i8*, i8** %4, align 4
+  %6 = getelementptr inbounds i8, i8* %0, i32 8
+  %7 = bitcast i8* %6 to i32*
+  %8 = load i32, i32* %7, align 4
+  %9 = getelementptr inbounds i8, i8* %0, i32 12
+  %10 = bitcast i8* %9 to i32*
+  %11 = load i32, i32* %10, align 4
+  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8* %2, i8* %5, i32 %8, i32 %11, i8* undef, i8* undef) #0
+  ret void
+}
+
 attributes #0 = { nounwind }
 attributes #1 = { nounwind "tinygo-gowrapper"="main.regularFunction" }
 attributes #2 = { nounwind "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
 attributes #3 = { nounwind "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
 attributes #4 = { nounwind "tinygo-gowrapper" }
+attributes #5 = { "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
+attributes #6 = { nounwind "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }

--- a/compiler/testdata/goroutine-wasm.ll
+++ b/compiler/testdata/goroutine-wasm.ll
@@ -14,6 +14,7 @@ target triple = "wasm32-unknown-wasi"
 @"main.inlineFunctionGoroutine$pack" = private unnamed_addr constant { i32, i8* } { i32 5, i8* undef }
 @"reflect/types.funcid:func:{basic:int}{}" = external constant i8
 @"main.closureFunctionGoroutine$1$withSignature" = linkonce_odr constant %runtime.funcValueWithSignature { i32 ptrtoint (void (i32, i8*, i8*)* @"main.closureFunctionGoroutine$1" to i32), i8* @"reflect/types.funcid:func:{basic:int}{}" }
+@"main.startInterfaceMethod$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
@@ -115,4 +116,26 @@ entry:
 
 declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*, i8*)
 
+; Function Attrs: nounwind
+define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %0 = call i8* @runtime.alloc(i32 16, i8* undef, i8* null) #0
+  %1 = bitcast i8* %0 to i8**
+  store i8* %itf.value, i8** %1, align 4
+  %2 = getelementptr inbounds i8, i8* %0, i32 4
+  %.repack = bitcast i8* %2 to i8**
+  store i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"main.startInterfaceMethod$string", i32 0, i32 0), i8** %.repack, align 4
+  %.repack1 = getelementptr inbounds i8, i8* %0, i32 8
+  %3 = bitcast i8* %.repack1 to i32*
+  store i32 4, i32* %3, align 4
+  %4 = getelementptr inbounds i8, i8* %0, i32 12
+  %5 = bitcast i8* %4 to i32*
+  store i32 %itf.typecode, i32* %5, align 4
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*, i8*, i32, i32, i8*, i8*)* @"interface:{Print:func:{basic:string}{}}.Print$invoke" to i32), i8* nonnull %0, i32 undef, i8* undef, i8* null) #0
+  ret void
+}
+
+declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8*, i8*, i32, i32, i8*, i8*) #1
+
 attributes #0 = { nounwind }
+attributes #1 = { "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }

--- a/compiler/testdata/goroutine.go
+++ b/compiler/testdata/goroutine.go
@@ -41,3 +41,11 @@ func closeBuiltinGoroutine(ch chan int) {
 }
 
 func regularFunction(x int)
+
+type simpleInterface interface {
+	Print(string)
+}
+
+func startInterfaceMethod(itf simpleInterface) {
+	go itf.Print("test")
+}

--- a/compiler/testdata/interface.go
+++ b/compiler/testdata/interface.go
@@ -49,6 +49,15 @@ func isStringer(itf interface{}) bool {
 	return ok
 }
 
+type fooInterface interface {
+	String() string
+	foo(int) byte
+}
+
+func callFooMethod(itf fooInterface) uint8 {
+	return itf.foo(3)
+}
+
 func callErrorMethod(itf error) string {
 	return itf.Error()
 }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -3,25 +3,24 @@ source_filename = "interface.go"
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-wasi"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID* }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 %runtime._interface = type { i32, i8* }
 %runtime._string = type { i8*, i32 }
 
-@"reflect/types.type:basic:int" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* null, i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:basic:int" }
-@"reflect/types.type:pointer:basic:int" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null }
-@"reflect/types.type:pointer:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:named:error", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null }
-@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:named:error" }
-@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }
+@"reflect/types.type:basic:int" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* null, i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:basic:int", i32 0 }
+@"reflect/types.type:pointer:basic:int" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
+@"reflect/types.type:pointer:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:named:error", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
+@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:named:error", i32 ptrtoint (i1 (i32)* @"interface:{Error:func:{}{basic:string}}.$typeassert" to i32) }
+@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}", i32 ptrtoint (i1 (i32)* @"interface:{Error:func:{}{basic:string}}.$typeassert" to i32) }
 @"reflect/methods.Error() string" = linkonce_odr constant i8 0, align 1
 @"reflect/types.interface:interface{Error() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.Error() string"]
-@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null }
-@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{String:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null }
-@"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{String() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" }
+@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
+@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{String:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
+@"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{String() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}", i32 ptrtoint (i1 (i32)* @"interface:{String:func:{}{basic:string}}.$typeassert" to i32) }
 @"reflect/methods.String() string" = linkonce_odr constant i8 0, align 1
 @"reflect/types.interface:interface{String() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.String() string"]
 @"reflect/types.typeid:basic:int" = external constant i8
-@"error$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.Error() string"]
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
 
@@ -49,11 +48,15 @@ entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:named:error" to i32), i8* null }
 }
 
+declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32) #1
+
 ; Function Attrs: nounwind
 define hidden %runtime._interface @main.anonymousInterfaceType(i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" to i32), i8* null }
 }
+
+declare i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32) #2
 
 ; Function Attrs: nounwind
 define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
@@ -73,7 +76,7 @@ declare i1 @runtime.typeAssert(i32, i8* dereferenceable_or_null(1), i8*, i8*)
 ; Function Attrs: nounwind
 define hidden i1 @main.isError(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* undef, i8* null) #0
+  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #0
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry
@@ -82,13 +85,11 @@ typeassert.ok:                                    ; preds = %entry
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
   ret i1 %0
 }
-
-declare i1 @runtime.interfaceImplements(i32, i8** dereferenceable_or_null(4), i8*, i8*)
 
 ; Function Attrs: nounwind
 define hidden i1 @main.isStringer(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.interfaceImplements(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"reflect/types.interface:interface{String() string}$interface", i32 0, i32 0), i8* undef, i8* null) #0
+  %0 = call i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #0
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.ok:                                    ; preds = %entry
@@ -99,14 +100,25 @@ typeassert.next:                                  ; preds = %typeassert.ok, %ent
 }
 
 ; Function Attrs: nounwind
+define hidden i8 @main.callFooMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
+entry:
+  %0 = call i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8* %itf.value, i32 3, i32 %itf.typecode, i8* undef, i8* undef) #0
+  ret i8 %0
+}
+
+declare i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8*, i32, i32, i8*, i8*) #3
+
+; Function Attrs: nounwind
 define hidden %runtime._string @main.callErrorMethod(i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %invoke.func = call i32 @runtime.interfaceMethod(i32 %itf.typecode, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"error$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Error() string", i8* undef, i8* null) #0
-  %invoke.func.cast = inttoptr i32 %invoke.func to %runtime._string (i8*, i8*, i8*)*
-  %0 = call %runtime._string %invoke.func.cast(i8* %itf.value, i8* undef, i8* undef) #0
+  %0 = call %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8* %itf.value, i32 %itf.typecode, i8* undef, i8* undef) #0
   ret %runtime._string %0
 }
 
-declare i32 @runtime.interfaceMethod(i32, i8** dereferenceable_or_null(4), i8* dereferenceable_or_null(1), i8*, i8*)
+declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8*, i32, i8*, i8*) #4
 
 attributes #0 = { nounwind }
+attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }
+attributes #2 = { "tinygo-methods"="reflect/methods.String() string" }
+attributes #3 = { "tinygo-invoke"="main.$methods.foo(int) byte" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) byte" }
+attributes #4 = { "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -117,6 +117,10 @@ type typecodeID struct {
 	// Keeping the type struct alive here is important so that values from
 	// reflect.New (which uses reflect.PtrTo) can be used in type asserts etc.
 	ptrTo *typecodeID
+
+	// typeAssert is a ptrtoint of a declared interface assert function.
+	// It only exists to make the rtcalls pass easier.
+	typeAssert uintptr
 }
 
 // structField is used by the compiler to pass information to the interface
@@ -133,11 +137,3 @@ type structField struct {
 // asserts. Also, it is replaced with const false if this type assert can never
 // happen.
 func typeAssert(actualType uintptr, assertedType *uint8) bool
-
-// Pseudo function call that returns whether a given type implements all methods
-// of the given interface.
-func interfaceImplements(typecode uintptr, interfaceMethodSet **uint8) bool
-
-// Pseudo function that returns a function pointer to the method to call.
-// See the interface lowering pass for how this is lowered to a real call.
-func interfaceMethod(typecode uintptr, interfaceMethodSet **uint8, signature *uint8) uintptr

--- a/testdata/goroutines.go
+++ b/testdata/goroutines.go
@@ -75,6 +75,8 @@ func main() {
 
 	testGoOnBuiltins()
 
+	testGoOnInterface(Foo(0))
+
 	testCond()
 
 	testIssue1790()
@@ -203,10 +205,35 @@ func testCond() {
 
 var once sync.Once
 
+func testGoOnInterface(f Itf) {
+	go f.Nowait()
+	time.Sleep(time.Millisecond)
+	go f.Wait()
+	time.Sleep(time.Millisecond * 2)
+	println("done with 'go on interface'")
+}
+
 // This tests a fix for issue 1790:
 // https://github.com/tinygo-org/tinygo/issues/1790
 func testIssue1790() *int {
 	once.Do(func() {})
 	i := 0
 	return &i
+}
+
+type Itf interface {
+	Nowait()
+	Wait()
+}
+
+type Foo string
+
+func (f Foo) Nowait() {
+	println("called: Foo.Nowait")
+}
+
+func (f Foo) Wait() {
+	println("called: Foo.Wait")
+	time.Sleep(time.Microsecond)
+	println("  ...waited")
 }

--- a/testdata/goroutines.txt
+++ b/testdata/goroutines.txt
@@ -20,3 +20,7 @@ acquired mutex from goroutine
 released mutex from goroutine
 re-acquired mutex
 done
+called: Foo.Nowait
+called: Foo.Wait
+  ...waited
+done with 'go on interface'

--- a/transform/interface-lowering.go
+++ b/transform/interface-lowering.go
@@ -3,32 +3,27 @@ package transform
 // This file provides function to lower interface intrinsics to their final LLVM
 // form, optimizing them in the process.
 //
-// During SSA construction, the following pseudo-calls are created:
+// During SSA construction, the following pseudo-call is created (see
+// src/runtime/interface.go):
 //     runtime.typeAssert(typecode, assertedType)
-//     runtime.interfaceImplements(typecode, interfaceMethodSet)
-//     runtime.interfaceMethod(typecode, interfaceMethodSet, signature)
-// See src/runtime/interface.go for details.
-// These calls are to declared but not defined functions, so the optimizer will
-// leave them alone.
+// Additionally, interface type asserts and interface invoke functions are
+// declared but not defined, so the optimizer will leave them alone.
 //
-// This pass lowers the above functions to their final form:
+// This pass lowers these functions to their final form:
 //
 // typeAssert:
 //     Replaced with an icmp instruction so it can be directly used in a type
 //     switch. This is very easy to optimize for LLVM: it will often translate a
 //     type switch into a regular switch statement.
 //
-// interfaceImplements:
-//     This call is translated into a call that checks whether the underlying
-//     type is one of the types implementing this interface.
+// interface type assert:
+//     These functions are defined by creating a big type switch over all the
+//     concrete types implementing this interface.
 //
-// interfaceMethod:
-//     This call is replaced with a call to a function that calls the
-//     appropriate method depending on the underlying type.
-//     When there is only one type implementing this interface, this call is
-//     translated into a direct call of that method.
-//     When there is no type implementing this interface, this code is marked
-//     unreachable as there is no way such an interface could be constructed.
+// interface invoke:
+//     These functions are defined with a similar type switch, but instead of
+//     checking for the appropriate type, these functions will call the
+//     underlying method instead.
 //
 // Note that this way of implementing interfaces is very different from how the
 // main Go compiler implements them. For more details on how the main Go
@@ -45,27 +40,8 @@ import (
 // any method in particular.
 type signatureInfo struct {
 	name       string
-	global     llvm.Value
 	methods    []*methodInfo
 	interfaces []*interfaceInfo
-}
-
-// methodName takes a method name like "func String()" and returns only the
-// name, which is "String" in this case.
-func (s *signatureInfo) methodName() string {
-	var methodName string
-	if strings.HasPrefix(s.name, "reflect/methods.") {
-		methodName = s.name[len("reflect/methods."):]
-	} else if idx := strings.LastIndex(s.name, ".$methods."); idx >= 0 {
-		methodName = s.name[idx+len(".$methods."):]
-	} else {
-		panic("could not find method name")
-	}
-	if openingParen := strings.IndexByte(methodName, '('); openingParen < 0 {
-		panic("no opening paren in signature name")
-	} else {
-		return methodName[:openingParen]
-	}
 }
 
 // methodInfo describes a single method on a concrete type.
@@ -98,21 +74,9 @@ func (t *typeInfo) getMethod(signature *signatureInfo) *methodInfo {
 // interfaceInfo keeps information about a Go interface type, including all
 // methods it has.
 type interfaceInfo struct {
-	name        string                        // name with $interface suffix
-	methodSet   llvm.Value                    // global which this interfaceInfo describes
-	signatures  []*signatureInfo              // method set
-	types       []*typeInfo                   // types this interface implements
-	assertFunc  llvm.Value                    // runtime.interfaceImplements replacement
-	methodFuncs map[*signatureInfo]llvm.Value // runtime.interfaceMethod replacements for each signature
-}
-
-// id removes the $interface suffix from the name and returns the clean
-// interface name including import path.
-func (itf *interfaceInfo) id() string {
-	if !strings.HasSuffix(itf.name, "$interface") {
-		panic("interface type does not have $interface suffix: " + itf.name)
-	}
-	return itf.name[:len(itf.name)-len("$interface")]
+	name       string                    // "tinygo-methods" attribute
+	signatures map[string]*signatureInfo // method set
+	types      []*typeInfo               // types this interface implements
 }
 
 // lowerInterfacesPass keeps state related to the interface lowering pass. The
@@ -172,25 +136,26 @@ func (p *lowerInterfacesPass) run() error {
 		}
 	}
 
-	// Find all interface method calls.
-	interfaceMethod := p.mod.NamedFunction("runtime.interfaceMethod")
-	interfaceMethodUses := getUses(interfaceMethod)
-	for _, use := range interfaceMethodUses {
-		methodSet := use.Operand(1).Operand(0)
-		name := methodSet.Name()
-		if _, ok := p.interfaces[name]; !ok {
-			p.addInterface(methodSet)
+	// Find all interface type asserts and interface method thunks.
+	var interfaceAssertFunctions []llvm.Value
+	var interfaceInvokeFunctions []llvm.Value
+	for fn := p.mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+		methodsAttr := fn.GetStringAttributeAtIndex(-1, "tinygo-methods")
+		if methodsAttr.IsNil() {
+			continue
 		}
-	}
-
-	// Find all interface type asserts.
-	interfaceImplements := p.mod.NamedFunction("runtime.interfaceImplements")
-	interfaceImplementsUses := getUses(interfaceImplements)
-	for _, use := range interfaceImplementsUses {
-		methodSet := use.Operand(1).Operand(0)
-		name := methodSet.Name()
-		if _, ok := p.interfaces[name]; !ok {
-			p.addInterface(methodSet)
+		if !hasUses(fn) {
+			// Don't bother defining this function.
+			continue
+		}
+		p.addInterface(methodsAttr.GetStringValue())
+		invokeAttr := fn.GetStringAttributeAtIndex(-1, "tinygo-invoke")
+		if invokeAttr.IsNil() {
+			// Type assert.
+			interfaceAssertFunctions = append(interfaceAssertFunctions, fn)
+		} else {
+			// Interface invoke.
+			interfaceInvokeFunctions = append(interfaceInvokeFunctions, fn)
 		}
 	}
 
@@ -254,63 +219,20 @@ func (p *lowerInterfacesPass) run() error {
 		})
 	}
 
-	// Replace all interface methods with their uses, if possible.
-	for _, use := range interfaceMethodUses {
-		typecode := use.Operand(0)
-		signature := p.signatures[use.Operand(2).Name()]
-
-		methodSet := use.Operand(1).Operand(0) // global variable
-		itf := p.interfaces[methodSet.Name()]
-
-		// Delegate calling the right function to a special wrapper function.
-		inttoptrs := getUses(use)
-		if len(inttoptrs) != 1 || inttoptrs[0].IsAIntToPtrInst().IsNil() {
-			return errorAt(use, "internal error: expected exactly one inttoptr use of runtime.interfaceMethod")
-		}
-		inttoptr := inttoptrs[0]
-		calls := getUses(inttoptr)
-		for _, call := range calls {
-			// Set up parameters for the call. First copy the regular params...
-			params := make([]llvm.Value, call.OperandsCount())
-			paramTypes := make([]llvm.Type, len(params))
-			for i := 0; i < len(params)-1; i++ {
-				params[i] = call.Operand(i)
-				paramTypes[i] = params[i].Type()
-			}
-			// then add the typecode to the end of the list.
-			params[len(params)-1] = typecode
-			paramTypes[len(params)-1] = p.uintptrType
-
-			// Create a function that redirects the call to the destination
-			// call, after selecting the right concrete type.
-			redirector := p.getInterfaceMethodFunc(itf, signature, call.Type(), paramTypes)
-
-			// Replace the old lookup/inttoptr/call with the new call.
-			p.builder.SetInsertPointBefore(call)
-			retval := p.builder.CreateCall(redirector, append(params, llvm.ConstNull(llvm.PointerType(p.ctx.Int8Type(), 0))), "")
-			if retval.Type().TypeKind() != llvm.VoidTypeKind {
-				call.ReplaceAllUsesWith(retval)
-			}
-			call.EraseFromParentAsInstruction()
-		}
-		inttoptr.EraseFromParentAsInstruction()
-		use.EraseFromParentAsInstruction()
+	// Define all interface invoke thunks.
+	for _, fn := range interfaceInvokeFunctions {
+		methodsAttr := fn.GetStringAttributeAtIndex(-1, "tinygo-methods")
+		invokeAttr := fn.GetStringAttributeAtIndex(-1, "tinygo-invoke")
+		itf := p.interfaces[methodsAttr.GetStringValue()]
+		signature := itf.signatures[invokeAttr.GetStringValue()]
+		p.defineInterfaceMethodFunc(fn, itf, signature)
 	}
 
-	// Replace all typeasserts on interface types with matches on their concrete
-	// types, if possible.
-	for _, use := range interfaceImplementsUses {
-		actualType := use.Operand(0)
-
-		methodSet := use.Operand(1).Operand(0) // global variable
-		itf := p.interfaces[methodSet.Name()]
-		// Create a function that does a type switch on all available types
-		// that implement this interface.
-		fn := p.getInterfaceImplementsFunc(itf)
-		p.builder.SetInsertPointBefore(use)
-		commaOk := p.builder.CreateCall(fn, []llvm.Value{actualType}, "typeassert.ok")
-		use.ReplaceAllUsesWith(commaOk)
-		use.EraseFromParentAsInstruction()
+	// Define all interface type assert functions.
+	for _, fn := range interfaceAssertFunctions {
+		methodsAttr := fn.GetStringAttributeAtIndex(-1, "tinygo-methods")
+		itf := p.interfaces[methodsAttr.GetStringValue()]
+		p.defineInterfaceImplementsFunc(fn, itf)
 	}
 
 	// Replace each type assert with an actual type comparison or (if the type
@@ -337,11 +259,14 @@ func (p *lowerInterfacesPass) run() error {
 	}
 
 	// Remove all method sets, which are now unnecessary and inhibit later
-	// optimizations if they are left in place.
+	// optimizations if they are left in place. Also remove references to the
+	// interface type assert functions just to be sure.
+	zeroUintptr := llvm.ConstNull(p.uintptrType)
 	for _, t := range p.types {
 		initializer := t.typecode.Initializer()
 		methodSet := llvm.ConstExtractValue(initializer, []uint32{2})
 		initializer = llvm.ConstInsertValue(initializer, llvm.ConstNull(methodSet.Type()), []uint32{2})
+		initializer = llvm.ConstInsertValue(initializer, zeroUintptr, []uint32{4})
 		t.typecode.SetInitializer(initializer)
 	}
 
@@ -366,7 +291,7 @@ func (p *lowerInterfacesPass) addTypeMethods(t *typeInfo, methodSet llvm.Value) 
 		signatureGlobal := llvm.ConstExtractValue(methodData, []uint32{0})
 		signatureName := signatureGlobal.Name()
 		function := llvm.ConstExtractValue(methodData, []uint32{1}).Operand(0)
-		signature := p.getSignature(signatureName, signatureGlobal)
+		signature := p.getSignature(signatureName)
 		method := &methodInfo{
 			function:      function,
 			signatureInfo: signature,
@@ -378,53 +303,43 @@ func (p *lowerInterfacesPass) addTypeMethods(t *typeInfo, methodSet llvm.Value) 
 
 // addInterface reads information about an interface, which is the
 // fully-qualified name and the signatures of all methods it has.
-func (p *lowerInterfacesPass) addInterface(methodSet llvm.Value) {
-	name := methodSet.Name()
-	t := &interfaceInfo{
-		name:      name,
-		methodSet: methodSet,
+func (p *lowerInterfacesPass) addInterface(methodsString string) {
+	if _, ok := p.interfaces[methodsString]; ok {
+		return
 	}
-	p.interfaces[name] = t
-	methodSet = methodSet.Initializer() // get global value from getelementptr
-	for i := 0; i < methodSet.Type().ArrayLength(); i++ {
-		signatureGlobal := llvm.ConstExtractValue(methodSet, []uint32{uint32(i)})
-		signatureName := signatureGlobal.Name()
-		signature := p.getSignature(signatureName, signatureGlobal)
+	t := &interfaceInfo{
+		name:       methodsString,
+		signatures: make(map[string]*signatureInfo),
+	}
+	p.interfaces[methodsString] = t
+	for _, method := range strings.Split(methodsString, "; ") {
+		signature := p.getSignature(method)
 		signature.interfaces = append(signature.interfaces, t)
-		t.signatures = append(t.signatures, signature)
+		t.signatures[method] = signature
 	}
 }
 
 // getSignature returns a new *signatureInfo, creating it if it doesn't already
 // exist.
-func (p *lowerInterfacesPass) getSignature(name string, global llvm.Value) *signatureInfo {
+func (p *lowerInterfacesPass) getSignature(name string) *signatureInfo {
 	if _, ok := p.signatures[name]; !ok {
 		p.signatures[name] = &signatureInfo{
-			name:   name,
-			global: global,
+			name: name,
 		}
 	}
 	return p.signatures[name]
 }
 
-// getInterfaceImplementsFunc returns a function that checks whether a given
-// interface type implements a given interface, by checking all possible types
-// that implement this interface.
+// defineInterfaceImplementsFunc defines the interface type assert function. It
+// checks whether the given interface type (passed as an argument) is one of the
+// types it implements.
 //
 // The type match is implemented using an if/else chain over all possible types.
 // This if/else chain is easily converted to a big switch over all possible
 // types by the LLVM simplifycfg pass.
-func (p *lowerInterfacesPass) getInterfaceImplementsFunc(itf *interfaceInfo) llvm.Value {
-	if !itf.assertFunc.IsNil() {
-		return itf.assertFunc
-	}
-
+func (p *lowerInterfacesPass) defineInterfaceImplementsFunc(fn llvm.Value, itf *interfaceInfo) {
 	// Create the function and function signature.
 	// TODO: debug info
-	fnName := itf.id() + "$typeassert"
-	fnType := llvm.FunctionType(p.ctx.Int1Type(), []llvm.Type{p.uintptrType}, false)
-	fn := llvm.AddFunction(p.mod, fnName, fnType)
-	itf.assertFunc = fn
 	fn.Param(0).SetName("actualType")
 	fn.SetLinkage(llvm.InternalLinkage)
 	fn.SetUnnamedAddr(true)
@@ -456,33 +371,21 @@ func (p *lowerInterfacesPass) getInterfaceImplementsFunc(itf *interfaceInfo) llv
 	// Fill 'then' block (type assert was successful).
 	p.builder.SetInsertPointAtEnd(thenBlock)
 	p.builder.CreateRet(llvm.ConstInt(p.ctx.Int1Type(), 1, false))
-
-	return itf.assertFunc
 }
 
-// getInterfaceMethodFunc returns a thunk for calling a method on an interface.
+// defineInterfaceMethodFunc defines this thunk by calling the concrete method
+// of the type that implements this interface.
 //
 // Matching the actual type is implemented using an if/else chain over all
 // possible types.  This is later converted to a switch statement by the LLVM
 // simplifycfg pass.
-func (p *lowerInterfacesPass) getInterfaceMethodFunc(itf *interfaceInfo, signature *signatureInfo, returnType llvm.Type, paramTypes []llvm.Type) llvm.Value {
-	if fn, ok := itf.methodFuncs[signature]; ok {
-		// This function has already been created.
-		return fn
-	}
-	if itf.methodFuncs == nil {
-		// initialize the above map
-		itf.methodFuncs = make(map[*signatureInfo]llvm.Value)
-	}
-
-	// Construct the function name, which is of the form:
-	//     (main.Stringer).String
-	fnName := "(" + itf.id() + ")." + signature.methodName()
-	fnType := llvm.FunctionType(returnType, append(paramTypes, llvm.PointerType(p.ctx.Int8Type(), 0)), false)
-	fn := llvm.AddFunction(p.mod, fnName, fnType)
-	llvm.PrevParam(fn.LastParam()).SetName("actualType")
-	fn.LastParam().SetName("parentHandle")
-	itf.methodFuncs[signature] = fn
+func (p *lowerInterfacesPass) defineInterfaceMethodFunc(fn llvm.Value, itf *interfaceInfo, signature *signatureInfo) {
+	parentHandle := fn.LastParam()
+	context := llvm.PrevParam(parentHandle)
+	actualType := llvm.PrevParam(context)
+	context.SetName("context")
+	actualType.SetName("actualType")
+	parentHandle.SetName("parentHandle")
 	fn.SetLinkage(llvm.InternalLinkage)
 	fn.SetUnnamedAddr(true)
 	if p.sizeLevel >= 2 {
@@ -494,17 +397,20 @@ func (p *lowerInterfacesPass) getInterfaceMethodFunc(itf *interfaceInfo, signatu
 	// Collect the params that will be passed to the functions to call.
 	// These params exclude the receiver (which may actually consist of multiple
 	// parts).
-	params := make([]llvm.Value, fn.ParamsCount()-3)
+	params := make([]llvm.Value, fn.ParamsCount()-4)
 	for i := range params {
 		params[i] = fn.Param(i + 1)
 	}
+	params = append(params,
+		llvm.Undef(llvm.PointerType(p.ctx.Int8Type(), 0)),
+		llvm.Undef(llvm.PointerType(p.ctx.Int8Type(), 0)),
+	)
 
 	// Start chain in the entry block.
 	entry := p.ctx.AddBasicBlock(fn, "entry")
 	p.builder.SetInsertPointAtEnd(entry)
 
 	// Define all possible functions that can be called.
-	actualType := llvm.PrevParam(fn.LastParam())
 	for _, typ := range itf.types {
 		// Create type check (if/else).
 		bb := p.ctx.AddBasicBlock(fn, typ.name)
@@ -562,6 +468,4 @@ func (p *lowerInterfacesPass) getInterfaceMethodFunc(itf *interfaceInfo, signatu
 		llvm.Undef(llvm.PointerType(p.ctx.Int8Type(), 0)),
 	}, "")
 	p.builder.CreateUnreachable()
-
-	return fn
 }

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -1,12 +1,12 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo* }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
 @"reflect/types.type:basic:uint8" = private constant %runtime.typecodeID zeroinitializer
 @"reflect/types.type:basic:int" = private constant %runtime.typecodeID zeroinitializer
-@"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* null }
+@"reflect/types.type:named:Number" = private constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:int", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
 
 declare void @runtime.printuint8(i8)
 
@@ -28,8 +28,8 @@ define void @printInterfaces() {
 }
 
 define void @printInterface(i32 %typecode, i8* %value) {
-  %typeassert.ok1 = call i1 @"Unmatched$typeassert"(i32 %typecode)
-  br i1 %typeassert.ok1, label %typeswitch.Unmatched, label %typeswitch.notUnmatched
+  %isUnmatched = call i1 @"Unmatched$typeassert"(i32 %typecode)
+  br i1 %isUnmatched, label %typeswitch.Unmatched, label %typeswitch.notUnmatched
 
 typeswitch.Unmatched:                             ; preds = %0
   %unmatched = ptrtoint i8* %value to i32
@@ -38,17 +38,17 @@ typeswitch.Unmatched:                             ; preds = %0
   ret void
 
 typeswitch.notUnmatched:                          ; preds = %0
-  %typeassert.ok = call i1 @"Doubler$typeassert"(i32 %typecode)
-  br i1 %typeassert.ok, label %typeswitch.Doubler, label %typeswitch.notDoubler
+  %isDoubler = call i1 @"Doubler$typeassert"(i32 %typecode)
+  br i1 %isDoubler, label %typeswitch.Doubler, label %typeswitch.notDoubler
 
 typeswitch.Doubler:                               ; preds = %typeswitch.notUnmatched
-  %1 = call i32 @"(Doubler).Double"(i8* %value, i8* null, i32 %typecode, i8* null)
-  call void @runtime.printint32(i32 %1)
+  %doubler.result = call i32 @"Doubler.Double$invoke"(i8* %value, i32 %typecode, i8* undef, i8* undef)
+  call void @runtime.printint32(i32 %doubler.result)
   ret void
 
 typeswitch.notDoubler:                            ; preds = %typeswitch.notUnmatched
-  %typeassert.ok2 = icmp eq i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:uint8" to i32), %typecode
-  br i1 %typeassert.ok2, label %typeswitch.byte, label %typeswitch.notByte
+  %typeassert.ok = icmp eq i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:uint8" to i32), %typecode
+  br i1 %typeassert.ok, label %typeswitch.byte, label %typeswitch.notByte
 
 typeswitch.byte:                                  ; preds = %typeswitch.notDoubler
   %byte = ptrtoint i8* %value to i8
@@ -69,32 +69,32 @@ typeswitch.notInt16:                              ; preds = %typeswitch.notByte
   ret void
 }
 
-define i32 @"(Number).Double"(i32 %receiver, i8* %parentHandle) {
+define i32 @"(Number).Double"(i32 %receiver, i8* %context, i8* %parentHandle) {
   %ret = mul i32 %receiver, 2
   ret i32 %ret
 }
 
-define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %parentHandle) {
+define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %context, i8* %parentHandle) {
   %receiver = ptrtoint i8* %receiverPtr to i32
-  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* null)
+  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* undef, i8* null)
   ret i32 %ret
 }
 
-define internal i32 @"(Doubler).Double"(i8* %0, i8* %1, i32 %actualType, i8* %parentHandle) unnamed_addr {
+define internal i32 @"Doubler.Double$invoke"(i8* %receiver, i32 %actualType, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
   %"named:Number.icmp" = icmp eq i32 %actualType, ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:Number" to i32)
   br i1 %"named:Number.icmp", label %"named:Number", label %"named:Number.next"
 
 "named:Number":                                   ; preds = %entry
-  %2 = call i32 @"(Number).Double$invoke"(i8* %0, i8* %1)
-  ret i32 %2
+  %0 = call i32 @"(Number).Double$invoke"(i8* %receiver, i8* undef, i8* undef)
+  ret i32 %0
 
 "named:Number.next":                              ; preds = %entry
   call void @runtime.nilPanic(i8* undef, i8* undef)
   unreachable
 }
 
-define internal i1 @"Doubler$typeassert"(i32 %actualType) unnamed_addr {
+define internal i1 @"Doubler$typeassert"(i32 %actualType) unnamed_addr #1 {
 entry:
   %"named:Number.icmp" = icmp eq i32 %actualType, ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:Number" to i32)
   br i1 %"named:Number.icmp", label %then, label %"named:Number.next"
@@ -106,10 +106,14 @@ then:                                             ; preds = %entry
   ret i1 false
 }
 
-define internal i1 @"Unmatched$typeassert"(i32 %actualType) unnamed_addr {
+define internal i1 @"Unmatched$typeassert"(i32 %actualType) unnamed_addr #2 {
 entry:
   ret i1 false
 
 then:                                             ; No predecessors!
   ret i1 true
 }
+
+attributes #0 = { "tinygo-invoke"="reflect/methods.Double() int" "tinygo-methods"="reflect/methods.Double() int" }
+attributes #1 = { "tinygo-methods"="reflect/methods.Double() int" }
+attributes #2 = { "tinygo-methods"="reflect/methods.NeverImplementedMethod()" }

--- a/transform/testdata/reflect-implements.ll
+++ b/transform/testdata/reflect-implements.ll
@@ -1,23 +1,19 @@
 target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
 target triple = "i686--linux"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo* }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
-@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null }
-@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null }
+@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 ptrtoint (i1 (i32)* @"error.$typeassert" to i32) }
+@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 ptrtoint (i1 (i32)* @"error.$typeassert" to i32) }
 @"reflect/methods.Error() string" = linkonce_odr constant i8 0
 @"reflect/types.interface:interface{Error() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.Error() string"]
 @"reflect/methods.Align() int" = linkonce_odr constant i8 0
 @"reflect/methods.Implements(reflect.Type) bool" = linkonce_odr constant i8 0
 @"reflect.Type$interface" = linkonce_odr constant [2 x i8*] [i8* @"reflect/methods.Align() int", i8* @"reflect/methods.Implements(reflect.Type) bool"]
-@"reflect/types.type:named:reflect.rawType" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:uintptr", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([20 x %runtime.interfaceMethodInfo], [20 x %runtime.interfaceMethodInfo]* @"reflect.rawType$methodset", i32 0, i32 0) }
+@"reflect/types.type:named:reflect.rawType" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:uintptr", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([20 x %runtime.interfaceMethodInfo], [20 x %runtime.interfaceMethodInfo]* @"reflect.rawType$methodset", i32 0, i32 0), %runtime.typecodeID* null, i32 0 }
 @"reflect.rawType$methodset" = linkonce_odr constant [20 x %runtime.interfaceMethodInfo] zeroinitializer
 @"reflect/types.type:basic:uintptr" = linkonce_odr constant %runtime.typecodeID zeroinitializer
-
-declare i1 @runtime.interfaceImplements(i32, i8**, i8*, i8*)
-
-declare i32 @runtime.interfaceMethod(i32, i8**, i8*, i8*, i8*)
 
 ; var errorType = reflect.TypeOf((*error)(nil)).Elem()
 ; func isError(typ reflect.Type) bool {
@@ -28,9 +24,7 @@ declare i32 @runtime.interfaceMethod(i32, i8**, i8*, i8*, i8*)
 ; known at compile time (after the interp pass has run).
 define i1 @main.isError(i32 %typ.typecode, i8* %typ.value, i8* %context, i8* %parentHandle) {
 entry:
-  %invoke.func = call i32 @runtime.interfaceMethod(i32 %typ.typecode, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"reflect.Type$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Implements(reflect.Type) bool", i8* undef, i8* null)
-  %invoke.func.cast = inttoptr i32 %invoke.func to i1 (i8*, i32, i8*, i8*, i8*)*
-  %result = call i1 %invoke.func.cast(i8* %typ.value, i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:reflect.rawType" to i32), i8* bitcast (%runtime.typecodeID* @"reflect/types.type:named:error" to i8*), i8* undef, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:named:reflect.rawType" to i32), i8* bitcast (%runtime.typecodeID* @"reflect/types.type:named:error" to i8*), i32 %typ.typecode, i8* undef, i8* undef)
   ret i1 %result
 }
 
@@ -41,8 +35,12 @@ entry:
 ; }
 define i1 @main.isUnknown(i32 %typ.typecode, i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) {
 entry:
-  %invoke.func = call i32 @runtime.interfaceMethod(i32 %typ.typecode, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"reflect.Type$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Implements(reflect.Type) bool", i8* undef, i8* null)
-  %invoke.func.cast = inttoptr i32 %invoke.func to i1 (i8*, i32, i8*, i8*, i8*)*
-  %result = call i1 %invoke.func.cast(i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i8* undef, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i32 %typ.typecode, i8* undef, i8* undef)
   ret i1 %result
 }
+
+declare i1 @"reflect.Type.Implements$invoke"(i8*, i32, i8*, i32, i8*, i8*) #0
+declare i1 @"error.$typeassert"(i32) #1
+
+attributes #0 = { "tinygo-invoke"="reflect/methods.Implements(reflect.Type) bool" "tinygo-methods"="reflect/methods.Align() int; reflect/methods.Implements(reflect.Type) bool" }
+attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }

--- a/transform/testdata/reflect-implements.out.ll
+++ b/transform/testdata/reflect-implements.out.ll
@@ -1,35 +1,36 @@
 target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
 target triple = "i686--linux"
 
-%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo* }
+%runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }
 %runtime.interfaceMethodInfo = type { i8*, i32 }
 
-@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null }
-@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null }
+@"reflect/types.type:named:error" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 ptrtoint (i1 (i32)* @"error.$typeassert" to i32) }
+@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* bitcast ([1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface" to %runtime.typecodeID*), i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 ptrtoint (i1 (i32)* @"error.$typeassert" to i32) }
 @"reflect/methods.Error() string" = linkonce_odr constant i8 0
 @"reflect/types.interface:interface{Error() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.Error() string"]
 @"reflect/methods.Align() int" = linkonce_odr constant i8 0
 @"reflect/methods.Implements(reflect.Type) bool" = linkonce_odr constant i8 0
 @"reflect.Type$interface" = linkonce_odr constant [2 x i8*] [i8* @"reflect/methods.Align() int", i8* @"reflect/methods.Implements(reflect.Type) bool"]
-@"reflect/types.type:named:reflect.rawType" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:uintptr", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([20 x %runtime.interfaceMethodInfo], [20 x %runtime.interfaceMethodInfo]* @"reflect.rawType$methodset", i32 0, i32 0) }
+@"reflect/types.type:named:reflect.rawType" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:uintptr", i32 0, %runtime.interfaceMethodInfo* getelementptr inbounds ([20 x %runtime.interfaceMethodInfo], [20 x %runtime.interfaceMethodInfo]* @"reflect.rawType$methodset", i32 0, i32 0), %runtime.typecodeID* null, i32 0 }
 @"reflect.rawType$methodset" = linkonce_odr constant [20 x %runtime.interfaceMethodInfo] zeroinitializer
 @"reflect/types.type:basic:uintptr" = linkonce_odr constant %runtime.typecodeID zeroinitializer
-
-declare i1 @runtime.interfaceImplements(i32, i8**, i8*, i8*)
-
-declare i32 @runtime.interfaceMethod(i32, i8**, i8*, i8*, i8*)
 
 define i1 @main.isError(i32 %typ.typecode, i8* %typ.value, i8* %context, i8* %parentHandle) {
 entry:
   %0 = ptrtoint i8* %typ.value to i32
-  %1 = call i1 @runtime.interfaceImplements(i32 %0, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"reflect/types.interface:interface{Error() string}$interface", i32 0, i32 0), i8* undef, i8* undef)
+  %1 = call i1 @"error.$typeassert"(i32 %0)
   ret i1 %1
 }
 
 define i1 @main.isUnknown(i32 %typ.typecode, i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i8* %context, i8* %parentHandle) {
 entry:
-  %invoke.func = call i32 @runtime.interfaceMethod(i32 %typ.typecode, i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"reflect.Type$interface", i32 0, i32 0), i8* nonnull @"reflect/methods.Implements(reflect.Type) bool", i8* undef, i8* null)
-  %invoke.func.cast = inttoptr i32 %invoke.func to i1 (i8*, i32, i8*, i8*, i8*)*
-  %result = call i1 %invoke.func.cast(i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i8* undef, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i32 %itf.typecode, i8* %itf.value, i32 %typ.typecode, i8* undef, i8* undef)
   ret i1 %result
 }
+
+declare i1 @"reflect.Type.Implements$invoke"(i8*, i32, i8*, i32, i8*, i8*) #0
+
+declare i1 @"error.$typeassert"(i32) #1
+
+attributes #0 = { "tinygo-invoke"="reflect/methods.Implements(reflect.Type) bool" "tinygo-methods"="reflect/methods.Align() int; reflect/methods.Implements(reflect.Type) bool" }
+attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }

--- a/transform/wasm-abi.go
+++ b/transform/wasm-abi.go
@@ -38,6 +38,12 @@ func ExternalInt64AsPtr(mod llvm.Module) error {
 			// coroutine lowering.
 			continue
 		}
+		if !fn.GetStringAttributeAtIndex(-1, "tinygo-methods").IsNil() {
+			// These are internal functions (interface method call, interface
+			// type assert) that will be lowered by the interface lowering pass.
+			// Don't transform them.
+			continue
+		}
 
 		hasInt64 := false
 		paramTypes := []llvm.Type{}


### PR DESCRIPTION
Most of this PR is a refactor of interface lowering, to make future changes possible. The result of it is that it is now trivial to add support for the go keyword on interface methods, as requested in https://github.com/tinygo-org/tinygo/issues/1961.