### PR TITLE
docker: have to copy build results to GOPATH at the very end of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ FROM tinygo-compiler AS tinygo-tools
 
 RUN cd /tinygo/ && \
     make wasi-libc binaryen && \
-    make gen-device -j4
+    make gen-device -j4 && \
+    cp build/* $GOPATH/bin/
 
 CMD ["tinygo"]


### PR DESCRIPTION
This PR corrects an omission in the Dockerfile by copying the final build files to the GOPATH at the very end of docker build or it returns an error such as the error in the current `dev` image:

```console
$ docker run tinygo/tinygo-dev
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "tinygo": executable file not found in $PATH: unknown.
ERRO[0001] error waiting for container: context canceled
```