### PR TITLE
Add GPIO interrupt for ESP32C3

### DIFF
--- a/src/examples/pininterrupt/pininterrupt.go
+++ b/src/examples/pininterrupt/pininterrupt.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	button = machine.BUTTON
-	led    = machine.LED
+	button          = machine.IO6
+	buttonMode      = machine.PinInputPullup
+	buttonPinChange = machine.PinRising
+	led             = machine.LED
 )
 
 func main() {

--- a/src/machine/board_esp32c3-12f.go
+++ b/src/machine/board_esp32c3-12f.go
@@ -1,0 +1,48 @@
+// +build esp32c312f
+
+package machine
+
+// Built-in LED on some ESP32 boards.
+const (
+	LED_RED = IO3
+	LED_GREEN = IO4
+	LED_BLUE = IO5
+	LED = LED_RED
+)
+
+const (
+	IO0  Pin = 0
+	IO1  Pin = 1
+	IO10 Pin = 10
+	IO18 Pin = 18
+	IO19 Pin = 19
+	IO2  Pin = 2
+	IO3  Pin = 3
+	IO4  Pin = 4
+	IO5  Pin = 5
+	IO6  Pin = 6
+	IO7  Pin = 7
+	IO8  Pin = 8
+	IO9  Pin = 9
+	RXD  Pin = 20
+	TXD  Pin = 21
+)
+
+// ADC pins
+const (
+	ADC0 Pin = ADC1_0
+	ADC1 Pin = ADC2_0
+
+	ADC1_0 Pin = IO0
+	ADC1_1 Pin = IO1
+	ADC1_2 Pin = IO2
+	ADC1_3 Pin = IO3
+	ADC2_0 Pin = IO5
+)
+
+// UART0 pins
+const (
+	UART_TX_PIN = TXD
+	UART_RX_PIN = RXD
+)
+

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -1,14 +1,19 @@
+//go:build esp32c3
 // +build esp32c3
 
 package machine
 
 import (
 	"device/esp"
+	"runtime/interrupt"
 	"runtime/volatile"
+	"sync"
 	"unsafe"
 )
 
 const deviceName = esp.Device
+const maxPin = 22
+const cpuInterrupt = 6
 
 // CPUFrequency returns the current CPU frequency of the chip.
 // Currently it is a fixed frequency but it may allow changing in the future.
@@ -21,6 +26,18 @@ const (
 	PinInput
 	PinInputPullup
 	PinInputPulldown
+)
+
+type PinChange uint8
+
+// Pin change interrupt constants for SetInterrupt.
+const (
+	PinNoInterrupt PinChange = iota
+	PinRising
+	PinFalling
+	PinToggle
+	PinLowLevel
+	PinHighLevel
 )
 
 // Configure this pin with the given configuration.
@@ -83,6 +100,11 @@ func (p Pin) mux() *volatile.Register32 {
 	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.IO_MUX.GPIO0)) + uintptr(p)*4)))
 }
 
