### PR TITLE
stm32: pull-up on I2C lines

### DIFF
--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -1,3 +1,4 @@
+//go:build stm32 && !stm32f103
 // +build stm32,!stm32f103
 
 package machine
@@ -110,13 +111,13 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OTYPER.ReplaceBits(stm32.GPIO_OTYPER_OT0_OpenDrain, stm32.GPIO_OTYPER_OT0_Msk, pos/2)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
-		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
+		port.PUPDR.ReplaceBits(gpioPullUp, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 	case PinModeI2CSDA:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OTYPER.ReplaceBits(stm32.GPIO_OTYPER_OT0_OpenDrain, stm32.GPIO_OTYPER_OT0_Msk, pos/2)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
-		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
+		port.PUPDR.ReplaceBits(gpioPullUp, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 
 	// SPI


### PR DESCRIPTION
Fixes #2310

This changes the default for all STM32 (except stm32f103)