### PR TITLE
Add peripherals to micro:bit v2

### DIFF
--- a/src/machine/board_microbit-v2.go
+++ b/src/machine/board_microbit-v2.go
@@ -99,6 +99,14 @@ const (
 	LED_ROW_5 Pin = P0_19
 )
 
+// Peripherals
+const (
+	BUZZER    = P27
+	CAP_TOUCH = P26
+	MIC       = P29
+	MIC_LED   = P28
+)
+
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "BBC micro:bit V2"


### PR DESCRIPTION
Add a few pin convenient names for the onboard buzzer, capacitive touch sensor and the mic.

Here's a short example using micro:bit v2's mic to detect sound change (light up the mic led to indicate mic is receiving):

```golang
package main

import (
	"machine"
	"time"
)

type Mic struct {
	run machine.Pin
	in  machine.ADC
}

func (mic *Mic) Init() {
	mic.run = machine.MIC_LED
	mic.run.Configure(machine.PinConfig{Mode: machine.PinOutput})
	mic.run.High()
	machine.InitADC()
	mic.in = machine.ADC{machine.MIC}
	mic.in.Configure(machine.ADCConfig{})
}

func (mic *Mic) MeasureVolume(samples uint16, gain float32) uint16 {
	var min, max uint16
	for i := uint16(0); i < samples; i++ {
		value := mic.in.Get()
		if value > max {
			max = value
		}
		if value < min {
			min = value
		}
	}
	output := uint32(float32(max-min) * gain)
	if output > 65535 {
		return uint16(65535)
	}
	return uint16(output)
}

func main() {
	mic := Mic{}
	mic.Init()
	for {
		println(mic.MeasureVolume(1024, 6.0))
		time.Sleep(time.Millisecond * 50)
	}
}
```