### PR TITLE
testing: benchmark: add -benchtime, spiff up -bench

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -514,7 +514,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/pass", out, out, &opts, false, false, false, "", "", "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/pass", out, out, &opts, false, false, false, "", "", "", "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -535,7 +535,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/fail", out, out, &opts, false, false, false, "", "", "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/fail", out, out, &opts, false, false, false, "", "", "", "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -562,7 +562,7 @@ func TestTest(t *testing.T) {
 
 				var output bytes.Buffer
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/nothing", io.MultiWriter(&output, out), out, &opts, false, false, false, "", "", "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/nothing", io.MultiWriter(&output, out), out, &opts, false, false, false, "", "", "", "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -586,7 +586,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/builderr", out, out, &opts, false, false, false, "", "", "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/builderr", out, out, &opts, false, false, false, "", "", "", "")
 				if err == nil {
 					t.Error("test did not error")
 				}

--- a/src/testing/match.go
+++ b/src/testing/match.go
@@ -5,8 +5,130 @@
 package testing
 
 import (
+	"fmt"
+	"os"
 	"strconv"
+	"strings"
+	"sync"
 )
+
+// matcher sanitizes, uniques, and filters names of subtests and subbenchmarks.
+type matcher struct {
+	filter    []string
+	matchFunc func(pat, str string) (bool, error)
+
+	mu       sync.Mutex
+	subNames map[string]int64
+}
+
+// TODO: fix test_main to avoid race and improve caching, also allowing to
+// eliminate this Mutex.
+var matchMutex sync.Mutex
+
+func newMatcher(matchString func(pat, str string) (bool, error), patterns, name string) *matcher {
+	var filter []string
+	if patterns != "" {
+		filter = splitRegexp(patterns)
+		for i, s := range filter {
+			filter[i] = rewrite(s)
+		}
+		// Verify filters before doing any processing.
+		for i, s := range filter {
+			if _, err := matchString(s, "non-empty"); err != nil {
+				fmt.Fprintf(os.Stderr, "testing: invalid regexp for element %d of %s (%q): %s\n", i, name, s, err)
+				os.Exit(1)
+			}
+		}
+	}
+	return &matcher{
+		filter:    filter,
+		matchFunc: matchString,
+		subNames:  map[string]int64{},
+	}
+}
+
+func (m *matcher) fullName(c *common, subname string) (name string, ok, partial bool) {
+	name = subname
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if c != nil && c.level > 0 {
+		name = m.unique(c.name, rewrite(subname))
+	}
+
+	matchMutex.Lock()
+	defer matchMutex.Unlock()
+
+	// We check the full array of paths each time to allow for the case that
+	// a pattern contains a '/'.
+	elem := strings.Split(name, "/")
+	for i, s := range elem {
+		if i >= len(m.filter) {
+			break
+		}
+		if ok, _ := m.matchFunc(m.filter[i], s); !ok {
+			return name, false, false
+		}
+	}
+	return name, true, len(elem) < len(m.filter)
+}
+
+func splitRegexp(s string) []string {
+	a := make([]string, 0, strings.Count(s, "/"))
+	cs := 0
+	cp := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '[':
+			cs++
+		case ']':
+			if cs--; cs < 0 { // An unmatched ']' is legal.
+				cs = 0
+			}
+		case '(':
+			if cs == 0 {
+				cp++
+			}
+		case ')':
+			if cs == 0 {
+				cp--
+			}
+		case '\\':
+			i++
+		case '/':
+			if cs == 0 && cp == 0 {
+				a = append(a, s[:i])
+				s = s[i+1:]
+				i = 0
+				continue
+			}
+		}
+		i++
+	}
+	return append(a, s)
+}
+
+// unique creates a unique name for the given parent and subname by affixing it
+// with one or more counts, if necessary.
+func (m *matcher) unique(parent, subname string) string {
+	name := fmt.Sprintf("%s/%s", parent, subname)
+	empty := subname == ""
+	for {
+		next, exists := m.subNames[name]
+		if !empty && !exists {
+			m.subNames[name] = 1 // next count is 1
+			return name
+		}
+		// Name was already used. We increment with the count and append a
+		// string with the count.
+		m.subNames[name] = next + 1
+
+		// Add a count to guarantee uniqueness.
+		name = fmt.Sprintf("%s#%02d", name, next)
+		empty = false
+	}
+}
 
 // rewrite rewrites a subname to having only printable characters and no white
 // space.

