### PR TITLE
stm32: fix timeout for i2c comms

### DIFF
--- a/src/machine/machine_stm32_i2c_revb.go
+++ b/src/machine/machine_stm32_i2c_revb.go
@@ -1,3 +1,4 @@
+//go:build stm32l5 || stm32f7 || stm32l4 || stm32l0
 // +build stm32l5 stm32f7 stm32l4 stm32l0
 
 package machine
@@ -27,7 +28,10 @@ const (
 
 const (
 	MAX_NBYTE_SIZE = 255
-	TIMEOUT_TICKS  = 100 // 100ms
+
+	// 100ms delay = 100e6ns / 16ns
+	// In runtime_stm32_timers.go, tick is fixed at 16ns per tick
+	TIMEOUT_TICKS = 100e6 / 16
 
 	I2C_NO_STARTSTOP         = 0x0
 	I2C_GENERATE_START_WRITE = 0x80000000 | stm32.I2C_CR2_START


### PR DESCRIPTION
ticks changed to 16ns causing timeouts to be very, very short.  This change updates timeouts for 16ns ticks.

This was causing a problem where the peripheral was busy, but instead of waiting for a reasonable delay to wait for peripheral to stop being busy, instead the code timed out.  This was particularly problematic for i2c scan code that expected a transmission error to indicate an address was unused, rather than the i2c peripheral in the MCU was busy.

This issue is symptomatic of the wider issue of the circular dependency...   runtime package uses machine package and machine package needs some notion of time to implement peripheral support.  We could really do with a 'clean' way for machine package to measure time.  For now, this is a quick fix to unbreak i2c.