### PR TITLE
Add support for LLVM 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-12-v1
+            - llvm-source-13-v1
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-12-v1
+          key: llvm-source-13-v1
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
@@ -118,12 +118,12 @@ commands:
             - go-cache-macos-v3-{{ checksum "go.mod" }}
       - restore_cache:
           keys:
-            - llvm-source-12-macos-v1
+            - llvm-source-13-macos-v1
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-12-macos-v1
+          key: llvm-source-13-macos-v1
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
@@ -131,7 +131,7 @@ commands:
             - llvm-project/llvm/include
       - restore_cache:
           keys:
-            - llvm-build-12-macos-v1
+            - llvm-build-13-macos-v1
       - run:
           name: "Build LLVM"
           command: |
@@ -145,7 +145,7 @@ commands:
               find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
             fi
       - save_cache:
-          key: llvm-build-12-macos-v1
+          key: llvm-build-13-macos-v1
           paths:
             llvm-build
       - restore_cache:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-12-linux-v1
+          key: llvm-source-13-linux-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-12-linux-v1
+          key: llvm-build-13-linux-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -174,7 +174,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-12-linux-asserts-v1
+          key: llvm-source-13-linux-asserts-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -187,7 +187,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-12-linux-asserts-v1
+          key: llvm-build-13-linux-asserts-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-12-windows-v1
+          key: llvm-source-13-windows-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-12-windows-v1
+          key: llvm-build-13-windows-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
 # Try to autodetect LLVM build tools.
 detect = $(shell command -v $(1) 2> /dev/null && echo $(1))
-CLANG ?= $(word 1,$(abspath $(call detect,llvm-build/bin/clang))$(call detect,clang-12)$(call detect,clang-11)$(call detect,clang))
-LLVM_AR ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-ar))$(call detect,llvm-ar-12)$(call detect,llvm-ar-11)$(call detect,llvm-ar))
-LLVM_NM ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-nm))$(call detect,llvm-nm-12)$(call detect,llvm-nm-11)$(call detect,llvm-nm))
+CLANG ?= $(word 1,$(abspath $(call detect,llvm-build/bin/clang))$(call detect,clang-13)$(call detect,clang-12)$(call detect,clang-11)$(call detect,clang))
+LLVM_AR ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-ar))$(call detect,llvm-ar-13)$(call detect,llvm-ar-12)$(call detect,llvm-ar-11)$(call detect,llvm-ar))
+LLVM_NM ?= $(word 1,$(abspath $(call detect,llvm-build/bin/llvm-nm))$(call detect,llvm-nm-13)$(call detect,llvm-nm-12)$(call detect,llvm-nm-11)$(call detect,llvm-nm))
 
 # Go binary and GOROOT to select
 GO ?= go
@@ -159,7 +159,7 @@ gen-device-rp: build/gen-device-svd
 
 # Get LLVM sources.
 $(LLVM_PROJECTDIR)/llvm:
-	git clone -b xtensa_release_12.0.1 --depth=1 https://github.com/tinygo-org/llvm-project $(LLVM_PROJECTDIR)
+	git clone -b xtensa_release_13.0.0 --depth=1 https://github.com/tinygo-org/llvm-project $(LLVM_PROJECTDIR)
 llvm-source: $(LLVM_PROJECTDIR)/llvm
 
 # Configure LLVM.

--- a/builder/cc1as.cpp
+++ b/builder/cc1as.cpp
@@ -115,29 +115,26 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
   // Any DebugInfoKind implies GenDwarfForAssembly.
   Opts.GenDwarfForAssembly = Args.hasArg(OPT_debug_info_kind_EQ);
 
