### PR TITLE
ci: cache Go cache for faster build times

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Cache Go
+        uses: actions/cache@v2
+        with:
+          key: go-cache-windows-v1-${{ hashFiles('go.mod') }}
+          path: |
+            ~/AppData/Local/go-build
+            ~/go/pkg/mod
       - name: Cache LLVM source
         uses: actions/cache@v2
         id: cache-llvm-source


### PR DESCRIPTION
This appears to reduce CI time for Windows by 1-2 minutes.