### PR TITLE
runtime: handle negative sleep times

### DIFF
--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -1,3 +1,4 @@
+//go:build !scheduler.none
 // +build !scheduler.none
 
 package runtime
@@ -7,6 +8,10 @@ import "internal/task"
 // Pause the current task for a given time.
 //go:linkname sleep time.Sleep
 func sleep(duration int64) {
+	if duration <= 0 {
+		return
+	}
+
 	addSleepTask(task.Current(), nanosecondsToTicks(duration))
 	task.Pause()
 }

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -1,9 +1,14 @@
+//go:build scheduler.none
 // +build scheduler.none
 
 package runtime
 
 //go:linkname sleep time.Sleep
 func sleep(duration int64) {
+	if duration <= 0 {
+		return
+	}
+
 	sleepTicks(nanosecondsToTicks(duration))
 }
 

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"time"
 )
 
 func main() {
@@ -28,6 +29,10 @@ func main() {
 	// package strings
 	fmt.Println("strings.IndexByte:", strings.IndexByte("asdf", 'd'))
 	fmt.Println("strings.Replace:", strings.Replace("An example string", " ", "-", -1))
+
+	// package time
+	time.Sleep(time.Millisecond)
+	time.Sleep(-1) // negative sleep should return immediately
 
 	// Exit the program normally.
 	os.Exit(0)


### PR DESCRIPTION
This change fixes the edge case where a negative sleep time is provided.
When this happens, the call now returns immediately (as specified by the docs for time.Sleep).

This change addresses #1268 