--- a/src/testing/match_test.go
+++ b/src/testing/match_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing
+
+import (
+	"reflect"
+	"regexp"
+	"unicode"
+)
+
+// Verify that our IsSpace agrees with unicode.IsSpace.
+func TestIsSpace(t *T) {
+	n := 0
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if isSpace(r) != unicode.IsSpace(r) {
+			t.Errorf("IsSpace(%U)=%t incorrect", r, isSpace(r))
+			n++
+			if n > 10 {
+				return
+			}
+		}
+	}
+}
+
+func TestSplitRegexp(t *T) {
+	res := func(s ...string) []string { return s }
+	testCases := []struct {
+		pattern string
+		result  []string
+	}{
+		// Correct patterns
+		// If a regexp pattern is correct, all split regexps need to be correct
+		// as well.
+		{"", res("")},
+		{"/", res("", "")},
+		{"//", res("", "", "")},
+		{"A", res("A")},
+		{"A/B", res("A", "B")},
+		{"A/B/", res("A", "B", "")},
+		{"/A/B/", res("", "A", "B", "")},
+		{"[A]/(B)", res("[A]", "(B)")},
+		{"[/]/[/]", res("[/]", "[/]")},
+		{"[/]/[:/]", res("[/]", "[:/]")},
+		{"/]", res("", "]")},
+		{"]/", res("]", "")},
+		{"]/[/]", res("]", "[/]")},
+		{`([)/][(])`, res(`([)/][(])`)},
+		{"[(]/[)]", res("[(]", "[)]")},
+
+		// Faulty patterns
+		// Errors in original should produce at least one faulty regexp in results.
+		{")/", res(")/")},
+		{")/(/)", res(")/(", ")")},
+		{"a[/)b", res("a[/)b")},
+		{"(/]", res("(/]")},
+		{"(/", res("(/")},
+		{"[/]/[/", res("[/]", "[/")},
+		{`\p{/}`, res(`\p{`, "}")},
+		{`\p/`, res(`\p`, "")},
+		{`[[:/:]]`, res(`[[:/:]]`)},
+	}
+	for _, tc := range testCases {
+		a := splitRegexp(tc.pattern)
+		if !reflect.DeepEqual(a, tc.result) {
+			t.Errorf("splitRegexp(%q) = %#v; want %#v", tc.pattern, a, tc.result)
+		}
+
+		// If there is any error in the pattern, one of the returned subpatterns
+		// needs to have an error as well.
+		if _, err := regexp.Compile(tc.pattern); err != nil {
+			ok := true
+			for _, re := range a {
+				if _, err := regexp.Compile(re); err != nil {
+					ok = false
+				}
+			}
+			if ok {
+				t.Errorf("%s: expected error in any of %q", tc.pattern, a)
+			}
+		}
+	}
+}
+
+func TestMatcher(t *T) {
+	testCases := []struct {
+		pattern     string
+		parent, sub string
+		ok          bool
+		partial     bool
+	}{
+		// Behavior without subtests.
+		{"", "", "TestFoo", true, false},
+		{"TestFoo", "", "TestFoo", true, false},
+		{"TestFoo/", "", "TestFoo", true, true},
+		{"TestFoo/bar/baz", "", "TestFoo", true, true},
+		{"TestFoo", "", "TestBar", false, false},
+		{"TestFoo/", "", "TestBar", false, false},
+		{"TestFoo/bar/baz", "", "TestBar/bar/baz", false, false},
+
+		// with subtests
+		{"", "TestFoo", "x", true, false},
+		{"TestFoo", "TestFoo", "x", true, false},
+		{"TestFoo/", "TestFoo", "x", true, false},
+		{"TestFoo/bar/baz", "TestFoo", "bar", true, true},
+		// Subtest with a '/' in its name still allows for copy and pasted names
+		// to match.
+		{"TestFoo/bar/baz", "TestFoo", "bar/baz", true, false},
+		{"TestFoo/bar/baz", "TestFoo/bar", "baz", true, false},
+		{"TestFoo/bar/baz", "TestFoo", "x", false, false},
+		{"TestFoo", "TestBar", "x", false, false},
+		{"TestFoo/", "TestBar", "x", false, false},
+		{"TestFoo/bar/baz", "TestBar", "x/bar/baz", false, false},
+
+		// subtests only
+		{"", "TestFoo", "x", true, false},
+		{"/", "TestFoo", "x", true, false},
+		{"./", "TestFoo", "x", true, false},
+		{"./.", "TestFoo", "x", true, false},
+		{"/bar/baz", "TestFoo", "bar", true, true},
+		{"/bar/baz", "TestFoo", "bar/baz", true, false},
+		{"//baz", "TestFoo", "bar/baz", true, false},
+		{"//", "TestFoo", "bar/baz", true, false},
+		{"/bar/baz", "TestFoo/bar", "baz", true, false},
+		{"//foo", "TestFoo", "bar/baz", false, false},
+		{"/bar/baz", "TestFoo", "x", false, false},
+		{"/bar/baz", "TestBar", "x/bar/baz", false, false},
+	}
+
+	for _, tc := range testCases {
+		m := newMatcher(regexp.MatchString, tc.pattern, "-test.run")
+
+		parent := &common{name: tc.parent}
+		if tc.parent != "" {
+			parent.level = 1
+		}
+		if n, ok, partial := m.fullName(parent, tc.sub); ok != tc.ok || partial != tc.partial {
+			t.Errorf("for pattern %q, fullName(parent=%q, sub=%q) = %q, ok %v partial %v; want ok %v partial %v",
+				tc.pattern, tc.parent, tc.sub, n, ok, partial, tc.ok, tc.partial)
+		}
+	}
+}
+
+func TestNaming(t *T) {
+	m := newMatcher(regexp.MatchString, "", "")
+
+	parent := &common{name: "x", level: 1} // top-level test.
+
+	// Rig the matcher with some preloaded values.
+	m.subNames["x/b"] = 1000
+
+	testCases := []struct {
+		name, want string
+	}{
+		// Uniqueness
+		{"", "x/#00"},
+		{"", "x/#01"},
+
+		{"t", "x/t"},
+		{"t", "x/t#01"},
+		{"t", "x/t#02"},
+
+		{"a#01", "x/a#01"}, // user has subtest with this name.
+		{"a", "x/a"},       // doesn't conflict with this name.
+		{"a", "x/a#01#01"}, // conflict, add disambiguating string.
+		{"a", "x/a#02"},    // This string is claimed now, so resume
+		{"a", "x/a#03"},    // with counting.
+		{"a#02", "x/a#02#01"},
+
+		{"b", "x/b#1000"}, // rigged, see above
+		{"b", "x/b#1001"},
+
+		// // Sanitizing
+		{"A:1 B:2", "x/A:1_B:2"},
+		{"s\t\r\u00a0", "x/s___"},
+		{"\x01", `x/\x01`},
+		{"\U0010ffff", `x/\U0010ffff`},
+	}
+
+	for i, tc := range testCases {
+		if got, _, _ := m.fullName(parent, tc.name); got != tc.want {
+			t.Errorf("%d:%s: got %q; want %q", i, tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
I needed to run one particular subbenchmark, and I couldn't stand the thought of rewriting the benchmark, so I grabbed that feature from upstream and plopped it down into tinygo.  (See "Running specific tests or benchmarks" in https://go.dev/blog/subtests .)

I didn't need it for tests just yet, so I will leave adding that behavior to -run for a later pull request.

-benchtime came along for the ride, as it was in the same area, and is quite useful.

