### PR TITLE
runtime: use LLVM intrinsic to read the stack pointer

### DIFF
--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -1,7 +1,5 @@
 package runtime
 
-import "device"
-
 const GOARCH = "386"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
@@ -13,5 +11,5 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr {
-	return device.AsmFull("movl %esp, {}", nil)
+	return uintptr(stacksave())
 }

--- a/src/runtime/arch_amd64.go
+++ b/src/runtime/arch_amd64.go
@@ -1,7 +1,5 @@
 package runtime
 
-import "device"
-
 const GOARCH = "amd64"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
@@ -15,5 +13,5 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr {
-	return device.AsmFull("movq %rsp, {}", nil)
+	return uintptr(stacksave())
 }

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -2,8 +2,6 @@
 
 package runtime
 
-import "device/arm"
-
 const GOARCH = "arm"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
@@ -15,5 +13,5 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr {
-	return arm.AsmFull("mov {}, sp", nil)
+	return uintptr(stacksave())
 }

--- a/src/runtime/arch_arm64.go
+++ b/src/runtime/arch_arm64.go
@@ -1,7 +1,5 @@
 package runtime
 
-import "device/arm"
-
 const GOARCH = "arm64"
 
 // The bitness of the CPU (e.g. 8, 32, 64).
@@ -11,6 +9,7 @@ const TargetBits = 64
 func align(ptr uintptr) uintptr {
 	return (ptr + 7) &^ 7
 }
+
 func getCurrentStackPointer() uintptr {
-	return arm.AsmFull("mov {}, sp", nil)
+	return uintptr(stacksave())
 }

--- a/src/runtime/arch_avr.go
+++ b/src/runtime/arch_avr.go
@@ -13,4 +13,6 @@ func align(ptr uintptr) uintptr {
 	return ptr
 }
 
-func getCurrentStackPointer() uintptr
+func getCurrentStackPointer() uintptr {
+	return uintptr(stacksave())
+}

--- a/src/runtime/arch_cortexm.go
+++ b/src/runtime/arch_cortexm.go
@@ -17,7 +17,7 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr {
-	return arm.AsmFull("mov {}, sp", nil)
+	return uintptr(stacksave())
 }
 
 // Documentation:

--- a/src/runtime/arch_tinygoriscv.go
+++ b/src/runtime/arch_tinygoriscv.go
@@ -5,7 +5,7 @@ package runtime
 import "device/riscv"
 
 func getCurrentStackPointer() uintptr {
-	return riscv.AsmFull("mv {}, sp", nil)
+	return uintptr(stacksave())
 }
 
 // Documentation:

--- a/src/runtime/arch_xtensa.go
+++ b/src/runtime/arch_xtensa.go
@@ -2,8 +2,6 @@
 
 package runtime
 
-import "device"
-
 const GOARCH = "arm" // xtensa pretends to be arm
 
 // The bitness of the CPU (e.g. 8, 32, 64).
@@ -15,6 +13,5 @@ func align(ptr uintptr) uintptr {
 }
 
 func getCurrentStackPointer() uintptr {
-	// The stack pointer (sp) is a1.
-	return device.AsmFull("mov {}, sp", nil)
+	return uintptr(stacksave())
 }

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -39,6 +39,12 @@ func memmove(dst, src unsafe.Pointer, size uintptr)
 // llvm.memset.p0i8.i32(ptr, 0, size, false).
 func memzero(ptr unsafe.Pointer, size uintptr)
 
+// This intrinsic returns the current stack pointer.
+// It is normally used together with llvm.stackrestore but also works to get the
+// current stack pointer in a platform-independent way.
+//export llvm.stacksave
+func stacksave() unsafe.Pointer
+
 //export strlen
 func strlen(ptr unsafe.Pointer) uintptr
 

--- a/targets/avr.S
+++ b/targets/avr.S
@@ -69,12 +69,3 @@ __vector_WDT:
 
     pop  r16
     reti
-
-; This is necessary for the garbage collector.
-; It returns the stack pointer as an uintptr.
-.section .text.runtime.getCurrentStackPointer
-.global  runtime.getCurrentStackPointer
-runtime.getCurrentStackPointer:
-    in  r24, 0x3d; SPL
-    in  r25, 0x3e; SPH
-    ret


### PR DESCRIPTION
This results in slightly smaller code and simplifies reading the stack pointer on AVR.