### PR TITLE
machine/rp2040: add `machine.Sleep` api

### DIFF
--- a/src/machine/machine_rp2040_xosc.go
+++ b/src/machine/machine_rp2040_xosc.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine
@@ -38,5 +39,16 @@ func (osc *xoscType) init() {
 
 	// Wait for xosc to be stable
 	for !osc.status.HasBits(rp.XOSC_STATUS_STABLE) {
+	}
+}
+
+// Dormant stops internal oscillator.
+// WARNING: This stops the xosc until woken up by an irq
+func (osc *xoscType) Dormant() {
+	const XOSC_DORMANT_VALUE_DORMANT = 0x636f6d61
+	osc.dormant.Set(XOSC_DORMANT_VALUE_DORMANT)
+	// Wait for it to become stable once woken up
+	// while(!(xosc_hw->status & XOSC_STATUS_STABLE_BITS));
+	for osc.status.Get()&rp.XOSC_STATUS_STABLE == 0 {
 	}
 }


### PR DESCRIPTION
@aykevl  @deadprogram @ysoldak   PTAL! This is a new API addition to `machine` package. Provides a way to set processor in a low power state until an interrupt is triggered via a PinEvent.

```go
// Sets raspberry pico in dormant state until interrupt event is triggered
// usage:
//  err := machine.Sleep(interruptPin, machine.PinRising)
// Above code will cause program to sleep until a high level signal
// is found on interruptPin. Be sure to configure pin as input beforehand.
// Taken from https://github.com/raspberrypi/pico-extras/ -> pico/sleep.h
func Sleep(pin Pin, change PinChange) error {
```