### PR TITLE
runtime: add stubs for Func.FileLine and Frame.PC

### DIFF
--- a/src/runtime/stack.go
+++ b/src/runtime/stack.go
@@ -11,6 +11,10 @@ func (f *Func) Name() string {
 	return ""
 }
 
+func (f *Func) FileLine(pc uintptr) (file string, line int) {
+	return "", 0
+}
+
 func Caller(skip int) (pc uintptr, file string, line int, ok bool) {
 	return 0, "", 0, false
 }

--- a/src/runtime/symtab.go
+++ b/src/runtime/symtab.go
@@ -9,6 +9,7 @@ type Frame struct {
 
 	File string
 	Line int
+	PC   uintptr
 }
 
 func CallersFrames(callers []uintptr) *Frames {


### PR DESCRIPTION
With this, 'tinygo test' in github.com/pkg/errors at least compiles and passes a few tests:
```
    $ git clone github.com/pkg/errors
    $ cd errors
    $ tinygo test -c
    $ for a in $(go test -list Test | grep Test); do ./errors.test -test.run $a -test.v  > $a.log 2>&1; done
    $ grep -l PASS *.log | wc -l
      19
    $ grep -l FAIL *.log | wc -l
      11
```
For https://github.com/tinygo-org/tinygo/issues/2445