### PR TITLE
os.Remove: avoid double-wrapping err; fixes TODO in test

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -47,7 +47,7 @@ func Remove(path string) error {
 	}
 	err := fs.Remove(suffix)
 	if err != nil {
-		return &PathError{"remove", path, err}
+		return err
 	}
 	return nil
 }

--- a/src/os/os_unix_test.go
+++ b/src/os/os_unix_test.go
@@ -63,9 +63,8 @@ func TestRemove(t *testing.T) {
 				t.Errorf("TestRemove: PathError returned path %q, expected %q", pe.Path, f)
 			}
 		}
-		// TODO: make this pass.
 		if !IsNotExist(err) {
-			t.Logf("TestRemove: TODO: expected IsNotExist(err) true, got false; err %q", err.Error())
+			t.Errorf("TestRemove: expected IsNotExist(err) true, got false; err %q", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Removing a nonexistent directory should generate true for IsNotExist(err).

It didn't because fs.Remove had already wrapped the underlying error, and double-wrapping confuses things.

This is like part two of https://github.com/tinygo-org/tinygo/pull/2265, which introduced the problem.