### PR TITLE
all: add support for GOARM

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -52,7 +52,9 @@ func TestClangAttributes(t *testing.T) {
 	for _, options := range []*compileopts.Options{
 		{GOOS: "linux", GOARCH: "386"},
 		{GOOS: "linux", GOARCH: "amd64"},
-		{GOOS: "linux", GOARCH: "arm"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "5"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "6"},
+		{GOOS: "linux", GOARCH: "arm", GOARM: "7"},
 		{GOOS: "linux", GOARCH: "arm64"},
 		{GOOS: "darwin", GOARCH: "amd64"},
 		{GOOS: "darwin", GOARCH: "arm64"},

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -60,6 +60,12 @@ func (c *Config) GOARCH() string {
 	return c.Target.GOARCH
 }
 
+// GOARM will return the GOARM environment variable given to the compiler when
+// building a program.
+func (c *Config) GOARM() string {
+	return c.Options.GOARM
+}
+
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
 	tags := append(c.Target.BuildTags, []string{"tinygo", "math_big_pure_go", "gc." + c.GC(), "scheduler." + c.Scheduler(), "serial." + c.Serial()}...)

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -21,6 +21,7 @@ var (
 type Options struct {
 	GOOS            string // environment variable
 	GOARCH          string // environment variable
+	GOARM           string // environment variable (only used with GOARCH=arm)
 	Target          string
 	Opt             string
 	GC              string

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -25,6 +25,12 @@ var Keys = []string{
 	"TINYGOROOT",
 }
 
+func init() {
+	if Get("GOARCH") == "arm" {
+		Keys = append(Keys, "GOARM")
+	}
+}
+
 // TINYGOROOT is the path to the final location for checking tinygo files. If
 // unset (by a -X ldflag), then sourceDir() will fallback to the original build
 // directory.
@@ -44,6 +50,20 @@ func Get(name string) string {
 			return dir
 		}
 		return runtime.GOARCH
+	case "GOARM":
+		if goarm := os.Getenv("GOARM"); goarm != "" {
+			return goarm
+		}
+		if goos := Get("GOOS"); goos == "windows" || goos == "android" {
+			// Assume Windows and Android are running on modern CPU cores.
+			// This matches upstream Go.
+			return "7"
+		}
+		// Default to ARMv6 on other devices.
+		// The difference between ARMv5 and ARMv6 is big, much bigger than the
+		// difference between ARMv6 and ARMv7. ARMv6 binaries are much smaller,
+		// especially when floating point instructions are involved.
+		return "6"
 	case "GOROOT":
 		return getGoroot()
 	case "GOPATH":

--- a/main.go
+++ b/main.go
@@ -1192,6 +1192,7 @@ func main() {
 	options := &compileopts.Options{
 		GOOS:            goenv.Get("GOOS"),
 		GOARCH:          goenv.Get("GOARCH"),
+		GOARM:           goenv.Get("GOARM"),
 		Target:          *target,
 		Opt:             *opt,
 		GC:              *gc,
@@ -1401,6 +1402,7 @@ func main() {
 		fmt.Printf("LLVM triple:       %s\n", config.Triple())
 		fmt.Printf("GOOS:              %s\n", config.GOOS())
 		fmt.Printf("GOARCH:            %s\n", config.GOARCH())
+		fmt.Printf("GOARM:             %s\n", config.GOARM())
 		fmt.Printf("build tags:        %s\n", strings.Join(config.BuildTags(), " "))
 		fmt.Printf("garbage collector: %s\n", config.GC())
 		fmt.Printf("scheduler:         %s\n", config.Scheduler())


### PR DESCRIPTION
This environment variable can be set to 5, 6, or 7 and controls which ARM version (ARMv5, ARMv6, ARMv7) is used when compiling for GOARCH=arm.

The default value is usually ARMv5. This is an old architecture variant and perhaps it makes sense to use a more recent one such as ARMv6.

We could even go further and support ARMv4 if anybody is interested. It should be pretty simple to add this if needed.