### PR TITLE
readme: remove multi core support non-goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Goals:
 
 Non-goals:
 
-* Using more than one core.
 * Be efficient while using zillions of goroutines. However, good goroutine support is certainly a goal.
 * Be as fast as `gc`. However, LLVM will probably be better at optimizing certain things so TinyGo might actually turn out to be faster for number crunching.
 * Be able to compile every Go program out there.


### PR DESCRIPTION
As the scope of TinyGo seems to change a bit, i've removed that one as a non-goal. 

See #2446 for example. 

