### PR TITLE
avr: fix time.Sleep() in init code

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -171,9 +171,6 @@ func TestCompiler(t *testing.T) {
 			case "float.go", "math.go", "print.go":
 				// Stuck in runtime.printfloat64.
 
-			case "goroutines.go":
-				// The main() never runs.
-
 			case "interface.go":
 				// Several comparison tests fail.
 

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -28,8 +28,6 @@ var _sidata [0]byte
 //go:extern _edata
 var _edata [0]byte
 
-func postinit() {}
-
 // Entry point for Go. Initialize all packages and call main.main().
 //export main
 func main() {

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -13,8 +13,6 @@ import (
 
 type timeUnit int64
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -12,8 +12,6 @@ import (
 
 type timeUnit int64
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	arm.SCB.CPACR.Set(0) // disable FPU if it is enabled

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -42,6 +42,7 @@ var _ebss [0]byte
 //export main
 func main() {
 	preinit()
+	initHardware()
 	run()
 	exit(0)
 }
@@ -55,15 +56,13 @@ func preinit() {
 	}
 }
 
-func postinit() {
-	// Enable interrupts after initialization.
-	avr.Asm("sei")
-}
-
-func init() {
+func initHardware() {
 	initUART()
 	machine.InitMonotonicTimer()
 	nextTimerRecalibrate = ticks() + timerRecalibrateInterval
+
+	// Enable interrupts after initialization.
+	avr.Asm("sei")
 }
 
 func ticksToNanoseconds(ticks timeUnit) int64 {

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -15,8 +15,6 @@ type timeUnit int64
 
 var timestamp timeUnit
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -14,8 +14,6 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
-func postinit() {}
-
 // Initialize .bss: zero-initialized global variables.
 // The .data section has already been loaded by the ROM bootloader.
 func clearbss() {

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -23,8 +23,6 @@ func putchar(c byte) {
 //export rom_i2c_writeReg
 func rom_i2c_writeReg(block, host_id, reg_add, data uint8)
 
-func postinit() {}
-
 //export main
 func main() {
 	// Clear .bss section. .data has already been loaded by the ROM bootloader.

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -16,8 +16,6 @@ import (
 
 type timeUnit int64
 
-func postinit() {}
-
 //export main
 func main() {
 	// Zero the PLIC enable bits on startup: they are not zeroed at reset.

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -15,8 +15,6 @@ import (
 
 type timeUnit int64
 
-func postinit() {}
-
 //export main
 func main() {
 

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -16,8 +16,6 @@ var _svectors [0]byte
 //go:extern _flexram_cfg
 var _flexram_cfg [0]byte
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -43,8 +43,6 @@ var (
 	totalHeap = uint64(0)
 )
 
-func postinit() {}
-
 func preinit() {
 	// Unsafe to use heap here
 	setupEnv()

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -15,8 +15,6 @@ type timeUnit int64
 //go:linkname systemInit SystemInit
 func systemInit()
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	if nrf.FPUPresent {

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -226,8 +226,6 @@ func initInternal() {
 	// 	analog_init();
 }
 
-func postinit() {}
-
 func putchar(c byte) {
 	machine.PutcharUART(machine.UART0, c)
 }

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -53,8 +53,6 @@ func init() {
 	machine.Serial.Configure(machine.UARTConfig{})
 }
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_stm32.go
+++ b/src/runtime/runtime_stm32.go
@@ -6,8 +6,6 @@ import "device/arm"
 
 type timeUnit int64
 
-func postinit() {}
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -15,8 +15,6 @@ type timeUnit int64
 
 var timestamp timeUnit
 
-func postinit() {}
-
 //export main
 func main() {
 	preinit()

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -22,8 +22,6 @@ func fd_write(id uint32, iovs *__wasi_iovec_t, iovs_len uint, nwritten *uint) (e
 //export proc_exit
 func proc_exit(exitcode uint32)
 
-func postinit() {}
-
 const (
 	putcharBufferSize = 120
 	stdout            = 1

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -65,8 +65,6 @@ type timespec struct {
 
 var stackTop uintptr
 
-func postinit() {}
-
 // Entry point for Go. Initialize all packages and call main.main().
 //export main
 func main(argc int32, argv *unsafe.Pointer) int {

--- a/src/runtime/runtime_windows.go
+++ b/src/runtime/runtime_windows.go
@@ -41,8 +41,6 @@ func __p___argc() *int32
 //export __p___argv
 func __p___argv() **unsafe.Pointer
 
-func postinit() {}
-
 //export mainCRTStartup
 func mainCRTStartup() int {
 	preinit()

--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -22,7 +22,6 @@ func run() {
 	initHeap()
 	go func() {
 		initAll()
-		postinit()
 		callMain()
 		schedulerDone = true
 	}()

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -23,7 +23,6 @@ func getSystemStackPointer() uintptr {
 func run() {
 	initHeap()
 	initAll()
-	postinit()
 	callMain()
 }
 


### PR DESCRIPTION
In the early days of TinyGo, the idea of `postinit` was to enable interrupts only after initializers have run. Which kind of makes sense... except that `time.Sleep` is allowed in init code and `time.Sleep` requires interrupts to be enabled. Therefore, interrupts must be enabled while initializers are being run.

This commit simply moves the enabling of interrupts to a point right before running package initializers. It also removes `runtime.postinit`, which is not necessary anymore (and was only used on AVR).

This fixes #2464.