### PR TITLE
os: implement and smoketest os.Chdir and os.Chmod

### DIFF
--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -27,6 +27,15 @@ const DevNull = "/dev/null"
 // filesystem support.
 const isOS = true
 
+// Chdir changes the current working directory to the named directory.
+// If there is an error, it will be of type *PathError.
+func Chdir(dir string) error {
+	if e := syscall.Chdir(dir); e != nil {
+		return &PathError{Op: "chdir", Path: dir, Err: e}
+	}
+	return nil
+}
+
 // unixFilesystem is an empty handle for a Unix/Linux filesystem. All operations
 // are relative to the current working directory.
 type unixFilesystem struct {

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,3 +1,5 @@
+// +build !baremetal,!js
+
 package os_test
 
 import (
@@ -21,5 +23,47 @@ func TestTempDir(t *testing.T) {
 	err = Remove(name)
 	if err != nil {
 		t.Errorf("Remove %s: %s", name, err)
+	}
+}
+
+func TestChdir(t *testing.T) {
+	// create and cd into a new directory
+	dir := "_os_test_TestChDir"
+	Remove(dir)
+	err := Mkdir(dir, 0755)
+	defer Remove(dir) // even though not quite sure which directory it will execute in
+	if err != nil {
+		t.Errorf("Mkdir(%s, 0755) returned %v", dir, err)
+	}
+	err = Chdir(dir)
+	if err != nil {
+		t.Fatalf("Chdir %s: %s", dir, err)
+		return
+	}
+	// create a file there
+	file := "_os_test_TestTempDir.dat"
+	f, err := OpenFile(file, O_RDWR|O_CREATE, 0644)
+	if err != nil {
+		t.Errorf("OpenFile %s: %s", file, err)
+	}
+	defer Remove(file) // even though not quite sure which directory it will execute in
+	err = f.Close()
+	if err != nil {
+		t.Errorf("Close %s: %s", file, err)
+	}
+	// cd back to original directory
+	err = Chdir("..")
+	if err != nil {
+		t.Errorf("Chdir ..: %s", err)
+	}
+	// clean up file and directory explicitly so we can check for errors
+	fullname := dir + "/" + file
+	err = Remove(fullname)
+	if err != nil {
+		t.Errorf("Remove %s: %s", fullname, err)
+	}
+	err = Remove(dir)
+	if err != nil {
+		t.Errorf("Remove %s: %s", dir, err)
 	}
 }

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -13,6 +13,11 @@ import (
 
 type syscallFd = int
 
+// fixLongPath is a noop on non-Windows platforms.
+func fixLongPath(path string) string {
+	return path
+}
+
 func Pipe() (r *File, w *File, err error) {
 	var p [2]int
 	err = handleSyscallError(syscall.Pipe2(p[:], syscall.O_CLOEXEC))
@@ -49,20 +54,4 @@ func (f unixFileHandle) ReadAt(b []byte, offset int64) (n int, err error) {
 		err = io.EOF
 	}
 	return
-}
-
-// ignoringEINTR makes a function call and repeats it if it returns an
-// EINTR error. This appears to be required even though we install all
-// signal handlers with SA_RESTART: see #22838, #38033, #38836, #40846.
-// Also #20400 and #36644 are issues in which a signal handler is
-// installed without setting SA_RESTART. None of these are the common case,
-// but there are enough of them that it seems that we can't avoid
-// an EINTR loop.
-func ignoringEINTR(fn func() error) error {
-	for {
-		err := fn()
-		if err != syscall.EINTR {
-			return err
-		}
-	}
 }

--- a/src/os/os_test.go
+++ b/src/os/os_test.go
@@ -25,6 +25,32 @@ func newFile(testName string, t *testing.T) (f *File) {
 	return
 }
 
+func checkMode(t *testing.T, path string, mode FileMode) {
+	dir, err := Stat(path)
+	if err != nil {
+		t.Fatalf("Stat %q (looking for mode %#o): %s", path, mode, err)
+	}
+	if dir.Mode()&ModePerm != mode {
+		t.Errorf("Stat %q: mode %#o want %#o", path, dir.Mode(), mode)
+	}
+}
+
+func TestChmod(t *testing.T) {
+	f := newFile("TestChmod", t)
+	defer Remove(f.Name())
+	defer f.Close()
+	// Creation mode is read write
+
+	fm := FileMode(0456)
+	if runtime.GOOS == "windows" {
+		fm = FileMode(0444) // read-only file
+	}
+	if err := Chmod(f.Name(), fm); err != nil {
+		t.Fatalf("chmod %s %#o: %s", f.Name(), fm, err)
+	}
+	checkMode(t, f.Name(), fm)
+}
+
 func TestReadAt(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Log("TODO: implement Pread for Windows")

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -59,6 +59,15 @@ func Open(path string, flag int, mode uint32) (fd int, err error) {
 	return
 }
 
+func Chdir(path string) (err error) {
+	data := cstring(path)
+	fail := int(libc_chdir(&data[0]))
+	if fail < 0 {
+		err = getErrno()
+	}
+	return
+}
+
 func Mkdir(path string, mode uint32) (err error) {
 	data := cstring(path)
 	fail := int(libc_mkdir(&data[0], mode))
@@ -197,6 +206,10 @@ func libc_mmap(addr unsafe.Pointer, length uintptr, prot, flags, fd int32, offse
 // int mprotect(void *addr, size_t len, int prot);
 //export mprotect
 func libc_mprotect(addr unsafe.Pointer, len uintptr, prot int32) int32
+
+// int chdir(const char *pathname, mode_t mode);
+//export chdir
+func libc_chdir(pathname *byte) int32
 
 // int mkdir(const char *pathname, mode_t mode);
 //export mkdir

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -68,6 +68,15 @@ func Chdir(path string) (err error) {
 	return
 }
 
+func Chmod(path string, mode uint32) (err error) {
+	data := cstring(path)
+	fail := int(libc_chmod(&data[0], mode))
+	if fail < 0 {
+		err = getErrno()
+	}
+	return
+}
+
 func Mkdir(path string, mode uint32) (err error) {
 	data := cstring(path)
 	fail := int(libc_mkdir(&data[0], mode))
@@ -210,6 +219,10 @@ func libc_mprotect(addr unsafe.Pointer, len uintptr, prot int32) int32
 // int chdir(const char *pathname, mode_t mode);
 //export chdir
 func libc_chdir(pathname *byte) int32
+
+// int chmod(const char *pathname, mode_t mode);
+//export chmod
+func libc_chmod(pathname *byte, mode uint32) int32
 
 // int mkdir(const char *pathname, mode_t mode);
 //export mkdir


### PR DESCRIPTION
And add the same build tags on file_anyos_test.go as on file_anyos.go, else it fails on some bare metalish targets in "make smoketest".

With this, "tinygo test io/ioutil" compiles, but does not yet pass.