### PR TITLE
wasmtest: fix resource cleanup and add logging

### DIFF
--- a/tests/wasm/chan_test.go
+++ b/tests/wasm/chan_test.go
@@ -15,8 +15,7 @@ func TestChan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := chromectx()
-	defer cancel()
+	ctx := chromectx(t)
 
 	err = chromedp.Run(ctx,
 		chromedp.Navigate(server.URL+"/run?file=chan.wasm"),

--- a/tests/wasm/event_test.go
+++ b/tests/wasm/event_test.go
@@ -15,8 +15,7 @@ func TestEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := chromectx()
-	defer cancel()
+	ctx := chromectx(t)
 
 	var log1, log2 string
 	err = chromedp.Run(ctx,

--- a/tests/wasm/fmt_test.go
+++ b/tests/wasm/fmt_test.go
@@ -15,8 +15,7 @@ func TestFmt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := chromectx()
-	defer cancel()
+	ctx := chromectx(t)
 
 	var log1 string
 	err = chromedp.Run(ctx,

--- a/tests/wasm/fmtprint_test.go
+++ b/tests/wasm/fmtprint_test.go
@@ -15,8 +15,7 @@ func TestFmtprint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := chromectx()
-	defer cancel()
+	ctx := chromectx(t)
 
 	var log1 string
 	err = chromedp.Run(ctx,

--- a/tests/wasm/log_test.go
+++ b/tests/wasm/log_test.go
@@ -15,8 +15,7 @@ func TestLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := chromectx()
-	defer cancel()
+	ctx := chromectx(t)
 
 	var log1 string
 	err = chromedp.Run(ctx,


### PR DESCRIPTION
The chromedp context was not cancelled, so resources may have been leaking.
Additionally this waits for the browser to start before the timer starts, and extends the timeout to 20 seconds.
Logging from chromedp has also been enabled, which may help identify possible issues?