### PR TITLE
runtime: allow comparing interfaces in reflectValueEqual()

### DIFF
--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -74,6 +74,8 @@ func reflectValueEqual(x, y reflect.Value) bool {
 			}
 		}
 		return true
+	case reflect.Interface:
+		return reflectValueEqual(x.Elem(), y.Elem())
 	default:
 		runtimePanic("comparing un-comparable type")
 		return false // unreachable

--- a/testdata/binop.go
+++ b/testdata/binop.go
@@ -86,6 +86,18 @@ func main() {
 	// check for signed integer overflow
 	println("-2147483648 / -1:", sdiv32(-2147483648, -1))
 	println("-2147483648 % -1:", srem32(-2147483648, -1))
+
+	type foo struct {
+		n   int
+		itf interface{}
+	}
+
+	var a interface{} = foo{3, float32(5)}
+	var b interface{} = foo{3, float32(3)}
+	var b2 interface{} = foo{3, float32(3)}
+	println("interface equality")
+	println("a==b", a == b)
+	println("b==b2", b == b2)
 }
 
 var x = true

--- a/testdata/binop.txt
+++ b/testdata/binop.txt
@@ -71,3 +71,6 @@ constant number
 0
 -2147483648 / -1: -2147483648
 -2147483648 % -1: 0
+interface equality
+a==b false
+b==b2 true


### PR DESCRIPTION
A few tests (such as `crypto/hmac` in the stdlib) panic with `comparing un-comparable type`.  It seems like the runtime is not able to compare interfaces.

This is *a* PR to address this, but I don't know if it's the right one.