-  if (const Arg *A = Args.getLastArg(OPT_compress_debug_sections,
-                                     OPT_compress_debug_sections_EQ)) {
-    if (A->getOption().getID() == OPT_compress_debug_sections) {
-      // TODO: be more clever about the compression type auto-detection
-      Opts.CompressDebugSections = llvm::DebugCompressionType::GNU;
-    } else {
-      Opts.CompressDebugSections =
-          llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
-              .Case("none", llvm::DebugCompressionType::None)
-              .Case("zlib", llvm::DebugCompressionType::Z)
-              .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
-              .Default(llvm::DebugCompressionType::None);
-    }
+  if (const Arg *A = Args.getLastArg(OPT_compress_debug_sections_EQ)) {
+    Opts.CompressDebugSections =
+        llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
+            .Case("none", llvm::DebugCompressionType::None)
+            .Case("zlib", llvm::DebugCompressionType::Z)
+            .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
+            .Default(llvm::DebugCompressionType::None);
   }
 
   Opts.RelaxELFRelocations = Args.hasArg(OPT_mrelax_relocations);
+  if (auto *DwarfFormatArg = Args.getLastArg(OPT_gdwarf64, OPT_gdwarf32))
+    Opts.Dwarf64 = DwarfFormatArg->getOption().matches(OPT_gdwarf64);
   Opts.DwarfVersion = getLastArgIntValue(Args, OPT_dwarf_version_EQ, 2, Diags);
   Opts.DwarfDebugFlags =
       std::string(Args.getLastArgValue(OPT_dwarf_debug_flags));
   Opts.DwarfDebugProducer =
       std::string(Args.getLastArgValue(OPT_dwarf_debug_producer));
-  Opts.DebugCompilationDir =
-      std::string(Args.getLastArgValue(OPT_fdebug_compilation_dir));
+  if (const Arg *A = Args.getLastArg(options::OPT_ffile_compilation_dir_EQ,
+                                     options::OPT_fdebug_compilation_dir_EQ))
+    Opts.DebugCompilationDir = A->getValue();
   Opts.MainFileName = std::string(Args.getLastArgValue(OPT_main_file_name));
 
   for (const auto &Arg : Args.getAllArgValues(OPT_fdebug_prefix_map_EQ)) {
@@ -219,7 +216,7 @@ getOutputStream(StringRef Path, DiagnosticsEngine &Diags, bool Binary) {
 
   std::error_code EC;
   auto Out = std::make_unique<raw_fd_ostream>(
-      Path, EC, (Binary ? sys::fs::OF_None : sys::fs::OF_Text));
+      Path, EC, (Binary ? sys::fs::OF_None : sys::fs::OF_TextWithCRLF));
   if (EC) {
     Diags.Report(diag::err_fe_unable_to_open_output) << Path << EC.message();
     return nullptr;
@@ -228,7 +225,8 @@ getOutputStream(StringRef Path, DiagnosticsEngine &Diags, bool Binary) {
   return Out;
 }
 
-bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
+static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
+                                 DiagnosticsEngine &Diags) {
   // Get the target specific parser.
   std::string Error;
   const Target *TheTarget = TargetRegistry::lookupTarget(Opts.Triple, Error);
@@ -236,7 +234,7 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
     return Diags.Report(diag::err_target_unknown_triple) << Opts.Triple;
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> Buffer =
-      MemoryBuffer::getFileOrSTDIN(Opts.InputFile);
+      MemoryBuffer::getFileOrSTDIN(Opts.InputFile, /*IsText=*/true);
 
   if (std::error_code EC = Buffer.getError()) {
     Error = EC.message();
@@ -277,11 +275,15 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
   if (!Opts.SplitDwarfOutput.empty())
     DwoOS = getOutputStream(Opts.SplitDwarfOutput, Diags, IsBinary);
 
-  // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
-  // MCObjectFileInfo needs a MCContext reference in order to initialize itself.
-  std::unique_ptr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
+  // Build up the feature string from the target feature list.
+  std::string FS = llvm::join(Opts.Features, ",");
 
-  MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr, &MCOptions);
+  std::unique_ptr<MCSubtargetInfo> STI(
+      TheTarget->createMCSubtargetInfo(Opts.Triple, Opts.CPU, FS));
+  assert(STI && "Unable to create subtarget info!");
+
+  MCContext Ctx(Triple(Opts.Triple), MAI.get(), MRI.get(), STI.get(), &SrcMgr,
+                &MCOptions);
 
   bool PIC = false;
   if (Opts.RelocationModel == "static") {
@@ -294,7 +296,12 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
     PIC = false;
   }
 
-  MOFI->InitMCObjectFileInfo(Triple(Opts.Triple), PIC, Ctx);
+  // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
+  // MCObjectFileInfo needs a MCContext reference in order to initialize itself.
+  std::unique_ptr<MCObjectFileInfo> MOFI(
+      TheTarget->createMCObjectFileInfo(Ctx, PIC));
+  Ctx.setObjectFileInfo(MOFI.get());
+
   if (Opts.SaveTemporaryLabels)
     Ctx.setAllowTemporaryLabels(false);
   if (Opts.GenDwarfForAssembly)
@@ -316,19 +323,16 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
       Ctx.addDebugPrefixMapEntry(KV.first, KV.second);
   if (!Opts.MainFileName.empty())
     Ctx.setMainFileName(StringRef(Opts.MainFileName));
+  Ctx.setDwarfFormat(Opts.Dwarf64 ? dwarf::DWARF64 : dwarf::DWARF32);
   Ctx.setDwarfVersion(Opts.DwarfVersion);
   if (Opts.GenDwarfForAssembly)
     Ctx.setGenDwarfRootFile(Opts.InputFile,
                             SrcMgr.getMemoryBuffer(BufferIndex)->getBuffer());
 
-  // Build up the feature string from the target feature list.
-  std::string FS = llvm::join(Opts.Features, ",");
-
   std::unique_ptr<MCStreamer> Str;
 
   std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
-  std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(Opts.Triple, Opts.CPU, FS));
+  assert(MCII && "Unable to create instruction info!");
 
   raw_pwrite_stream *Out = FDOS.get();
   std::unique_ptr<buffer_ostream> BOS;
@@ -367,6 +371,8 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
         TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx));
     std::unique_ptr<MCAsmBackend> MAB(
         TheTarget->createMCAsmBackend(*STI, *MRI, MCOptions));
