### PR TITLE
goenv: update version for start of 0.22.0 development cycle

### DIFF
--- a/goenv/version.go
+++ b/goenv/version.go
@@ -12,7 +12,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const Version = "0.21.0"
+const Version = "0.22.0-dev"
 
 // GetGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.


### PR DESCRIPTION
As usual, this updates the version to a `-dev` for the upcoming development cycle.