### PR TITLE
net/interface: use internal implementation for itoa.Uitoa

### DIFF
--- a/src/net/interface.go
+++ b/src/net/interface.go
@@ -8,6 +8,7 @@ package net
 
 import (
 	"errors"
+	"internal/itoa"
 	"sync"
 	"time"
 )
@@ -226,7 +227,7 @@ func (zc *ipv6ZoneCache) name(index int) string {
 		zoneCache.RUnlock()
 	}
 	if !ok { // last resort
-		name = uitoa(uint(index))
+		name = itoa.Uitoa(uint(index))
 	}
 	return name
 }


### PR DESCRIPTION
This PR switches to use the internal implementation for itoa.Uitoa for the recent additions for `net.Interface`. It should fix the CI build issues introduced by #2165 