### PR TITLE
testing: -run now allows filtering subtests

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -77,9 +77,6 @@ type InternalBenchmark struct {
 // affecting benchmark results.
 type B struct {
 	common
-	hasSub       bool          // TODO: should be in common, and atomic
-	start        time.Time     // TODO: should be in common
-	duration     time.Duration // TODO: should be in common
 	context      *benchContext
 	N            int
 	benchFunc    func(b *B)

--- a/src/testing/sub_test.go
+++ b/src/testing/sub_test.go
@@ -32,7 +32,7 @@ func TestRunCleanup(t *T) {
 		t.Errorf("unexpected inner cleanup count; got %d want 1", innerCleanup)
 	}
 	if outerCleanup != 1 {
-		t.Errorf("unexpected outer cleanup count; got %d want 0", outerCleanup)
+		t.Errorf("unexpected outer cleanup count; got %d want 1", outerCleanup) // wrong upstream!
 	}
 }
 

--- a/testdata/testing.txt
+++ b/testdata/testing.txt
@@ -12,5 +12,10 @@
         failed
         after failed
     log Bar end
+--- FAIL: TestAllLowercase (0.00s)
+    --- FAIL: TestAllLowercase/BETA (0.00s)
+        expected lowercase name, got BETA
+    --- FAIL: TestAllLowercase/DELTA (0.00s)
+        expected lowercase name, got DELTA
 FAIL
 exitcode: 1


### PR DESCRIPTION
-run now allows filtering subtests just like upstream (and -bench, which was fixed last week).

A few comments from upstream were preserved even though they refer to things that aren't
in tinygo yet, to make diffing slightly easier (or maybe out of laziness).