### PR TITLE
Set/update target JSON `features` key

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -136,7 +136,6 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		DefaultStackSize:   config.Target.DefaultStackSize,
 		NeedsStackObjects:  config.NeedsStackObjects(),
 		Debug:              true,
-		LLVMFeatures:       config.LLVMFeatures(),
 	}
 
 	// Load the target machine, which is the LLVM object that contains all

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -34,10 +34,16 @@ func (c *Config) CPU() string {
 }
 
 // Features returns a list of features this CPU supports. For example, for a
-// RISC-V processor, that could be ["+a", "+c", "+m"]. For many targets, an
-// empty list will be returned.
-func (c *Config) Features() []string {
-	return c.Target.Features
+// RISC-V processor, that could be "+a,+c,+m". For many targets, an empty list
+// will be returned.
+func (c *Config) Features() string {
+	if c.Target.Features == "" {
+		return c.Options.LLVMFeatures
+	}
+	if c.Options.LLVMFeatures == "" {
+		return c.Target.Features
+	}
+	return c.Target.Features + "," + c.Options.LLVMFeatures
 }
 
 // GOOS returns the GOOS of the target. This might not always be the actual OS:
@@ -439,10 +445,6 @@ func (c *Config) WasmAbi() string {
 		return c.Options.WasmAbi
 	}
 	return c.Target.WasmAbi
-}
-
-func (c *Config) LLVMFeatures() string {
-	return c.Options.LLVMFeatures
 }
 
 type TestConfig struct {

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -94,7 +94,7 @@ func (spec *TargetSpec) overrideProperties(child *TargetSpec) {
 					dst.Set(src)
 				case "append", "":
 					// or append the field of child to spec
-					dst.Set(reflect.AppendSlice(src, dst))
+					dst.Set(reflect.AppendSlice(dst, src))
 				default:
 					panic("override mode must be 'copy' or 'append' (default). I don't know how to '" + tag + "'.")
 				}

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -25,7 +25,7 @@ type TargetSpec struct {
 	Inherits         []string `json:"inherits"`
 	Triple           string   `json:"llvm-target"`
 	CPU              string   `json:"cpu"`
-	Features         []string `json:"features"`
+	Features         string   `json:"features"`
 	GOOS             string   `json:"goos"`
 	GOARCH           string   `json:"goarch"`
 	BuildTags        []string `json:"build-tags"`
@@ -234,12 +234,16 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 	switch goarch {
 	case "386":
 		spec.CPU = "pentium4"
+		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "amd64":
 		spec.CPU = "x86-64"
+		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
+		spec.Features = "+armv7-a,+dsp,+fp64,+vfp2,+vfp2sp,+vfp3d16,+vfp3d16sp,-thumb-mode"
 	case "arm64":
 		spec.CPU = "generic"
+		spec.Features = "+neon"
 	}
 	if goos == "darwin" {
 		spec.CFlags = append(spec.CFlags, "-isysroot", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk")

--- a/compileopts/target_test.go
+++ b/compileopts/target_test.go
@@ -27,7 +27,7 @@ func TestOverrideProperties(t *testing.T) {
 	base := &TargetSpec{
 		GOOS:             "baseGoos",
 		CPU:              "baseCpu",
-		Features:         []string{"bf1", "bf2"},
+		CFlags:           []string{"-base-foo", "-base-bar"},
 		BuildTags:        []string{"bt1", "bt2"},
 		Emulator:         []string{"be1", "be2"},
 		DefaultStackSize: 42,
@@ -37,7 +37,7 @@ func TestOverrideProperties(t *testing.T) {
 	child := &TargetSpec{
 		GOOS:             "",
 		CPU:              "chlidCpu",
-		Features:         []string{"cf1", "cf2"},
+		CFlags:           []string{"-child-foo", "-child-bar"},
 		Emulator:         []string{"ce1", "ce2"},
 		AutoStackSize:    &childAutoStackSize,
 		DefaultStackSize: 64,
@@ -51,8 +51,8 @@ func TestOverrideProperties(t *testing.T) {
 	if base.CPU != "chlidCpu" {
 		t.Errorf("Overriding failed : got %v", base.CPU)
 	}
-	if !reflect.DeepEqual(base.Features, []string{"cf1", "cf2", "bf1", "bf2"}) {
-		t.Errorf("Overriding failed : got %v", base.Features)
+	if !reflect.DeepEqual(base.CFlags, []string{"-base-foo", "-base-bar", "-child-foo", "-child-bar"}) {
+		t.Errorf("Overriding failed : got %v", base.CFlags)
 	}
 	if !reflect.DeepEqual(base.BuildTags, []string{"bt1", "bt2"}) {
 		t.Errorf("Overriding failed : got %v", base.BuildTags)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -43,7 +43,7 @@ type Config struct {
 	// Target and output information.
 	Triple          string
 	CPU             string
-	Features        []string
+	Features        string
 	GOOS            string
 	GOARCH          string
 	CodeModel       string
@@ -57,7 +57,6 @@ type Config struct {
 	DefaultStackSize   uint64
 	NeedsStackObjects  bool
 	Debug              bool // Whether to emit debug information in the LLVM module.
-	LLVMFeatures       string
 }
 
 // compilerContext contains function-independent data that should still be
@@ -189,12 +188,6 @@ func NewTargetMachine(config *Config) (llvm.TargetMachine, error) {
 		return llvm.TargetMachine{}, err
 	}
 
-	feat := config.Features
-	if len(config.LLVMFeatures) > 0 {
-		feat = append(feat, config.LLVMFeatures)
-	}
-	features := strings.Join(feat, ",")
-
 	var codeModel llvm.CodeModel
 	var relocationModel llvm.RelocMode
 
@@ -222,7 +215,7 @@ func NewTargetMachine(config *Config) (llvm.TargetMachine, error) {
 		relocationModel = llvm.RelocDynamicNoPic
 	}
 
-	machine := target.CreateTargetMachine(config.Triple, config.CPU, features, llvm.CodeGenLevelDefault, relocationModel, codeModel)
+	machine := target.CreateTargetMachine(config.Triple, config.CPU, config.Features, llvm.CodeGenLevelDefault, relocationModel, codeModel)
 	return machine, nil
 }
 

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -1,5 +1,6 @@
 {
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
-	"cpu": "cortex-m0"
+	"cpu": "cortex-m0",
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -1,5 +1,6 @@
 {
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
-	"cpu": "cortex-m0plus"
+	"cpu": "cortex-m0plus",
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -1,5 +1,6 @@
 {
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7m-unknown-unknown-eabi",
-	"cpu": "cortex-m3"
+	"cpu": "cortex-m3",
+	"features": "+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -2,6 +2,7 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m4",
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
 	"cflags": [
 		"-mfloat-abi=soft"
 	]

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -2,6 +2,7 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
 	"cflags": [
 		"-mfloat-abi=soft"
 	]

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -1,10 +1,13 @@
 {
 	"inherits": ["riscv32"],
-	"features": ["+c", "+m"],
+	"features": "+c,+m,-relax,-save-restore",
 	"build-tags": ["esp32c3", "esp"],
 	"serial": "uart",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
+	"cflags": [
+		"-march=rv32imc"
+	],
 	"linkerscript": "targets/esp32c3.ld",
 	"extra-files": [
 		"src/device/esp/esp32c3.S"

--- a/targets/fe310.json
+++ b/targets/fe310.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
 	"cpu": "sifive-e31",
-	"features": ["+a", "+c", "+m"],
+	"features": "+a,+c,+m,-64bit,-relax,-save-restore",
 	"build-tags": ["fe310", "sifive"]
 }

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,6 +1,7 @@
 {
 	"llvm-target": "armv4t-unknown-unknown-eabi",
 	"cpu": "arm7tdmi",
+	"features": "+armv4t,+soft-float,+strict-align,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",

--- a/targets/k210.json
+++ b/targets/k210.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv64"],
-	"features": ["+a", "+c", "+m", "+f", "+d"],
+	"features": "+a,+c,+d,+f,+m,-relax,-save-restore",
 	"build-tags": ["k210", "kendryte"],
 	"code-model": "medium"
 }

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -1,6 +1,7 @@
 {
   "llvm-target": "aarch64",
   "cpu": "cortex-a57",
+  "features": "+aes,+crc,+crypto,+fp-armv8,+neon,+sha2",
   "build-tags": ["nintendoswitch", "arm64"],
   "scheduler": "tasks",
   "goos": "linux",

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
-	"features": ["+a", "+c", "+m"],
+	"features": "+a,+c,+m,-relax,-save-restore",
 	"build-tags": ["virt", "qemu"],
 	"linkerscript": "targets/riscv-qemu.ld",
 	"emulator": ["qemu-system-riscv32", "-machine", "virt", "-nographic", "-bios", "none", "-kernel"]

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -8,6 +8,7 @@
 	"libc": "picolibc",
 	"cflags": [
 		"-Werror",
+		"-mno-relax",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],


### PR DESCRIPTION
This makes sure that the LLVM target features match the one generated by Clang:

  - This fixes a bug (#2234) introduced when setting the target CPU for all targets: Cortex-M4 would now start using floating point operations while they were disabled in C.
  - This will make it possible in the future to inline C functions in Go and vice versa. This will need some more work though.

There is a code size impact. Cortex-M4 targets are increased slightly in binary size while Cortex-M0 targets tend to be reduced a little bit. Other than that, there is little impact.