### PR TITLE
ci: move all cross compilation tests to Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,20 +163,17 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install --no-install-recommends \
-                libgnutls30 libssl1.0.2 \
                 qemu-system-arm \
+                qemu-system-riscv32 \
                 qemu-user \
                 gcc-avr \
                 avr-libc \
                 ninja-build \
                 python3
       - install-node
-      - install-chrome
       - install-wasmtime
       - install-cmake
       - hack-ninja-jobs
-      - install-xtensa-toolchain:
-          variant: "linux-amd64"
       - restore_cache:
           keys:
             - go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
@@ -201,12 +198,7 @@ commands:
           key: llvm-build-11-linux-v4-assert
           paths:
             llvm-build
-      - build-binaryen-linux-stretch
-      - run:
-          name: "Build TinyGo"
-          command: |
-            make ASSERT=1
-            echo 'export PATH=$(pwd)/build:$PATH' >> $BASH_ENV
+      - build-binaryen-linux
       - build-wasi-libc
       - run:
           name: "Test TinyGo"
@@ -217,14 +209,22 @@ commands:
             # necessary to keep memory consumption down and avoid OOM (for a
             # 2CPU/4GB executor).
             GOFLAGS: -p=2
+      - run:
+          name: "Build TinyGo"
+          command: |
+            make ASSERT=1
+            echo 'export PATH=$(pwd)/build:$PATH' >> $BASH_ENV
+      - run: make tinygo-test
       - save_cache:
           key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - ~/.cache/go-build
             - /go/pkg/mod
+      - install-xtensa-toolchain:
+          variant: "linux-amd64"
       - run: make gen-device -j4
       - run: make smoketest
-      - run: make tinygo-test
+      - install-chrome
       - run: make wasmtest
   build-linux:
     steps:
@@ -323,7 +323,7 @@ commands:
             curl https://dl.google.com/go/go1.17.darwin-amd64.tar.gz -o go1.17.darwin-amd64.tar.gz
             sudo tar -C /usr/local -xzf go1.17.darwin-amd64.tar.gz
             ln -s /usr/local/go/bin/go /usr/local/bin/go
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu cmake ninja
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
       - install-xtensa-toolchain:
           variant: "macos"
       - restore_cache:
@@ -388,7 +388,7 @@ commands:
             - lib/wasi-libc/sysroot
       - run:
           name: "Test TinyGo"
-          command: make test
+          command: make test GOTESTFLAGS="-v -short"
           no_output_timeout: 20m
       - run:
           name: "Build TinyGo release"
@@ -426,7 +426,7 @@ jobs:
           llvm: "11"
   assert-test-linux:
     docker:
-      - image: circleci/golang:1.17-stretch
+      - image: circleci/golang:1.17-buster
     steps:
       - assert-test-linux
   build-linux:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,11 +15,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - name: Install QEMU
-        shell: bash
-        run: |
-          choco install qemu --version=2020.06.12
-          echo "C:\Program Files\QEMU" >> $GITHUB_PATH
       - name: Install Ninja
         shell: bash
         run: |
@@ -78,7 +73,7 @@ jobs:
         run: make binaryen
       - name: Test TinyGo
         shell: bash
-        run: make test
+        run: make test GOTESTFLAGS="-v -short"
       - name: Build TinyGo release tarball
         run: make build/release -j4
       - name: Make release artifact

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ LLVM_NM ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-nm))$(call detec
 GO ?= go
 export GOROOT = $(shell $(GO) env GOROOT)
 
+# Flags to pass to go test.
+GOTESTFLAGS ?= -v
+
 # md5sum binary
 MD5SUM = md5sum
 
@@ -192,7 +195,7 @@ tinygo:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm -ldflags="-X main.gitSha1=`git rev-parse --short HEAD`" .
 
 test: wasi-libc
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test -v -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
 
 TEST_PACKAGES = \
 	compress/bzip2 \

--- a/main_test.go
+++ b/main_test.go
@@ -75,40 +75,6 @@ func TestCompiler(t *testing.T) {
 		runPlatTests(optionsFromTarget(""), tests, t)
 	})
 
-	if testing.Short() {
-		return
-	}
-
-	t.Run("EmulatedCortexM3", func(t *testing.T) {
-		runPlatTests(optionsFromTarget("cortex-m-qemu"), tests, t)
-	})
-
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// Note: running only on Windows and macOS because Linux (as of 2020)
-		// usually has an outdated QEMU version that doesn't support RISC-V yet.
-		t.Run("EmulatedRISCV", func(t *testing.T) {
-			runPlatTests(optionsFromTarget("riscv-qemu"), tests, t)
-		})
-	}
-
-	if runtime.GOOS == "linux" {
-		t.Run("X86Linux", func(t *testing.T) {
-			runPlatTests(optionsFromOSARCH("linux/386"), tests, t)
-		})
-		t.Run("ARMLinux", func(t *testing.T) {
-			runPlatTests(optionsFromOSARCH("linux/arm/6"), tests, t)
-		})
-		t.Run("ARM64Linux", func(t *testing.T) {
-			runPlatTests(optionsFromOSARCH("linux/arm64"), tests, t)
-		})
-		t.Run("WebAssembly", func(t *testing.T) {
-			runPlatTests(optionsFromTarget("wasm"), tests, t)
-		})
-		t.Run("WASI", func(t *testing.T) {
-			runPlatTests(optionsFromTarget("wasi"), tests, t)
-		})
-	}
-
 	// Test a few build options.
 	t.Run("build-options", func(t *testing.T) {
 		t.Parallel()
@@ -150,6 +116,38 @@ func TestCompiler(t *testing.T) {
 			}, nil, nil)
 		})
 	})
+
+	if testing.Short() {
+		// Don't test other targets when the -short flag is used. Only test the
+		// host system.
+		return
+	}
+
+	t.Run("EmulatedCortexM3", func(t *testing.T) {
+		runPlatTests(optionsFromTarget("cortex-m-qemu"), tests, t)
+	})
+
+	t.Run("EmulatedRISCV", func(t *testing.T) {
+		runPlatTests(optionsFromTarget("riscv-qemu"), tests, t)
+	})
+
+	if runtime.GOOS == "linux" {
+		t.Run("X86Linux", func(t *testing.T) {
+			runPlatTests(optionsFromOSARCH("linux/386"), tests, t)
+		})
+		t.Run("ARMLinux", func(t *testing.T) {
+			runPlatTests(optionsFromOSARCH("linux/arm/6"), tests, t)
+		})
+		t.Run("ARM64Linux", func(t *testing.T) {
+			runPlatTests(optionsFromOSARCH("linux/arm64"), tests, t)
+		})
+		t.Run("WebAssembly", func(t *testing.T) {
+			runPlatTests(optionsFromTarget("wasm"), tests, t)
+		})
+		t.Run("WASI", func(t *testing.T) {
+			runPlatTests(optionsFromTarget("wasi"), tests, t)
+		})
+	}
 }
 
 func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {


### PR DESCRIPTION
The idea here is as follows:
  - Run all Linux and cross compilation tests in the asser-test-linux job.
  - Only run native tests on MacOS and Windows.

This reduces testing time on MacOS and Windows, which are generally more expensive in CI. Also, by not duplicating tests in Windows and MacOS we can reduce overall CI usage a bit.

The downside is of course that assert-test-linux will take a longer time to run. I've mitigated that slightly by moving the important test (`make test`) above some other less important tests like `make smoketest`.