### PR TITLE
os: isWine: be compatible with older versions of wine, too

### DIFF
--- a/src/os/path_windows_test.go
+++ b/src/os/path_windows_test.go
@@ -54,7 +54,7 @@ func TestFixLongPath(t *testing.T) {
 // isWine returns true if executing on wine (Wine Is Not an Emulator), which
 // is compatible with windows but does not reproduce all its quirks.
 func isWine() bool {
-	return os.Getenv("WINEUSERNAME") != ""
+	return os.Getenv("WINECONFIGDIR") != ""
 }
 
 func TestMkdirAllExtendedLength(t *testing.T) {


### PR DESCRIPTION
Turns out wine 5.x doesn't export WINEUSERNAME.