### PR TITLE
arm: Explicitly disable unwind tables

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -149,7 +149,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 		}
 	}
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
-		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft")
+		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft", "-fno-unwind-tables")
 	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -265,6 +265,7 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
+		spec.CFlags = append(spec.CFlags, "-fno-unwind-tables")
 		switch strings.Split(triple, "-")[0] {
 		case "armv5":
 			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"


### PR DESCRIPTION
Some clang builds (e.g., Fedora's) enable unwind tables by default. As tinygo does not need nor support them, that leads to undefined symbols when linking.

Fixes #2477