### PR TITLE
loader: respect $GOROOT when running `go list`

### DIFF
--- a/loader/list.go
+++ b/loader/list.go
@@ -3,9 +3,11 @@ package loader
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/goenv"
 )
 
 // List returns a ready-to-run *exec.Cmd for running the `go list` command with
@@ -24,7 +26,7 @@ func List(config *compileopts.Config, extraArgs, pkgs []string) (*exec.Cmd, erro
 	if config.CgoEnabled() {
 		cgoEnabled = "1"
 	}
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(filepath.Join(goenv.Get("GOROOT"), "bin", "go"), args...)
 	cmd.Env = append(os.Environ(), "GOROOT="+goroot, "GOOS="+config.GOOS(), "GOARCH="+config.GOARCH(), "CGO_ENABLED="+cgoEnabled)
 	return cmd, nil
 }


### PR DESCRIPTION
This makes it possible to select the Go version using GOROOT, and works even if the `go` binary is not in $PATH.

This is an alternative of sorts to #2429 and something that we should have been doing anyway.