### PR TITLE
runtime (chan): support blocking without a scheduler

### DIFF
--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -62,7 +62,13 @@ func scheduleLogChan(msg string, ch *channel, t *task.Task) {
 //go:noinline
 func deadlock() {
 	// call yield without requesting a wakeup
-	task.Pause()
+	if hasScheduler {
+		task.Pause()
+	} else {
+		for {
+			waitForEvents()
+		}
+	}
 	panic("unreachable")
 }
 


### PR DESCRIPTION
This change modifies the implementation of channels such that they can still block without a scheduler.
An example that works with this change is `examples/systick` which sends to a channel from an interrupt.