### PR TITLE
interp: take care of constant globals

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -145,6 +145,9 @@ func Run(mod llvm.Module, debug bool) error {
 		if obj.buffer == nil {
 			continue
 		}
+		if obj.constant {
+			continue // constant buffers can't have been modified
+		}
 		initializer, err := obj.buffer.toLLVMValue(obj.llvmGlobal.Type().ElementType(), &mem)
 		if err == errInvalidPtrToIntSize {
 			// This can happen when a previous interp run did not have the
@@ -247,6 +250,9 @@ func RunFunc(fn llvm.Value, debug bool) error {
 		}
 		if obj.buffer == nil {
 			continue
+		}
+		if obj.constant {
+			continue // constant, so can't have been modified
 		}
 		initializer, err := obj.buffer.toLLVMValue(obj.llvmGlobal.Type().ElementType(), &mem)
 		if err != nil {

--- a/interp/testdata/basic.ll
+++ b/interp/testdata/basic.ll
@@ -6,6 +6,7 @@ target triple = "x86_64--linux"
 @main.nonConst2 = global i64 0
 @main.someArray = global [8 x {i16, i32}] zeroinitializer
 @main.exportedValue = global [1 x i16*] [i16* @main.exposedValue1]
+@main.exportedConst = constant i64 42
 @main.exposedValue1 = global i16 0
 @main.exposedValue2 = global i16 0
 @main.insertedValue = global {i8, i32, {float, {i64, i16}}} zeroinitializer
@@ -62,6 +63,11 @@ entry:
   call void @modifyExternal(i32* bitcast ([1 x i16*]* @main.exportedValue to i32*))
   store i16 5, i16* @main.exposedValue1
 
+  ; Test that marking a constant as external still allows loading from it.
+  call void @readExternal(i32* bitcast (i64* @main.exportedConst to i32*))
+  %constLoad = load i64, i64 * @main.exportedConst
+  call void @runtime.printint64(i64 %constLoad)
+
   ; Test that this even propagates through functions.
   call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
   store i16 7, i16* @main.exposedValue2
@@ -95,6 +101,8 @@ entry:
 declare i64 @someValue()
 
 declare void @modifyExternal(i32*)
+
+declare void @readExternal(i32*)
 
 ; This function will modify an external value. By passing this function as a
 ; function pointer to an external function, @main.exposedValue2 should be

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -5,6 +5,7 @@ target triple = "x86_64--linux"
 @main.nonConst2 = local_unnamed_addr global i64 0
 @main.someArray = global [8 x { i16, i32 }] zeroinitializer
 @main.exportedValue = global [1 x i16*] [i16* @main.exposedValue1]
+@main.exportedConst = constant i64 42
 @main.exposedValue1 = global i16 0
 @main.exposedValue2 = local_unnamed_addr global i16 0
 @main.insertedValue = local_unnamed_addr global { i8, i32, { float, { i64, i16 } } } zeroinitializer
@@ -24,6 +25,8 @@ entry:
   call void @modifyExternal(i32* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ([8 x { i16, i32 }]* @main.someArray to i8*), i32 28) to i32*))
   call void @modifyExternal(i32* bitcast ([1 x i16*]* @main.exportedValue to i32*))
   store i16 5, i16* @main.exposedValue1, align 2
+  call void @readExternal(i32* bitcast (i64* @main.exportedConst to i32*))
+  call void @runtime.printint64(i64 42)
   call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
   store i16 7, i16* @main.exposedValue2, align 2
   call void @modifyExternal(i32* bitcast (void ()* @hasInlineAsm to i32*))
@@ -53,6 +56,8 @@ entry:
 declare i64 @someValue() local_unnamed_addr
 
 declare void @modifyExternal(i32*) local_unnamed_addr
+
+declare void @readExternal(i32*) local_unnamed_addr
 
 define void @willModifyGlobal() {
 entry:


### PR DESCRIPTION
Constant globals can't have been modified, even if a pointer is passed
externally. Therefore, don't treat it as such in hasExternalStore.

In addition, it doesn't make sense to update values of constant globals
after the interp pass is finished. So don't do this.

TODO: track whether objects are actually modified and only update the
globals if this is the case.

---

This fixes the `panic: interp: load from object with external store` issue in #2236.