+    assert(MAB && "Unable to create asm backend!");
+
     std::unique_ptr<MCObjectWriter> OW =
         DwoOS ? MAB->createDwoObjectWriter(*Out, *DwoOS)
               : MAB->createObjectWriter(*Out);
@@ -381,8 +387,7 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
 
   // When -fembed-bitcode is passed to clang_as, a 1-byte marker
   // is emitted in __LLVM,__asm section if the object file is MachO format.
-  if (Opts.EmbedBitcode && Ctx.getObjectFileInfo()->getObjectFileType() ==
-                               MCObjectFileInfo::IsMachO) {
+  if (Opts.EmbedBitcode && Ctx.getObjectFileType() == MCContext::IsMachO) {
     MCSection *AsmLabel = Ctx.getMachOSection(
         "__LLVM", "__asm", MachO::S_REGULAR, 4, SectionKind::getReadOnly());
     Str.get()->SwitchSection(AsmLabel);
@@ -419,12 +424,12 @@ bool ExecuteAssembler(AssemblerInvocation &Opts, DiagnosticsEngine &Diags) {
     Failed = Parser->Run(Opts.NoInitialTextSection);
   }
 
-  // Close Streamer first.
-  // It might have a reference to the output stream.
-  Str.reset();
-  // Close the output stream early.
-  BOS.reset();
-  FDOS.reset();
+  return Failed;
+}
+
+bool ExecuteAssembler(AssemblerInvocation &Opts,
+                             DiagnosticsEngine &Diags) {
+  bool Failed = ExecuteAssemblerImpl(Opts, Diags);
 
   // Delete output file if there were errors.
   if (Failed) {
@@ -472,7 +477,7 @@ int cc1as_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
     return 1;
 
   if (Asm.ShowHelp) {
-    getDriverOptTable().PrintHelp(
+    getDriverOptTable().printHelp(
         llvm::outs(), "clang -cc1as [options] file...",
         "Clang Integrated Assembler",
         /*Include=*/driver::options::CC1AsOption, /*Exclude=*/0,

--- a/builder/cc1as.h
+++ b/builder/cc1as.h
@@ -39,6 +39,7 @@ struct AssemblerInvocation {
   unsigned SaveTemporaryLabels : 1;
   unsigned GenDwarfForAssembly : 1;
   unsigned RelaxELFRelocations : 1;
+  unsigned Dwarf64 : 1;
   unsigned DwarfVersion;
   std::string DwarfDebugFlags;
   std::string DwarfDebugProducer;
@@ -108,6 +109,7 @@ public:
     FatalWarnings = 0;
     NoWarn = 0;
     IncrementalLinkerCompatible = 0;
+    Dwarf64 = 0;
     DwarfVersion = 0;
     EmbedBitcode = 0;
   }

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -28,7 +28,7 @@ var Picolibc = Library{
 			"-DHAVE_ALIAS_ATTRIBUTE",
 			"-DTINY_STDIO",
 			"-nostdlibinc",
-			"-Xclang", "-internal-isystem", "-Xclang", picolibcDir + "/include",
+			"-isystem", picolibcDir + "/include",
 			"-I" + picolibcDir + "/tinystdio",
 			"-I" + headerPath,
 		}

--- a/cgo/libclang_config.go
+++ b/cgo/libclang_config.go
@@ -1,5 +1,5 @@
 // +build !byollvm
-// +build !llvm12
+// +build !llvm12,!llvm13
 
 package cgo
 

--- a/cgo/libclang_config_llvm13.go
+++ b/cgo/libclang_config_llvm13.go
@@ -1,0 +1,14 @@
+// +build !byollvm
+// +build llvm13
+
+package cgo
+
+/*
+#cgo linux   CFLAGS:  -I/usr/lib/llvm-13/include
+#cgo darwin  CFLAGS:  -I/usr/local/opt/llvm@13/include
+#cgo freebsd CFLAGS:  -I/usr/local/llvm13/include
+#cgo linux   LDFLAGS: -L/usr/lib/llvm-13/lib -lclang
+#cgo darwin  LDFLAGS: -L/usr/local/opt/llvm@13/lib -lclang -lffi
+#cgo freebsd LDFLAGS: -L/usr/local/llvm13/lib -lclang
+*/
+import "C"

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -257,17 +257,18 @@ func (c *Config) CFlags() []string {
 		path, _ := c.LibcPath("picolibc")
 		cflags = append(cflags,
 			"--sysroot="+path,
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(picolibcDir, "include"),
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(picolibcDir, "tinystdio"),
+			"-isystem", filepath.Join(picolibcDir, "include"),
+			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
 		)
 	case "musl":
 		root := goenv.Get("TINYGOROOT")
 		path, _ := c.LibcPath("musl")
 		arch := MuslArchitecture(c.Triple())
 		cflags = append(cflags,
-			"--sysroot="+path,
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "musl", "arch", arch),
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "musl", "include"),
+			"-nostdlibinc",
+			"-isystem", filepath.Join(path, "include"),
+			"-isystem", filepath.Join(root, "lib", "musl", "arch", arch),
+			"-isystem", filepath.Join(root, "lib", "musl", "include"),
 		)
 	case "wasi-libc":
 		root := goenv.Get("TINYGOROOT")
@@ -277,8 +278,8 @@ func (c *Config) CFlags() []string {
 		path, _ := c.LibcPath("mingw-w64")
 		cflags = append(cflags,
 			"--sysroot="+path,
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "crt"),
-			"-Xclang", "-internal-isystem", "-Xclang", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "defaults", "include"),
+			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "crt"),
+			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "defaults", "include"),
 			"-D_UCRT",
 		)
 	case "":

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -267,11 +267,11 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		spec.CPU = "generic"
 		switch strings.Split(triple, "-")[0] {
 		case "armv5":
-			spec.Features = "+armv5t,+strict-align,-thumb-mode"
+			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		case "armv6":
-			spec.Features = "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-thumb-mode"
+			spec.Features = "+armv6,+dsp,+fp64,+strict-align,+vfp2,+vfp2sp,-aes,-d32,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-neon,-sha2,-thumb-mode,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		case "armv7":
-			spec.Features = "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-thumb-mode"
+			spec.Features = "+armv7-a,+d32,+dsp,+fp64,+neon,+vfp2,+vfp2sp,+vfp3,+vfp3d16,+vfp3d16sp,+vfp3sp,-aes,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fullfp16,-sha2,-thumb-mode,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 		}
 	case "arm64":
 		spec.CPU = "generic"

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -224,7 +224,12 @@ func filterIrrelevantIRLines(lines []string) []string {
 		}
 		if llvmVersion < 12 && strings.HasPrefix(line, "attributes ") {
 			// Ignore attribute groups. These may change between LLVM versions.
-			// Right now test outputs are for LLVM 12.
+			// Right now test outputs are for LLVM 12 and higher.
+			continue
+		}
+		if llvmVersion < 13 && strings.HasPrefix(line, "target datalayout = ") {
+			// The datalayout string may vary betewen LLVM versions.
+			// Right now test outputs are for LLVM 13 and higher.
 			continue
 		}
 		out = append(out, line)

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -56,7 +56,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		}
 		constraints += ",~{rcx},~{r11}"
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
-		target := llvm.InlineAsm(fnType, "syscall", constraints, true, false, llvm.InlineAsmDialectIntel)
+		target := llvm.InlineAsm(fnType, "syscall", constraints, true, false, llvm.InlineAsmDialectIntel, false)
 		return b.CreateCall(target, args, ""), nil
 	case b.GOARCH == "386" && b.GOOS == "linux":
 		// Sources:
@@ -82,7 +82,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 			argTypes = append(argTypes, llvmValue.Type())
 		}
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
-		target := llvm.InlineAsm(fnType, "int 0x80", constraints, true, false, llvm.InlineAsmDialectIntel)
+		target := llvm.InlineAsm(fnType, "int 0x80", constraints, true, false, llvm.InlineAsmDialectIntel, false)
 		return b.CreateCall(target, args, ""), nil
 	case b.GOARCH == "arm" && b.GOOS == "linux":
 		// Implement the EABI system call convention for Linux.
@@ -114,7 +114,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 			constraints += ",~{r" + strconv.Itoa(i) + "}"
 		}
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
-		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0)
+		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0, false)
 		return b.CreateCall(target, args, ""), nil
 	case b.GOARCH == "arm64" && b.GOOS == "linux":
 		// Source: syscall(2) man page.
