### PR TITLE
machine: add no-op io.Reader implementation to NullSerial

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -10,7 +10,7 @@ import (
 	"unsafe"
 )
 
-type io struct {
+type rpio struct {
 	status volatile.Register32
 	ctrl   volatile.Register32
 }
@@ -22,7 +22,7 @@ type irqCtrl struct {
 }
 
 type ioBank0Type struct {
-	io                 [30]io
+	io                 [30]rpio
 	intR               [4]volatile.Register32
 	proc0IRQctrl       irqCtrl
 	proc1IRQctrl       irqCtrl

--- a/src/machine/serial.go
+++ b/src/machine/serial.go
@@ -1,6 +1,9 @@
 package machine
 
-import "errors"
+import (
+	"errors"
+	"io"
+)
 
 var errNoByte = errors.New("machine: no byte read")
 
@@ -44,3 +47,14 @@ func (ns NullSerial) Buffered() int {
 func (ns NullSerial) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
+
+// Read is a no-op; always returns that zero bytes were read with no error
+func (ns NullSerial) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+// type check to ensure NullSerial implements interfaces for drivers.UART
+var (
+	_ io.Reader = NullSerial{}
+	_ io.Writer = NullSerial{}
+)


### PR DESCRIPTION
When compiling with `-serial=usb` or `-serial=uart`, `machine.Serial` implements `drivers.UART`.

Currently the same is not true for `-serial=none`, because `machine.NullSerial` does not implement `io.Reader` as necessary: https://github.com/tinygo-org/drivers/blob/a15f2167cc7e46864d82e08904a3ddaa3e610d5e/uart.go#L8

Adding a no-op Read() method so that NullSerial implements `drivers.UART`