### PR TITLE
ci: improve caching for GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,11 @@
 name: Windows
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - release
 
 jobs:
   build-windows:


### PR DESCRIPTION
Previously the cache would be stale for every new branch.
With this change, PRs use the cache from the base branch and therefore don't need to rebuild LLVM from scratch.