### PR TITLE
example: naive debouncing for pininterrupt example

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4600, 280, 0, 2268},
 		{"microbit", "examples/serial", 2908, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 6140, 1484, 116, 6824},
+		{"wioterminal", "examples/pininterrupt", 7286, 1486, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/examples/pininterrupt/pininterrupt.go
+++ b/src/examples/pininterrupt/pininterrupt.go
@@ -3,7 +3,7 @@ package main
 // This example demonstrates how to use pin change interrupts.
 //
 // This is only an example and should not be copied directly in any serious
-// circuit, because it lacks an important feature: debouncing.
+// circuit, because it only naively implements an important feature: debouncing.
 // See: https://en.wikipedia.org/wiki/Switch#Contact_bounce
 
 import (
@@ -14,6 +14,8 @@ import (
 const (
 	led = machine.LED
 )
+
+var lastPress time.Time
 
 func main() {
 
@@ -29,6 +31,13 @@ func main() {
 
 	// Set an interrupt on this pin.
 	err := button.SetInterrupt(buttonPinChange, func(machine.Pin) {
+
+		// Ignore events that are too close to the last registered press (debouncing)
+		if time.Since(lastPress) < 100*time.Millisecond {
+			return
+		}
+		lastPress = time.Now()
+
 		led.Set(!led.Get())
 	})
 	if err != nil {


### PR DESCRIPTION
I found it annoying to have no debouncing implemented in the pininterrupt example, so I've implemented it.

Context: @soypat PR about interrupts #2215

Sharing for fun, but you may find it useful to have in the example.
Feel free to bounce the PR, haha.