### PR TITLE
Check for /run/media on Linux for non-debian-based distros

### DIFF
--- a/main.go
+++ b/main.go
@@ -713,7 +713,12 @@ func flashUF2UsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var infoPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
+		_, err := os.ReadDir("/run/media")
+		if err != nil {
+			infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
+		} else {
+			infoPath = "/run/media/*/" + volume + "/INFO_UF2.TXT"
+		}
 	case "darwin":
 		infoPath = "/Volumes/" + volume + "/INFO_UF2.TXT"
 	case "windows":
@@ -737,7 +742,12 @@ func flashHexUsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var destPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		destPath = "/media/*/" + volume
+		_, err := os.ReadDir("/run/media")
+		if err != nil {
+			destPath = "/media/*/" + volume
+		} else {
+			destPath = "/run/media/*/" + volume
+		}
 	case "darwin":
 		destPath = "/Volumes/" + volume
 	case "windows":


### PR DESCRIPTION
On non-debian-based distros, the directory for mounted drives is `/run/media` rather than `/media`

This PR uses `os.ReadDir()` to check if the `/run/media` directory exists on Linux, and changes the glob based on that.

This has only been tested on Arch, so further testing would be appreciated.

**This PR is not the correct one, please see** #2437