### PR TITLE
machine/samd51: add support for RND

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32wlx
-// +build stm32wlx
+//go:build stm32wlx || (sam && atsamd51) || (sam && atsame5x)
+// +build stm32wlx sam,atsamd51 sam,atsame5x
 
 package rand
 

--- a/src/examples/rand/main.go
+++ b/src/examples/rand/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+func main() {
+	var result [32]byte
+	for {
+		rand.Read(result[:])
+		encodedString := hex.EncodeToString(result[:])
+		println(encodedString)
+		time.Sleep(time.Second)
+	}
+}

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsamd51) || (sam && atsame5x)
 // +build sam,atsamd51 sam,atsame5x
 
 // Peripheral abstraction layer for the atsamd51.
@@ -2732,4 +2733,21 @@ func syncDAC() {
 	}
 	for sam.DAC.SYNCBUSY.HasBits(sam.DAC_SYNCBUSY_DATA0) {
 	}
+}
+
+var rngInitDone = false
+
+// GetRNG returns 32 bits of cryptographically secure random data
+func GetRNG() (uint32, error) {
+	if !rngInitDone {
+		// Turn on clock for TRNG
+		sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TRNG_)
+
+		// enable
+		sam.TRNG.CTRLA.Set(sam.TRNG_CTRLA_ENABLE)
+
+		rngInitDone = true
+	}
+	ret := sam.TRNG.DATA.Get()
+	return ret, nil
 }


### PR DESCRIPTION
As a followup to @ofauchon recent #2351 this PR adds support for TRND to the ATSAMD51/ATSAMD5x family of processors.

It also adds an example program in a separate commit, tested on my ItsyBitsy-M4:

```
$ tinygo flash -size short -target itsybitsy-m4 examples/rand
   code    data     bss |   flash     ram
   7856      36    6336 |    7892    6372
```

Which produces output like this:

```
Terminal ready
55873090e4aa1dfffa605d4490f5b211129f76956653172ee3a62d1527e163d1
283050f711b6cc474dd9e999a00f28fa7383cbcc52066d91384ba2a9527a87f5
a5d93849709afcf19287aa644359c025f6a0dd2976f92e89f838ac559a7f4e3c
7e06e398e1d7c891262aaa15506d16802f43a1bae2ba08d577d38323cf9fe273
c4968d2f50fc4e08d748f00898667ccd40f71c29b67f30e2875013a551c2f744
51e87f5f77f7aa4a0893deb357788fc4315a696f62f73a1b813087043f36496a

Terminating...
```
