### PR TITLE
transform: allocate the correct amount of bytes in an alloca

### DIFF
--- a/transform/testdata/allocs.out.ll
+++ b/transform/testdata/allocs.out.ll
@@ -6,17 +6,17 @@ target triple = "armv7m-none-eabi"
 declare nonnull i8* @runtime.alloc(i32, i8*)
 
 define void @testInt() {
-  %stackalloc.alloca = alloca [1 x i32], align 4
-  store [1 x i32] zeroinitializer, [1 x i32]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [1 x i32]* %stackalloc.alloca to i32*
+  %stackalloc.alloca = alloca [4 x i8], align 4
+  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
+  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
   store i32 5, i32* %stackalloc, align 4
   ret void
 }
 
 define i16 @testArray() {
-  %stackalloc.alloca = alloca [2 x i32], align 4
-  store [2 x i32] zeroinitializer, [2 x i32]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [2 x i32]* %stackalloc.alloca to i16*
+  %stackalloc.alloca = alloca [6 x i8], align 2
+  store [6 x i8] zeroinitializer, [6 x i8]* %stackalloc.alloca, align 2
+  %stackalloc = bitcast [6 x i8]* %stackalloc.alloca to i16*
   %1 = getelementptr i16, i16* %stackalloc, i32 1
   store i16 5, i16* %1, align 2
   %2 = getelementptr i16, i16* %stackalloc, i32 2
@@ -39,9 +39,9 @@ define void @testEscapingCall2() {
 }
 
 define void @testNonEscapingCall() {
-  %stackalloc.alloca = alloca [1 x i32], align 4
-  store [1 x i32] zeroinitializer, [1 x i32]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [1 x i32]* %stackalloc.alloca to i32*
+  %stackalloc.alloca = alloca [4 x i8], align 4
+  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
+  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
   %1 = call i32* @noescapeIntPtr(i32* %stackalloc)
   ret void
 }
@@ -54,12 +54,12 @@ define i32* @testEscapingReturn() {
 
 define void @testNonEscapingLoop() {
 entry:
-  %stackalloc.alloca = alloca [1 x i32], align 4
+  %stackalloc.alloca = alloca [4 x i8], align 4
   br label %loop
 
 loop:                                             ; preds = %loop, %entry
-  store [1 x i32] zeroinitializer, [1 x i32]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [1 x i32]* %stackalloc.alloca to i32*
+  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
+  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
   %0 = call i32* @noescapeIntPtr(i32* %stackalloc)
   %1 = icmp eq i32* null, %0
   br i1 %1, label %loop, label %end


### PR DESCRIPTION
When I wrote the code originally, I didn't know about SetAlignment so I hacked a way around it by allocating [...]uintptr types. However, this allocates a few too many bytes in some cases. This commit changes this to only allocate the space that we actually need.

The code size effect is mixed, but generally positive. The combined average of the drivers repo is reduced by 0.27% with more programs being reduced in size than are increasing in size (although I couldn't run all tests due to #2354).