### PR TITLE
Check for /run/media on Linux for non-debian-based distros (fixed)

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,7 +719,12 @@ func flashUF2UsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var infoPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
+		_, err := os.ReadDir("/run/media")
+		if err != nil {
+			infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
+		} else {
+			infoPath = "/run/media/*/" + volume + "/INFO_UF2.TXT"
+		}
 	case "darwin":
 		infoPath = "/Volumes/" + volume + "/INFO_UF2.TXT"
 	case "windows":
@@ -743,7 +748,12 @@ func flashHexUsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var destPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		destPath = "/media/*/" + volume
+		_, err := os.ReadDir("/run/media")
+		if err != nil {
+			infoPath = "/media/*/" + volume
+		} else {
+			infoPath = "/run/media/*/" + volume
+		}
 	case "darwin":
 		destPath = "/Volumes/" + volume
 	case "windows":

--- a/main.go
+++ b/main.go
@@ -719,8 +719,8 @@ func flashUF2UsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var infoPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		_, err := os.ReadDir("/run/media")
-		if err != nil {
+		fi, err := os.Stat("/run/media")
+		if err != nil || !fi.IsDir() {
 			infoPath = "/media/*/" + volume + "/INFO_UF2.TXT"
 		} else {
 			infoPath = "/run/media/*/" + volume + "/INFO_UF2.TXT"
@@ -748,11 +748,11 @@ func flashHexUsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	var destPath string
 	switch runtime.GOOS {
 	case "linux", "freebsd":
-		_, err := os.ReadDir("/run/media")
-		if err != nil {
-			infoPath = "/media/*/" + volume
+		fi, err := os.Stat("/run/media")
+		if err != nil || !fi.IsDir() {
+			destPath = "/media/*/" + volume
 		} else {
-			infoPath = "/run/media/*/" + volume
+			destPath = "/run/media/*/" + volume
 		}
 	case "darwin":
 		destPath = "/Volumes/" + volume


### PR DESCRIPTION
On non-debian-based distros, the directory for mounted drives is `/run/media` rather than `/media`

This PR uses `os.Stat()` to check if the `/run/media` directory exists on Linux, and changes the glob based on that.

This has only been tested on Arch, so further testing would be appreciated.

This is my second PR as I made the first one (#2436) against release accidentally. Sorry about that.

Fixes #954 and  #1740 