### PR TITLE
src/runtime: strengthen hash function for structs and arrays

### DIFF
--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -391,13 +391,13 @@ func hashmapInterfaceHash(itf interface{}) uint32 {
 	case reflect.Array:
 		var hash uint32
 		for i := 0; i < x.Len(); i++ {
-			hash |= hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)))
+			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)))
 		}
 		return hash
 	case reflect.Struct:
 		var hash uint32
 		for i := 0; i < x.NumField(); i++ {
-			hash |= hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)))
+			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)))
 		}
 		return hash
 	default:


### PR DESCRIPTION
Using `|` to combine hash values with slowly turn every bit on.
Hashes combined with `^` with keep more entropy.