@@ -146,7 +146,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		}
 		constraints += ",~{x16},~{x17}" // scratch registers
 		fnType := llvm.FunctionType(b.uintptrType, argTypes, false)
-		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0)
+		target := llvm.InlineAsm(fnType, "svc #0", constraints, true, false, 0, false)
 		return b.CreateCall(target, args, ""), nil
 	default:
 		return llvm.Value{}, b.makeError(call.Pos(), "unknown GOOS/GOARCH for syscall: "+b.GOOS+"/"+b.GOARCH)

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'basic.go'
 source_filename = "basic.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %main.kv = type { float }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'channel.go'
 source_filename = "channel.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'float.go'
 source_filename = "float.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)

--- a/compiler/testdata/func-coroutines.ll
+++ b/compiler/testdata/func-coroutines.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'func.go'
 source_filename = "func.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.funcValueWithSignature = type { i32, i8* }

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'gc.go'
 source_filename = "gc.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'go1.17.go'
 source_filename = "go1.17.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/goroutine-wasm-coroutines.ll
+++ b/compiler/testdata/goroutine-wasm-coroutines.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.funcValueWithSignature = type { i32, i8* }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'interface.go'
 source_filename = "interface.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pointer.go'
 source_filename = "pointer.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pragma.go'
 source_filename = "pragma.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 @extern_global = external global [0 x i8], align 1

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'slice.go'
 source_filename = "slice.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*, i8*)

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'string.go'
 source_filename = "string.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime._string = type { i8*, i32 }

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,5 @@ require (
 	go.bug.st/serial v1.1.3
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
-	tinygo.org/x/go-llvm v0.0.0-20211229125312-df8bd725853c
+	tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6
 )

