### PR TITLE
Also search for wasm-opt under libexec/

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -113,6 +113,7 @@ func findWasmOpt() string {
 	searchPaths := []string{
 		tinygoroot + "/bin/wasm-opt",
 		tinygoroot + "/build/wasm-opt",
+		tinygoroot + "/libexec/wasm-opt", // for Homebrew
 	}
 
 	var paths []string


### PR DESCRIPTION
With this change, we could drop the dependency on binaryen in the macos package (homebrew) and copy the binary as part of the release process to libexec/.

In the future, we could extend this change to all the platforms and let tinygo pick it up from there, but we can burn that bridge when we get there.