### PR TITLE
interp: work around AVR function pointers in globals

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -28,6 +28,7 @@ type runner struct {
 	builder       llvm.Builder
 	pointerSize   uint32                   // cached pointer size from the TargetData
 	i8ptrType     llvm.Type                // often used type so created in advance
+	uintptrType   llvm.Type                // equivalent to uintptr in Go
 	maxAlign      int                      // maximum alignment of an object, alignment of runtime.alloc() result
 	debug         bool                     // log debug messages
 	pkgName       string                   // package name of the currently executing package
@@ -50,6 +51,7 @@ func newRunner(mod llvm.Module, debug bool) *runner {
 	}
 	r.pointerSize = uint32(r.targetData.PointerSize())
 	r.i8ptrType = llvm.PointerType(mod.Context().Int8Type(), 0)
+	r.uintptrType = mod.Context().IntType(r.targetData.PointerSize() * 8)
 	r.maxAlign = r.targetData.PrefTypeAlignment(r.i8ptrType) // assume pointers are maximally aligned (this is not always the case)
 	return &r
 }


### PR DESCRIPTION
Not sure how to test this, since we don't really have any AVR tests configured.

See https://github.com/tinygo-org/tinygo/issues/2374