### PR TITLE
Match Clang optsize/minsize attributes

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -48,6 +48,7 @@ type Config struct {
 	GOARCH          string
 	CodeModel       string
 	RelocationModel string
+	SizeLevel       int
 
 	// Various compiler options that determine how code is generated.
 	Scheduler          string
@@ -816,7 +817,7 @@ func (b *builder) createFunction() {
 		b.addError(b.fn.Pos(), errValue)
 		return
 	}
-	b.addStandardAttributes(b.llvmFn)
+	b.addStandardDefinedAttributes(b.llvmFn)
 	if !b.info.exported {
 		b.llvmFn.SetVisibility(llvm.HiddenVisibility)
 		b.llvmFn.SetUnnamedAddr(true)

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -457,6 +457,7 @@ func (c *compilerContext) getInterfaceImplementsFunc(assertedType types.Type) ll
 	if llvmFn.IsNil() {
 		llvmFnType := llvm.FunctionType(c.ctx.Int1Type(), []llvm.Type{c.uintptrType}, false)
 		llvmFn = llvm.AddFunction(c.mod, fnName, llvmFnType)
+		c.addStandardDeclaredAttributes(llvmFn)
 		methods := c.getMethodsString(assertedType.Underlying().(*types.Interface))
 		llvmFn.AddFunctionAttr(c.ctx.CreateStringAttribute("tinygo-methods", methods))
 	}
@@ -478,6 +479,7 @@ func (c *compilerContext) getInvokeFunction(instr *ssa.CallCommon) llvm.Value {
 		paramTuple = append(paramTuple, types.NewVar(token.NoPos, nil, "$typecode", types.Typ[types.Uintptr]))
 		llvmFnType := c.getRawFuncType(types.NewSignature(sig.Recv(), types.NewTuple(paramTuple...), sig.Results(), false)).ElementType()
 		llvmFn = llvm.AddFunction(c.mod, fnName, llvmFnType)
+		c.addStandardDeclaredAttributes(llvmFn)
 		llvmFn.AddFunctionAttr(c.ctx.CreateStringAttribute("tinygo-invoke", c.getMethodSignatureName(instr.Method)))
 		methods := c.getMethodsString(instr.Value.Type().Underlying().(*types.Interface))
 		llvmFn.AddFunctionAttr(c.ctx.CreateStringAttribute("tinygo-methods", methods))

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -327,10 +327,17 @@ func getParams(sig *types.Signature) []*types.Var {
 // addStandardDeclaredAttributes adds attributes that are set for any function,
 // whether declared or defined.
 func (c *compilerContext) addStandardDeclaredAttributes(llvmFn llvm.Value) {
-	if c.SizeLevel >= 2 {
+	if c.SizeLevel >= 1 {
 		// Set the "optsize" attribute to make slightly smaller binaries at the
-		// cost of some performance.
+		// cost of minimal performance loss (-Os in Clang).
 		kind := llvm.AttributeKindID("optsize")
+		attr := c.ctx.CreateEnumAttribute(kind, 0)
+		llvmFn.AddFunctionAttr(attr)
+	}
+	if c.SizeLevel >= 2 {
+		// Set the "minsize" attribute to reduce code size even further,
+		// regardless of performance loss (-Oz in Clang).
+		kind := llvm.AttributeKindID("minsize")
 		attr := c.ctx.CreateEnumAttribute(kind, 0)
 		llvmFn.AddFunctionAttr(attr)
 	}

--- a/stacksize/stacksize.go
+++ b/stacksize/stacksize.go
@@ -180,8 +180,8 @@ func CallGraph(f *elf.File, callsIndirectFunction []string) (map[string][]*CallN
 					// used for getting a function pointer
 					isCall = false
 				case elf.R_ARM_ABS32:
-					// used in the reset vector for pointers
-					isCall = false
+					// when compiling with -Oz (minsize), used for calling
+					isCall = true
 				default:
 					return nil, fmt.Errorf("unknown relocation: %s", relocType)
 				}

--- a/transform/interface-lowering_test.go
+++ b/transform/interface-lowering_test.go
@@ -3,6 +3,7 @@ package transform_test
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
@@ -10,7 +11,7 @@ import (
 func TestInterfaceLowering(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/interface", func(mod llvm.Module) {
-		err := transform.LowerInterfaces(mod, 0)
+		err := transform.LowerInterfaces(mod, &compileopts.Config{Options: &compileopts.Options{Opt: "2"}})
 		if err != nil {
 			t.Error(err)
 		}

--- a/transform/interrupt.go
+++ b/transform/interrupt.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -22,7 +23,7 @@ import (
 // simply call the registered handlers. This might seem like it causes extra
 // overhead, but in fact inlining and const propagation will eliminate most if
 // not all of that.
-func LowerInterrupts(mod llvm.Module, sizeLevel int) []error {
+func LowerInterrupts(mod llvm.Module, config *compileopts.Config) []error {
 	var errs []error
 
 	// Discover interrupts. The runtime/interrupt.Register call is a compiler
@@ -174,9 +175,7 @@ func LowerInterrupts(mod llvm.Module, sizeLevel int) []error {
 		// Create the wrapper function which is the actual interrupt handler
 		// that is inserted in the interrupt vector.
 		fn.SetUnnamedAddr(true)
-		if sizeLevel >= 2 {
-			fn.AddFunctionAttr(ctx.CreateEnumAttribute(llvm.AttributeKindID("optsize"), 0))
-		}
+		AddStandardAttributes(fn, config)
 		fn.SetSection(".text." + name)
 		if isSoftwareVectored {
 			fn.SetLinkage(llvm.InternalLinkage)

--- a/transform/interrupt_test.go
+++ b/transform/interrupt_test.go
@@ -3,6 +3,7 @@ package transform_test
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
@@ -12,7 +13,7 @@ func TestInterruptLowering(t *testing.T) {
 	for _, subtest := range []string{"avr", "cortexm"} {
 		t.Run(subtest, func(t *testing.T) {
 			testTransform(t, "testdata/interrupt-"+subtest, func(mod llvm.Module) {
-				errs := transform.LowerInterrupts(mod, 0)
+				errs := transform.LowerInterrupts(mod, &compileopts.Config{Options: &compileopts.Options{Opt: "2"}})
 				if len(errs) != 0 {
 					t.Fail()
 					for _, err := range errs {

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -68,12 +68,12 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		OptimizeStringToBytes(mod)
 		OptimizeReflectImplements(mod)
 		OptimizeAllocs(mod, nil, nil)
-		err := LowerInterfaces(mod, sizeLevel)
+		err := LowerInterfaces(mod, config)
 		if err != nil {
 			return []error{err}
 		}
 
-		errs := LowerInterrupts(mod, sizeLevel)
+		errs := LowerInterrupts(mod, config)
 		if len(errs) > 0 {
 			return errs
 		}
@@ -97,7 +97,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 
 	} else {
 		// Must be run at any optimization level.
-		err := LowerInterfaces(mod, sizeLevel)
+		err := LowerInterfaces(mod, config)
 		if err != nil {
 			return []error{err}
 		}
@@ -105,7 +105,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		if config.FuncImplementation() == "switch" {
 			LowerFuncValues(mod)
 		}
-		errs := LowerInterrupts(mod, sizeLevel)
+		errs := LowerInterrupts(mod, config)
 		if len(errs) > 0 {
 			return errs
 		}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -11,3 +11,18 @@
 // lowering pass, which replaces stub runtime calls to get an interface method
 // with the method implementation (either a direct call or a thunk).
 package transform
+
+import (
+	"github.com/tinygo-org/tinygo/compileopts"
+	"tinygo.org/x/go-llvm"
+)
+
+// AddStandardAttributes is a helper function to add standard function
+// attributes to a function. For example, it adds optsize when requested from
+// the -opt= compiler flag.
+func AddStandardAttributes(fn llvm.Value, config *compileopts.Config) {
+	_, sizeLevel, _ := config.OptLevels()
+	if sizeLevel >= 2 {
+		fn.AddFunctionAttr(fn.Type().Context().CreateEnumAttribute(llvm.AttributeKindID("optsize"), 0))
+	}
+}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -22,7 +22,10 @@ import (
 // the -opt= compiler flag.
 func AddStandardAttributes(fn llvm.Value, config *compileopts.Config) {
 	_, sizeLevel, _ := config.OptLevels()
-	if sizeLevel >= 2 {
+	if sizeLevel >= 1 {
 		fn.AddFunctionAttr(fn.Type().Context().CreateEnumAttribute(llvm.AttributeKindID("optsize"), 0))
+	}
+	if sizeLevel >= 2 {
+		fn.AddFunctionAttr(fn.Type().Context().CreateEnumAttribute(llvm.AttributeKindID("minsize"), 0))
 	}
 }

--- a/transform/wasm-abi.go
+++ b/transform/wasm-abi.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -15,7 +16,7 @@ import (
 //
 // This pass can be enabled/disabled with the -wasm-abi flag, and is enabled by
 // default as of december 2019.
-func ExternalInt64AsPtr(mod llvm.Module) error {
+func ExternalInt64AsPtr(mod llvm.Module, config *compileopts.Config) error {
 	ctx := mod.Context()
 	builder := ctx.NewBuilder()
 	defer builder.Dispose()
@@ -79,10 +80,7 @@ func ExternalInt64AsPtr(mod llvm.Module) error {
 		fn.SetName(name + "$i64wrap")
 		externalFnType := llvm.FunctionType(returnType, paramTypes, fnType.IsFunctionVarArg())
 		externalFn := llvm.AddFunction(mod, name, externalFnType)
-		optsize := fn.GetEnumFunctionAttribute(llvm.AttributeKindID("optsize"))
-		if !optsize.IsNil() {
-			fn.AddFunctionAttr(optsize)
-		}
+		AddStandardAttributes(fn, config)
 
 		if fn.IsDeclaration() {
 			// Just a declaration: the definition doesn't exist on the Go side

--- a/transform/wasm-abi_test.go
+++ b/transform/wasm-abi_test.go
@@ -3,6 +3,7 @@ package transform_test
 import (
 	"testing"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/transform"
 	"tinygo.org/x/go-llvm"
 )
@@ -11,7 +12,7 @@ func TestWasmABI(t *testing.T) {
 	t.Parallel()
 	testTransform(t, "testdata/wasm-abi", func(mod llvm.Module) {
 		// Run ABI change pass.
-		err := transform.ExternalInt64AsPtr(mod)
+		err := transform.ExternalInt64AsPtr(mod, &compileopts.Config{Options: &compileopts.Options{Opt: "2"}})
 		if err != nil {
 			t.Errorf("failed to change wasm ABI: %v", err)
 		}


### PR DESCRIPTION
This PR adjusts code size function attributes (`optsize` and `minsize`) to match Clang. I've found that while the code size changes vary a lot, on average there is a slight reduction in code size.

I've kept the default at `-opt=z` (which now more aggressively optimizes for code size) because for where TinyGo is used, I think `-opt=z` is more appropriate. If performance is a concern, users should use `-opt=2` or `-opt=s` instead.