--- a/go.sum
+++ b/go.sum
@@ -70,7 +70,5 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-tinygo.org/x/go-llvm v0.0.0-20210907125547-fd2d62ea06be h1:syIpWbi/yESuoyijF2nhRdgX4422sNfmij+o73B3+vU=
-tinygo.org/x/go-llvm v0.0.0-20210907125547-fd2d62ea06be/go.mod h1:fv1F0BSNpxMfCL0zF3M4OPFbgYHnhtB6ST0HvUtu/LE=
-tinygo.org/x/go-llvm v0.0.0-20211229125312-df8bd725853c h1:wLTSvRhuNJVvjVfRpPTwS/sftSbzhGbSiuZdjHwRwxg=
-tinygo.org/x/go-llvm v0.0.0-20211229125312-df8bd725853c/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6 h1:p9huJkDeMFLOE5A4puIPRIewaTpQXX6OmjguUmGXJj4=
+tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -406,7 +406,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		initialCFlags = append(initialCFlags, p.program.config.CFlags()...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
 		if p.program.clangHeaders != "" {
-			initialCFlags = append(initialCFlags, "-Xclang", "-internal-isystem", "-Xclang", p.program.clangHeaders)
+			initialCFlags = append(initialCFlags, "-isystem", p.program.clangHeaders)
 		}
 		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, initialCFlags)
 		p.CFlags = append(initialCFlags, cflags...)

