### PR TITLE
builder: fix off-by-one in size calculation

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -96,6 +96,17 @@ const (
 	memoryStack
 )
 
+func (t memoryType) String() string {
+	return [...]string{
+		0:            "-",
+		memoryCode:   "code",
+		memoryData:   "data",
+		memoryROData: "rodata",
+		memoryBSS:    "bss",
+		memoryStack:  "stack",
+	}[t]
+}
+
 // Regular expressions to match particular symbol names. These are not stored as
 // DWARF variables because they have no mapping to source code global variables.
 var (
@@ -513,8 +524,11 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 	// section. We start at the beginning.
 	addr := section.Address
 	sectionEnd := section.Address + section.Size
+	if sizesDebug {
+		fmt.Printf("%08x..%08x %5d: %s\n", addr, sectionEnd, section.Size, section.Type)
+	}
 	for _, line := range addresses {
-		if line.Address < section.Address || line.Address+line.Length >= sectionEnd {
+		if line.Address < section.Address || line.Address+line.Length > sectionEnd {
 			// Check that this line is entirely within the section.
 			// Don't bother dealing with line entries that cross sections (that
 			// seems rather unlikely anyway).
@@ -525,7 +539,7 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 			// previous line entry.
 			addSize("(unknown)", line.Address-addr, false)
 			if sizesDebug {
-				fmt.Printf("%08x..%08x %4d: unknown (gap)\n", addr, line.Address, line.Address-addr)
+				fmt.Printf("%08x..%08x %5d:  unknown (gap)\n", addr, line.Address, line.Address-addr)
 			}
 		}
 		if addr > line.Address+line.Length {
@@ -550,7 +564,7 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 		// There is a gap at the end of the section.
 		addSize("(unknown)", sectionEnd-addr, false)
 		if sizesDebug {
-			fmt.Printf("%08x..%08x %4d: unknown (end)\n", addr, sectionEnd, sectionEnd-addr)
+			fmt.Printf("%08x..%08x %5d:  unknown (end)\n", addr, sectionEnd, sectionEnd-addr)
 		}
 	}
 }


### PR DESCRIPTION
> There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.

Because of this bug, sometimes the last object in a section might not be attributed correctly to a source location.

Before:

```
$ tinygo build -size=full -o test ./testdata/alias.go
   code  rodata    data     bss |   flash     ram | package
------------------------------- | --------------- | -------
     33    2046      24      86 |    2103     110 | (unknown)
   2843       8       0     560 |    2851     560 | C musl
    333      24       0       8 |     357       8 | internal/task
     58       6       0       0 |      64       0 | main
   1778     112       8      50 |    1898      58 | runtime
------------------------------- | --------------- | -------
   5045    2196      32     704 |    7273     736 | total
```

After:

```
$ tinygo build -size=full -o test ./testdata/alias.go
   code  rodata    data     bss |   flash     ram | package
------------------------------- | --------------- | -------
     28    2038      20      78 |    2086      98 | (unknown)
   2848      16       4     568 |    2868     572 | C musl
    333      24       0       8 |     357       8 | internal/task
     58       6       0       0 |      64       0 | main
   1778     112       8      50 |    1898      58 | runtime
------------------------------- | --------------- | -------
   5045    2196      32     704 |    7273     736 | total
```

As you can see, all four data kinds (code, rodata, data, bss) are reduced a bit in the `(unknown)` pseudo-package and have the size correctly attributed (in this case, to musl). My goal is of course to make `(unknown)` eventually disappear with everything correctly attributed :)