### PR TITLE
builder/buildid.go: accept alternate name for buildid section on Linux

### DIFF
--- a/builder/buildid.go
+++ b/builder/buildid.go
@@ -31,7 +31,8 @@ func ReadBuildID() ([]byte, error) {
 			return nil, err
 		}
 		for _, section := range file.Sections {
-			if section.Type != elf.SHT_NOTE || section.Name != ".note.gnu.build-id" {
+			if section.Type != elf.SHT_NOTE ||
+				(section.Name != ".note.gnu.build-id" && section.Name != ".note.go.buildid") {
 				continue
 			}
 			buf := make([]byte, section.Size)


### PR DESCRIPTION
On Ubuntu, using standard go, both go and gnu buildid sections are present.
On Alpine, the gnu buildid section is absent, which caused tinygo to abort early.

It is possible that we could hit a situation where only the gnu
buildid section is present, so accept either one just in case.

Fixes https://github.com/tinygo-org/tinygo/issues/2580