### PR TITLE
goenv: add GO variable to use alternate go versions

### DIFF
--- a/loader/list.go
+++ b/loader/list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/goenv"
 )
 
 // List returns a ready-to-run *exec.Cmd for running the `go list` command with
@@ -24,7 +25,7 @@ func List(config *compileopts.Config, extraArgs, pkgs []string) (*exec.Cmd, erro
 	if config.CgoEnabled() {
 		cgoEnabled = "1"
 	}
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(goenv.Get("GO"), args...)
 	cmd.Env = append(os.Environ(), "GOROOT="+goroot, "GOOS="+config.GOOS(), "GOARCH="+config.GOARCH(), "CGO_ENABLED="+cgoEnabled)
 	return cmd, nil
 }


### PR DESCRIPTION
This adds a GO environment variable which may be used to select and test other Go versions.

For example:
```
go install golang.org/dl/go1.15.4
go1.15.4 download
GO=go1.15.4 make smoketest
```