### PR TITLE
os: add File.WriteString and File.WriteAt

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -111,6 +111,16 @@ func (f *File) Write(b []byte) (n int, err error) {
 	return
 }
 
+// WriteString is like Write, but writes the contents of string s rather than a
+// slice of bytes.
+func (f *File) WriteString(s string) (n int, err error) {
+	return f.Write([]byte(s))
+}
+
+func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
+	return 0, ErrNotImplemented
+}
+
 // Close closes the File, rendering it unusable for I/O.
 func (f *File) Close() (err error) {
 	err = f.handle.Close()


### PR DESCRIPTION
WriteString just does the simple and and converts the passed string
to a byte-slice.  This can be made zero-copy later with unsafe, if needed.

WriteAt returns ErrNotImplemented, to match Seek() and ReadAt().

Fixes #2157