### PR TITLE
all: update license year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-Copyright (c) 2018-2021 TinyGo Authors. All rights reserved.
+Copyright (c) 2018-2022 The TinyGo Authors. All rights reserved.
 
 TinyGo includes portions of the Go standard library.
-Copyright (c) 2009-2021 The Go Authors. All rights reserved.
+Copyright (c) 2009-2022 The Go Authors. All rights reserved.
 
 TinyGo includes portions of LLVM, which is under the Apache License v2.0 with
 LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
This PR simply updates the license year to 2022. Happy new year!