### PR TITLE
testing: implement Cleanup(), with tests

### DIFF
--- a/src/testing/sub_test.go
+++ b/src/testing/sub_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing
+
+import (
+	"reflect"
+)
+
+func TestCleanup(t *T) {
+	var cleanups []int
+	t.Run("test", func(t *T) {
+		t.Cleanup(func() { cleanups = append(cleanups, 1) })
+		t.Cleanup(func() { cleanups = append(cleanups, 2) })
+	})
+	if got, want := cleanups, []int{2, 1}; !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected cleanup record; got %v want %v", got, want)
+	}
+}
+
+func TestRunCleanup(t *T) {
+	outerCleanup := 0
+	innerCleanup := 0
+	t.Run("test", func(t *T) {
+		t.Cleanup(func() { outerCleanup++ })
+		t.Run("x", func(t *T) {
+			t.Cleanup(func() { innerCleanup++ })
+		})
+	})
+	if innerCleanup != 1 {
+		t.Errorf("unexpected inner cleanup count; got %d want 1", innerCleanup)
+	}
+	if outerCleanup != 1 {
+		t.Errorf("unexpected outer cleanup count; got %d want 0", outerCleanup)
+	}
+}
+
+func TestCleanupParallelSubtests(t *T) {
+	ranCleanup := 0
+	t.Run("test", func(t *T) {
+		t.Cleanup(func() { ranCleanup++ })
+		t.Run("x", func(t *T) {
+			t.Parallel()
+			if ranCleanup > 0 {
+				t.Error("outer cleanup ran before parallel subtest")
+			}
+		})
+	})
+	if ranCleanup != 1 {
+		t.Errorf("unexpected cleanup count; got %d want 1", ranCleanup)
+	}
+}
+
+func TestNestedCleanup(t *T) {
+	ranCleanup := 0
+	t.Run("test", func(t *T) {
+		t.Cleanup(func() {
+			if ranCleanup != 2 {
+				t.Errorf("unexpected cleanup count in first cleanup: got %d want 2", ranCleanup)
+			}
+			ranCleanup++
+		})
+		t.Cleanup(func() {
+			if ranCleanup != 0 {
+				t.Errorf("unexpected cleanup count in second cleanup: got %d want 0", ranCleanup)
+			}
+			ranCleanup++
+			t.Cleanup(func() {
+				if ranCleanup != 1 {
+					t.Errorf("unexpected cleanup count in nested cleanup: got %d want 1", ranCleanup)
+				}
+				ranCleanup++
+			})
+		})
+	})
+	if ranCleanup != 3 {
+		t.Errorf("unexpected cleanup count: got %d want 3", ranCleanup)
+	}
+}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -43,6 +44,7 @@ func Init() {
 // captures common methods such as Errorf.
 type common struct {
 	output bytes.Buffer
+	w      io.Writer // either &output, or at top level, os.Stdout
 	indent string
 
 	failed   bool   // Test or benchmark has failed.
@@ -50,6 +52,7 @@ type common struct {
 	finished bool   // Test function has completed.
 	level    int    // Nesting depth of test or benchmark.
 	name     string // Name of test or benchmark.
+	parent   *common
 }
 
 // TB is the interface common to T and B.
@@ -205,7 +208,30 @@ func (c *common) Parallel() {
 	// Unimplemented.
 }
 
-// Run runs a subtest of f t called name. It waits until the subtest is finished
+func tRunner(t *T, fn func(t *T)) {
+	// Run the test.
+	if flagVerbose {
+		fmt.Fprintf(t.w, "=== RUN   %s\n", t.name)
+	}
+
+	fn(t)
+
+	// Process the result (pass or fail).
+	if t.failed {
+		if t.parent != nil {
+			t.parent.failed = true
+		}
+		fmt.Fprintf(t.w, t.indent+"--- FAIL: %s\n", t.name)
+		t.w.Write(t.output.Bytes())
+	} else {
+		if flagVerbose {
+			fmt.Fprintf(t.w, t.indent+"--- PASS: %s\n", t.name)
+			t.w.Write(t.output.Bytes())
+		}
+	}
+}
+
+// Run runs f as a subtest of t called name. It waits until the subtest is finished
 // and returns whether the subtest succeeded.
 func (t *T) Run(name string, f func(t *T)) bool {
 	// Create a subtest.
@@ -213,27 +239,12 @@ func (t *T) Run(name string, f func(t *T)) bool {
 		common: common{
 			name:   t.name + "/" + rewrite(name),
 			indent: t.indent + "    ",
+			w:      &t.output,
+			parent: &t.common,
 		},
 	}
 
-	// Run the test.
-	if flagVerbose {
-		fmt.Fprintf(&t.output, "=== RUN   %s\n", sub.name)
-
-	}
-	f(&sub)
-
-	// Process the result (pass or fail).
-	if sub.failed {
-		t.failed = true
-		fmt.Fprintf(&t.output, sub.indent+"--- FAIL: %s\n", sub.name)
-		t.output.Write(sub.output.Bytes())
-	} else {
-		if flagVerbose {
-			fmt.Fprintf(&t.output, sub.indent+"--- PASS: %s\n", sub.name)
-			t.output.Write(sub.output.Bytes())
-		}
-	}
+	tRunner(&sub, f)
 	return !sub.failed
 }
 
@@ -313,23 +324,11 @@ func (m *M) Run() int {
 		t := &T{
 			common: common{
 				name: test.Name,
+				w:    os.Stdout,
 			},
 		}
 
-		if flagVerbose {
-			fmt.Printf("=== RUN   %s\n", test.Name)
-		}
-		test.F(t)
-
-		if t.failed {
-			fmt.Printf("--- FAIL: %s\n", test.Name)
-			os.Stdout.Write(t.output.Bytes())
-		} else {
-			if flagVerbose {
-				fmt.Printf("--- PASS: %s\n", test.Name)
-				os.Stdout.Write(t.output.Bytes())
-			}
-		}
+		tRunner(t, test.F)
 
 		if t.failed {
 			failures++


### PR DESCRIPTION
t.Cleanup() will be needed when we implement t.TempDir().

Land it now with tests to reduce the size of the future pull request for t.TempDir().

Also update testdata/testing.go to run properly with go 1.16 (it crashed without this).
This was useful while I was debugging the tRunner() change.