### PR TITLE
os_unix_test.go: rename to os_anyos_test.go, add windows build tag

### DIFF
--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux,!baremetal freebsd,!baremetal
+// +build windows darwin linux,!baremetal
 
 package os_test
 


### PR DESCRIPTION
os_unix_test.go passes on windows, too, so rename and fix build tag.

Also remove obsolete build tag freebsd.