### PR TITLE
musl: reduce binary file size

### DIFF
--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -11,6 +11,14 @@ package runtime
 // The primary use case is `tinygo test`, which takes some parameters (such as
 // -test.v).
 
+// This is the default set of arguments, if nothing else has been set.
+var args = []string{"/proc/self/exe"}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return args
+}
+
 var env []string
 
 //go:linkname syscall_runtime_envs syscall.runtime_envs

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -23,16 +23,6 @@ func GOROOT() string {
 	return "/usr/local/go"
 }
 
-// This is the default set of arguments, if nothing else has been set.
-// This may be overriden by modifying this global at runtime init (for example,
-// on Linux where there are real command line arguments).
-var args = []string{"/proc/self/exe"}
-
-//go:linkname os_runtime_args os.runtime_args
-func os_runtime_args() []string {
-	return args
-}
-
 // Copy size bytes from src to dst. The memory areas must not overlap.
 // Calls to this function are converted to LLVM intrinsic calls such as
 // llvm.memcpy.p0i8.p0i8.i32(dst, src, size, false).

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -7,8 +7,8 @@ import (
 	"unsafe"
 )
 
-//export putchar
-func _putchar(c int) int
+//export write
+func libc_write(fd int32, buf unsafe.Pointer, count uint) int
 
 //export usleep
 func usleep(usec uint) int
@@ -145,7 +145,8 @@ func syscall_runtime_envs() []string {
 }
 
 func putchar(c byte) {
-	_putchar(int(c))
+	buf := [1]byte{c}
+	libc_write(1, unsafe.Pointer(&buf[0]), 1)
 }
 
 func ticksToNanoseconds(ticks timeUnit) int64 {

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -26,30 +26,38 @@ func _start() {
 //     wasmtime ./program.wasm arg1 arg2
 func init() {
 	__wasm_call_ctors()
+}
 
-	// Read the number of args (argc) and the buffer size required to store all
-	// these args (argv).
-	var argc, argv_buf_size uint32
-	args_sizes_get(&argc, &argv_buf_size)
-	if argc == 0 {
-		return
-	}
+var args []string
 
-	// Obtain the command line arguments
-	argsSlice := make([]unsafe.Pointer, argc)
-	buf := make([]byte, argv_buf_size)
-	args_get(&argsSlice[0], unsafe.Pointer(&buf[0]))
-
-	// Convert the array of C strings to an array of Go strings.
-	args = make([]string, argc)
-	for i, cstr := range argsSlice {
-		length := strlen(cstr)
-		argString := _string{
-			length: length,
-			ptr:    (*byte)(cstr),
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	if args == nil {
+		// Read the number of args (argc) and the buffer size required to store
+		// all these args (argv).
+		var argc, argv_buf_size uint32
+		args_sizes_get(&argc, &argv_buf_size)
+		if argc == 0 {
+			return nil
 		}
-		args[i] = *(*string)(unsafe.Pointer(&argString))
+
+		// Obtain the command line arguments
+		argsSlice := make([]unsafe.Pointer, argc)
+		buf := make([]byte, argv_buf_size)
+		args_get(&argsSlice[0], unsafe.Pointer(&buf[0]))
+
+		// Convert the array of C strings to an array of Go strings.
+		args = make([]string, argc)
+		for i, cstr := range argsSlice {
+			length := strlen(cstr)
+			argString := _string{
+				length: length,
+				ptr:    (*byte)(cstr),
+			}
+			args[i] = *(*string)(unsafe.Pointer(&argString))
+		}
 	}
+	return args
 }
 
 func ticksToNanoseconds(ticks timeUnit) int64 {


### PR DESCRIPTION
With some small tweaks, I managed to reduce binary size by around 4.4kB which is most of the code size increase caused by #2110. I also reduced code size on WASI in the case that the os package is not imported.