### PR TITLE
Bump go-llvm to support llvm12 and 13 under macos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,5 @@ require (
 	go.bug.st/serial v1.1.3
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
-	tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6
+	tinygo.org/x/go-llvm v0.0.0-20220119143719-a55dfcdd0c2b
 )

--- a/go.sum
+++ b/go.sum
@@ -90,3 +90,5 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6 h1:p9huJkDeMFLOE5A4puIPRIewaTpQXX6OmjguUmGXJj4=
 tinygo.org/x/go-llvm v0.0.0-20211230181020-1ddc904f6bf6/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20220119143719-a55dfcdd0c2b h1:1EMJbfrkIe6k5N6DZKFiiivRRid0xKDDkI3HwKBKDkQ=
+tinygo.org/x/go-llvm v0.0.0-20220119143719-a55dfcdd0c2b/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
Fixes #2544.