### PR TITLE
Stm32 rng l0 l5

### DIFF
--- a/src/crypto/rand/rand.go
+++ b/src/crypto/rand/rand.go
@@ -15,5 +15,9 @@ var Reader io.Reader
 // Read is a helper function that calls Reader.Read using io.ReadFull.
 // On return, n == len(b) if and only if err == nil.
 func Read(b []byte) (n int, err error) {
+	if Reader == nil {
+		panic("no rng")
+	}
+
 	return io.ReadFull(Reader, b)
 }

--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32wlx || stm32f4 || stm32f7 || stm32l4 || (sam && atsamd51) || (sam && atsame5x)
-// +build stm32wlx stm32f4 stm32f7 stm32l4 sam,atsamd51 sam,atsame5x
+//go:build stm32 || (sam && atsamd51) || (sam && atsame5x)
+// +build stm32 sam,atsamd51 sam,atsame5x
 
 package rand
 

--- a/src/machine/machine_stm32_rng.go
+++ b/src/machine/machine_stm32_rng.go
@@ -1,5 +1,5 @@
-//go:build stm32f4 || stm32f7 || stm32l4 || stm32wlx
-// +build stm32f4 stm32f7 stm32l4 stm32wlx
+//go:build stm32 && !(stm32f103 || stm32l0x1)
+// +build stm32,!stm32f103,!stm32l0x1
 
 package machine
 

--- a/src/machine/machine_stm32l0x2.go
+++ b/src/machine/machine_stm32l0x2.go
@@ -1,3 +1,4 @@
+//go:build stm32l0x2
 // +build stm32l0x2
 
 package machine
@@ -252,3 +253,8 @@ const (
 	ARR_MAX = 0x10000
 	PSC_MAX = 0x10000
 )
+
+func initRNG() {
+	stm32.RCC.AHBENR.SetBits(stm32.RCC_AHBENR_RNGEN)
+	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+}

--- a/src/machine/machine_stm32l5.go
+++ b/src/machine/machine_stm32l5.go
@@ -1,3 +1,4 @@
+//go:build stm32l5
 // +build stm32l5
 
 package machine
@@ -546,3 +547,12 @@ const (
 	ARR_MAX = 0x10000
 	PSC_MAX = 0x10000
 )
+
+func initRNG() {
+	stm32.RCC.CRRCR.SetBits(stm32.RCC_CRRCR_HSI48ON)
+	for !stm32.RCC.CRRCR.HasBits(stm32.RCC_CRRCR_HSI48RDY) {
+	}
+
+	stm32.RCC.AHB2ENR.SetBits(stm32.RCC_AHB2ENR_RNGEN)
+	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+}

--- a/targets/nucleo-l552ze.json
+++ b/targets/nucleo-l552ze.json
@@ -7,6 +7,6 @@
       "src/device/stm32/stm32l552.s"
     ],
     "flash-method": "openocd",
-    "openocd-interface": "stlink-v2-1",
+    "openocd-interface": "stlink",
     "openocd-target": "stm32l5x"
   }


### PR DESCRIPTION
All stm32 that support hardware RNG are now implemented, so changing stm32_rng.go logic to only exclude supported MCUs that lack RNG hardware.