### PR TITLE
wasi: restore support for -scheduler=none

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -172,6 +172,14 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 		t.Parallel()
 		runTest("env.go", options, t, []string{"first", "second"}, []string{"ENV1=VALUE1", "ENV2=VALUE2"})
 	})
+	if options.Target == "wasi" {
+		t.Run("alias.go-scheduler-none", func(t *testing.T) {
+			t.Parallel()
+			options := compileopts.Options(options)
+			options.Scheduler = "none"
+			runTest("alias.go", options, t, nil, nil)
+		})
+	}
 	if options.Target == "" || options.Target == "wasi" {
 		t.Run("filesystem.go", func(t *testing.T) {
 			t.Parallel()

--- a/src/internal/task/task_asyncify_wasm.S
+++ b/src/internal/task/task_asyncify_wasm.S
@@ -1,6 +1,7 @@
 .globaltype __stack_pointer, i32
 
 .global  tinygo_unwind
+.hidden  tinygo_unwind
 .type    tinygo_unwind,@function
 tinygo_unwind: // func (state *stackState) unwind()
     .functype tinygo_unwind (i32) -> ()
@@ -27,6 +28,7 @@ tinygo_unwind: // func (state *stackState) unwind()
     end_function
 
 .global tinygo_launch
+.hidden tinygo_launch
 .type tinygo_launch,@function
 tinygo_launch: // func (state *state) launch()
     .functype tinygo_launch (i32) -> ()
@@ -50,6 +52,7 @@ tinygo_launch: // func (state *state) launch()
     end_function
 
 .global  tinygo_rewind
+.hidden  tinygo_rewind
 .type    tinygo_rewind,@function
 tinygo_rewind: // func (state *state) rewind()
     .functype tinygo_rewind (i32) -> ()


### PR DESCRIPTION
The assembly symbols were not marked as hidden and so were exported, leading to unreferenced symbols.

Example error message:

    Error: failed to run main module `/tmp/tinygo3961039405/main`

    Caused by:
        0: failed to instantiate "/tmp/tinygo3961039405/main"
        1: unknown import: `asyncify::stop_rewind` has not been defined

This commit fixes this issue.

Unfortunately, `-scheduler=none` doesn't work for `-target=wasm` yet. I think that's fixable, possibly in a follow-up PR.