### PR TITLE
ci: fix Binaryen cache on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,8 +66,8 @@ jobs:
         uses: actions/cache@v2
         id: cache-binaryen
         with:
-          key: binaryen-v1
-          path: build/binaryen
+          key: binaryen-windows-v2
+          path: build/wasm-opt.exe
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: make binaryen

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ $(LLVM_BUILDDIR): $(LLVM_BUILDDIR)/build.ninja
 .PHONY: binaryen
 binaryen: build/wasm-opt
 build/wasm-opt:
-	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON $(BINARYEN_OPTION) && ninja
+	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
 	cp lib/binaryen/bin/wasm-opt build/wasm-opt
 
 # Build wasi-libc sysroot

--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,10 @@ $(LLVM_BUILDDIR): $(LLVM_BUILDDIR)/build.ninja
 
 # Build Binaryen
 .PHONY: binaryen
-binaryen: build/wasm-opt
-build/wasm-opt:
+binaryen: build/wasm-opt$(EXE)
+build/wasm-opt$(EXE):
 	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
-	cp lib/binaryen/bin/wasm-opt build/wasm-opt
+	cp lib/binaryen/bin/wasm-opt$(EXE) build/wasm-opt$(EXE)
 
 # Build wasi-libc sysroot
 .PHONY: wasi-libc


### PR DESCRIPTION
The wrong path was used to cache binaryen, so it wasn't actually getting
cached. Therefore, wasm-opt was rebuilt on every new PR (slowing down
the "Build TinyGo release tarball" a lot).

EDIT: in draft to check that it now actually works.