### PR TITLE
Fix SPI on stm32f103

### DIFF
--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -358,7 +358,7 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	default:
 		conf |= stm32.SPI_CR1_BR_Div256
 	}
-	return conf
+	return conf << stm32.SPI_CR1_BR_Pos
 }
 
 // Configure SPI pins for input output and clock

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -339,24 +339,23 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32
 
 	// set frequency dependent on PCLK2 prescaler (div 1)
-	switch config.Frequency {
-	case 125000:
+	switch {
+	case config.Frequency < 125000:
 		// Note: impossible to achieve lower frequency with current PCLK2!
 		conf |= stm32.SPI_CR1_BR_Div256
-	case 250000:
+	case config.Frequency < 250000:
 		conf |= stm32.SPI_CR1_BR_Div256
-	case 500000:
+	case config.Frequency < 500000:
 		conf |= stm32.SPI_CR1_BR_Div128
-	case 1000000:
+	case config.Frequency < 1000000:
 		conf |= stm32.SPI_CR1_BR_Div64
-	case 2000000:
+	case config.Frequency < 2000000:
 		conf |= stm32.SPI_CR1_BR_Div32
-	case 4000000:
+	case config.Frequency < 4000000:
 		conf |= stm32.SPI_CR1_BR_Div16
-	case 8000000:
-		conf |= stm32.SPI_CR1_BR_Div8
 	default:
-		conf |= stm32.SPI_CR1_BR_Div256
+		// When its bigger than Div16, just round to the maximum frequency.
+		conf |= stm32.SPI_CR1_BR_Div8
 	}
 	return conf << stm32.SPI_CR1_BR_Pos
 }


### PR DESCRIPTION
There was a mistake somewhere in the evolution of the SPI driver for the stm32f103. In the original driver it does exist, but somewhere along the line the shift for the frequency multiplier was left out. I didnt have time to track this down more yesterday, I will today. This fixes the SPI code so that it woks again. This was tested using the WIP sx127x LoRa driver by sending messages over LoRa.