### PR TITLE
ci (Windows/Mac): use binaryen from scoop/brew

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - name: Install QEMU
+      - name: Install Dependencies
         shell: bash
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu binaryen
       - name: Install Xtensa toolchain
         shell: bash
         run: |
@@ -71,19 +71,6 @@ jobs:
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
         run: make wasi-libc
-      - name: Cache Binaryen
-        uses: actions/cache@v2
-        id: cache-binaryen
-        with:
-          key: binaryen-macos-v1
-          path: build/wasm-opt
-      - name: Build Binaryen
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
-        run: |
-          # install dependencies
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
-          # build!
-          make binaryen
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-v -short"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,10 +15,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - name: Install Ninja
+      - uses: MinoruSekine/setup-scoop@v1
+      - name: Install Dependencies
         shell: bash
         run: |
-          choco install ninja
+          scoop install ninja binaryen
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -69,15 +70,6 @@ jobs:
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
         run: make wasi-libc
-      - name: Cache Binaryen
-        uses: actions/cache@v2
-        id: cache-binaryen
-        with:
-          key: binaryen-windows-v2
-          path: build/wasm-opt.exe
-      - name: Build Binaryen
-        if: steps.cache-binaryen.outputs.cache-hit != 'true'
-        run: make binaryen
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-v -short"


### PR DESCRIPTION
The scoop and brew package managers now bundle up-to-date copies of binaryen.
As a result, there is no longer a strong need for us to build and package our own copy.