### PR TITLE
interp: always run atomic and volatile loads/stores at runtime

### DIFF
--- a/interp/testdata/revert.ll
+++ b/interp/testdata/revert.ll
@@ -7,6 +7,9 @@ declare void @externalCall(i64)
 @bar.knownAtRuntime = global i64 0
 @baz.someGlobal = external global [3 x {i64, i32}]
 @baz.someInt = global i32 0
+@x.atomicNum = global i32 0
+@x.volatileNum = global i32 0
+@y.ready = global i32 0
 
 define void @runtime.initAll() unnamed_addr {
 entry:
@@ -14,6 +17,8 @@ entry:
   call void @foo.init(i8* undef, i8* undef)
   call void @bar.init(i8* undef, i8* undef)
   call void @main.init(i8* undef, i8* undef)
+  call void @x.init(i8* undef, i8* undef)
+  call void @y.init(i8* undef, i8* undef)
   ret void
 }
 
@@ -39,5 +44,31 @@ define internal void @baz.init(i8* %context, i8* %parentHandle) unnamed_addr {
 define internal void @main.init(i8* %context, i8* %parentHandle) unnamed_addr {
 entry:
   call void @externalCall(i64 3)
+  ret void
+}
+
+
+define internal void @x.init(i8* %context, i8* %parentHandle) unnamed_addr {
+  ; Test atomic and volatile memory accesses.
+  store atomic i32 1, i32* @x.atomicNum seq_cst, align 4
+  %x = load atomic i32, i32* @x.atomicNum seq_cst, align 4
+  store i32 %x, i32* @x.atomicNum
+  %y = load volatile i32, i32* @x.volatileNum
+  store volatile i32 %y, i32* @x.volatileNum
+  ret void
+}
+
+define internal void @y.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  br label %loop
+
+loop:
+  ; Test a wait-loop.
+  ; This function must be reverted.
+  %val = load atomic i32, i32* @y.ready seq_cst, align 4
+  %ready = icmp eq i32 %val, 1
+  br i1 %ready, label %end, label %loop
+
+end:
   ret void
 }

--- a/interp/testdata/revert.out.ll
+++ b/interp/testdata/revert.out.ll
@@ -5,6 +5,9 @@ target triple = "x86_64--linux"
 @bar.knownAtRuntime = local_unnamed_addr global i64 0
 @baz.someGlobal = external local_unnamed_addr global [3 x { i64, i32 }]
 @baz.someInt = local_unnamed_addr global i32 0
+@x.atomicNum = local_unnamed_addr global i32 0
+@x.volatileNum = global i32 0
+@y.ready = local_unnamed_addr global i32 0
 
 declare void @externalCall(i64) local_unnamed_addr
 
@@ -15,6 +18,12 @@ entry:
   %val = load i64, i64* @foo.knownAtRuntime, align 8
   store i64 %val, i64* @bar.knownAtRuntime, align 8
   call void @externalCall(i64 3)
+  store atomic i32 1, i32* @x.atomicNum seq_cst, align 4
+  %x = load atomic i32, i32* @x.atomicNum seq_cst, align 4
+  store i32 %x, i32* @x.atomicNum, align 4
+  %y = load volatile i32, i32* @x.volatileNum, align 4
+  store volatile i32 %y, i32* @x.volatileNum, align 4
+  call fastcc void @y.init(i8* undef, i8* undef)
   ret void
 }
 
@@ -25,4 +34,17 @@ define internal fastcc void @foo.init(i8* %context, i8* %parentHandle) unnamed_a
 
 define internal fastcc void @baz.init(i8* %context, i8* %parentHandle) unnamed_addr {
   unreachable
+}
+
+define internal fastcc void @y.init(i8* %context, i8* %parentHandle) unnamed_addr {
+entry:
+  br label %loop
+
+loop:                                             ; preds = %loop, %entry
+  %val = load atomic i32, i32* @y.ready seq_cst, align 4
+  %ready = icmp eq i32 %val, 1
+  br i1 %ready, label %end, label %loop
+
+end:                                              ; preds = %loop
+  ret void
 }


### PR DESCRIPTION
This addresses part of the issue in #2409 (but does not completely solve it).