### PR TITLE
compiler: fix string compare functions

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2276,16 +2276,16 @@ func (b *builder) createBinOp(op token.Token, typ, ytyp types.Type, x, y llvm.Va
 			case token.NEQ: // !=
 				result := b.createRuntimeCall("stringEqual", []llvm.Value{x, y}, "")
 				return b.CreateNot(result, ""), nil
-			case token.LSS: // <
+			case token.LSS: // x < y
 				return b.createRuntimeCall("stringLess", []llvm.Value{x, y}, ""), nil
-			case token.LEQ: // <=
+			case token.LEQ: // x <= y becomes NOT (y < x)
 				result := b.createRuntimeCall("stringLess", []llvm.Value{y, x}, "")
 				return b.CreateNot(result, ""), nil
-			case token.GTR: // >
+			case token.GTR: // x > y becomes y < x
+				return b.createRuntimeCall("stringLess", []llvm.Value{y, x}, ""), nil
+			case token.GEQ: // x >= y becomes NOT (x < y)
 				result := b.createRuntimeCall("stringLess", []llvm.Value{x, y}, "")
 				return b.CreateNot(result, ""), nil
-			case token.GEQ: // >=
-				return b.createRuntimeCall("stringLess", []llvm.Value{y, x}, ""), nil
 			default:
 				panic("binop on string: " + op.String())
 			}

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -71,9 +71,8 @@ entry:
 ; Function Attrs: nounwind
 define hidden i1 @main.stringCompareLarger(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context, i8* %parentHandle) unnamed_addr #0 {
 entry:
-  %0 = call i1 @runtime.stringLess(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef, i8* null) #0
-  %1 = xor i1 %0, true
-  ret i1 %1
+  %0 = call i1 @runtime.stringLess(i8* %s2.data, i32 %s2.len, i8* %s1.data, i32 %s1.len, i8* undef, i8* null) #0
+  ret i1 %0
 }
 
 declare i1 @runtime.stringLess(i8*, i32, i8*, i32, i8*, i8*)

--- a/testdata/binop.go
+++ b/testdata/binop.go
@@ -24,6 +24,13 @@ func main() {
 	println("ab" < "aa")
 	println("aa" < "ab")
 
+	h := "hello"
+	println("h < h", h < h)
+	println("h <= h", h <= h)
+	println("h == h", h == h)
+	println("h >= h", h >= h)
+	println("h > h", h > h)
+
 	println("array equality")
 	println(a1 == [2]int{1, 2})
 	println(a1 != [2]int{1, 2})

--- a/testdata/binop.txt
+++ b/testdata/binop.txt
@@ -20,6 +20,11 @@ true
 false
 false
 true
+h < h false
+h <= h true
+h == h true
+h >= h true
+h > h false
 array equality
 true
 false


### PR DESCRIPTION
Before:
	x < x false
	x <= x true
	x == x true
	x >= x false
	x > x true

After:
	x < x false
	x <= x true
	x == x true
	x >= x true
	x > x false