### PR TITLE
rp2040: implement PWMGroup func to get peripheral from pin

### DIFF
--- a/src/machine/machine_rp2040_pwm.go
+++ b/src/machine/machine_rp2040_pwm.go
@@ -94,6 +94,16 @@ func (pwm *pwmGroup) Channel(pin Pin) (channel uint8, err error) {
 	return pwmGPIOToChannel(pin), nil
 }
 
+// PWMGroup returns the RP2040 PWM Group for the given pin. If pin does
+// not belong to PWM peripheral ErrInvalidOutputPin error is returned.
+func PWMGroup(pin Pin) (pwm *pwmGroup, err error) {
+	sliceNum, err := PWMPeripheral(pin)
+	if err != nil {
+		return nil, err
+	}
+	return getPWMGroup(uintptr(sliceNum)), nil
+}
+
 // Peripheral returns the RP2040 PWM peripheral which ranges from 0 to 7. Each
 // PWM peripheral has 2 channels, A and B which correspond to 0 and 1 in the program.
 // This number corresponds to the package's PWM0 throughout PWM7 handles


### PR DESCRIPTION
This PR implements a PWMGroup function which allows for easier fetching of the pwm group via the pin.

Related to this issue: https://github.com/tinygo-org/tinygo/issues/2304

If you're happy with this solution, let me know and I'll also raise a PR to update the documentation.