### PR TITLE
src/runtime: fix off-by-one in metadata size calculation due to rounding

### DIFF
--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -240,7 +240,7 @@ func calculateHeapAddresses() {
 	totalSize := heapEnd - heapStart
 
 	// Allocate some memory to keep 2 bits of information about every block.
-	metadataSize := totalSize / (blocksPerStateByte * bytesPerBlock)
+	metadataSize := (totalSize + blocksPerStateByte*bytesPerBlock) / (1 + blocksPerStateByte*bytesPerBlock)
 	metadataStart = unsafe.Pointer(heapEnd - metadataSize)
 
 	// Use the rest of the available memory as heap.

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -110,7 +110,11 @@ func (b gcBlock) pointer() unsafe.Pointer {
 
 // Return the address of the start of the allocated object.
 func (b gcBlock) address() uintptr {
-	return heapStart + uintptr(b)*bytesPerBlock
+	addr := heapStart + uintptr(b)*bytesPerBlock
+	if gcAsserts && addr > uintptr(metadataStart) {
+		runtimePanic("gc: block pointing inside metadata")
+	}
+	return addr
 }
 
 // findHead returns the head (first block) of an object, assuming the block

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -14,7 +14,7 @@ package runtime
 // any free space, it will perform a garbage collection cycle and try again. If
 // it still cannot find any free space, it gives up.
 //
-// Every block has some metadata, which is stored at the beginning of the heap.
+// Every block has some metadata, which is stored at the end of the heap.
 // The four states are "free", "head", "tail", and "mark". During normal
 // operation, there are no marked blocks. Every allocated object starts with a
 // "head" and is followed by "tail" blocks. The reason for this distinction is

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -134,7 +134,7 @@ func (b gcBlock) findNext() gcBlock {
 	if b.state() == blockStateHead || b.state() == blockStateMark {
 		b++
 	}
-	for b.state() == blockStateTail {
+	for b.address() < uintptr(metadataStart) && b.state() == blockStateTail {
 		b++
 	}
 	return b


### PR DESCRIPTION
This fixes the `archive/zip` stdlib test corpus and `dgryski/go-factor` from the corpus on `target=wasi`