### PR TITLE
Docker: add picolibc-include directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN cd /tinygo/ && \
     git submodule update --init --recursive --force
 
 COPY ./lib/picolibc-* /tinygo/lib/
+COPY ./lib/picolibc-include/* /tinygo/lib/picolibc-include/
 
 RUN cd /tinygo/ && \
     go install /tinygo/


### PR DESCRIPTION
Fixes #2205 

Verified locally by building docker image and running `make smoke-test` in tinygo-drivers.