### PR TITLE
When running tests under wasmtime, provide a fresh TMPDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ TEST_PACKAGES_BASE = \
 	math/cmplx \
 	net/http/internal/ascii \
 	net/mail \
+	os \
 	path \
 	reflect \
 	sync \
@@ -243,7 +244,6 @@ TEST_PACKAGES = \
 	$(TEST_PACKAGES_BASE) \
 	compress/flate \
 	compress/zlib \
-	os \
 
 # Standard library packages that pass tests on wasi
 TEST_PACKAGES_WASI = \

--- a/main.go
+++ b/main.go
@@ -253,6 +253,14 @@ func runPackageTest(config *compileopts.Config, stdout, stderr io.Writer, result
 		// Run in an emulator.
 		args := append(config.Target.Emulator[1:], result.Binary)
 		if config.Target.Emulator[0] == "wasmtime" {
+			// create a new temp directory just for this run, announce it to os.TempDir() via TMPDIR
+			tmpdir, err := ioutil.TempDir("", "tinygotmp")
+			if err != nil {
+				return false, &commandError{"failed to create temporary directory", "tinygotmp", err}
+			}
+			args = append(args, "--dir="+tmpdir, "--env=TMPDIR="+tmpdir)
+			// TODO: add option to not delete temp dir for debugging?
+			defer os.RemoveAll(tmpdir)
 			// allow reading from current directory: --dir=.
 			// mark end of wasmtime arguments and start of program ones: --
 			args = append(args, "--dir=.", "--")

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -19,7 +19,7 @@ func randomName() string {
 }
 
 func TestMkdir(t *testing.T) {
-	dir := "TestMkdir" + randomName()
+	dir := TempDir() + "/TestMkdir" + randomName()
 	Remove(dir)
 	err := Mkdir(dir, 0755)
 	defer Remove(dir)
@@ -65,7 +65,7 @@ func writeFile(t *testing.T, fname string, flag int, text string) string {
 }
 
 func TestRemove(t *testing.T) {
-	f := "TestRemove" + randomName()
+	f := TempDir() + "/TestRemove" + randomName()
 
 	err := Remove(f)
 	if err == nil {


### PR DESCRIPTION
Also:
- fix a couple tests that assumed one can write to current directory
- add os to the list of stdlib packages to test in tinygo-test-wasi
