### PR TITLE
build: fix build-library subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,9 +590,9 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libc
 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libm
 	@mkdir -p build/release/tinygo/lib/wasi-libc
-	@mkdir -p build/release/tinygo/pkg/armv6m-unknown-unknown-eabi
-	@mkdir -p build/release/tinygo/pkg/armv7m-unknown-unknown-eabi
-	@mkdir -p build/release/tinygo/pkg/armv7em-unknown-unknown-eabi
+	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0
+	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus
+	@mkdir -p build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4
 	@echo copying source files
 	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
 ifneq ($(USE_SYSTEM_BINARYEN),1)
@@ -641,12 +641,12 @@ endif
 	@cp -rp lib/wasi-libc/sysroot        build/release/tinygo/lib/wasi-libc/sysroot
 	@cp -rp src                          build/release/tinygo/src
 	@cp -rp targets                      build/release/tinygo/targets
-	./build/tinygo build-library -target=armv6m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv6m-unknown-unknown-eabi/compiler-rt compiler-rt
-	./build/tinygo build-library -target=armv7m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv7m-unknown-unknown-eabi/compiler-rt compiler-rt
-	./build/tinygo build-library -target=armv7em-unknown-unknown-eabi -o build/release/tinygo/pkg/armv7em-unknown-unknown-eabi/compiler-rt compiler-rt
-	./build/tinygo build-library -target=armv6m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv6m-unknown-unknown-eabi/picolibc picolibc
-	./build/tinygo build-library -target=armv7m-unknown-unknown-eabi  -o build/release/tinygo/pkg/armv7m-unknown-unknown-eabi/picolibc picolibc
-	./build/tinygo build-library -target=armv7em-unknown-unknown-eabi -o build/release/tinygo/pkg/armv7em-unknown-unknown-eabi/picolibc picolibc
+	./build/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/compiler-rt     compiler-rt
+	./build/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/compiler-rt compiler-rt
+	./build/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/compiler-rt    compiler-rt
+	./build/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/picolibc     picolibc
+	./build/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/picolibc picolibc
+	./build/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/picolibc    picolibc
 
 release: build/release
 	tar -czf build/release.tar.gz -C build/release tinygo

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -199,8 +199,13 @@ func MuslArchitecture(triple string) string {
 // a precompiled libc shipped with a TinyGo build, or a libc path in the cache
 // directory (which might not yet be built).
 func (c *Config) LibcPath(name string) (path string, precompiled bool) {
+	archname := c.Triple()
+	if c.CPU() != "" {
+		archname += "-" + c.CPU()
+	}
+
 	// Try to load a precompiled library.
-	precompiledDir := filepath.Join(goenv.Get("TINYGOROOT"), "pkg", c.Triple(), name)
+	precompiledDir := filepath.Join(goenv.Get("TINYGOROOT"), "pkg", archname, name)
 	if _, err := os.Stat(precompiledDir); err == nil {
 		// Found a precompiled library for this OS/architecture. Return the path
 		// directly.
@@ -209,13 +214,7 @@ func (c *Config) LibcPath(name string) (path string, precompiled bool) {
 
 	// No precompiled library found. Determine the path name that will be used
 	// in the build cache.
-	var outname string
-	if c.CPU() != "" {
-		outname = name + "-" + c.Triple() + "-" + c.CPU()
-	} else {
-		outname = name + "-" + c.Triple()
-	}
-	return filepath.Join(goenv.Get("GOCACHE"), outname), false
+	return filepath.Join(goenv.Get("GOCACHE"), name+"-"+archname), false
 }
 
 // CFlags returns the flags to pass to the C compiler. This is necessary for CGo

--- a/main.go
+++ b/main.go
@@ -1366,11 +1366,13 @@ func main() {
 			handleCompilerError(err)
 		}
 		defer os.RemoveAll(tmpdir)
+		spec, err := compileopts.LoadTarget(options)
+		if err != nil {
+			handleCompilerError(err)
+		}
 		config := &compileopts.Config{
 			Options: options,
-			Target: &compileopts.TargetSpec{
-				Triple: *target,
-			},
+			Target:  spec,
 		}
 		path, err := lib.Load(config, tmpdir)
 		handleCompilerError(err)


### PR DESCRIPTION
This subcommand has been broken for a while, since libraries also use the CPU flag. This commit fixes this.

Previously, libraries were usable for most Cortex-M cores. But with the addition of the CPU field, I've limited it to three popular cores: the Cortex-M0 (microbit), Cortex-M0+ (atsamd21), and Cortex-M4 (atsamd21, nrf52, and many others).

In the future we might consider also building libraries for the current OS/arch so that libraries like musl are already precompiled.

---

@QuLogic this PR might be relevant to you.