### PR TITLE
rp2040: watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,6 +477,9 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m4          examples/pwm
 	@$(MD5SUM) test.hex
+	# test watchdog
+	$(TINYGO) build -size short -o test.hex -target=nano-rp2040         examples/watchdog/basic
+	@$(MD5SUM) test.hex
 ifneq ($(STM32), 0)
 	$(TINYGO) build -size short -o test.hex -target=bluepill            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/examples/watchdog/basic/watchdog-basic.go
+++ b/src/examples/watchdog/basic/watchdog-basic.go
@@ -1,0 +1,51 @@
+//go:build rp2040
+// +build rp2040
+
+package main
+
+// This example demonstrates use of watchdog on RP2040.
+// System can be rebooted either by force or timer.
+// A reason of the reboot can be extracted too.
+
+import (
+	"machine"
+	"time"
+)
+
+var wdc = machine.WatchdogConfig{
+	Ticks:        1_100_000, // 1.1 sec
+	PauseOnDebug: false,
+}
+
+func main() {
+
+	println()
+
+	wdReason, _ := machine.Watchdog.Reason()
+	if wdReason == machine.WatchdogReasonNone {
+		println("Hardware reset")
+	}
+	if wdReason == machine.WatchdogReasonTimer {
+		println("Timer reset")
+	}
+	if wdReason == machine.WatchdogReasonForce {
+		println("Force reset")
+	}
+
+	machine.Watchdog.Configure(wdc)
+	machine.Watchdog.Enable()
+
+	i := 10
+	for {
+		println(i)
+		if i > 0 {
+			machine.Watchdog.Kick()
+		}
+		if i == 5 && wdReason == machine.WatchdogReasonTimer {
+			machine.Watchdog.Force()
+		}
+		time.Sleep(time.Second)
+		i--
+	}
+
+}

--- a/src/examples/watchdog/busy-loop/watchdog-busy-loop.go
+++ b/src/examples/watchdog/busy-loop/watchdog-busy-loop.go
@@ -1,0 +1,42 @@
+//go:build rp2040
+// +build rp2040
+
+package main
+
+// This example demonstrates watchdog handling of a blocked goroutine in cooperative environment.
+// Goroutine spins, watchdog is not kicked, counter elapses and system reboots.
+
+import (
+	"machine"
+	"time"
+)
+
+var wdc = machine.WatchdogConfig{
+	Ticks:        1_100_000, // 1.1 sec
+	PauseOnDebug: false,
+}
+
+func main() {
+
+	go func() {
+		machine.Watchdog.Configure(wdc)
+		machine.Watchdog.Enable()
+		for {
+			machine.Watchdog.Kick()
+			time.Sleep(time.Second)
+		}
+	}()
+
+	i := 10
+	for {
+		println(i)
+		if i == 0 {
+			for {
+				// simulate a busy loop, spinning
+			}
+		}
+		time.Sleep(time.Second)
+		i--
+	}
+
+}

--- a/src/examples/watchdog/runtime-panic/watchdog-runtime-panic.go
+++ b/src/examples/watchdog/runtime-panic/watchdog-runtime-panic.go
@@ -1,0 +1,41 @@
+//go:build rp2040
+// +build rp2040
+
+package main
+
+// This example demonstrates watchdog handling of a runtime panic.
+// System hangs on panic, watchdog is not kicked, counter elapses and system reboots.
+
+import (
+	"machine"
+	"time"
+)
+
+var wdc = machine.WatchdogConfig{
+	Ticks:        1_100_000, // 1.1 sec
+	PauseOnDebug: false,
+}
+
+func main() {
+
+	go func() {
+		machine.Watchdog.Configure(wdc)
+		machine.Watchdog.Enable()
+		for {
+			machine.Watchdog.Kick()
+			time.Sleep(time.Second)
+		}
+	}()
+
+	i := 10
+	for {
+		println(i)
+		if i == 0 {
+			j := 10 / i // simulate runtime panic
+			println(j)
+		}
+		time.Sleep(time.Second)
+		i--
+	}
+
+}

