### PR TITLE
Makefile: add tinygo-test-wasi; like tinygo-test but with -target wasi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,10 +196,8 @@ tinygo:
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
 
-TEST_PACKAGES = \
+TEST_PACKAGES_BASE = \
 	compress/bzip2 \
-	compress/flate \
-	compress/zlib \
 	container/heap \
 	container/list \
 	container/ring \
@@ -231,7 +229,6 @@ TEST_PACKAGES = \
 	math/cmplx \
 	net/http/internal/ascii \
 	net/mail \
-	os \
 	path \
 	reflect \
 	sync \
@@ -242,11 +239,24 @@ TEST_PACKAGES = \
 	unicode/utf16 \
 	unicode/utf8 \
 
+# Standard library packages that pass tests natively
+TEST_PACKAGES = \
+	$(TEST_PACKAGES_BASE) \
+	compress/flate \
+	compress/zlib \
+	os \
+
+# Standard library packages that pass tests on wasi
+TEST_PACKAGES_WASI = \
+	$(TEST_PACKAGES_BASE)
+
 # Test known-working standard library packages.
 # TODO: parallelize, and only show failing tests (no implied -v flag).
 .PHONY: tinygo-test
 tinygo-test:
 	$(TINYGO) test $(TEST_PACKAGES)
+tinygo-test-wasi:
+	$(TINYGO) test -target wasi $(TEST_PACKAGES_WASI)
 
 .PHONY: smoketest
 smoketest:


### PR DESCRIPTION
Skips the standard library modules whose tests don't pass yet in wasi (see recently filed bugs).