### PR TITLE
stm32wlx i2c implementation

### DIFF
--- a/src/machine/board_gnse.go
+++ b/src/machine/board_gnse.go
@@ -17,7 +17,11 @@ const (
 	LED3      = LED_BLUE  // Blue
 	LED       = LED_GREEN // Default
 
-	BUTTON = PB3
+	BUTTON    = PB3
+	BUZZER    = PA15
+	VBATT_ADC = PB2
+	SENSOR_EN = PB12
+	FLASH_EN  = PC13
 
 	// SPI0
 	SPI0_NSS_PIN = PA4
@@ -32,6 +36,22 @@ const (
 	// DEFAULT USART
 	UART_RX_PIN = UART2_RX_PIN
 	UART_TX_PIN = UART2_TX_PIN
+
+	// I2C1 pins
+	// I2C1 is connected to Flash, Accelerometer, Env. Sensor, Crypto Element)
+	I2C1_SCL_PIN  = PA9
+	I2C1_SDA_PIN  = PA10
+	I2C1_ALT_FUNC = 4
+
+	// I2C2 pins
+	// I2C2 is expansion J10 QWIIC Connector
+	I2C2_SCL_PIN  = PA12
+	I2C2_SDA_PIN  = PA11
+	I2C2_ALT_FUNC = 4
+
+	// I2C0 alias for I2C1
+	I2C0_SDA_PIN = I2C1_SDA_PIN
+	I2C0_SCL_PIN = I2C1_SCL_PIN
 )
 
 var (
@@ -45,6 +65,17 @@ var (
 	}
 
 	DefaultUART = UART0
+
+	// I2C Busses
+	I2C1 = &I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: I2C1_ALT_FUNC,
+	}
+	I2C2 = &I2C{
+		Bus:             stm32.I2C2,
+		AltFuncSelector: I2C2_ALT_FUNC,
+	}
+	I2C0 = I2C1
 
 	// SPI
 	SPI3 = SPI{

--- a/src/machine/board_lorae5.go
+++ b/src/machine/board_lorae5.go
@@ -34,6 +34,16 @@ const (
 	// DEFAULT USART
 	UART_TX_PIN = UART1_TX_PIN
 	UART_RX_PIN = UART1_RX_PIN
+
+	// I2C1 pins
+	// I2C1 is connected to Flash, Accelerometer, Env. Sensor, Crypto Element)
+	I2C1_SCL_PIN  = PA9
+	I2C1_SDA_PIN  = PA10
+	I2C1_ALT_FUNC = 4
+
+	// I2C0 alias for I2C1
+	I2C0_SDA_PIN = I2C1_SDA_PIN
+	I2C0_SCL_PIN = I2C1_SCL_PIN
 )
 
 var (
@@ -47,6 +57,13 @@ var (
 	}
 	DefaultUART = UART0
 
+	// I2C Busses
+	I2C1 = &I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: I2C1_ALT_FUNC,
+	}
+
+	I2C0 = I2C1
 	// SPI
 	SPI3 = SPI{
 		Bus: stm32.SPI3,

--- a/src/machine/board_nucleowl55jc.go
+++ b/src/machine/board_nucleowl55jc.go
@@ -36,6 +36,20 @@ const (
 	// DEFAULT USART
 	UART_RX_PIN = UART2_RX_PIN
 	UART_TX_PIN = UART2_TX_PIN
+
+	// I2C1 pins
+	I2C1_SCL_PIN  = PA9
+	I2C1_SDA_PIN  = PA10
+	I2C1_ALT_FUNC = 4
+
+	// I2C2 pins
+	I2C2_SCL_PIN  = PA12
+	I2C2_SDA_PIN  = PA11
+	I2C2_ALT_FUNC = 4
+
+	// I2C0 alias for I2C1
+	I2C0_SDA_PIN = I2C1_SDA_PIN
+	I2C0_SCL_PIN = I2C1_SCL_PIN
 )
 
 var (
@@ -58,6 +72,17 @@ var (
 	}
 
 	DefaultUART = UART0
+
+	// I2C Busses
+	I2C1 = &I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: I2C1_ALT_FUNC,
+	}
+	I2C2 = &I2C{
+		Bus:             stm32.I2C2,
+		AltFuncSelector: I2C2_ALT_FUNC,
+	}
+	I2C0 = I2C1
 
 	// SPI
 	SPI3 = SPI{

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,5 +1,5 @@
-//go:build atmega || nrf || sam || (stm32 && !stm32wlx) || fe310 || k210 || rp2040
-// +build atmega nrf sam stm32,!stm32wlx fe310 k210 rp2040
+//go:build atmega || nrf || sam || stm32 || fe310 || k210 || rp2040
+// +build atmega nrf sam stm32 fe310 k210 rp2040
 
 package machine
 

--- a/src/machine/machine_stm32_i2c_revb.go
+++ b/src/machine/machine_stm32_i2c_revb.go
@@ -1,5 +1,5 @@
-//go:build stm32l5 || stm32f7 || stm32l4 || stm32l0
-// +build stm32l5 stm32f7 stm32l4 stm32l0
+//go:build stm32l5 || stm32f7 || stm32l4 || stm32l0 || stm32wlx
+// +build stm32l5 stm32f7 stm32l4 stm32l0 stm32wlx
 
 package machine
 

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -283,6 +283,16 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 	return uint32(div) << stm32.SPI_CR1_BR_Pos
 }
 
+//---------- I2C related code
+
+// Gets the value for TIMINGR register
+func (i2c *I2C) getFreqRange() uint32 {
+	// This is a 'magic' value calculated by STM32CubeMX
+	// for 48Mhz PCLK1.
+	// TODO: Do calculations based on PCLK1
+	return 0x20303E5D
+}
+
 //---------- UART related code
 
 // Configure the UART.


### PR DESCRIPTION
This PR enables I2C buses on stm32wlx devices. 
It has been tested on GNSE devices and SHTC3 i2c sensor