### PR TITLE
Fix ranging over a map with non-trivially-comparable key types

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1792,20 +1792,7 @@ func (b *builder) createExpr(expr ssa.Value) (llvm.Value, error) {
 		if expr.IsString {
 			return b.createRuntimeCall("stringNext", []llvm.Value{llvmRangeVal, it}, "range.next"), nil
 		} else { // map
-			llvmKeyType := b.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Key())
-			llvmValueType := b.getLLVMType(rangeVal.Type().Underlying().(*types.Map).Elem())
-
-			mapKeyAlloca, mapKeyPtr, mapKeySize := b.createTemporaryAlloca(llvmKeyType, "range.key")
-			mapValueAlloca, mapValuePtr, mapValueSize := b.createTemporaryAlloca(llvmValueType, "range.value")
-			ok := b.createRuntimeCall("hashmapNext", []llvm.Value{llvmRangeVal, it, mapKeyPtr, mapValuePtr}, "range.next")
-
-			tuple := llvm.Undef(b.ctx.StructType([]llvm.Type{b.ctx.Int1Type(), llvmKeyType, llvmValueType}, false))
-			tuple = b.CreateInsertValue(tuple, ok, 0, "")
-			tuple = b.CreateInsertValue(tuple, b.CreateLoad(mapKeyAlloca, ""), 1, "")
-			tuple = b.CreateInsertValue(tuple, b.CreateLoad(mapValueAlloca, ""), 2, "")
-			b.emitLifetimeEnd(mapKeyPtr, mapKeySize)
-			b.emitLifetimeEnd(mapValuePtr, mapValueSize)
-			return tuple, nil
+			return b.createMapIteratorNext(rangeVal, llvmRangeVal, it), nil
 		}
 	case *ssa.Phi:
 		phi := b.CreatePHI(b.getLLVMType(expr.Type()), "")

--- a/testdata/map.go
+++ b/testdata/map.go
@@ -78,15 +78,24 @@ func main() {
 	println("itfMap[true]:", itfMap[true])
 	delete(itfMap, 8)
 	println("itfMap[8]:", itfMap[8])
+	for key, value := range itfMap {
+		if key == "eight" {
+			println("itfMap: found key \"eight\":", value)
+		}
+	}
 
 	// test map with float keys
 	floatMap := map[float32]int{
-		42: 84,
+		42:   84,
+		3.14: 6,
 	}
 	println("floatMap[42]:", floatMap[42])
 	println("floatMap[43]:", floatMap[43])
 	delete(floatMap, 42)
 	println("floatMap[42]:", floatMap[42])
+	for k, v := range floatMap {
+		println("floatMap key, value:", k, v)
+	}
 
 	// test maps with struct keys
 	structMap := map[namedFloat]int{

--- a/testdata/map.txt
+++ b/testdata/map.txt
@@ -63,9 +63,11 @@ itfMap["eight"]: 800
 itfMap[[2]int{5, 2}]: 52
 itfMap[true]: 1
 itfMap[8]: 0
+itfMap: found key "eight": 800
 floatMap[42]: 84
 floatMap[43]: 0
 floatMap[42]: 0
+floatMap key, value: +3.140000e+000 6
 structMap[{"tau", 6.28}]: 5
 structMap[{"Tau", 6.28}]: 0
 structMap[{"tau", 3.14}]: 0


### PR DESCRIPTION
Some map keys are hard to compare, such as floats. They are stored as if
the map keys are of interface type instead of the key type itself. This
makes working with them in the runtime package easier: they are compared
as regular interfaces.

Iterating over maps didn't care about this special case though. It just
returns the key, value pair as it is stored in the map. This is buggy,
and this commit fixes this bug.

This should fix https://github.com/tinygo-org/tinygo/issues/2339.