### PR TITLE
Add stubs for more unimplemented reflect methods

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -721,7 +721,8 @@ func (t rawType) MethodByName(name string) (Method, bool) {
 }
 
 func (t rawType) PkgPath() string {
-	panic("unimplemented: (reflect.Type).PkgPath()")
+	// panic("unimplemented: (reflect.Type).PkgPath()")
+	return "<unimplemented>"
 }
 
 // A StructField describes a single field in a struct.

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -837,4 +837,3 @@ func align(offset uintptr, alignment uintptr) uintptr {
 func SliceOf(t Type) Type {
 	panic("unimplemented: reflect.SliceOf()")
 }
-

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -833,3 +833,8 @@ func (e *TypeError) Error() string {
 func align(offset uintptr, alignment uintptr) uintptr {
 	return (offset + alignment - 1) &^ (alignment - 1)
 }
+
+func SliceOf(t Type) Type {
+	panic("unimplemented: reflect.SliceOf()")
+}
+

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -126,6 +126,23 @@ func (k Kind) basicType() rawType {
 	return rawType(k << 1)
 }
 
+// Method represents a single method.
+type Method struct {
+	// Name is the method name.
+	Name string
+
+	// PkgPath is the package path that qualifies a lower case (unexported)
+	// method name. It is empty for upper case (exported) method names.
+	// The combination of PkgPath and Name uniquely identifies a method
+	// in a method set.
+	// See https://golang.org/ref/spec#Uniqueness_of_identifiers
+	PkgPath string
+
+	Type  Type  // method type
+	Func  Value // func with receiver as first argument
+	Index int   // index for Type.Method
+}
+
 // The following Type type has been copied almost entirely from
 // https://github.com/golang/go/blob/go1.15/src/reflect/type.go#L27-L212.
 // Some methods have been commented out as they haven't yet been implemented.
@@ -173,7 +190,7 @@ type Type interface {
 	//
 	// For an interface type, the returned Method's Type field gives the
 	// method signature, without a receiver, and the Func field is nil.
-	//MethodByName(string) (Method, bool)
+	MethodByName(string) (Method, bool)
 
 	// NumMethod returns the number of exported methods in the type's method set.
 	NumMethod() int
@@ -187,7 +204,7 @@ type Type interface {
 	// If the type was predeclared (string, error) or not defined (*T, struct{},
 	// []int, or A where A is an alias for a non-defined type), the package path
 	// will be the empty string.
-	//PkgPath() string
+	PkgPath() string
 
 	// Size returns the number of bytes needed to store
 	// a value of the given type; it is analogous to unsafe.Sizeof.
@@ -286,7 +303,7 @@ type Type interface {
 	// In returns the type of a function type's i'th input parameter.
 	// It panics if the type's Kind is not Func.
 	// It panics if i is not in the range [0, NumIn()).
-	//In(i int) Type
+	In(i int) Type
 
 	// Key returns a map type's key type.
 	// It panics if the type's Kind is not Map.
@@ -311,7 +328,7 @@ type Type interface {
 	// Out returns the type of a function type's i'th output parameter.
 	// It panics if the type's Kind is not Func.
 	// It panics if i is not in the range [0, NumOut()).
-	//Out(i int) Type
+	Out(i int) Type
 }
 
 // The typecode as used in an interface{}.
@@ -689,6 +706,22 @@ func (t rawType) Name() string {
 
 func (t rawType) Key() Type {
 	panic("unimplemented: (reflect.Type).Key()")
+}
+
+func (t rawType) In(i int) Type {
+	panic("unimplemented: (reflect.Type).In()")
+}
+
+func (t rawType) Out(i int) Type {
+	panic("unimplemented: (reflect.Type).Out()")
+}
+
+func (t rawType) MethodByName(name string) (Method, bool) {
+	panic("unimplemented: (reflect.Type).MethodByName()")
+}
+
+func (t rawType) PkgPath() string {
+	panic("unimplemented: (reflect.Type).PkgPath()")
 }
 
 // A StructField describes a single field in a struct.

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -721,8 +721,7 @@ func (t rawType) MethodByName(name string) (Method, bool) {
 }
 
 func (t rawType) PkgPath() string {
-	// panic("unimplemented: (reflect.Type).PkgPath()")
-	return "<unimplemented>"
+	panic("unimplemented: (reflect.Type).PkgPath()")
 }
 
 // A StructField describes a single field in a struct.

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -128,7 +128,7 @@ func (v Value) IsNil() bool {
 		_, val := decomposeInterface(*(*interface{})(v.value))
 		return val == nil
 	default:
-			panic(&ValueError{Method: "IsNil"})
+		panic(&ValueError{Method: "IsNil"})
 	}
 }
 
@@ -144,7 +144,7 @@ func (v Value) Pointer() uintptr {
 	case Func:
 		panic("unimplemented: (reflect.Value).Pointer()")
 	default: // not implemented: Func
-	panic(&ValueError{Method: "Pointer"})
+		panic(&ValueError{Method: "Pointer"})
 	}
 }
 
@@ -187,7 +187,7 @@ func (v Value) Bool() bool {
 			return uintptr(v.value) != 0
 		}
 	default:
-			panic(&ValueError{Method: "Bool"})
+		panic(&ValueError{Method: "Bool"})
 	}
 }
 
@@ -224,7 +224,7 @@ func (v Value) Int() int64 {
 			return int64(int64(uintptr(v.value)))
 		}
 	default:
-			panic(&ValueError{Method: "Int"})
+		panic(&ValueError{Method: "Int"})
 	}
 }
 
