### PR TITLE
all: remove FreeBSD support

### DIFF
--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -157,7 +157,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 // functions, depending on the target OS/arch.
 func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 	switch b.GOOS {
-	case "linux", "freebsd":
+	case "linux":
 		syscallResult, err := b.createRawSyscall(call)
 		if err != nil {
 			return syscallResult, err

--- a/src/crypto/rand/rand_arc4random.go
+++ b/src/crypto/rand/rand_arc4random.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd tinygo.wasm
+// +build darwin tinygo.wasm
 
 // This implementation of crypto/rand uses the arc4random_buf function
 // (available on both MacOS and WASI) to generate random numbers.

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal freebsd,!baremetal
+// +build darwin linux,!baremetal
 
 package os
 

--- a/src/runtime/os_freebsd.go
+++ b/src/runtime/os_freebsd.go
@@ -1,5 +1,0 @@
-// +build freebsd
-
-package runtime
-
-const GOOS = "freebsd"

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal,!wasi freebsd,!baremetal
+// +build darwin linux,!baremetal,!wasi
 // +build !nintendoswitch
 
 package runtime

--- a/src/runtime/runtime_unix_heap.go
+++ b/src/runtime/runtime_unix_heap.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal,!wasi freebsd,!baremetal
+// +build darwin linux,!baremetal,!wasi
 // +build !nintendoswitch
 
 // +build gc.conservative gc.leaking

--- a/src/runtime/runtime_unix_noheap.go
+++ b/src/runtime/runtime_unix_noheap.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal,!wasi freebsd,!baremetal
+// +build darwin linux,!baremetal,!wasi
 
 // +build !nintendoswitch
 


### PR DESCRIPTION
FreeBSD support has been broken for a long time, probably since https://github.com/tinygo-org/tinygo/pull/1860 (merged in May). Nobody has complained yet, so I am going to assume nobody uses it.

This doesn't remove support for FreeBSD entirely: the code necessary to build TinyGo on FreeBSD is still there. It just removes the code necessary to build binaries targetting FreeBSD. But again, it could very well be broken as we don't test it.

If anybody wants to re-enable support for FreeBSD, they would be welcome to do that. But I think it would at the very least need a smoke test of some sort.

CC @dmgk 