### PR TITLE
machine/stm32f4, stm32f7, stm32l4: implement TRNG for randomness

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32wlx || (sam && atsamd51) || (sam && atsame5x)
-// +build stm32wlx sam,atsamd51 sam,atsame5x
+//go:build stm32wlx || stm32f4 || stm32f7 || stm32l4 || (sam && atsamd51) || (sam && atsame5x)
+// +build stm32wlx stm32f4 stm32f7 stm32l4 sam,atsamd51 sam,atsame5x
 
 package rand
 

--- a/src/machine/machine_stm32_rng.go
+++ b/src/machine/machine_stm32_rng.go
@@ -1,0 +1,29 @@
+//go:build stm32f4 || stm32f7 || stm32l4
+// +build stm32f4 stm32f7 stm32l4
+
+package machine
+
+import "device/stm32"
+
+var rngInitDone = false
+
+const RNG_MAX_READ_RETRIES = 1000
+
+// GetRNG returns 32 bits of cryptographically secure random data
+func GetRNG() (uint32, error) {
+	if !rngInitDone {
+		initRNG()
+		rngInitDone = true
+	}
+
+	cnt := RNG_MAX_READ_RETRIES
+	for !stm32.RNG.SR.HasBits(stm32.RNG_SR_DRDY) {
+		cnt--
+		if cnt == 0 {
+			return 0, ErrTimeoutRNG
+		}
+	}
+
+	ret := stm32.RNG.DR.Get()
+	return ret, nil
+}

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -1,3 +1,4 @@
+//go:build stm32f4
 // +build stm32f4
 
 package machine
@@ -586,3 +587,8 @@ const (
 	ARR_MAX = 0x10000
 	PSC_MAX = 0x10000
 )
+
+func initRNG() {
+	stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_RNGEN)
+	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+}

--- a/src/machine/machine_stm32f7.go
+++ b/src/machine/machine_stm32f7.go
@@ -1,3 +1,4 @@
+//go:build stm32f7
 // +build stm32f7
 
 package machine
@@ -716,3 +717,8 @@ const (
 	ARR_MAX = 0x10000
 	PSC_MAX = 0x10000
 )
+
+func initRNG() {
+	stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_RNGEN)
+	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+}

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -1,3 +1,4 @@
+//go:build stm32l0
 // +build stm32l0
 
 package machine

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -1,3 +1,4 @@
+//go:build stm32l4
 // +build stm32l4
 
 package machine
@@ -494,3 +495,12 @@ const (
 	ARR_MAX = 0x10000
 	PSC_MAX = 0x10000
 )
+
+func initRNG() {
+	stm32.RCC.CRRCR.SetBits(stm32.RCC_CRRCR_HSI48ON)
+	for !stm32.RCC.CRRCR.HasBits(stm32.RCC_CRRCR_HSI48RDY) {
+	}
+
+	stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_RNGEN)
+	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+}


### PR DESCRIPTION
This PR continues getting random with RNG implementations for stm32f4, stm32f7, stm32l4 processors.

Tested on Nucleo-L432kc:

```
$ tinygo flash -size short -target nucleo-l432kc examples/rand                                                                                                               
   code    data     bss |   flash     ram                                                                                                                                    
   9976     908    4352 |   10884    5260
```

With following output:

```
Terminal ready
a32215302cefe0b0f4153c7c79920203acf584e3da22613ac92276b9bee6562e
4038bfdca65e0dd27c9ae2c9d10c8cb7648be3f9ad43dad8c0be6ab75aa72ca5
7abe159bb21c953d9d0f3141697c29a574f349cf18e983ba5795809ade405085
d313170dbab7ba58bd783caf59673f651810172f7f1cefbaca249bc811739b07
856962668509e35aefb1d41d9dd6af3e86e14a9fe33f283a4c3b6cd7d56a47da
ba94f1a336e77f44856d5fa834ccc7ddb69c8b25765920f15d2f18559f2eabcf
cc25fbf27661517eda3b8574da889afb4a73f3d9845276a07b8b546320a282b8
d6a93db9751e1d80382916e29e8af86e19d217c29afe6f76111dba79cbdd1504
4da9d33a138f258c243f70a21124b8ceceda7693a9b0f3b1555701ed3660e120
4c05a9c87035cb191609bf8b5a05a94e144e58185a395c36d89875c7cd75ed6f
1fb3f98a65ec1a3d77631b72018a79e2f918b6a5ebd294698816f152fa2f9128
72f7dc1395de3d149ea12c4a746f192aad52afe028a8b713ddcae7f54d83a8f5

Terminating...
```