+// pin returns the PIN register corresponding to the given GPIO pin.
+func (p Pin) pin() *volatile.Register32 {
+	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.PIN0)) + uintptr(p)*4)))
+}
+
 // Set the pin to high or low.
 // Warning: only use this on an output pin!
 func (p Pin) Set(value bool) {
@@ -119,6 +141,70 @@ func (p Pin) portMaskSet() (*volatile.Register32, uint32) {
 
 func (p Pin) portMaskClear() (*volatile.Register32, uint32) {
 	return &esp.GPIO.OUT_W1TC, 1 << p
+}
+
+// SetInterrupt sets an interrupt to be executed when a particular pin changes
+// state. The pin should already be configured as an input, including a pull up
+// or down if no external pull is provided.
+//
+// You can pass a nil func to unset the pin change interrupt. If you do so,
+// the change parameter is ignored and can be set to any value (such as 0).
+// If the pin is already configured with a callback, you must first unset
+// this pins interrupt before you can set a new callback.
+func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) (err error) {
+	if p >= maxPin {
+		return ErrInvalidInputPin
+	}
+
+	if callback == nil || change == PinNoInterrupt {
+		// Disable this pin interrupt
+		p.pin().ClearBits(esp.GPIO_PIN_PIN_INT_TYPE_Msk | esp.GPIO_PIN_PIN_INT_ENA_Msk)
+
+		if pinCallbacks[p] != nil {
+			pinCallbacks[p] = nil
+		}
+		return nil
+	}
+
+	if pinCallbacks[p] != nil {
+		// The pin was already configured.
+		// To properly re-configure a pin, unset it first and set a new
+		// configuration.
+		return ErrNoPinChangeChannel
+	}
+	pinCallbacks[p] = callback
+
+	onceSetupPinInterrupt.Do(func() {
+		err = setupPinInterrupt()
+	})
+	if err != nil {
+		return err
+	}
+
+	p.pin().Set(
+		(p.pin().Get() & ^uint32(esp.GPIO_PIN_PIN_INT_TYPE_Msk|esp.GPIO_PIN_PIN_INT_ENA_Msk)) |
+			uint32(change)<<esp.GPIO_PIN_PIN_INT_TYPE_Pos | uint32(1)<<esp.GPIO_PIN_PIN_INT_ENA_Pos)
+
+	return nil
+}
+
+var (
+	pinCallbacks          [maxPin]func(Pin)
+	onceSetupPinInterrupt sync.Once
+)
+
+func setupPinInterrupt() error {
+	esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(cpuInterrupt)
+	return interrupt.New(cpuInterrupt, func(interrupt.Interrupt) {
+		status := esp.GPIO.STATUS.Get()
+		for i := 0; i < maxPin; i++ {
+			if (status&(1<<i)) != 0 && pinCallbacks[i] != nil {
+				pinCallbacks[i](Pin(i))
+			}
+		}
+		// clear interrupt bit
+		esp.GPIO.STATUS_W1TC.SetBits(status)
+	}).Enable()
 }
 
 var DefaultUART = UART0

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -1,3 +1,4 @@
+//go:build esp32c3
 // +build esp32c3
 
 package interrupt
@@ -46,6 +47,45 @@ func (i Interrupt) Enable() error {
 	return nil
 }
 
+// Adding pseudo function calls that is replaced by the compiler with the actual
+// functions registered through interrupt.New.
+//go:linkname callHandlers runtime/interrupt.callHandlers
+func callHandlers(num int)
+
+const (
+	IRQNUM_1 = 1 + iota
+	IRQNUM_2
+	IRQNUM_3
+	IRQNUM_4
+	IRQNUM_5
+	IRQNUM_6
+	IRQNUM_7
+	IRQNUM_8
+	IRQNUM_9
+	IRQNUM_10
+	IRQNUM_11
+	IRQNUM_12
+	IRQNUM_13
+	IRQNUM_14
+	IRQNUM_15
+	IRQNUM_16
+	IRQNUM_17
+	IRQNUM_18
+	IRQNUM_19
+	IRQNUM_20
+	IRQNUM_21
+	IRQNUM_22
+	IRQNUM_23
+	IRQNUM_24
+	IRQNUM_25
+	IRQNUM_26
+	IRQNUM_27
+	IRQNUM_28
+	IRQNUM_29
+	IRQNUM_30
+	IRQNUM_31
+)
+
 //export handleInterrupt
 func handleInterrupt() {
 	mcause := riscv.MCAUSE.Get()
@@ -74,7 +114,70 @@ func handleInterrupt() {
 		riscv.MSTATUS.SetBits(0x8)
 
 		// Call registered interrupt handler(s)
-		esp.HandleInterrupt(int(interruptNumber))
+		switch interruptNumber {
+		// case IRQNUM_1:
+		// 	callHandlers(IRQNUM_1)
+		// case 2:
+		// 	callHandlers(IRQNUM_2)
+		// case 3:
+		// 	callHandlers(IRQNUM_3)
+		// case 4:
+		// 	callHandlers(IRQNUM_4)
+		// case IRQNUM_5:
+		// 	callHandlers(IRQNUM_5)
+		case IRQNUM_6:
+			callHandlers(IRQNUM_6)
+			// case 7:
+			// 	callHandlers(IRQNUM_7)
+			// case 8:
+			// 	callHandlers(IRQNUM_8)
+			// case 9:
+			// 	callHandlers(IRQNUM_9)
+			// case 10:
+			// 	callHandlers(IRQNUM_10)
+			// case 11:
+			// 	callHandlers(IRQNUM_11)
+			// case 12:
+			// 	callHandlers(IRQNUM_12)
+			// case 13:
+			// 	callHandlers(IRQNUM_13)
+			// case 14:
+			// 	callHandlers(IRQNUM_14)
+			// case 15:
+			// 	callHandlers(IRQNUM_15)
+			// case 16:
+			// 	callHandlers(IRQNUM_16)
+			// case 17:
+			// 	callHandlers(IRQNUM_17)
+			// case 18:
+			// 	callHandlers(IRQNUM_18)
+			// case 19:
+			// 	callHandlers(IRQNUM_19)
+			// case 20:
+			// 	callHandlers(IRQNUM_20)
+			// case 21:
+			// 	callHandlers(IRQNUM_21)
+			// case 22:
+			// 	callHandlers(IRQNUM_22)
+			// case 23:
+			// 	callHandlers(IRQNUM_23)
+			// case 24:
+			// 	callHandlers(IRQNUM_24)
+			// case 25:
+			// 	callHandlers(IRQNUM_25)
+			// case 26:
+			// 	callHandlers(IRQNUM_26)
+			// case 27:
+			// 	callHandlers(IRQNUM_27)
+			// case 28:
+			// 	callHandlers(IRQNUM_28)
+			// case 29:
+			// 	callHandlers(IRQNUM_29)
+			// case 30:
+			// 	callHandlers(IRQNUM_30)
+			// case IRQNUM_31:
+			// 	callHandlers(IRQNUM_31)
+		}
 
 		// disable CPU interrupts
 		riscv.MSTATUS.ClearBits(0x8)

--- a/targets/esp32c3-12f.json
+++ b/targets/esp32c3-12f.json
@@ -1,0 +1,5 @@
+{
+	"inherits": ["esp32c3"],
+	"build-tags": ["esp32c312f", "esp32c3", "esp"]
+}
+


### PR DESCRIPTION
I have stumble upon compiler issue related to interrupts.
This is a test branch with working pininterrupt test. 
If you uncomment one case (5) in switch statement the tinygo will start failing in link with missing symbols.
And if you uncomment more cases (like 1-5) in switch statement the tinygo will just crash.
I am using LLVM13 build with make make llvm-build and make to build tinygo:
```
arm64:pininterrupt zdima$ tinygo version
tinygo version 0.23.0-dev-a7a69d38 darwin/arm64 (using go version go1.17.3 and LLVM version 13.0.0)
```
```
$ tinygo flash -x -target=esp32c3-12f pininterrupt.go 
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x2 addr=0xe61e1d679400 pc=0x1034d2428]

runtime stack:
runtime.throw({0x10376119a, 0x2a})
	/usr/local/go/src/runtime/panic.go:1198 +0x54
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:719 +0x230

goroutine 52 [syscall]:
runtime.cgocall(0x10044a65c, 0x1400674f538)
	/usr/local/go/src/runtime/cgocall.go:156 +0x50 fp=0x1400674f4f0 sp=0x1400674f4b0 pc=0x1000ffc40
tinygo.org/x/go-llvm._Cfunc_LLVMIsAConstantInt(0xe61e1d6793f0)
	_cgo_gotypes.go:7424 +0x44 fp=0x1400674f530 sp=0x1400674f4f0 pc=0x1002f5ae4
tinygo.org/x/go-llvm.Value.IsAConstantInt.func1({0xe61e1d6793f0})
	/Users/zdima/go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20220121152956-4fa2ab2718f3/ir.go:739 +0x50 fp=0x1400674f570 sp=0x1400674f530 pc=0x100300e00
tinygo.org/x/go-llvm.Value.IsAConstantInt({0xe61e1d6793f0})
	/Users/zdima/go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20220121152956-4fa2ab2718f3/ir.go:739 +0x28 fp=0x1400674f590 sp=0x1400674f570 pc=0x100300d88
github.com/tinygo-org/tinygo/transform.LowerInterrupts({0x149f31850})
	/Users/zdima/WorkFolder/tinygo-test/transform/interrupt.go:78 +0x65c fp=0x1400674fa70 sp=0x1400674f590 pc=0x1003e1bbc
```