### PR TITLE
testing: show duration

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -439,6 +440,11 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		actual = bytes.Replace(actual, []byte{0x1b, '[', '3', '2', 'm'}, nil, -1)
 		actual = bytes.Replace(actual, []byte{0x1b, '[', '0', 'm'}, nil, -1)
 		actual = bytes.Replace(actual, []byte{'.', '.', '\n'}, []byte{'\n'}, -1)
+	}
+	if name == "testing.go" {
+		// Strip actual time.
+		re := regexp.MustCompile(`\([0-9]\.[0-9][0-9]s\)`)
+		actual = re.ReplaceAllLiteral(actual, []byte{'(', '0', '.', '0', '0', 's', ')'})
 	}
 
 	// Check whether the command ran successfully.

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -1,0 +1,18 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testing_test
+
+import (
+	"os"
+	"testing"
+)
+
+// This is exactly what a test would do without a TestMain.
+// It's here only so that there is at least one package in the
+// standard library with a TestMain, so that code is executed.
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/testdata/testing.txt
+++ b/testdata/testing.txt
@@ -1,10 +1,10 @@
---- FAIL: TestBar
+--- FAIL: TestBar (0.00s)
     log Bar
     log g
         h
         i
         
-    --- FAIL: TestBar/Bar2
+    --- FAIL: TestBar/Bar2 (0.00s)
         log Bar2
             a
             b


### PR DESCRIPTION
Also rearrange a couple functions to make diffing with upstream a little easier; the two commits are best reviewed one at a time.

Doesn't include Cleanup() in the duration yet, but this is good enough for the moment.