### PR TITLE
builder: add support for -size= flag for WebAssembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,17 +258,17 @@ smoketest:
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/test
 	@$(MD5SUM) test.hex
 	# test simulated boards on play.tinygo.org
-	$(TINYGO) build             -o test.wasm -tags=arduino              examples/blinky1
+	$(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build             -o test.wasm -tags=hifive1b             examples/blinky1
+	$(TINYGO) build -size short -o test.wasm -tags=hifive1b             examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build             -o test.wasm -tags=reelboard            examples/blinky1
+	$(TINYGO) build -size short -o test.wasm -tags=reelboard            examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build             -o test.wasm -tags=pca10040             examples/blinky2
+	$(TINYGO) build -size short -o test.wasm -tags=pca10040             examples/blinky2
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build             -o test.wasm -tags=pca10056             examples/blinky2
+	$(TINYGO) build -size short -o test.wasm -tags=pca10056             examples/blinky2
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build             -o test.wasm -tags=circuitplay_express  examples/blinky1
+	$(TINYGO) build -size short -o test.wasm -tags=circuitplay_express  examples/blinky1
 	@$(MD5SUM) test.wasm
 	# test all targets/boards
 	$(TINYGO) build -size short -o test.hex -target=pca10040-s132v6     examples/blinky1
@@ -452,8 +452,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=maixbit             examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/export
-	$(TINYGO) build             -o wasm.wasm -target=wasm               examples/wasm/main
+	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/export
+	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/main
 	# test various compiler flags
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -gc=none -scheduler=none examples/blinky1
 	@$(MD5SUM) test.hex

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tinygo-org/tinygo
 go 1.15
 
 require (
+	github.com/aykevl/go-wasm v0.0.2-0.20211030161413-11881cb9032d // indirect
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/chromedp/cdproto v0.0.0-20210113043257-dabd2f2e7693
 	github.com/chromedp/chromedp v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aykevl/go-wasm v0.0.2-0.20211030161413-11881cb9032d h1:JeuI5/546naK5hpOIX+Lq5xE8rvt7uwiTp6iL+pLQgk=
+github.com/aykevl/go-wasm v0.0.2-0.20211030161413-11881cb9032d/go.mod h1:7sXyiaA0WtSogCu67R2252fQpVmJMh9JWJ9ddtGkpWw=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/chromedp/cdproto v0.0.0-20210113043257-dabd2f2e7693 h1:11eq/RkpaotwdF6b1TRMcdgQUPNmyFEJOB7zLvh0O/Y=


### PR DESCRIPTION
Look at that! A breakdown of binary file usage per package! For WebAssembly! :grinning: 

```
$ tinygo build -o test.wasm -size=full ./testdata/json.go
   code  rodata    data     bss |   flash     ram | package
------------------------------- | --------------- | -------
  10435       0   15168  103481 |   25603  118649 | (unknown)
   1887       0       0       0 |    1887       0 | bytes
    185       0       0       0 |     185       0 | encoding/base64
  37790       0     256      32 |   38046     288 | encoding/json
     49       0       0       0 |      49       0 | errors
  20926       0       8       0 |   20934       8 | fmt
    463       0       0       0 |     463       0 | internal/bytealg
   2264       0       0       0 |    2264       0 | internal/fmtsort
     25       0       0       0 |      25       0 | internal/reflectlite
    569       0       0       0 |     569       0 | internal/task
   1494       0       0       0 |    1494       0 | main
     65       0       0       0 |      65       0 | math
    348       0      64       0 |     412      64 | math/bits
  14162       0       0       0 |   14162       0 | reflect
  13285       0      12     147 |   13297     159 | runtime
   4780       0       0       0 |    4780       0 | sort
  18676       0   11320       0 |   29996   11320 | strconv
    461       0       0       0 |     461       0 | strings
   2745       0       0       0 |    2745       0 | sync
   9661       0       0      40 |    9661      40 | syscall/js
    900       0     256       0 |    1156     256 | unicode
   2433       0     288       0 |    2721     288 | unicode/utf8
------------------------------- | --------------- | -------
 143603       0   27372  103700 |  170975  131072 | whole program
```

The output still needs some cosmetic changes (like replacing "flash" with something else) but the idea should be clear.

I've forked https://github.com/akupila/go-wasm to fix a bug and add some features that were useful. I can move it over to tinygo-org if that's better.

This PR is still in draft until #2212 is merged.