### PR TITLE
os: implement file.Seek, add smoke test

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -176,9 +176,17 @@ func (f *File) Readdirnames(n int) (names []string, err error) {
 	return nil, &PathError{"readdirnames", f.name, ErrNotImplemented}
 }
 
-// Seek is a stub, not yet implemented
+// Seek sets the offset for the next Read or Write on file to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1 means
+// relative to the current offset, and 2 means relative to the end.
+// It returns the new offset and an error, if any.
+// The behavior of Seek on a file opened with O_APPEND is not specified.
+//
+// If f is a directory, the behavior of Seek varies by operating
+// system; you can seek to the beginning of the directory on Unix-like
+// operating systems, but not on Windows.
 func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
-	return 0, &PathError{"seek", f.name, ErrNotImplemented}
+	return f.handle.Seek(offset, whence)
 }
 
 // Stat is a stub, not yet implemented

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -50,6 +50,11 @@ func (f stdioFileHandle) Close() error {
 	return ErrUnsupported
 }
 
+// Seek wraps syscall.Seek.
+func (f stdioFileHandle) Seek(offset int64, whence int) (int64, error) {
+	return -1, ErrUnsupported
+}
+
 //go:linkname putchar runtime.putchar
 func putchar(c byte)
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -55,3 +55,9 @@ func (f unixFileHandle) ReadAt(b []byte, offset int64) (n int, err error) {
 	}
 	return
 }
+
+// Seek wraps syscall.Seek.
+func (f unixFileHandle) Seek(offset int64, whence int) (int64, error) {
+	newoffset, err := syscall.Seek(syscallFd(f), offset, whence)
+	return newoffset, handleSyscallError(err)
+}

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -57,6 +57,12 @@ func (f unixFileHandle) ReadAt(b []byte, offset int64) (n int, err error) {
 	return -1, ErrNotImplemented
 }
 
+// Seek wraps syscall.Seek.
+func (f unixFileHandle) Seek(offset int64, whence int) (int64, error) {
+	newoffset, err := syscall.Seek(syscallFd(f), offset, whence)
+	return newoffset, handleSyscallError(err)
+}
+
 // isWindowsNulName reports whether name is os.DevNull ('NUL') on Windows.
 // True is returned if name is 'NUL' whatever the case.
 func isWindowsNulName(name string) bool {

--- a/src/os/filesystem.go
+++ b/src/os/filesystem.go
@@ -49,6 +49,9 @@ type FileHandle interface {
 	// ReadAt reads up to len(b) bytes from the file starting at the given absolute offset
 	ReadAt(b []byte, offset int64) (n int, err error)
 
+	// Seek resets the file pointer relative to start, current position, or end
+	Seek(offset int64, whence int) (newoffset int64, err error)
+
 	// Write writes up to len(b) bytes to the file.
 	Write(b []byte) (n int, err error)
 

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -46,8 +46,12 @@ func Pread(fd int, p []byte, offset int64) (n int, err error) {
 	return
 }
 
-func Seek(fd int, offset int64, whence int) (off int64, err error) {
-	return 0, ENOSYS // TODO
+func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
+	newoffset = libc_lseek(int32(fd), offset, whence)
+	if newoffset < 0 {
+		err = getErrno()
+	}
+	return
 }
 
 func Open(path string, flag int, mode uint32) (fd int, err error) {
@@ -237,6 +241,10 @@ func libc_read(fd int32, buf *byte, count uint) int
 // ssize_t pread(int fd, void *buf, size_t count, off_t offset);
 //export pread
 func libc_pread(fd int32, buf *byte, count uint, offset int64) int
+
+// ssize_t lseek(int fd, off_t offset, int whence);
+//export lseek
+func libc_lseek(fd int32, offset int64, whence int) int64
 
 // int open(const char *pathname, int flags, mode_t mode);
 //export open


### PR DESCRIPTION
For some reason I couldn't reopen #2476, so here's the FileHandle-friendly implementation of file.Seek again, rebased to dev.