### PR TITLE
pass more --dirs to wasmtime so it can read the entire module tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ test: wasi-libc
 
 TEST_PACKAGES_BASE = \
 	compress/bzip2 \
+	compress/flate \
+	compress/zlib \
 	container/heap \
 	container/list \
 	container/ring \
@@ -242,9 +244,7 @@ TEST_PACKAGES_BASE = \
 
 # Standard library packages that pass tests natively
 TEST_PACKAGES = \
-	$(TEST_PACKAGES_BASE) \
-	compress/flate \
-	compress/zlib \
+	$(TEST_PACKAGES_BASE)
 
 # Standard library packages that pass tests on wasi
 TEST_PACKAGES_WASI = \

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -47,6 +47,14 @@ type PackageJSON struct {
 	ImportPath string
 	Name       string
 	ForTest    string
+	Root       string
+	Module     struct {
+		Path      string
+		Main      bool
+		Dir       string
+		GoMod     string
+		GoVersion string
+	}
 
 	// Source files
 	GoFiles  []string


### PR DESCRIPTION
This allows compress/flate to pass on -target=wasi out of the box.

Fixes #2367