@@ -267,7 +267,7 @@ func (v Value) Uint() uint64 {
 			return uint64(uintptr(v.value))
 		}
 	default:
-			panic(&ValueError{Method: "Uint"})
+		panic(&ValueError{Method: "Uint"})
 	}
 }
 
@@ -293,7 +293,7 @@ func (v Value) Float() float64 {
 			return *(*float64)(unsafe.Pointer(&v.value))
 		}
 	default:
-			panic(&ValueError{Method: "Float"})
+		panic(&ValueError{Method: "Float"})
 	}
 }
 
@@ -315,7 +315,7 @@ func (v Value) Complex() complex128 {
 		// architectures with 128-bit pointers, however.
 		return *(*complex128)(v.value)
 	default:
-			panic(&ValueError{Method: "Complex"})
+		panic(&ValueError{Method: "Complex"})
 	}
 }
 
@@ -360,7 +360,7 @@ func (v Value) Len() int {
 	case String:
 		return int((*stringHeader)(v.value).len)
 	default:
-			panic(&ValueError{Method: "Len"})
+		panic(&ValueError{Method: "Len"})
 	}
 }
 
@@ -378,7 +378,7 @@ func (v Value) Cap() int {
 	case Slice:
 		return int((*sliceHeader)(v.value).cap)
 	default:
-			panic(&ValueError{Method: "Cap"})
+		panic(&ValueError{Method: "Cap"})
 	}
 }
 
@@ -408,7 +408,7 @@ func (v Value) Elem() Value {
 			flags:    v.flags &^ valueFlagIndirect,
 		}
 	default:
-			panic(&ValueError{Method: "Elem"})
+		panic(&ValueError{Method: "Elem"})
 	}
 }
 
@@ -552,7 +552,7 @@ func (v Value) Index(i int) Value {
 			value:    unsafe.Pointer(value),
 		}
 	default:
-			panic(&ValueError{Method: "Index"})
+		panic(&ValueError{Method: "Index"})
 	}
 }
 
@@ -631,7 +631,7 @@ func (v Value) SetBool(x bool) {
 	case Bool:
 		*(*bool)(v.value) = x
 	default:
-			panic(&ValueError{Method: "SetBool"})
+		panic(&ValueError{Method: "SetBool"})
 	}
 }
 
