### PR TITLE
Makefile: Move slow tests to end of tinygo-test. .github: test-linux-build: run tinygo-test-wasi-fast

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,6 +108,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v2
         with:
@@ -128,6 +132,7 @@ jobs:
           sudo tar -C /usr/local -xf xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
           sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
           rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
+      - run: make tinygo-test-wasi-fast
       - run: make smoketest
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch

--- a/Makefile
+++ b/Makefile
@@ -196,15 +196,19 @@ tinygo:
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .
 
-TEST_PACKAGES_BASE = \
+# Tests that take over a minute in wasi
+TEST_PACKAGES_SLOW = \
 	compress/bzip2 \
 	compress/flate \
+	crypto/dsa \
+	index/suffixarray \
+
+TEST_PACKAGES_BASE = \
 	compress/zlib \
 	container/heap \
 	container/list \
 	container/ring \
 	crypto/des \
-	crypto/dsa \
 	crypto/elliptic/internal/fiat \
 	crypto/internal/subtle \
 	crypto/md5 \
@@ -224,7 +228,6 @@ TEST_PACKAGES_BASE = \
 	hash/crc64 \
 	hash/fnv \
 	html \
-	index/suffixarray \
 	internal/itoa \
 	internal/profile \
 	math \
@@ -254,12 +257,20 @@ TEST_PACKAGES_WASI = \
 # TODO: parallelize, and only show failing tests (no implied -v flag).
 .PHONY: tinygo-test
 tinygo-test:
+	$(TINYGO) test $(TEST_PACKAGES) $(TEST_PACKAGES_SLOW)
+tinygo-test-fast:
 	$(TINYGO) test $(TEST_PACKAGES)
 tinygo-bench:
+	$(TINYGO) test -bench . $(TEST_PACKAGES) $(TEST_PACKAGES_SLOW)
+tinygo-bench-fast:
 	$(TINYGO) test -bench . $(TEST_PACKAGES)
 tinygo-test-wasi:
+	$(TINYGO) test -target wasi $(TEST_PACKAGES_WASI) $(TEST_PACKAGES_SLOW)
+tinygo-test-wasi-fast:
 	$(TINYGO) test -target wasi $(TEST_PACKAGES_WASI)
 tinygo-bench-wasi:
+	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_WASI) $(TEST_PACKAGES_SLOW)
+tinygo-bench-wasi-fast:
 	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_WASI)
 
 .PHONY: smoketest


### PR DESCRIPTION
With the Makefile change, impatient developers now see test results quicker, and can skip the slowest tests if they like.

With the ci change, all but the slowest stdlib packages get tested on wasi.