### PR TITLE
compileopts: move {root} replacement to compileopts.Emulator()

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -463,6 +463,15 @@ func (c *Config) WasmAbi() string {
 	return c.Target.WasmAbi
 }
 
+// Emulator returns the emulator target config
+func (c *Config) Emulator() []string {
+	var emulator []string
+	for _, s := range c.Target.Emulator {
+		emulator = append(emulator, strings.ReplaceAll(s, "{root}", goenv.Get("TINYGOROOT")))
+	}
+	return emulator
+}
+
 type TestConfig struct {
 	CompileTestBinary bool
 	// TODO: Filter the test functions to run, include verbose flag, etc

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -232,13 +232,6 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 		spec.ExtraFiles = append(spec.ExtraFiles, "src/internal/task/task_asyncify_wasm.S")
 	}
 
-	// TODO(dgryski): handle CFLAGS and LDFLAGS here too?
-	var emu []string
-	for _, s := range spec.Emulator {
-		emu = append(emu, strings.ReplaceAll(s, "{root}", goenv.Get("TINYGOROOT")))
-	}
-	spec.Emulator = emu
-
 	return spec, nil
 }
 


### PR DESCRIPTION
Follow up for https://github.com/tinygo-org/tinygo/pull/2387#issuecomment-1002309218