### PR TITLE
testing: implement Skip

### DIFF
--- a/testdata/testing.go
+++ b/testdata/testing.go
@@ -24,9 +24,16 @@ func TestBar(t *testing.T) {
 	t.Log("log Bar end")
 }
 
+func TestSkip(t *testing.T) {
+	t.Skip("skip")
+
+	panic("test not skipped")
+}
+
 var tests = []testing.InternalTest{
 	{"TestFoo", TestFoo},
 	{"TestBar", TestBar},
+	{"TestSkip", TestSkip},
 }
 
 var benchmarks = []testing.InternalBenchmark{}

--- a/tests/tinygotest/main_test.go
+++ b/tests/tinygotest/main_test.go
@@ -21,5 +21,11 @@ func TestPass(t *testing.T) {
 	t.Log("TestPass passed")
 }
 
+func TestSkip(t *testing.T) {
+	t.Skip("skip this")
+
+	panic("test was not skipped")
+}
+
 func BenchmarkNotImplemented(b *testing.B) {
 }


### PR DESCRIPTION
The Skip methods were left unimplemented due to a lack of runtime.Goexit.
While runtime.Goexit does not currently run defers, it is close enough to the intended functionality that all current tests we have pass with it.