### PR TITLE
esp32c3: add support for input pin

### DIFF
--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -95,6 +95,13 @@ func (p Pin) Set(value bool) {
 	}
 }
 
+// Get returns the current value of a GPIO pin when configured as an input or as
+// an output.
+func (p Pin) Get() bool {
+	reg := &esp.GPIO.IN
+	return (reg.Get()>>p)&1 > 0
+}
+
 // Return the register and mask to enable a given GPIO pin. This can be used to
 // implement bit-banged drivers.
 //


### PR DESCRIPTION
This PR adds the basic PinInput functionality of ESP32-C3.

https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf


If Pin.Get() does not exist, then GPIO does not exist as documented in tinygo-site.
https://github.com/tinygo-org/tinygo-site/blob/release/doc-gen/main.go#L365