### PR TITLE
build: update XCode version for CircleCI builds to 11.4.1 due to deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
           llvm: "12"
   build-macos:
     macos:
-      xcode: "11.1.0" # macOS 10.14
+      xcode: "11.4.1" # macOS 10.15.4
     steps:
       - build-macos
 


### PR DESCRIPTION
This PR updates the version of XCode being used for CircleCI builds to 11.4.1 due to deprecation of older versions on the service.