--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -190,8 +190,6 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 //
 // Must be called before any other clock function.
 func (clks *clocksType) init() {
-	// Start the watchdog tick
-	watchdog.startTick(xoscFreq)
 
 	// Disable resus that may be enabled from previous software
 	clks.resus.ctrl.Set(0)

--- a/src/machine/machine_rp2040_psm.go
+++ b/src/machine/machine_rp2040_psm.go
@@ -1,0 +1,19 @@
+//go:build rp2040
+// +build rp2040
+
+package machine
+
+import (
+	"device/rp"
+	"runtime/volatile"
+	"unsafe"
+)
+
+type psmType struct {
+	frceOn  volatile.Register32
+	frceOff volatile.Register32
+	wdsel   volatile.Register32
+	done    volatile.Register32
+}
+
+var psm = (*psmType)(unsafe.Pointer(rp.PSM))

--- a/src/machine/machine_rp2040_watchdog.go
+++ b/src/machine/machine_rp2040_watchdog.go
@@ -3,11 +3,46 @@
 
 package machine
 
+// Hardware Watchdog Timer API
+//
+// The RP2040 has a built in HW watchdog Timer. This is a countdown timer that can restart parts of the chip if it reaches zero.
+// For example, this can be used to restart the processor if the software running on it gets stuck in an infinite loop
+// or similar. The programmer has to periodically write a value to the watchdog to stop it reaching zero.
+
 import (
 	"device/rp"
+	"errors"
 	"runtime/volatile"
 	"unsafe"
 )
+
+const watchdogRegularBootMagic = 0x6ab73121
+const watchdogJumpBootMagic = 0xb007c0d3
+const watchdogJumpBootMagicInverse = 0x4ff83f2d
+
+const WatchdogMaxPeriod = uint32(0x7fffff)
+
+const (
+	WatchdogReasonNone uint32 = iota
+	WatchdogReasonTimer
+	WatchdogReasonForce
+)
+
+type WatchdogConfig struct {
+	// Watchdog ticks before it elapses. Each tick is 1 microsecond.
+	// Minimum value is 1.
+	// Maximum value is 8388607 (0x7fffff) or approximately 8.4 seconds.
+	Ticks uint32
+
+	// Watchdog should be paused when the debugger is stepping through code.
+	PauseOnDebug bool
+
+	// If Zero, a standard boot will be performed, if non-zero this is the program counter to jump to on reset.
+	ProgramCounter uint32
+
+	// If ProgramCounter is non-zero, this will be the stack pointer used.
+	StackPointer uint32
+}
 
 type watchdogType struct {
 	ctrl    volatile.Register32
@@ -17,12 +52,112 @@ type watchdogType struct {
 	tick    volatile.Register32
 }
 
-var watchdog = (*watchdogType)(unsafe.Pointer(rp.WATCHDOG))
+type watchdog struct {
+	reg   *watchdogType
+	load  uint32
+	pause bool
+	pc    uint32
+	sp    uint32
+}
 
-// startTick starts the watchdog tick.
-// cycles needs to be a divider that when applied to the xosc input,
-// produces a 1MHz clock. So if the xosc frequency is 12MHz,
-// this will need to be 12.
-func (wd *watchdogType) startTick(cycles uint32) {
-	wd.tick.Set(cycles | rp.WATCHDOG_TICK_ENABLE)
+var Watchdog = watchdog{
+	reg:   (*watchdogType)(unsafe.Pointer(rp.WATCHDOG)),
+	load:  0,
+	pause: false,
+}
+
+// Configure watchdog but not enable/start it, shall call Enable() method separately.
+func (wd *watchdog) Configure(config WatchdogConfig) error {
+	if config.Ticks < 1 {
+		return errors.New("watchdog period too short")
+	}
+	if config.Ticks > WatchdogMaxPeriod {
+		return errors.New("watchdog period too long")
+	}
+	// Note, we have x2 here as the watchdog HW currently decrements twice per tick
+	wd.load = config.Ticks * 2
+	wd.pause = config.PauseOnDebug
+	wd.pc = config.ProgramCounter
+	wd.sp = config.StackPointer
+	return nil
+}
+
+// Enable watchdog, set registers and start tick counter
+func (wd *watchdog) Enable() error {
+
+	wd.reg.ctrl.ClearBits(rp.WATCHDOG_CTRL_ENABLE)
+
+	// Tick cycles needs to be a divider that when applied to the xosc input,
+	// produces a 1MHz clock. So if the xosc frequency is 12MHz, this will need to be 12.
+	wd.reg.tick.Set(xoscFreq | rp.WATCHDOG_TICK_ENABLE)
+
+	// Reset everything apart from ROSC and XOSC
+	psm.wdsel.SetBits(0x0001ffff & ^(rp.PSM_WDSEL_ROSC | rp.PSM_WDSEL_XOSC))
+
+	// Jump on reboot
+	if wd.pc != 0 {
+		pc := wd.pc | 1 // thumb mode (sic!), as seen in Pico SDK
+		// See section "2.8.1.1. Watchdog Boot" of datasheet
+		wd.reg.scratch[4].Set(watchdogJumpBootMagic)
+		wd.reg.scratch[5].Set(pc ^ watchdogJumpBootMagicInverse)
+		wd.reg.scratch[6].Set(wd.sp)
+		wd.reg.scratch[7].Set(pc)
+	} else {
+		wd.reg.scratch[4].Set(watchdogRegularBootMagic)
+	}
+
+	dbgBits := uint32(rp.WATCHDOG_CTRL_PAUSE_DBG0 | rp.WATCHDOG_CTRL_PAUSE_DBG1 | rp.WATCHDOG_CTRL_PAUSE_JTAG)
+	if wd.pause {
+		wd.reg.ctrl.SetBits(dbgBits)
+	} else {
+		wd.reg.ctrl.ClearBits(dbgBits)
+	}
+
+	err := wd.Kick()
+	if err != nil {
+		return err
+	}
+
+	wd.reg.ctrl.SetBits(rp.WATCHDOG_CTRL_ENABLE)
+
+	return nil
+}
+
+// IsEnabled can be used to check if watchdog is active
+func (wd *watchdog) IsEnabled() (bool, error) {
+	return wd.reg.ctrl.HasBits(rp.WATCHDOG_CTRL_ENABLE), nil
+}
+
+// Disable watchdog, no watchdog reboot shall happen
+func (wd *watchdog) Disable() error {
+	wd.reg.ctrl.ClearBits(rp.WATCHDOG_CTRL_ENABLE)
+	return nil
+}
+
+// Kick watchdog and reset the tick counter to the configured value
+func (wd *watchdog) Kick() error {
+	if wd.load == 0 {
+		return errors.New("watchdog not configured")
+	}
+	wd.reg.load.Set(wd.load)
+	return nil
+}
+
+// Force watchdog trigger (reboots system)
+func (wd *watchdog) Force() error {
+	wd.reg.ctrl.SetBits(rp.WATCHDOG_CTRL_TRIGGER)
+	return nil
+}
+
+// Reason tells the kind of the last reboot.
+// 0) hardware reset (power cycle or reset button toggled);
+// 1) watchdog timer reset (tick counter elapses);
+// 2) watchdog forced reset (Force() method call)
+func (wd *watchdog) Reason() (uint32, error) {
+	return wd.reg.reason.Get(), nil
+}
+
+// IsRegularBoot can be used to distinguish regular from jump boots
+func (wd *watchdog) IsRegularBoot() (bool, error) {
+	return wd.reg.scratch[4].Get() == watchdogRegularBootMagic, nil
 }


### PR DESCRIPTION
Implements hardware watchdog timer for RP2040.

Implementation inspired by [Pico SDK](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_watchdog/watchdog.c)
It ended up quite different though.

I could not use `time.Duration` to have nice "period" configuration parameter instead of "ticks" due to an import loop.

Examples demonstrate basic usage, watchdog triggering on runtime panic and while spinning.
Basic example added to the list of smoke tests.

