### PR TITLE
builder: support -size= flag on the esp32

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -288,6 +288,13 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 			if symType != elf.STT_FUNC && symType != elf.STT_OBJECT && symType != elf.STT_NOTYPE {
 				continue
 			}
+			if symbol.Section >= elf.SHN_LORESERVE {
+				// Not a regular section, so skip it.
+				// One example is elf.SHN_ABS, which is used for symbols
+				// declared with an absolute value such as the memset function
+				// on the ESP32 which is defined in the mask ROM.
+				continue
+			}
 			section := file.Sections[symbol.Section]
 			if section.Flags&elf.SHF_ALLOC == 0 {
 				continue


### PR DESCRIPTION
This fixes a small mistake when calculating binary size for an Xtensa file. Previously it would exit with the following error:

    $ tinygo build -o test.elf -size=short -target=esp32-mini32 examples/serial
    panic: runtime error: index out of range [65521] with length 18

Now it runs as expected:

    $ tinygo build -o test.elf -size=short -target=esp32-mini32 examples/serial
       code    data     bss |   flash     ram
       2897       0    4136 |    2897    4136

I'm not sure why it works in CI but not locally. It might be a different linker version (we don't use the LLVM linker for Xtensa).