--- a/main_test.go
+++ b/main_test.go
@@ -173,9 +173,7 @@ func TestBuild(t *testing.T) {
 				avrTests = append(avrTests, t)
 			}
 		}
-		opts := optionsFromTarget("atmega1284p", sema)
-		opts.Scheduler = "tasks"
-		runPlatTests(opts, avrTests, t)
+		runPlatTests(optionsFromTarget("simavr", sema), avrTests, t)
 	})
 
 	if runtime.GOOS == "linux" {

--- a/src/internal/task/task_asyncify_wasm.S
+++ b/src/internal/task/task_asyncify_wasm.S
@@ -1,5 +1,14 @@
 .globaltype __stack_pointer, i32
 
+.functype start_unwind (i32) -> ()
+.import_module start_unwind, asyncify
+.functype stop_unwind () -> ()
+.import_module stop_unwind, asyncify
+.functype start_rewind (i32) -> ()
+.import_module start_rewind, asyncify
+.functype stop_rewind () -> ()
+.import_module stop_rewind, asyncify
+
 .global  tinygo_unwind
 .hidden  tinygo_unwind
 .type    tinygo_unwind,@function
@@ -83,15 +92,6 @@ tinygo_rewind: // func (state *state) rewind()
     global.set __stack_pointer // setStackPointer(prev)
     return
     end_function
-
-.functype start_unwind (i32) -> ()
-.import_module start_unwind, asyncify
-.functype stop_unwind () -> ()
-.import_module stop_unwind, asyncify
-.functype start_rewind (i32) -> ()
-.import_module start_rewind, asyncify
-.functype stop_rewind () -> ()
-.import_module stop_rewind, asyncify
 
         .hidden tinygo_rewinding                # @tinygo_rewinding
         .type   tinygo_rewinding,@object

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -13,6 +13,7 @@
 		"-Werror",
 		"-fshort-enums",
 		"-fomit-frame-pointer",
+		"-mfloat-abi=soft",
 		"-fno-exceptions", "-fno-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0",
-	"features": "+armv6-m,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-dotprod,-dsp,-fp16fml,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-ras,-sb,-sha2"
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0plus",
-	"features": "+armv6-m,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-dotprod,-dsp,-fp16fml,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-ras,-sb,-sha2"
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7m-unknown-unknown-eabi",
 	"cpu": "cortex-m3",
-	"features": "+armv7-m,+hwdiv,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-dotprod,-dsp,-fp16fml,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-ras,-sb,-sha2"
+	"features": "+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m33.json
+++ b/targets/cortex-m33.json
@@ -1,7 +1,4 @@
 {
     "inherits": ["cortex-m"],
-    "llvm-target": "thumbv7m-unknown-unknown-eabi",
-    "cflags": [
-        "-mfloat-abi=soft"
-    ]
+    "llvm-target": "thumbv7m-unknown-unknown-eabi"
 }

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -2,8 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m4",
-	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
-	"cflags": [
-		"-mfloat-abi=soft"
-	]
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -2,8 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
-	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
-	"cflags": [
-		"-mfloat-abi=soft"
-	]
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "armv4t-unknown-unknown-eabi",
 	"cpu": "arm7tdmi",
-	"features": "+armv4t,+strict-align,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-dotprod,-dsp,-fp16fml,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-ras,-sb,-sha2,-thumb-mode",
+	"features": "+armv4t,+strict-align,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",

--- a/targets/k210.json
+++ b/targets/k210.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv64"],
-	"features": "+a,+c,+d,+f,+m,-relax,-save-restore",
+	"features": "+64bit,+a,+c,+d,+f,+m,-relax,-save-restore",
 	"build-tags": ["k210", "kendryte"],
 	"code-model": "medium"
 }

