### PR TITLE
machine/rp2040: refactor PWM code. fix Period calculation

### DIFF
--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -18,6 +18,12 @@ func CPUFrequency() uint32 {
 	return 125 * MHz
 }
 
+// Returns the period of a clock cycle for the raspberry pi pico in nanoseconds.
+// Used in PWM API.
+func cpuPeriod() uint32 {
+	return 1e9 / CPUFrequency()
+}
+
 // clockIndex identifies a hardware clock
 type clockIndex uint8
 


### PR DESCRIPTION
Fixes Period calculation. Now has pinpoint accuracy. 

```pwm.Period()``` before could overflow for periods above 8ms. Fixed in new version.

Move ```cpuPeriod()``` to be next to relevant functions.

PTAL! 