### PR TITLE
main (tinygo test): fail tests on build error

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 		return false, err
 	}
 
-	passed := true
+	passed := false
 	err = builder.Build(pkgName, outpath, config, func(result builder.BuildResult) error {
 		if testCompileOnly || outpath != "" {
 			// Write test binary to the specified file name.
@@ -198,6 +198,7 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 		}
 		if testCompileOnly {
 			// Do not run the test.
+			passed = true
 			return nil
 		}
 


### PR DESCRIPTION
This fixes a bug where build errors (e.g. linker errors) would be ignored by tinygo test.

This addresses #2466 

This is a bug in #1925 which became exposed by #2412 