--- a/targets/simavr.json
+++ b/targets/simavr.json
@@ -1,0 +1,5 @@
+{
+    "inherits": ["atmega1284p"],
+    "scheduler": "tasks",
+    "default-stack-size": 512
+}

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -59,6 +59,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		goPasses.AddGlobalDCEPass()
 		goPasses.AddGlobalOptimizerPass()
 		goPasses.AddIPSCCPPass()
+		goPasses.AddInstructionCombiningPass() // necessary for OptimizeReflectImplements
 		goPasses.AddAggressiveDCEPass()
 		goPasses.AddFunctionAttrsPass()
 		goPasses.Run(mod)


### PR DESCRIPTION
This adds support for building with `-tags=llvm13` and switches to LLVM 13 for tinygo binaries that are statically linked against LLVM.

Some notes on this PR:

  * Added `-mfloat-abi=soft` to all Cortex-M targets because otherwise nrfx would complain that floating point was enabled on Cortex-M0. That's not the case, but with `-mfloat-abi=soft` the `__SOFTFP__` macro is defined which silences this warning.
    See: https://reviews.llvm.org/D100372
  * Changed from `--sysroot=<root>` to `-nostdlib -isystem <root>/include` for musl because with Clang 13, even with `--sysroot` some system libraries are used which we don't want.
  * Changed all `-Xclang -internal-isystem -Xclang` to simply `-isystem`, for consistency with the above change. It appears to have the same effect.
  * Moved WebAssembly function declarations to the top of the file in task_asyncify_wasm.S because (apparently) the assembler has become more strict.

@QuLogic pinging you in case you hadn't seen this yet