### PR TITLE
main (test): add tests to `tinygo test`

### DIFF
--- a/tests/testing/builderr/builderr.go
+++ b/tests/testing/builderr/builderr.go
@@ -1,0 +1,10 @@
+package builderr
+
+import _ "unsafe"
+
+//go:linkname x notARealFunction
+func x()
+
+func Thing() {
+	x()
+}

--- a/tests/testing/builderr/builderr_test.go
+++ b/tests/testing/builderr/builderr_test.go
@@ -1,0 +1,11 @@
+package builderr_test
+
+import (
+	"testing"
+
+	"github.com/tinygo-org/tinygo/tests/testing/builderr"
+)
+
+func TestThing(t *testing.T) {
+	builderr.Thing()
+}

--- a/tests/testing/fail/fail_test.go
+++ b/tests/testing/fail/fail_test.go
@@ -1,0 +1,7 @@
+package fail_test
+
+import "testing"
+
+func TestFail(t *testing.T) {
+	t.Error("fail")
+}

--- a/tests/testing/nothing/nothing.go
+++ b/tests/testing/nothing/nothing.go
@@ -1,0 +1,3 @@
+package nothing
+
+// This package has no tests.

--- a/tests/testing/pass/pass_test.go
+++ b/tests/testing/pass/pass_test.go
@@ -1,0 +1,7 @@
+package pass_test
+
+import "testing"
+
+func TestPass(t *testing.T) {
+	// This test passes.
+}


### PR DESCRIPTION
This adds some tests of `tinygo test`, to ensure that we handle failures and emulators consistently.