### PR TITLE
interp: don't log from the interp package

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -103,11 +103,6 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 		}
 		switch inst.opcode {
 		case llvm.Ret:
-			t1 := time.Since(r.start)
-			if t1-t0 > time.Second {
-				// Provide some breadcrumbs for user trying to find their slow init functions.
-				fmt.Fprintln(os.Stderr, "interp: slow: startms", int(t0.Milliseconds()), "endms", int(t1.Milliseconds()), "func", fn.name)
-			}
 			const maxInterpSeconds = 180
 			if t0 > maxInterpSeconds*time.Second {
 				// Running for more than maxInterpSeconds seconds. This should never happen, but does.


### PR DESCRIPTION
We shouldn't be logging anything when not explicitly requested via a flag or some other way.