@@ -649,7 +649,7 @@ func (v Value) SetInt(x int64) {
 	case Int64:
 		*(*int64)(v.value) = x
 	default:
-			panic(&ValueError{Method: "SetInt"})
+		panic(&ValueError{Method: "SetInt"})
 	}
 }
 
@@ -669,7 +669,7 @@ func (v Value) SetUint(x uint64) {
 	case Uintptr:
 		*(*uintptr)(v.value) = uintptr(x)
 	default:
-			panic(&ValueError{Method: "SetUint"})
+		panic(&ValueError{Method: "SetUint"})
 	}
 }
 
@@ -681,7 +681,7 @@ func (v Value) SetFloat(x float64) {
 	case Float64:
 		*(*float64)(v.value) = x
 	default:
-			panic(&ValueError{Method: "SetFloat"})
+		panic(&ValueError{Method: "SetFloat"})
 	}
 }
 
@@ -693,7 +693,7 @@ func (v Value) SetComplex(x complex128) {
 	case Complex128:
 		*(*complex128)(v.value) = x
 	default:
-			panic(&ValueError{Method: "SetComplex"})
+		panic(&ValueError{Method: "SetComplex"})
 	}
 }
 
@@ -703,7 +703,7 @@ func (v Value) SetString(x string) {
 	case String:
 		*(*string)(v.value) = x
 	default:
-			panic(&ValueError{Method: "SetString"})
+		panic(&ValueError{Method: "SetString"})
 	}
 }
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -128,7 +128,7 @@ func (v Value) IsNil() bool {
 		_, val := decomposeInterface(*(*interface{})(v.value))
 		return val == nil
 	default:
-		panic(&ValueError{"IsNil"})
+			panic(&ValueError{Method: "IsNil"})
 	}
 }
 
@@ -144,7 +144,7 @@ func (v Value) Pointer() uintptr {
 	case Func:
 		panic("unimplemented: (reflect.Value).Pointer()")
 	default: // not implemented: Func
-		panic(&ValueError{"Pointer"})
+	panic(&ValueError{Method: "Pointer"})
 	}
 }
 
@@ -187,7 +187,7 @@ func (v Value) Bool() bool {
 			return uintptr(v.value) != 0
 		}
 	default:
-		panic(&ValueError{"Bool"})
+			panic(&ValueError{Method: "Bool"})
 	}
 }
 
@@ -224,7 +224,7 @@ func (v Value) Int() int64 {
 			return int64(int64(uintptr(v.value)))
 		}
 	default:
-		panic(&ValueError{"Int"})
+			panic(&ValueError{Method: "Int"})
 	}
 }
 
@@ -267,7 +267,7 @@ func (v Value) Uint() uint64 {
 			return uint64(uintptr(v.value))
 		}
 	default:
-		panic(&ValueError{"Uint"})
+			panic(&ValueError{Method: "Uint"})
 	}
 }
 
@@ -293,7 +293,7 @@ func (v Value) Float() float64 {
 			return *(*float64)(unsafe.Pointer(&v.value))
 		}
 	default:
-		panic(&ValueError{"Float"})
+			panic(&ValueError{Method: "Float"})
 	}
 }
 
@@ -315,7 +315,7 @@ func (v Value) Complex() complex128 {
 		// architectures with 128-bit pointers, however.
 		return *(*complex128)(v.value)
 	default:
-		panic(&ValueError{"Complex"})
+			panic(&ValueError{Method: "Complex"})
 	}
 }
 
@@ -360,7 +360,7 @@ func (v Value) Len() int {
 	case String:
 		return int((*stringHeader)(v.value).len)
 	default:
-		panic(&ValueError{"Len"})
+			panic(&ValueError{Method: "Len"})
 	}
 }
 
@@ -378,7 +378,7 @@ func (v Value) Cap() int {
 	case Slice:
 		return int((*sliceHeader)(v.value).cap)
 	default:
-		panic(&ValueError{"Cap"})
+			panic(&ValueError{Method: "Cap"})
 	}
 }
 
