### PR TITLE
fix wasmtest randomly failing in CI

### DIFF
--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -22,7 +22,6 @@ func TestChan(t *testing.T) {
 		chromedp.Navigate(server.URL+"/run?file=chan.wasm"),
 		waitLog(`1
 4
-2
 3
 true`),
 	)

--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -18,14 +18,17 @@ func TestChan(t *testing.T) {
 	ctx, cancel := chromectx()
 	defer cancel()
 
-	err = chromedp.Run(ctx,
-		chromedp.Navigate(server.URL+"/run?file=chan.wasm"),
-		waitLog(`1
+	for i := 0; i < 40; i++ {
+		err = chromedp.Run(ctx,
+			chromedp.Navigate(server.URL+"/run?file=chan.wasm"),
+			waitLog(`1
 4
+2
 3
 true`),
-	)
-	if err != nil {
-		t.Fatal(err)
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/tests/wasm/setup_test.go
+++ b/tests/wasm/setup_test.go
@@ -162,7 +162,7 @@ func waitInnerTextMatch(sel string, re *regexp.Regexp) chromedp.QueryAction {
 				return nodes, err
 			}
 			if !re.MatchString(ret) {
-				// log.Printf("found text: %s", ret)
+				log.Printf("found text: [%s]\n", ret)
 				return nodes, errors.New("unexpected value: " + ret)
 			}
 

--- a/tests/wasm/setup_test.go
+++ b/tests/wasm/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"

--- a/tests/wasm/testdata/chan.go
+++ b/tests/wasm/testdata/chan.go
@@ -5,6 +5,7 @@ func main() {
 	ch := make(chan bool, 1)
 	println("1")
 	go func() {
+		println("2")
 		ch <- true
 		println("3")
 	}()

--- a/tests/wasm/testdata/chan.go
+++ b/tests/wasm/testdata/chan.go
@@ -5,7 +5,6 @@ func main() {
 	ch := make(chan bool, 1)
 	println("1")
 	go func() {
-		println("2")
 		ch <- true
 		println("3")
 	}()


### PR DESCRIPTION
Fix https://github.com/tinygo-org/tinygo/issues/2400
The result is not what expected when the go routine start faster and println("2") finish printing before println("4") does.