### PR TITLE
Fix LLVM build constraints

### DIFF
--- a/cgo/libclang_config_llvm11.go
+++ b/cgo/libclang_config_llvm11.go
@@ -5,12 +5,12 @@ package cgo
 
 /*
 #cgo linux        CFLAGS:  -I/usr/lib/llvm-11/include
-#cgo darwin amd64 CFLAGS:  -I/usr/local/opt/llvm@11/include
-#cgo darwin arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@11/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@11/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@11/include
 #cgo freebsd      CFLAGS:  -I/usr/local/llvm11/include
 #cgo linux        LDFLAGS: -L/usr/lib/llvm-11/lib -lclang
-#cgo darwin amd64 LDFLAGS: -L/usr/local/opt/llvm@11/lib -lclang -lffi
-#cgo darwin arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@11/lib -lclang -lffi
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@11/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@11/lib -lclang -lffi
 #cgo freebsd      LDFLAGS: -L/usr/local/llvm11/lib -lclang
 */
 import "C"

--- a/cgo/libclang_config_llvm12.go
+++ b/cgo/libclang_config_llvm12.go
@@ -5,12 +5,12 @@ package cgo
 
 /*
 #cgo linux        CFLAGS:  -I/usr/lib/llvm-12/include
-#cgo darwin amd64 CFLAGS:  -I/usr/local/opt/llvm@12/include
-#cgo darwin arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@12/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@12/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@12/include
 #cgo freebsd      CFLAGS:  -I/usr/local/llvm12/include
 #cgo linux        LDFLAGS: -L/usr/lib/llvm-12/lib -lclang
-#cgo darwin amd64 LDFLAGS: -L/usr/local/opt/llvm@12/lib -lclang -lffi
-#cgo darwin arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@12/lib -lclang -lffi
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@12/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@12/lib -lclang -lffi
 #cgo freebsd      LDFLAGS: -L/usr/local/llvm12/lib -lclang
 */
 import "C"

--- a/cgo/libclang_config_llvm13.go
+++ b/cgo/libclang_config_llvm13.go
@@ -5,12 +5,12 @@ package cgo
 
 /*
 #cgo linux        CFLAGS:  -I/usr/lib/llvm-13/include
-#cgo darwin amd64 CFLAGS:  -I/usr/local/opt/llvm@13/include
-#cgo darwin arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@13/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@13/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@13/include
 #cgo freebsd      CFLAGS:  -I/usr/local/llvm13/include
 #cgo linux        LDFLAGS: -L/usr/lib/llvm-13/lib -lclang
-#cgo darwin amd64 LDFLAGS: -L/usr/local/opt/llvm@13/lib -lclang -lffi
-#cgo darwin arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@13/lib -lclang -lffi
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@13/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@13/lib -lclang -lffi
 #cgo freebsd      LDFLAGS: -L/usr/local/llvm13/lib -lclang
 */
 import "C"


### PR DESCRIPTION
The include and linker search paths probably do nothing since they won't exist, but `-lffi` will break building if you don't have `libffi.so` installed.