### PR TITLE
machine/samd51, machine/nrf: implement hardware based random number generation

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32wle5 || (sam && atsamd51) || (sam && atsame5x)
-// +build stm32wle5 sam,atsamd51 sam,atsame5x
+//go:build stm32wle5 || (sam && atsamd51) || (sam && atsame5x) || nrf
+// +build stm32wle5 sam,atsamd51 sam,atsame5x nrf
 
 package rand
 

--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32wle5
-// +build stm32wle5
+//go:build stm32wle5 || (sam && atsamd51) || (sam && atsame5x)
+// +build stm32wle5 sam,atsamd51 sam,atsame5x
 
 package rand
 

--- a/src/examples/rand/main.go
+++ b/src/examples/rand/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+func main() {
+	var result [32]byte
+	for {
+		rand.Read(result[:])
+		encodedString := hex.EncodeToString(result[:])
+		println(encodedString)
+		time.Sleep(time.Second)
+	}
+}

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -3,12 +3,13 @@ package machine
 import "errors"
 
 var (
-	ErrTimeoutRNG         = errors.New("machine: RNG Timeout")
 	ErrInvalidInputPin    = errors.New("machine: invalid input pin")
 	ErrInvalidOutputPin   = errors.New("machine: invalid output pin")
 	ErrInvalidClockPin    = errors.New("machine: invalid clock pin")
 	ErrInvalidDataPin     = errors.New("machine: invalid data pin")
 	ErrNoPinChangeChannel = errors.New("machine: no channel available for pin interrupt")
+	ErrTimeoutRNG         = errors.New("machine: RNG Timeout")
+	ErrNoRNG              = errors.New("machine: no RNG error")
 )
 
 // Device is the running program's chip name, such as "ATSAMD51J19A" or

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsamd51) || (sam && atsame5x)
 // +build sam,atsamd51 sam,atsame5x
 
 // Peripheral abstraction layer for the atsamd51.
@@ -2732,4 +2733,21 @@ func syncDAC() {
 	}
 	for sam.DAC.SYNCBUSY.HasBits(sam.DAC_SYNCBUSY_DATA0) {
 	}
+}
+
+var rngInitDone = false
+
+// GetRNG returns 32 bits of cryptographically secure random data
+func GetRNG() (uint32, error) {
+	if !rngInitDone {
+		// Turn on clock for TRNG
+		sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TRNG_)
+
+		// enable
+		sam.TRNG.CTRLA.Set(sam.TRNG_CTRLA_ENABLE)
+
+		rngInitDone = true
+	}
+	ret := sam.TRNG.DATA.Get()
+	return ret, nil
 }

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -339,8 +339,8 @@ var rngInitDone = false
 
 const RNG_MAX_READ_RETRIES = 1000
 
-// GetRNG returns 32 bits of cryptographically secure random data
-func GetRNG() (uint32, error) {
+// getRNG returns 32 bits of cryptographically secure random data
+func getRNG() (uint32, error) {
 	if !rngInitDone {
 		nrf.RNG.CONFIG.Set(nrf.RNG_CONFIG_DERCEN)
 		nrf.RNG.SHORTS.ClearBits(nrf.RNG_SHORTS_VALRDY_STOP)

--- a/src/machine/machine_nrf_rand.go
+++ b/src/machine/machine_nrf_rand.go
@@ -1,0 +1,9 @@
+//go:build nrf && !softdevice
+// +build nrf,!softdevice
+
+package machine
+
+// GetRNG returns 32 bits of cryptographically secure random data
+func GetRNG() (uint32, error) {
+	return getRNG()
+}

--- a/src/machine/machine_nrf_rand_softdevice.go
+++ b/src/machine/machine_nrf_rand_softdevice.go
@@ -1,0 +1,42 @@
+//go:build nrf && softdevice
+// +build nrf,softdevice
+
+package machine
+
+import (
+	"device/arm"
+	"device/nrf"
+)
+
+//export sd_rand_application_vector_get
+func sd_rand_application_vector_get(*[4]uint8, uint8)
+
+// This is a global variable to avoid a heap allocation in GetRNG.
+var softdeviceEnabled uint8
+var rngData [4]uint8
+
+// GetRNG returns 32 bits of cryptographically secure random data
+func GetRNG() (uint32, error) {
+	// First check whether the SoftDevice is enabled.
+	arm.SVCall1(0x12, &softdeviceEnabled) // sd_softdevice_is_enabled
+
+	if softdeviceEnabled != 0 {
+		// Now pick the appropriate SVCall number. Hopefully they won't change
+		// in the future with a different SoftDevice version.
+		if nrf.Device == "nrf51" {
+			// sd_rand_application_vector_get: SOC_SVC_BASE_NOT_AVAILABLE + 15
+			arm.SVCall2(0x2B+15, &rngData, 4)
+		} else if nrf.Device == "nrf52" || nrf.Device == "nrf52840" || nrf.Device == "nrf52833" {
+			// sd_rand_application_vector_get: SOC_SVC_BASE_NOT_AVAILABLE + 5
+			arm.SVCall2(0x2C+5, &rngData, 4)
+		} else {
+			sd_rand_application_vector_get(&rngData, 4)
+		}
+
+		result := uint32(rngData[0])<<24 | uint32(rngData[1])<<16 | uint32(rngData[2])<<8 | uint32(rngData[3])
+		return result, nil
+	}
+
+	// SoftDevice is disabled so we use normal call.
+	return getRNG()
+}


### PR DESCRIPTION
EDIT: also added support for all Nordic Semiconductor chips.

As a followup to @ofauchon recent #2351 this PR adds support for TRND to the ATSAMD51/ATSAMD5x family, and for RND to the nrf family.

I have also added an example program to display some random numbers, tested on my ItsyBitsy-M4:

```console
$ tinygo flash -size short -target=itsybitsy-m4 examples/rand                                                                                                                
   code    data     bss |   flash     ram                                                                                                                                    
   7856      36    6336 |    7892    6372
```

Here were the results:

```console
Terminal ready
5e2dee02d4b21a6b0eeaf9d4e937c40b1bc69a1e7bfb9b306e3ab8142ce45693
483acb05666a847212b108d8ff20187718676ba8e43180dc9231a450a5e2f0a3
d0bbb811823ba5d7471ea0e1b78899c656cd9aeae3877dc30bbf495d29383a42
77f43343191c7553ef1ef814a6084eb3a652e76cd4fd4cd3c5ba57c18b722513
33f708d2ae331b6fde210371130b37bafbdf51f75c3dde3c4b2b4edcc3ca1cd7
4fb465c7123d298848f79b994ed654fcd7bc86b2e7b9eba0a7bd005896b83429
edfaee83188dfc2751d74a691e0ca25ea7274e923a7f3c116a26e4a38a97e54f
96551acb8f68abe66a7edf378ac0d078e08ef89b3ca84b80c2d9929f909243b3
b07b3c5e3684041588447c95c583481f4c0ab27c242b00aae4add95d5cc6db75
726829cdb5b8f67731d3f3341c929ae7725af24ffc91c8abe2f1ef822649cafa
e9fe81988164b99bd1d3c676a2c832289ce248caeaaca403d03f9bd33cbe2e99
fbe524ce3683d5c1c55a0df7608c7bb25679c5c1baf348a51dba01f661a7c0db
052eb5cc600075c6f72075eea464348e9124e345513ca202380ea7333c6a98d1

Terminating...
Thanks for using picocom
```

Let's make all the things random!