### PR TITLE
src/os/stat.go: fix regression on baremetal targets

### DIFF
--- a/src/os/stat.go
+++ b/src/os/stat.go
@@ -1,5 +1,3 @@
-// +build !baremetal,!js
-
 // Copyright 2017 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,0 +1,22 @@
+//  +build baremetal wasm,!wasi
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package os
+
+// Sync is a stub, not yet implemented
+func (f *File) Sync() error {
+	return ErrNotImplemented
+}
+
+// statNolog stats a file with no test logging.
+func statNolog(name string) (FileInfo, error) {
+	return nil, &PathError{Op: "stat", Path: name, Err: ErrNotImplemented}
+}
+
+// lstatNolog lstats a file with no test logging.
+func lstatNolog(name string) (FileInfo, error) {
+	return nil, &PathError{Op: "lstat", Path: name, Err: ErrNotImplemented}
+}


### PR DESCRIPTION
Fix https://github.com/tinygo-org/tinygo/issues/2354

Doesn't seem to handle wasi yet, but that is not a regression: 
```
$ build/tinygo test -target wasi os
Error: failed to run main module `/var/folders/v0/0k9hwftd29b18z9z7s2g2sfc0000gn/T/tinygo186587511/main`

Caused by:
    0: failed to instantiate "/var/folders/v0/0k9hwftd29b18z9z7s2g2sfc0000gn/T/tinygo186587511/main"
    1: unknown import: `env::chmod` has not been defined
FAIL	os	0.032s
```