### PR TITLE
tinygo: set cmd.Dir even when running emulators

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -232,6 +232,13 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 		spec.ExtraFiles = append(spec.ExtraFiles, "src/internal/task/task_asyncify_wasm.S")
 	}
 
+	// TODO(dgryski): handle CFLAGS and LDFLAGS here too?
+	var emu []string
+	for _, s := range spec.Emulator {
+		emu = append(emu, strings.ReplaceAll(s, "{root}", goenv.Get("TINYGOROOT")))
+	}
+	spec.Emulator = emu
+
 	return spec, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -244,7 +244,6 @@ func runPackageTest(config *compileopts.Config, result builder.BuildResult, test
 			flags = append(flags, "-test.run="+testRunRegexp)
 		}
 		cmd = executeCommand(config.Options, result.Binary, flags...)
-		cmd.Dir = result.MainDir
 	} else {
 		// Run in an emulator.
 		args := append(config.Target.Emulator[1:], result.Binary)
@@ -264,6 +263,7 @@ func runPackageTest(config *compileopts.Config, result builder.BuildResult, test
 		}
 		cmd = executeCommand(config.Options, config.Target.Emulator[0], args...)
 	}
+	cmd.Dir = result.MainDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -13,6 +13,6 @@
 		"--stack-first",
 		"--no-demangle"
 	],
-	"emulator":      ["node", "targets/wasm_exec.js"],
+	"emulator":      ["node", "{root}/targets/wasm_exec.js"],
 	"wasm-abi":      "js"
 }


### PR DESCRIPTION
This allows compress/bzip2 to pass with -target=wasi

Fixes #2367