### PR TITLE
nano-33-ble: internal i2c config, power led and sensors switch

### DIFF
--- a/src/machine/board_nano-33-ble.go
+++ b/src/machine/board_nano-33-ble.go
@@ -1,9 +1,14 @@
+//go:build nano_33_ble
 // +build nano_33_ble
 
 // This contains the pin mappings for the Arduino Nano 33 BLE [Sense] boards.
+// - https://store.arduino.cc/arduino-nano-33-ble
+// - https://store.arduino.cc/arduino-nano-33-ble-sense
 //
-// Flashing the board requires special version of bossac.
+// ----------------------------------------------------------------------------
+// Flashing
 //
+// Special version of bossac is required.
 // This executable can be obtained two ways:
 // 1) In Arduino IDE, install support for the board ("Arduino Mbed OS Nano Boards")
 //    Search for "tools/bossac/1.9.1-arduino2/bossac" in Arduino IDEs directory
@@ -16,9 +21,14 @@
 // It is possible to replace original bossac with this new one (this only adds support for nrf chip).
 // In that case make "bossac_arduino2" symlink on it, for the board target to be able to find it.
 //
-// For more information, see:
-// - https://store.arduino.cc/arduino-nano-33-ble
-// - https://store.arduino.cc/arduino-nano-33-ble-sense
+// ----------------------------------------------------------------------------
+// Bluetooth
+//
+// SoftDevice (s140v7) must be flashed first to enable use of bluetooth on this board.
+// See https://github.com/tinygo-org/bluetooth
+//
+// SoftDevice overwrites original bootloader and flashing method described above is not avalable anymore.
+// Instead, please use debug probe and flash your code with "nano-33-ble-s140v7" target.
 //
 package machine
 
@@ -62,6 +72,7 @@ const (
 	LED_RED     = P0_24
 	LED_GREEN   = P0_16
 	LED_BLUE    = P0_06
+	LED_PWR     = P1_09
 )
 
 // UART0 pins
@@ -72,8 +83,19 @@ const (
 
 // I2C pins
 const (
-	SDA_PIN = P0_31
-	SCL_PIN = P0_02
+	// Defaults to internal
+	SDA_PIN = SDA1_PIN
+	SCL_PIN = SCL1_PIN
+
+	// I2C0 (external) pins
+	SDA0_PIN = P0_31
+	SCL0_PIN = P0_02
+
+	// I2C1 (internal) pins
+	SDA1_PIN = P0_14
+	SCL1_PIN = P0_15
+
+	I2C_PULLUP = P1_00 // Set high for I2C to work
 )
 
 // SPI pins
@@ -81,6 +103,19 @@ const (
 	SPI0_SCK_PIN = P0_13
 	SPI0_SDO_PIN = P1_01
 	SPI0_SDI_PIN = P1_08
+)
+
+// Peripherals
+const (
+	APDS_INT = P0_19 // Proximity (APDS9960) interrupt pin
+
+	LSM_PWR = P0_22 // IMU (LSM9DS1) power
+	LSP_PWR = P0_22 // Pressure (LSP22) power
+	HTS_PWR = P0_22 // Humidity (HTS221) power
+
+	MIC_PWR = P0_17 // Microphone (MP34DT06JTR) power
+	MIC_CLK = P0_26
+	MIC_DIN = P0_25
 )
 
 // USB CDC identifiers


### PR DESCRIPTION
Adds missing pin definitions to work with onboard sensors