### PR TITLE
builder: update configuration to support Arch Linux LLVM 13 installation

### DIFF
--- a/builder/env.go
+++ b/builder/env.go
@@ -84,6 +84,20 @@ func getClangHeaderPath(TINYGOROOT string) string {
 		}
 	}
 
+	// On Arch Linux, the clang executable is stored in /usr/bin rather than being symlinked from there.
+	// Search directly in /usr/lib for clang.
+	if matches, err := filepath.Glob("/usr/lib/clang/" + llvmMajor + ".*.*"); err == nil {
+		// Check for the highest version first.
+		sort.Strings(matches)
+		for i := len(matches) - 1; i >= 0; i-- {
+			path := filepath.Join(matches[i], "include")
+			_, err := os.Stat(filepath.Join(path, "stdint.h"))
+			if err == nil {
+				return path
+			}
+		}
+	}
+
 	// Could not find it.
 	return ""
 }

--- a/builder/musl.go
+++ b/builder/musl.go
@@ -101,6 +101,7 @@ var Musl = Library{
 			"-I" + muslDir + "/src/internal",
 			"-I" + headerPath,
 			"-I" + muslDir + "/include",
+			"-fno-stack-protector",
 		}
 	},
 	sourceDir: "lib/musl/src",


### PR DESCRIPTION
This PR makes two changes which make TinyGo work with the default installed LLVM/clang on Arch:
1. Adds `-fno-stack-protector` to musl - it is on by default on Arch, which causes TLS to be used before initialization
2. Updates the clang headers search path to handle the differences in installation paths