### PR TITLE
board: add M5Stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,8 @@ ifneq ($(XTENSA), 0)
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target m5stack-core2       examples/serial
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target m5stack             examples/serial
+	@$(MD5SUM) test.bin
 endif
 	$(TINYGO) build -size short -o test.bin -target=esp32c3           	examples/serial
 	@$(MD5SUM) test.bin

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 71 microcontroller boards are currently supported:
+The following 72 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -84,6 +84,7 @@ The following 71 microcontroller boards are currently supported:
 * [ESP32](https://www.espressif.com/en/products/socs/esp32)
 * [ESP8266](https://www.espressif.com/en/products/socs/esp8266)
 * [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
+* [M5Stack](https://docs.m5stack.com/en/core/basic)
 * [M5Stack Core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit)
 * [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
 * [Makerdiary nRF52840-MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)

--- a/src/machine/board_m5stack.go
+++ b/src/machine/board_m5stack.go
@@ -1,0 +1,130 @@
+// +build m5stack
+
+package machine
+
+const (
+	//     GND     | ADC     G35
+	//     GND     | ADC     G36
+	//     GND     | RST     EN
+	// G23 MOSI    | DAC/SPK G25
+	// G19 MISO    | DAC     G26
+	// G18 SCK     | 3.3V
+	// G3  RXD1    | TXD1    G1
+	// G16 RXD2    | TXD2    G17
+	// G21 SDA     | DCL     G22
+	// G2  GPIO    | GPIO    G5
+	// G12 IIS_SK  | IIS_WS  G13
+	// G15 IIS_OUT | IIS_MK  G0
+	//     HPWR    | IIS_IN  G34
+	//     HPWR    | 5V
+	//     HPWR    | BATTERY
+
+	IO0  Pin = 0
+	IO1  Pin = 1
+	IO2  Pin = 2
+	IO3  Pin = 3
+	IO4  Pin = 4
+	IO5  Pin = 5
+	IO6  Pin = 6
+	IO7  Pin = 7
+	IO8  Pin = 8
+	IO9  Pin = 9
+	IO10 Pin = 10
+	IO11 Pin = 11
+	IO12 Pin = 12
+	IO13 Pin = 13
+	IO14 Pin = 14
+	IO15 Pin = 15
+	IO16 Pin = 16
+	IO17 Pin = 17
+	IO18 Pin = 18
+	IO19 Pin = 19
+	IO20 Pin = 20
+	IO21 Pin = 21
+	IO22 Pin = 22
+	IO23 Pin = 23
+	IO24 Pin = 24
+	IO25 Pin = 25
+	IO26 Pin = 26
+	IO27 Pin = 27
+	IO28 Pin = 28
+	IO29 Pin = 29
+	IO30 Pin = 30
+	IO31 Pin = 31
+	IO32 Pin = 32
+	IO33 Pin = 33
+	IO34 Pin = 34
+	IO35 Pin = 35
+	IO36 Pin = 36
+	IO37 Pin = 37
+	IO38 Pin = 38
+	IO39 Pin = 39
+)
+
+const (
+	// Buttons
+	BUTTON_A = IO39
+	BUTTON_B = IO38
+	BUTTON_C = IO37
+	BUTTON   = BUTTON_A
+
+	// Speaker
+	SPEAKER_PIN = IO25
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = IO18
+	SPI0_SDO_PIN = IO23
+	SPI0_SDI_PIN = IO19
+	SPI0_CS0_PIN = IO14
+
+	// LCD (ILI9342C)
+	LCD_SCK_PIN = SPI0_SCK_PIN
+	LCD_SDO_PIN = SPI0_SDO_PIN
+	LCD_SDI_PIN = SPI0_SDI_PIN // NoPin ?
+	LCD_SS_PIN  = SPI0_CS0_PIN
+	LCD_DC_PIN  = IO27
+	LCD_RST_PIN = IO33
+	LCD_BL_PIN  = IO32
+
+	// SD CARD
+	SDCARD_SCK_PIN = SPI0_SCK_PIN
+	SDCARD_SDO_PIN = SPI0_SDO_PIN
+	SDCARD_SDI_PIN = SPI0_SDI_PIN
+	SDCARD_SS_PIN  = IO4
+)
+
+// I2C pins
+const (
+	SDA0_PIN = IO21
+	SCL0_PIN = IO22
+
+	SDA_PIN = SDA0_PIN
+	SCL_PIN = SCL0_PIN
+)
+
+// ADC pins
+const (
+	ADC1 Pin = IO35
+	ADC2 Pin = IO36
+)
+
+// DAC pins
+const (
+	DAC1 Pin = IO25
+	DAC2 Pin = IO26
+)
+
+// UART pins
+const (
+	// UART0 (CP2104)
+	UART0_TX_PIN = IO1
+	UART0_RX_PIN = IO3
+
+	UART1_TX_PIN = IO17
+	UART1_RX_PIN = IO16
+
+	UART_TX_PIN = UART0_TX_PIN
+	UART_RX_PIN = UART0_RX_PIN
+)

--- a/targets/m5stack.json
+++ b/targets/m5stack.json
@@ -1,0 +1,5 @@
+{
+	"inherits": ["esp32"],
+	"build-tags": ["m5stack"],
+	"serial-port": ["acm:10c4:ea60"]
+}


### PR DESCRIPTION
This PR adds M5Stack (Basic / Gray) support.

* Board
    * Name
        * M5Stack
    * Board developer / designer / manufacturer
        * M5Stack
    * schematic
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/schematic/Core/M5-Core-Schematic(20171206).pdf
    * pinout and stuff
        * https://docs.m5stack.com/en/core/basic
    * URL
        * https://docs.m5stack.com/en/core/basic
        * https://github.com/m5stack/M5Stack
    * User manual for the board (if it exists)
        * (none)
* Chip
    * chip name
        * ESP32 D0WDQ6-V3 (dual core Xtensa 32-bit)
    * Clock / ROM / RAM size
        * 240Mhz / 16MB / 8MB
    * datasheet URL of the chip
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/esp32_datasheet_en.pdf
* URL of the source, such as arduino (if it exists)
    * https://github.com/espressif/arduino-esp32/blob/master/variants/m5stack_core_esp32/pins_arduino.h ???

There are no LEDs on the board.
