### PR TITLE
Nano-33-BLE: SoftDevice s140v7 support

### DIFF
--- a/targets/nano-33-ble-s140v7.json
+++ b/targets/nano-33-ble-s140v7.json
@@ -1,0 +1,6 @@
+{
+	"inherits": ["nano-33-ble", "nrf52840-s140v7"],
+	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
+	"flash-1200-bps-reset": "false",
+	"openocd-interface": "jlink"
+}

--- a/targets/nano-33-ble-sense.json
+++ b/targets/nano-33-ble-sense.json
@@ -1,3 +1,0 @@
-{
-	"inherits": ["nano-33-ble"]
-}

--- a/targets/nrf52840-s140v7.json
+++ b/targets/nrf52840-s140v7.json
@@ -1,4 +1,7 @@
 {
 	"build-tags": ["softdevice", "s140v7"],
-	"linkerscript": "targets/nrf52840-s140v7.ld"
+	"linkerscript": "targets/nrf52840-s140v7.ld",
+	"ldflags": [
+		"--defsym=__softdevice_stack=0x700"
+	]
 }

--- a/targets/nrf52840-s140v7.ld
+++ b/targets/nrf52840-s140v7.ld
@@ -5,9 +5,10 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x20000000 + 0x000039c0, LENGTH = 256K - 0x000039c0
 }
 
-_stack_size = 4K;
+_stack_size = 4K + __softdevice_stack;
 
 /* This value is needed by the Nordic SoftDevice. */
 __app_ram_base = ORIGIN(RAM);
+__softdevice_stack = DEFINED(__softdevice_stack) ? __softdevice_stack : 0;
 
 INCLUDE "targets/arm.ld"


### PR DESCRIPTION
Verified on my Arduino Nano 33 BLE Sense.

Installed `nrfjprog`, soldered [SWD debug wires](https://create.arduino.cc/projecthub/arduinocc/arduino-nano-33-iot-debugging-633ad8) and connected to J-Link EDU debug probe.


In [my branch](https://github.com/ysoldak/bluetooth/tree/nrf-s140v7) of `tinygo-org/bluetooth`
```
nrfjprog -f nrf52 --eraseall
nrfjprog -f nrf52 --program s140_nrf52_7.3.0/s140_nrf52_7.3.0_softdevice.hex
tinygo flash -target nano-33-ble-s140v7 ./examples/advertisement/
```

Reverting back to Arduino's bootloader is as easy as:
```
nrfjprog -f nrf52 --eraseall
nrfjprog -f nrf52 --program ~/Library/Arduino15/packages/arduino/hardware/mbed_nano/2.5.2/bootloaders/nano33ble/bootloader.hex --reset
```
Note: you may need to unplug your device and plug it again, to really power-cycle it.

