### PR TITLE
Add stubbed internal/testenv to allow more stdlib tests to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,33 +198,47 @@ tinygo:
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
 
+# These packages pass `tinygo test` but fail in CI due to cpu or memory requirements
+FAIL_IN_CI = \
+	compress/lzw \
+	regexp/syntax \
+
 TEST_PACKAGES = \
 	compress/bzip2 \
+	compress/flate \
+	compress/zlib \
 	container/heap \
 	container/list \
 	container/ring \
 	crypto/des \
 	crypto/dsa \
+	crypto/elliptic/internal/fiat \
+	crypto/internal/subtle \
 	crypto/md5 \
 	crypto/rc4 \
 	crypto/sha1 \
 	crypto/sha256 \
 	crypto/sha512 \
-	encoding \
+	debug/macho \
 	encoding/ascii85 \
 	encoding/base32 \
+	encoding/csv \
 	encoding/hex \
+	go/scanner \
 	hash \
 	hash/adler32 \
-	hash/fnv \
 	hash/crc64 \
+	hash/fnv \
 	html \
 	index/suffixarray \
 	internal/itoa \
+	internal/profile \
 	math \
 	math/cmplx \
+	net/http/internal/ascii \
 	net/mail \
 	os \
+	path \
 	reflect \
 	testing \
 	testing/iotest \

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -229,6 +229,7 @@ func pathsToOverride(needsSyscallPackage bool) map[string]bool {
 		"internal/reflectlite/": false,
 		"internal/task/":        false,
 		"internal/itoa/":        false, // TODO: Remove when we drop support for go 1.16
+		"internal/testenv/":     false,
 		"machine/":              false,
 		"net/":                  true,
 		"os/":                   true,

--- a/src/internal/testenv/testenv.go
+++ b/src/internal/testenv/testenv.go
@@ -1,0 +1,9 @@
+package testenv
+
+func Builder() string {
+	return ""
+}
+
+func HasSrc() bool {
+	return true
+}


### PR DESCRIPTION
Tiny patch to make running stdlib tests easier (while we wait for https://github.com/tinygo-org/tinygo/pull/2268 to land)