### PR TITLE
make: use tinygo source directory for byollvm, as needed by docker dev build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,15 @@
-name: CI for tinygo-dev docker container
+# This is the GH action to build and push the tinygo/tinygo-dev Docker image.
+# If you are looking for the tinygo/tinygo "release" Docker image please see
+# https://github.com/tinygo-org/docker
+#
+name: Docker
 on:
   push:
     branches: [ dev, fix-docker-llvm-build ]
 
 jobs:
   push_to_registry:
-    name: Push Docker image to GHCR/Docker Hub
+    name: build-push-dev
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(shell uname -s),Darwin)
 	toolSearchPathsVersion += $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)-$(2) $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)
 endif
 # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
-findLLVMTool = $(call detect,$(1),llvm-build/bin/$(1) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
+findLLVMTool = $(call detect,$(1),$(TINYGO_SOURCE_DIR)llvm-build/bin/$(1) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
 CLANG ?= $(call findLLVMTool,clang)
 LLVM_AR ?= $(call findLLVMTool,llvm-ar)
 LLVM_NM ?= $(call findLLVMTool,llvm-nm)


### PR DESCRIPTION
This PR uses the tinygo source directory in the Makefile for byollvm, as needed by docker dev build.

After this commit, the Docker CI build should be green again.