@@ -408,7 +408,7 @@ func (v Value) Elem() Value {
 			flags:    v.flags &^ valueFlagIndirect,
 		}
 	default:
-		panic(&ValueError{"Elem"})
+			panic(&ValueError{Method: "Elem"})
 	}
 }
 
@@ -552,7 +552,7 @@ func (v Value) Index(i int) Value {
 			value:    unsafe.Pointer(value),
 		}
 	default:
-		panic(&ValueError{"Index"})
+			panic(&ValueError{Method: "Index"})
 	}
 }
 
@@ -631,7 +631,7 @@ func (v Value) SetBool(x bool) {
 	case Bool:
 		*(*bool)(v.value) = x
 	default:
-		panic(&ValueError{"SetBool"})
+			panic(&ValueError{Method: "SetBool"})
 	}
 }
 
@@ -649,7 +649,7 @@ func (v Value) SetInt(x int64) {
 	case Int64:
 		*(*int64)(v.value) = x
 	default:
-		panic(&ValueError{"SetInt"})
+			panic(&ValueError{Method: "SetInt"})
 	}
 }
 
@@ -669,7 +669,7 @@ func (v Value) SetUint(x uint64) {
 	case Uintptr:
 		*(*uintptr)(v.value) = uintptr(x)
 	default:
-		panic(&ValueError{"SetUint"})
+			panic(&ValueError{Method: "SetUint"})
 	}
 }
 
@@ -681,7 +681,7 @@ func (v Value) SetFloat(x float64) {
 	case Float64:
 		*(*float64)(v.value) = x
 	default:
-		panic(&ValueError{"SetFloat"})
+			panic(&ValueError{Method: "SetFloat"})
 	}
 }
 
@@ -693,7 +693,7 @@ func (v Value) SetComplex(x complex128) {
 	case Complex128:
 		*(*complex128)(v.value) = x
 	default:
-		panic(&ValueError{"SetComplex"})
+			panic(&ValueError{Method: "SetComplex"})
 	}
 }
 
@@ -703,7 +703,7 @@ func (v Value) SetString(x string) {
 	case String:
 		*(*string)(v.value) = x
 	default:
-		panic(&ValueError{"SetString"})
+			panic(&ValueError{Method: "SetString"})
 	}
 }
 
@@ -788,10 +788,14 @@ type stringHeader struct {
 
 type ValueError struct {
 	Method string
+	Kind   Kind
 }
 
 func (e *ValueError) Error() string {
-	return "reflect: call of reflect.Value." + e.Method + " on invalid type"
+	if e.Kind == 0 {
+		return "reflect: call of " + e.Method + " on zero Value"
+	}
+	return "reflect: call of " + e.Method + " on " + e.Kind.String() + " Value"
 }
 
 // Calls to this function are converted to LLVM intrinsic calls such as
@@ -868,4 +872,8 @@ func (v Value) Call(in []Value) []Value {
 
 func (v Value) MethodByName(name string) Value {
 	panic("unimplemented: (reflect.Value).MethodByName()")
+}
+
+func NewAt(typ Type, p unsafe.Pointer) Value {
+	panic("unimplemented: reflect.New()")
 }

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -865,3 +865,7 @@ func MakeMap(typ Type) Value {
 func (v Value) Call(in []Value) []Value {
 	panic("unimplemented: (reflect.Value).Call()")
 }
+
+func (v Value) MethodByName(name string) Value {
+	panic("unimplemented: (reflect.Value).MethodByName()")
+}


### PR DESCRIPTION
I'm current working on solving #447 by getting https://github.com/protocolbuffers/protobuf-go to compile with TinyGo. In combination with https://github.com/planetscale/vtprotobuf, I think there's a chance I get the code generated by protoc to compile and run without any changes.

This is my first attempt to "implement" some of the missing methods in the reflect package. This is my first time contributing to TinyGo, so I have no idea if I'm doing things correctly. Please let me know!

I've included some code copied directly from the Go source code. Is this allowed? How do I mark that code?