### PR TITLE
main (test): skip AVR tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -133,8 +133,8 @@ func TestBuild(t *testing.T) {
 	t.Run("AVR", func(t *testing.T) {
 		// LLVM backend crash:
 		// LIBCLANG FATAL ERROR: Cannot select: t3: i16 = JumpTable<0>
-		// This bug is non-deterministic, and only happens when run concurrently with non-AVR tests.
-		// For this reason, we do not t.Parallel() here.
+		// This bug is non-deterministic.
+		t.Skip("skipped due to non-deterministic backend bugs")
 
 		var avrTests []string
 		for _, t := range tests {


### PR DESCRIPTION
The AVR tests fail inconsistently now due to non-deterministic backend bugs.
This disables them until this can be understood and fixed.