### PR TITLE
board: add M5Stamp C3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,6 +490,8 @@ ifneq ($(XTENSA), 0)
 endif
 	$(TINYGO) build -size short -o test.bin -target=esp32c3           	examples/serial
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=m5stamp-c3          examples/serial
+	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.hex -target=hifive1b            examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=hifive1-qemu        examples/serial

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 78 microcontroller boards are currently supported:
+The following 79 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -88,6 +88,7 @@ The following 78 microcontroller boards are currently supported:
 * [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
 * [M5Stack](https://docs.m5stack.com/en/core/basic)
 * [M5Stack Core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit)
+* [M5Stamp C3](https://docs.m5stack.com/en/core/stamp_c3)
 * [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
 * [Makerdiary nRF52840-MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)
 * [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/productdetails/atsame54-xpro)

--- a/src/machine/board_m5stamp_c3.go
+++ b/src/machine/board_m5stamp_c3.go
@@ -1,0 +1,49 @@
+//go:build m5stamp_c3
+// +build m5stamp_c3
+
+package machine
+
+const (
+	IO0  Pin = 0
+	IO1  Pin = 1
+	IO2  Pin = 2
+	IO3  Pin = 3
+	IO4  Pin = 4
+	IO5  Pin = 5
+	IO6  Pin = 6
+	IO7  Pin = 7
+	IO8  Pin = 8
+	IO9  Pin = 9
+	IO10 Pin = 10
+	IO11 Pin = 11
+	IO12 Pin = 12
+	IO13 Pin = 13
+	IO14 Pin = 14
+	IO15 Pin = 15
+	IO16 Pin = 16
+	IO17 Pin = 17
+	IO18 Pin = 18
+	IO19 Pin = 19
+	IO20 Pin = 20
+	IO21 Pin = 21
+
+	XTAL_32K_P = IO0
+	XTAL_32K_N = IO1
+	MTMS       = IO4
+	MTDI       = IO5
+	MTCK       = IO6
+	MTDO       = IO7
+	VDD_SPI    = IO11
+	SPIHD      = IO12
+	SPISP      = IO13
+	SPICS0     = IO14
+	SPICLK     = IO15
+	SPID       = IO16
+	SPIQ       = IO17
+	U0RXD      = IO20
+	U0TXD      = IO21
+)
+
+const (
+	WS2812 = IO2
+)

--- a/targets/m5stamp-c3.json
+++ b/targets/m5stamp-c3.json
@@ -1,0 +1,6 @@
+{
+	"inherits": ["esp32c3"],
+	"build-tags": ["m5stamp_c3"],
+	"serial-port": ["acm:1a86:55d4"]
+}
+


### PR DESCRIPTION
This PR adds `M5Stamp C3` support.
Since there is no board definition for the ESP32C3 chip at the moment, I added M5StampC3.

* Board
    * Name
        * M5Stamp C3
    * Board developer / designer / manufacturer
        * M5Stack
    * schematic
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/static/assets/img/product_pics/core/stamp_c3/stamp_c3_sch_01.webp
    * pinout and stuff
        * https://docs.m5stack.com/en/core/stamp_c3
    * URL
        * https://docs.m5stack.com/en/core/stamp_c3
    * User manual for the board (if it exists)
        * (none)
* Chip
    * chip name
        * ESPRESSIF ESP32-C3 RISC-V MCU
    * Clock / ROM / RAM size
        * 384KB ROM, 400KB SRAM, 8KB RTC SRAM, 4MB FLASH
    * datasheet URL of the chip
        * https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/esp32-c3_datasheet_en.pdf
* URL of the source, such as arduino (if it exists)
    * ???

There are no LEDs on the board.

At this time, only the following examples will work.

* examples/serial
* tinygo.org/x/drivers/examples/ws2812
    * Since M5StampC3 does not have LEDs, we need to rewrite machine.