### PR TITLE
docker: remove only subdirectories (which are updated as submodules) …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ FROM tinygo-llvm-build AS tinygo-compiler
 
 COPY . /tinygo
 
-# remove submodules directories and re-init them to fix any hard-coded paths
-# after copying the tinygo directory in the previous step.
+# update submodules
 RUN cd /tinygo/ && \
-    rm -rf ./lib/* && \
+    rm -rf ./lib/*/ && \
     git submodule sync && \
     git submodule update --init --recursive --force
 


### PR DESCRIPTION
This PR corrects the Dockerfile by removing only subdirectories (which are updated as submodules) from lib to keep picolibc file in its correct place. This is required to correctly build any code running bare metal, and will fix the build on the `drivers` repo.