### PR TITLE
all: use compiler-rt from LLVM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,16 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-13-v1
+            - llvm-source-13-v3
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-13-v1
+          key: llvm-source-13-v3
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
+            - llvm-project/compiler-rt
             - llvm-project/lld/include
             - llvm-project/llvm/include
   hack-ninja-jobs:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,10 +35,11 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-macos-v1
+          key: llvm-source-13-macos-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
+            llvm-project/compiler-rt
             llvm-project/lld/include
             llvm-project/llvm/include
       - name: Download LLVM source

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,10 +38,11 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-linux-v1
+          key: llvm-source-13-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
+            llvm-project/compiler-rt
             llvm-project/lld/include
             llvm-project/llvm/include
       - name: Download LLVM source
@@ -179,10 +180,11 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-linux-asserts-v1
+          key: llvm-source-13-linux-asserts-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
+            llvm-project/compiler-rt
             llvm-project/lld/include
             llvm-project/llvm/include
       - name: Download LLVM source

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,10 +35,11 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-windows-v1
+          key: llvm-source-13-windows-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
+            llvm-project/compiler-rt
             llvm-project/lld/include
             llvm-project/llvm/include
       - name: Download LLVM source

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 [submodule "lib/cmsis-svd"]
 	path = lib/cmsis-svd
 	url = https://github.com/tinygo-org/cmsis-svd
-[submodule "lib/compiler-rt"]
-	path = lib/compiler-rt
-	url = https://github.com/llvm-mirror/compiler-rt.git
-	branch = release_80
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc
 	url = https://github.com/CraneStation/wasi-libc

--- a/Makefile
+++ b/Makefile
@@ -619,7 +619,6 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
 	@mkdir -p build/release/tinygo/bin
 	@mkdir -p build/release/tinygo/lib/clang/include
 	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
-	@mkdir -p build/release/tinygo/lib/compiler-rt/lib
 	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-headers/defaults
@@ -641,9 +640,6 @@ endif
 	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
 	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
 	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
-	@cp -rp lib/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt/lib
-	@cp -rp lib/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt
-	@cp -rp lib/compiler-rt/README.txt   build/release/tinygo/lib/compiler-rt
 	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
 	@cp -rp lib/musl/arch/aarch64        build/release/tinygo/lib/musl/arch
 	@cp -rp lib/musl/arch/arm            build/release/tinygo/lib/musl/arch
@@ -680,6 +676,8 @@ endif
 	@cp -rp lib/picolibc/newlib/libm/common      build/release/tinygo/lib/picolibc/newlib/libm
 	@cp -rp lib/picolibc-stdio.c         build/release/tinygo/lib
 	@cp -rp lib/wasi-libc/sysroot        build/release/tinygo/lib/wasi-libc/sysroot
+	@cp -rp llvm-project/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
+	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
 	@cp -rp src                          build/release/tinygo/src
 	@cp -rp targets                      build/release/tinygo/targets
 	./build/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/compiler-rt     compiler-rt

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -1,7 +1,11 @@
 package builder
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/tinygo-org/tinygo/goenv"
 )
 
 // These are the GENERIC_SOURCES according to CMakeList.txt.
@@ -72,6 +76,7 @@ var genericBuiltins = []string{
 	"floatunsisf.c",
 	"floatuntidf.c",
 	"floatuntisf.c",
+	"fp_mode.c",
 	//"int_util.c",
 	"lshrdi3.c",
 	"lshrti3.c",
@@ -161,7 +166,15 @@ var CompilerRT = Library{
 	cflags: func(target, headerPath string) []string {
 		return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"}
 	},
-	sourceDir: "lib/compiler-rt/lib/builtins",
+	sourceDir: func() string {
+		llvmDir := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project/compiler-rt/lib/builtins")
+		if _, err := os.Stat(llvmDir); err == nil {
+			// Release build.
+			return llvmDir
+		}
+		// Development build.
+		return filepath.Join(goenv.Get("TINYGOROOT"), "lib/compiler-rt-builtins")
+	},
 	librarySources: func(target string) []string {
 		builtins := append([]string{}, genericBuiltins...) // copy genericBuiltins
 		if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -26,6 +26,7 @@ var MinGW = Library{
 		_, err = io.Copy(outf, inf)
 		return err
 	},
+	sourceDir: func() string { return "" }, // unused
 	cflags: func(target, headerPath string) []string {
 		// No flags necessary because there are no files to compile.
 		return nil

--- a/builder/musl.go
+++ b/builder/musl.go
@@ -104,7 +104,7 @@ var Musl = Library{
 			"-fno-stack-protector",
 		}
 	},
-	sourceDir: "lib/musl/src",
+	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/musl/src") },
 	librarySources: func(target string) []string {
 		arch := compileopts.MuslArchitecture(target)
 		globs := []string{

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -33,7 +33,7 @@ var Picolibc = Library{
 			"-I" + headerPath,
 		}
 	},
-	sourceDir: "lib/picolibc/newlib/libc",
+	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib/libc") },
 	librarySources: func(target string) []string {
 		return picolibcSources
 	},


### PR DESCRIPTION
This is important to stay up to date with developments in LLVM. The compiler-rt builtins don't change very often, but sometimes they do. And the latest LLVM versions have some fixes in them for AVR.