### PR TITLE
Remove unused arrtype from package runtime

### DIFF
--- a/src/machine/machine_stm32_tim.go
+++ b/src/machine/machine_stm32_tim.go
@@ -2,6 +2,9 @@
 
 package machine
 
+// The type alias `arrtype` should be defined to either uint32 or uint16
+// depending on the size of that register in the MCU's TIM_Type structure.
+
 import (
 	"device/stm32"
 	"runtime/interrupt"

--- a/src/runtime/runtime_stm32_timers.go
+++ b/src/runtime/runtime_stm32_timers.go
@@ -8,9 +8,6 @@ package runtime
 // periodic interrupts at 100Hz (TICK_INTR_PERIOD_NS).  The PWM counter
 // register is used for fine-grained resolution (down to ~150ns) with an
 // Output Comparator used for fine-grained sleeps.
-//
-// The type alias `arrtype` should be defined to either uint32 or uint16
-// depending on the size of that register in the MCU's TIM_Type structure.
 
 import (
 	"device/stm32"

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -7,8 +7,6 @@ import (
 	"machine"
 )
 
-type arrtype = uint32
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -64,8 +64,6 @@ const (
 	FLASH_OPTIONS = stm32.FLASH_ACR_ICEN | stm32.FLASH_ACR_DCEN | stm32.FLASH_ACR_PRFTEN
 )
 
-type arrtype = uint32
-
 func init() {
 	initOSC() // configure oscillators
 	initCLK()

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -26,8 +26,6 @@ const (
 	PLL_Q = 7 // USB OTS FS, SDIO and RNG Clock = PLL_VCO / PLL_Q
 )
 
-type arrtype = uint32
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -25,8 +25,6 @@ const (
 	PLL_Q               = 2
 )
 
-type arrtype = uint32
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -11,8 +11,6 @@ const (
 	RCC_SYSCLK_DIV1 = 0 // Needs SVD update (should be stm32.RCC_SYSCLK_DIV1)
 )
 
-type arrtype = uint16
-
 func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }

--- a/src/runtime/runtime_stm32l4x2.go
+++ b/src/runtime/runtime_stm32l4x2.go
@@ -50,8 +50,6 @@ const (
 	RCC_PLL_SYSCLK = stm32.RCC_PLLCFGR_PLLREN
 )
 
-type arrtype = uint32
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -26,8 +26,6 @@ const (
 	PLL_R               = 2 // RCC_PLLR_DIV2
 )
 
-type arrtype = uint32
-
 func init() {
 	initCLK()
 

--- a/src/runtime/runtime_stm32wlx.go
+++ b/src/runtime/runtime_stm32wlx.go
@@ -8,8 +8,6 @@ import (
 	"machine"
 )
 
-type arrtype = uint32
-
 const (
 	/* PLL Options RMN0461.p247 */
 	PLL_M = 2


### PR DESCRIPTION
It doesn't seem used, contrary to what a comment states. This PR moves the comment to package machine where I believe it belongs.