### PR TITLE
board/stm32: Add STM32 Nucleo WL55JC board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,8 @@ ifneq ($(STM32), 0)
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-l552ze       examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nucleo-wl55jc       examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=stm32f4disco        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=stm32f4disco        examples/blinky2

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following 72 microcontroller boards are currently supported:
 * [ST Micro "Nucleo" L031K6](https://www.st.com/ja/evaluation-tools/nucleo-l031k6.html)
 * [ST Micro "Nucleo" L432KC](https://www.st.com/ja/evaluation-tools/nucleo-l432kc.html)
 * [ST Micro "Nucleo" L552ZE](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html)
+* [ST Micro "Nucleo" WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html)
 * [ST Micro STM32F103XX "Bluepill"](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill)
 * [ST Micro STM32F407 "Discovery"](https://www.st.com/en/evaluation-tools/stm32f4discovery.html)
 * [X9 Pro smartwatch](https://github.com/curtpw/nRF5x-device-reverse-engineering/tree/master/X9-nrf52832-activity-tracker/)

--- a/src/machine/board_nucleowl55jc.go
+++ b/src/machine/board_nucleowl55jc.go
@@ -1,0 +1,67 @@
+//go:build nucleowl55jc
+// +build nucleowl55jc
+
+package machine
+
+import (
+	"device/stm32"
+	"runtime/interrupt"
+)
+
+const (
+	LED_BLUE  = PB15
+	LED_GREEN = PB9
+	LED_RED   = PB11
+	LED       = LED_RED
+
+	BTN1   = PA0
+	BTN2   = PA1
+	BTN3   = PC6
+	BUTTON = BTN1
+
+	// SubGhz (SPI3)
+	SPI0_NSS_PIN = PA4
+	SPI0_SCK_PIN = PA5
+	SPI0_SDO_PIN = PA6
+	SPI0_SDI_PIN = PA7
+
+	//MCU USART1
+	UART1_TX_PIN = PB6
+	UART1_RX_PIN = PB7
+
+	//MCU USART2
+	UART2_RX_PIN = PA3
+	UART2_TX_PIN = PA2
+
+	// DEFAULT USART
+	UART_RX_PIN = UART2_RX_PIN
+	UART_TX_PIN = UART2_TX_PIN
+)
+
+var (
+	// STM32 UART2 is connected to the embedded STLINKV3 Virtual Com Port
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART2,
+		TxAltFuncSelector: 7,
+		RxAltFuncSelector: 7,
+	}
+
+	// UART1 is free
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART1,
+		TxAltFuncSelector: 7,
+		RxAltFuncSelector: 7,
+	}
+
+	DefaultUART = UART0
+)
+
+func init() {
+	// Enable UARTs Interrupts
+	UART0.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART1, _UART1.handleInterrupt)
+}

--- a/targets/nucleo-wl55jc.json
+++ b/targets/nucleo-wl55jc.json
@@ -1,0 +1,13 @@
+{
+	"inherits": [
+		"stm32wle5"
+	],
+	"build-tags": [
+		"nucleowl55jc"
+	],
+	"serial": "uart",
+	"linkerscript": "targets/stm32wle5.ld",
+	"flash-method": "openocd",
+	"openocd-interface": "stlink",
+	"openocd-target": "stm32wlx"
+}


### PR DESCRIPTION
Support for Nucleo WL55JC boards (WL55JC1/WL55JC2) 