### PR TITLE
os: add stubs for Readlink and File.Seek for baremetal targets

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -92,4 +92,4 @@ jobs:
           path: build/tinygo.darwin-amd64.tar.gz
       - name: Smoke tests
         shell: bash
-        run: make smoketest TINYGO=build/tinygo AVR=0
+        run: make smoketest TINYGO=$(PWD)/build/tinygo AVR=0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,6 +92,6 @@ jobs:
           path: build/release/release.zip
       - name: Smoke tests
         shell: bash
-        run: make smoketest TINYGO=build/tinygo AVR=0 XTENSA=0
+        run: make smoketest TINYGO=$(PWD)/build/tinygo AVR=0 XTENSA=0
       - name: Test stdlib packages
         run: make tinygo-test

--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,8 @@ tinygo-bench-wasi-fast:
 .PHONY: smoketest
 smoketest:
 	$(TINYGO) version
+	# regression test for #2563
+	cd tests/os/smoke && $(TINYGO) test -c -target=pybadge && rm smoke.test
 	# test all examples (except pwm)
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GOTESTFLAGS ?= -v
 MD5SUM = md5sum
 
 # tinygo binary for tests
-TINYGO ?= $(call detect,tinygo,tinygo build/tinygo)
+TINYGO ?= $(call detect,tinygo,tinygo $(CURDIR)/build/tinygo)
 
 # Use CCACHE for LLVM if possible
 ifneq (, $(shell command -v ccache 2> /dev/null))

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -62,6 +62,14 @@ func Pipe() (r *File, w *File, err error) {
 	return nil, nil, ErrNotImplemented
 }
 
+func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
+	return 0, ErrNotImplemented
+}
+
+func Readlink(name string) (string, error) {
+	return "", ErrNotImplemented
+}
+
 func tempDir() string {
 	return "/tmp"
 }

--- a/tests/os/smoke/smoke_test.go
+++ b/tests/os/smoke/smoke_test.go
@@ -1,0 +1,27 @@
+package os_smoke_test
+
+// Simple smoke tests for the os package or things that depend on it.
+// Intended to catch build tag mistakes affecting bare metal targets.
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// Regression test for https://github.com/tinygo-org/tinygo/issues/2563
+func TestFilepath(t *testing.T) {
+	if filepath.Base("foo/bar") != "bar" {
+		t.Errorf("filepath.Base is very confused")
+	}
+}
+
+// Regression test for https://github.com/tinygo-org/tinygo/issues/2530
+func TestFmt(t *testing.T) {
+	n, err := fmt.Printf("Hello, world!\n")
+	if err != nil {
+		t.Errorf("printf returned error %s", err)
+	} else if n != 14 {
+		t.Errorf("printf returned %d, expected 14", n)
+	}
+}


### PR DESCRIPTION
With smoke test, currently enabled on pybadge (chosen at random).

Fixes https://github.com/tinygo-org/tinygo/issues/2563

TODO:
- enable test on arduino; currently fails with "interp: ptrtoint integer size..." (https://github.com/tinygo-org/tinygo/issues/2389 )
- enable test on nintendoswitch; currently fails with many missing definitions (https://github.com/tinygo-org/tinygo/issues/2530 )