### PR TITLE
targets: match LLVM triple to the one Clang uses

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -107,6 +107,11 @@ func testClangAttributes(t *testing.T, options *compileopts.Options) {
 	}
 	defer mod.Dispose()
 
+	// Check whether the LLVM target matches.
+	if mod.Target() != config.Triple() {
+		t.Errorf("target has LLVM triple %#v but Clang makes it LLVM triple %#v", config.Triple(), mod.Target())
+	}
+
 	// Check the "target-cpu"  string attribute of the add function.
 	add := mod.NamedFunction("add")
 	var cpu string

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -165,7 +165,6 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 	if options.Target == "" {
 		// Configure based on GOOS/GOARCH environment variables (falling back to
 		// runtime.GOOS/runtime.GOARCH), and generate a LLVM target based on it.
-		llvmos := options.GOOS
 		llvmarch := map[string]string{
 			"386":   "i386",
 			"amd64": "x86_64",
@@ -174,6 +173,17 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 		}[options.GOARCH]
 		if llvmarch == "" {
 			llvmarch = options.GOARCH
+		}
+		llvmos := options.GOOS
+		if llvmos == "darwin" {
+			// Use macosx* instead of darwin, otherwise darwin/arm64 will refer
+			// to iOS!
+			llvmos = "macosx10.12.0"
+			if llvmarch == "aarch64" {
+				// Looks like Apple prefers to call this architecture ARM64
+				// instead of AArch64.
+				llvmarch = "arm64"
+			}
 		}
 		// Target triples (which actually have four components, but are called
 		// triples for historical reasons) have the form:

--- a/compiler/atomic.go
+++ b/compiler/atomic.go
@@ -38,11 +38,10 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		old := b.getValue(call.Args[1])
 		newVal := b.getValue(call.Args[2])
 		if strings.HasSuffix(name, "64") {
-			arch := strings.Split(b.Triple, "-")[0]
-			if strings.HasPrefix(arch, "arm") && strings.HasSuffix(arch, "m") {
+			if strings.HasPrefix(b.Triple, "thumb") {
 				// Work around a bug in LLVM, at least LLVM 11:
 				// https://reviews.llvm.org/D95891
-				// Check for armv6m, armv7, armv7em, and perhaps others.
+				// Check for thumbv6m, thumbv7, thumbv7em, and perhaps others.
 				// See also: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html
 				compareAndSwap := b.mod.NamedFunction("__sync_val_compare_and_swap_8")
 				if compareAndSwap.IsNil() {

--- a/compiler/testdata/goroutine-cortex-m-qemu.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-target triple = "armv7m-unknown-unknown-eabi"
+target triple = "thumbv7m-unknown-unknown-eabi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }

--- a/compiler/testdata/intrinsics-cortex-m-qemu.ll
+++ b/compiler/testdata/intrinsics-cortex-m-qemu.ll
@@ -1,7 +1,7 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-target triple = "armv7m-unknown-unknown-eabi"
+target triple = "thumbv7m-unknown-unknown-eabi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)
 

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -10,7 +10,6 @@
 	"automatic-stack-size": true,
 	"default-stack-size": 2048,
 	"cflags": [
-		"-mthumb",
 		"-Werror",
 		"-fshort-enums",
 		"-fomit-frame-pointer",

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -1,5 +1,5 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv6m-unknown-unknown-eabi",
+	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -1,5 +1,5 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv6m-unknown-unknown-eabi",
+	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0plus"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -1,5 +1,5 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7m-unknown-unknown-eabi",
+	"llvm-target": "thumbv7m-unknown-unknown-eabi",
 	"cpu": "cortex-m3"
 }

--- a/targets/cortex-m33.json
+++ b/targets/cortex-m33.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["cortex-m"],
-    "llvm-target": "armv7m-unknown-unknown-eabi",
+    "llvm-target": "thumbv7m-unknown-unknown-eabi",
     "cflags": [
         "-mfloat-abi=soft"
     ]

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-unknown-unknown-eabi",
+	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m4",
 	"cflags": [
 		"-mfloat-abi=soft"

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["cortex-m"],
-	"llvm-target": "armv7em-unknown-unknown-eabi",
+	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
 	"cflags": [
 		"-mfloat-abi=soft"

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,5 +1,5 @@
 {
-	"llvm-target": "arm4-unknown-unknown-eabi",
+	"llvm-target": "armv4t-unknown-unknown-eabi",
 	"cpu": "arm7tdmi",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",

--- a/targets/riscv32.json
+++ b/targets/riscv32.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv"],
-	"llvm-target": "riscv32--none",
+	"llvm-target": "riscv32-unknown-none",
 	"build-tags": ["tinygo.riscv32"],
 	"scheduler": "tasks",
 	"default-stack-size": 2048,

--- a/targets/riscv64.json
+++ b/targets/riscv64.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv"],
-	"llvm-target": "riscv64--none",
+	"llvm-target": "riscv64-unknown-none",
 	"build-tags": ["tinygo.riscv64"],
 	"cflags": [
 		"-march=rv64gc",


### PR DESCRIPTION
The target triples have to match mostly to be able to link LLVM modules (for CGo). Linking LLVM modules is already possible (the triples are already close enough), but testing becomes much easier when they match exactly.

For macOS, I picked "macosx10.12.0". That's an old and unsupported version, but I had to pick _something_. Clang by default uses "macos10.4.0", which is much older.