### PR TITLE
ci: try to build LLVM with thread support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-14-windows-v2
+          key: llvm-build-14-windows-v3
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,6 @@ ifeq ($(OS),Windows_NT)
     START_GROUP = -Wl,--start-group
     END_GROUP = -Wl,--end-group
 
-    # LLVM compiled using MinGW on Windows appears to have problems with threads.
-    # Without this flag, linking results in errors like these:
-    #     libLLVMSupport.a(Threading.cpp.obj):Threading.cpp:(.text+0x55): undefined reference to `std::thread::hardware_concurrency()'
-    LLVM_OPTION += -DLLVM_ENABLE_THREADS=OFF -DLLVM_ENABLE_PIC=OFF
-
     CGO_CPPFLAGS += -DCINDEX_NO_EXPORTS
     CGO_LDFLAGS += -static -static-libgcc -static-libstdc++
     CGO_LDFLAGS_EXTRA += -lversion


### PR DESCRIPTION
This should fix a number of concurrency/threading issues.