### PR TITLE
wasm: remove heap allocator from wasi-libc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ commands:
       - run: go install -tags=llvm<<parameters.llvm>> .
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-systemclang-v3
+            - wasi-libc-sysroot-systemclang-v4
       - run: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-systemclang-v3
+          key: wasi-libc-sysroot-systemclang-v4
           paths:
             - lib/wasi-libc/sysroot
       - run: make gen-device -j4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v1
+          key: wasi-libc-sysroot-v2
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-asserts-v2
+          key: wasi-libc-sysroot-linux-asserts-v3
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
@@ -217,7 +217,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-asserts-v2
+          key: wasi-libc-sysroot-linux-asserts-v3
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v1
+          key: wasi-libc-sysroot-v2
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ endif
 wasi-libc: lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a
 lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
 	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
-	cd lib/wasi-libc && make -j4 WASM_CFLAGS="-O2 -g -DNDEBUG" WASM_CC=$(CLANG) WASM_AR=$(LLVM_AR) WASM_NM=$(LLVM_NM)
+	cd lib/wasi-libc && make -j4 WASM_CFLAGS="-O2 -g -DNDEBUG" MALLOC_IMPL=none WASM_CC=$(CLANG) WASM_AR=$(LLVM_AR) WASM_NM=$(LLVM_NM)
 
 
 # Build the Go compiler.

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -86,21 +86,3 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
 	return realloc(ptr, size)
 }
-
-//export posix_memalign
-func libc_posix_memalign(memptr *unsafe.Pointer, alignment, size uintptr) int {
-	runtimePanic("unimplemented: posix_memalign")
-	return 0
-}
-
-//export aligned_alloc
-func libc_aligned_alloc(alignment, bytes uintptr) unsafe.Pointer {
-	runtimePanic("unimplemented: aligned_alloc")
-	return nil
-}
-
-//export malloc_usable_size
-func libc_malloc_usable_size(ptr unsafe.Pointer) uintptr {
-	runtimePanic("unimplemented: malloc_usable_size")
-	return 0
-}


### PR DESCRIPTION
This would conflict with our own heap. We previously defined all those functions to make sure it's not used, but with a more recent wasi-libc version (https://github.com/WebAssembly/wasi-libc/pull/250) we can simply not compile the wasi-libc heap, which is the proper fix.