### PR TITLE
machine: add Device constant

### DIFF
--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -10,6 +10,13 @@ var (
 	ErrNoPinChangeChannel = errors.New("machine: no channel available for pin interrupt")
 )
 
+// Device is the running program's chip name, such as "ATSAMD51J19A" or
+// "nrf52840". It is not the same as the CPU name.
+//
+// The constant is some hardcoded default value if the program does not target a
+// particular chip but instead runs in WebAssembly for example.
+const Device = deviceName
+
 // PinMode sets the direction and pull mode of the pin. For example, PinOutput
 // sets the pin as an output and PinInputPullup sets the pin as an input with a
 // pull-up.

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -16,6 +16,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = sam.Device
+
 const (
 	PinAnalog    PinMode = 1
 	PinSERCOM    PinMode = 2

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -16,6 +16,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = sam.Device
+
 func CPUFrequency() uint32 {
 	return 120000000
 }

--- a/src/machine/machine_avr.go
+++ b/src/machine/machine_avr.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = avr.DEVICE
+
 const (
 	PinInput PinMode = iota
 	PinInputPullup

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -9,6 +9,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = esp.Device
+
 const peripheralClock = 80000000 // 80MHz
 
 // CPUFrequency returns the current CPU frequency of the chip.

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = esp.Device
+
 // CPUFrequency returns the current CPU frequency of the chip.
 // Currently it is a fixed frequency but it may allow changing in the future.
 func CPUFrequency() uint32 {

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -7,6 +7,8 @@ import (
 	"runtime/volatile"
 )
 
+const deviceName = esp.Device
+
 func CPUFrequency() uint32 {
 	return 80000000 // 80MHz
 }

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = sifive.Device
+
 func CPUFrequency() uint32 {
 	return 320000000 // 320MHz
 }

--- a/src/machine/machine_gameboyadvance.go
+++ b/src/machine/machine_gameboyadvance.go
@@ -9,6 +9,10 @@ import (
 	"unsafe"
 )
 
+// Not sure what name to pick here. Not using ARM7TDMI because that's the CPU
+// name, not the device name.
+const deviceName = "GBA"
+
 // Interrupt numbers as used on the GameBoy Advance. Register them with
 // runtime/interrupt.New.
 const (

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -4,6 +4,8 @@ package machine
 
 // Dummy machine package that calls out to external functions.
 
+const deviceName = "generic"
+
 var (
 	UART0 = &UART{0}
 	USB   = &UART{100}

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -10,6 +10,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = kendryte.Device
+
 func CPUFrequency() uint32 {
 	return 390000000
 }

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -11,6 +11,8 @@ import (
 
 // Peripheral abstraction layer for the MIMXRT1062
 
+const deviceName = nxp.Device
+
 func CPUFrequency() uint32 {
 	return 600000000
 }

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -13,6 +13,8 @@ var (
 	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
 )
 
+const deviceName = nrf.Device
+
 const (
 	PinInput         PinMode = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 	PinInputPullup   PinMode = PinInput | (nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos)

--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -37,6 +37,8 @@ import (
 	"unsafe"
 )
 
+const deviceName = nxp.Device
+
 const (
 	PinInput PinMode = iota
 	PinInputPullUp

--- a/src/machine/machine_rp2040.go
+++ b/src/machine/machine_rp2040.go
@@ -8,6 +8,8 @@ import (
 	"runtime/interrupt"
 )
 
+const deviceName = rp.Device
+
 const (
 	// GPIO pins
 	GPIO0  Pin = 0

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -2,6 +2,10 @@
 
 package machine
 
+import "device/stm32"
+
+const deviceName = stm32.Device
+
 // Peripheral abstraction layer for the stm32.
 
 const (


### PR DESCRIPTION
This field contains the microcontroller name that we're compiling for, or "generic" if we're not running on a microcontroller.

See: https://github.com/tinygo-org/tinygo/issues/2326