### PR TITLE
nrf: fix race in i2c

### DIFF
--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -1,3 +1,4 @@
+//go:build nrf
 // +build nrf
 
 package machine
@@ -284,7 +285,9 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error) {
 				// To trigger stop task when last byte is received, set before resume task.
 				i2c.Bus.SHORTS.Set(nrf.TWI_SHORTS_BB_STOP)
 			}
-			i2c.Bus.TASKS_RESUME.Set(1) // re-start transmission for reading
+			if i > 0 {
+				i2c.Bus.TASKS_RESUME.Set(1) // re-start transmission for reading
+			}
 			if r[i], err = i2c.readByte(); err != nil {
 				// goto/break are practically equivalent here,
 				// but goto makes this more easily understandable for maintenance.


### PR DESCRIPTION
Fixes: #2533 

There is a race in nRF implementation of I2C, this PR fixes it.
We want to trigger RESUME task only after we fully read the first byte.

SoftDevice has nothing to do with this per se, that's Bluetooth use that makes whole system bit slower and probability of the race condition rises.