### PR TITLE
compiler: work around AVR atomics bugs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -140,7 +140,8 @@ func TestBuild(t *testing.T) {
 		for _, t := range tests {
 			switch t {
 			case "atomic.go":
-				// Not supported due to unaligned atomic accesses.
+				// Requires GCC 11.2.0 or above for interface comparison.
+				// https://github.com/gcc-mirror/gcc/commit/f30dd607669212de135dec1f1d8a93b8954c327c
 
 			case "reflect.go":
 				// Reflect tests do not work due to type code issues.

--- a/src/runtime/arch_avr.go
+++ b/src/runtime/arch_avr.go
@@ -1,6 +1,9 @@
+//go:build avr
 // +build avr
 
 package runtime
+
+import "runtime/interrupt"
 
 const GOARCH = "arm" // avr pretends to be arm
 
@@ -15,4 +18,20 @@ func align(ptr uintptr) uintptr {
 
 func getCurrentStackPointer() uintptr {
 	return uintptr(stacksave())
+}
+
+// The safest thing to do here would just be to disable interrupts for
+// procPin/procUnpin. Note that a global variable is safe in this case, as any
+// access to procPinnedMask will happen with interrupts disabled.
+
+var procPinnedMask interrupt.State
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+	procPinnedMask = interrupt.Disable()
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+	interrupt.Restore(procPinnedMask)
 }


### PR DESCRIPTION
The AVR backend has several critical atomics bugs.
This change invokes libcalls for some atomic operations on AVR.
Now `testdata/atomic.go` compiles and runs correctly.

This came up when working on #2458, as it triggered a full crash rather than a compiler error or test failure.