### PR TITLE
all: update build constraints to Go 1.17

### DIFF
--- a/builder/tools-builtin.go
+++ b/builder/tools-builtin.go
@@ -1,3 +1,4 @@
+//go:build byollvm
 // +build byollvm
 
 package builder

--- a/builder/tools-external.go
+++ b/builder/tools-external.go
@@ -1,3 +1,4 @@
+//go:build !byollvm
 // +build !byollvm
 
 package builder

--- a/src/device/arm/scb.go
+++ b/src/device/arm/scb.go
@@ -1,6 +1,7 @@
 // Hand created file. DO NOT DELETE.
 // Cortex-M System Control Block-related definitions.
 
+//go:build cortexm
 // +build cortexm
 
 package arm

--- a/src/examples/can/feather-m4-can.go
+++ b/src/examples/can/feather-m4-can.go
@@ -1,3 +1,4 @@
+//go:build feather_m4_can
 // +build feather_m4_can
 
 package main

--- a/src/examples/caninterrupt/feather-m4-can.go
+++ b/src/examples/caninterrupt/feather-m4-can.go
@@ -1,3 +1,4 @@
+//go:build feather_m4_can
 // +build feather_m4_can
 
 package main

--- a/src/examples/dac/circuitplay_express.go
+++ b/src/examples/dac/circuitplay_express.go
@@ -1,3 +1,4 @@
+//go:build circuitplay_express
 // +build circuitplay_express
 
 package main

--- a/src/examples/dac/pyportal.go
+++ b/src/examples/dac/pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package main

--- a/src/examples/pininterrupt/circuitplay-express.go
+++ b/src/examples/pininterrupt/circuitplay-express.go
@@ -1,3 +1,4 @@
+//go:build circuitplay_express
 // +build circuitplay_express
 
 package main

--- a/src/examples/pininterrupt/pca10040.go
+++ b/src/examples/pininterrupt/pca10040.go
@@ -1,3 +1,4 @@
+//go:build pca10040
 // +build pca10040
 
 package main

--- a/src/examples/pininterrupt/stm32.go
+++ b/src/examples/pininterrupt/stm32.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package main

--- a/src/examples/pininterrupt/wioterminal.go
+++ b/src/examples/pininterrupt/wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package main

--- a/src/examples/pwm/arduino-mega1280.go
+++ b/src/examples/pwm/arduino-mega1280.go
@@ -1,3 +1,4 @@
+//go:build arduino_mega1280
 // +build arduino_mega1280
 
 package main

--- a/src/examples/pwm/arduino.go
+++ b/src/examples/pwm/arduino.go
@@ -1,3 +1,4 @@
+//go:build arduino
 // +build arduino
 
 package main

--- a/src/examples/pwm/bluepill.go
+++ b/src/examples/pwm/bluepill.go
@@ -1,3 +1,4 @@
+//go:build bluepill
 // +build bluepill
 
 package main

--- a/src/examples/pwm/feather-m4.go
+++ b/src/examples/pwm/feather-m4.go
@@ -1,3 +1,4 @@
+//go:build feather_m4
 // +build feather_m4
 
 package main

--- a/src/examples/pwm/itsybitsy-m0.go
+++ b/src/examples/pwm/itsybitsy-m0.go
@@ -1,3 +1,4 @@
+//go:build itsybitsy_m0
 // +build itsybitsy_m0
 
 package main

--- a/src/examples/pwm/itsybitsy-m4.go
+++ b/src/examples/pwm/itsybitsy-m4.go
@@ -1,3 +1,4 @@
+//go:build itsybitsy_m4
 // +build itsybitsy_m4
 
 package main

--- a/src/examples/pwm/nucleo-f722ze.go
+++ b/src/examples/pwm/nucleo-f722ze.go
@@ -1,3 +1,4 @@
+//go:build stm32f7
 // +build stm32f7
 
 package main

--- a/src/examples/pwm/nucleo-l031k6.go
+++ b/src/examples/pwm/nucleo-l031k6.go
@@ -1,3 +1,4 @@
+//go:build stm32l0
 // +build stm32l0
 
 package main

--- a/src/examples/pwm/nucleo-l432kc.go
+++ b/src/examples/pwm/nucleo-l432kc.go
@@ -1,3 +1,4 @@
+//go:build stm32l4
 // +build stm32l4
 
 package main

--- a/src/examples/pwm/nucleo-l552ze.go
+++ b/src/examples/pwm/nucleo-l552ze.go
@@ -1,3 +1,4 @@
+//go:build stm32l5
 // +build stm32l5
 
 package main

--- a/src/examples/pwm/pico.go
+++ b/src/examples/pwm/pico.go
@@ -1,3 +1,4 @@
+//go:build pico
 // +build pico
 
 package main

--- a/src/examples/pwm/stm32f4disco.go
+++ b/src/examples/pwm/stm32f4disco.go
@@ -1,3 +1,4 @@
+//go:build stm32f4disco
 // +build stm32f4disco
 
 package main

--- a/src/machine/board_arduino.go
+++ b/src/machine/board_arduino.go
@@ -1,3 +1,4 @@
+//go:build arduino
 // +build arduino
 
 package machine

--- a/src/machine/board_arduino_mega1280.go
+++ b/src/machine/board_arduino_mega1280.go
@@ -1,3 +1,4 @@
+//go:build arduino_mega1280
 // +build arduino_mega1280
 
 package machine

--- a/src/machine/board_arduino_mega2560.go
+++ b/src/machine/board_arduino_mega2560.go
@@ -1,3 +1,4 @@
+//go:build arduino_mega2560
 // +build arduino_mega2560
 
 package machine

--- a/src/machine/board_arduino_mkr1000.go
+++ b/src/machine/board_arduino_mkr1000.go
@@ -1,3 +1,4 @@
+//go:build arduino_mkr1000
 // +build arduino_mkr1000
 
 // This contains the pin mappings for the Arduino MKR1000 board.

--- a/src/machine/board_arduino_mkrwifi1010.go
+++ b/src/machine/board_arduino_mkrwifi1010.go
@@ -1,3 +1,4 @@
+//go:build arduino_mkrwifi1010
 // +build arduino_mkrwifi1010
 
 // This contains the pin mappings for the Arduino MKR WiFi 1010 board.

--- a/src/machine/board_arduino_nano.go
+++ b/src/machine/board_arduino_nano.go
@@ -1,3 +1,4 @@
+//go:build arduino_nano
 // +build arduino_nano
 
 package machine

--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -1,3 +1,4 @@
+//go:build arduino_nano33
 // +build arduino_nano33
 
 // This contains the pin mappings for the Arduino Nano33 IoT board.

--- a/src/machine/board_arduino_zero.go
+++ b/src/machine/board_arduino_zero.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && arduino_zero
 // +build sam,atsamd21,arduino_zero
 
 package machine

--- a/src/machine/board_atmega328p.go
+++ b/src/machine/board_atmega328p.go
@@ -1,3 +1,4 @@
+//go:build (avr && atmega328p) || arduino || arduino_nano
 // +build avr,atmega328p arduino arduino_nano
 
 package machine

--- a/src/machine/board_atsamd21.go
+++ b/src/machine/board_atsamd21.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsamd21) || arduino_nano33 || circuitplay_express
 // +build sam,atsamd21 arduino_nano33 circuitplay_express
 
 package machine

--- a/src/machine/board_atsame54-xpro.go
+++ b/src/machine/board_atsame54-xpro.go
@@ -1,3 +1,4 @@
+//go:build atsame54_xpro
 // +build atsame54_xpro
 
 package machine

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -1,3 +1,4 @@
+//go:build circuitplay_bluefruit
 // +build circuitplay_bluefruit
 
 package machine

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -1,3 +1,4 @@
+//go:build circuitplay_express
 // +build circuitplay_express
 
 package machine

--- a/src/machine/board_clue_alpha.go
+++ b/src/machine/board_clue_alpha.go
@@ -1,3 +1,4 @@
+//go:build clue_alpha
 // +build clue_alpha
 
 package machine

--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -1,3 +1,4 @@
+//go:build digispark
 // +build digispark
 
 package machine

--- a/src/machine/board_esp32-coreboard-v2.go
+++ b/src/machine/board_esp32-coreboard-v2.go
@@ -1,3 +1,4 @@
+//go:build esp32_coreboard_v2
 // +build esp32_coreboard_v2
 
 package machine

--- a/src/machine/board_fe310.go
+++ b/src/machine/board_fe310.go
@@ -1,3 +1,4 @@
+//go:build hifive1b
 // +build hifive1b
 
 package machine

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && feather_m0
 // +build sam,atsamd21,feather_m0
 
 package machine

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -1,3 +1,4 @@
+//go:build feather_m4_can
 // +build feather_m4_can
 
 package machine

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -1,3 +1,4 @@
+//go:build feather_m4
 // +build feather_m4
 
 package machine

--- a/src/machine/board_feather-nrf52840-sense.go
+++ b/src/machine/board_feather-nrf52840-sense.go
@@ -1,3 +1,4 @@
+//go:build feather_nrf52840_sense
 // +build feather_nrf52840_sense
 
 package machine

--- a/src/machine/board_feather-nrf52840.go
+++ b/src/machine/board_feather-nrf52840.go
@@ -1,3 +1,4 @@
+//go:build feather_nrf52840
 // +build feather_nrf52840
 
 package machine

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -1,3 +1,4 @@
+//go:build feather_stm32f405
 // +build feather_stm32f405
 
 package machine

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -1,3 +1,4 @@
+//go:build feather_rp2040
 // +build feather_rp2040
 
 package machine

--- a/src/machine/board_grandcentral-m4.go
+++ b/src/machine/board_grandcentral-m4.go
@@ -1,3 +1,4 @@
+//go:build grandcentral_m4
 // +build grandcentral_m4
 
 package machine

--- a/src/machine/board_hifive1b.go
+++ b/src/machine/board_hifive1b.go
@@ -1,3 +1,4 @@
+//go:build hifive1b
 // +build hifive1b
 
 package machine

--- a/src/machine/board_hifive1b_baremetal.go
+++ b/src/machine/board_hifive1b_baremetal.go
@@ -1,3 +1,4 @@
+//go:build fe310 && hifive1b
 // +build fe310,hifive1b
 
 package machine

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && itsybitsy_m0
 // +build sam,atsamd21,itsybitsy_m0
 
 package machine

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -1,3 +1,4 @@
+//go:build itsybitsy_m4
 // +build itsybitsy_m4
 
 package machine

--- a/src/machine/board_itsybitsy-nrf52840.go
+++ b/src/machine/board_itsybitsy-nrf52840.go
@@ -1,3 +1,4 @@
+//go:build itsybitsy_nrf52840
 // +build itsybitsy_nrf52840
 
 package machine

--- a/src/machine/board_k210.go
+++ b/src/machine/board_k210.go
@@ -1,3 +1,4 @@
+//go:build maixbit
 // +build maixbit
 
 // Chip datasheet: https://s3.cn-north-1.amazonaws.com.cn/dl.kendryte.com/documents/kendryte_datasheet_20181011163248_en.pdf

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -1,3 +1,4 @@
+//go:build lgt92
 // +build lgt92
 
 package machine

--- a/src/machine/board_m5stack.go
+++ b/src/machine/board_m5stack.go
@@ -1,3 +1,4 @@
+//go:build m5stack
 // +build m5stack
 
 package machine

--- a/src/machine/board_m5stack_core2.go
+++ b/src/machine/board_m5stack_core2.go
@@ -1,3 +1,4 @@
+//go:build m5stack_core2
 // +build m5stack_core2
 
 package machine

--- a/src/machine/board_maixbit.go
+++ b/src/machine/board_maixbit.go
@@ -1,3 +1,4 @@
+//go:build maixbit
 // +build maixbit
 
 package machine

--- a/src/machine/board_maixbit_baremetal.go
+++ b/src/machine/board_maixbit_baremetal.go
@@ -1,3 +1,4 @@
+//go:build k210 && maixbit
 // +build k210,maixbit
 
 package machine

--- a/src/machine/board_matrixportal-m4.go
+++ b/src/machine/board_matrixportal-m4.go
@@ -1,3 +1,4 @@
+//go:build matrixportal_m4
 // +build matrixportal_m4
 
 package machine

--- a/src/machine/board_mdbt50qrx.go
+++ b/src/machine/board_mdbt50qrx.go
@@ -1,3 +1,4 @@
+//go:build mdbt50qrx
 // +build mdbt50qrx
 
 package machine

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -1,3 +1,4 @@
+//go:build metro_m4_airlift
 // +build metro_m4_airlift
 
 package machine

--- a/src/machine/board_microbit-v2.go
+++ b/src/machine/board_microbit-v2.go
@@ -1,3 +1,4 @@
+//go:build microbit_v2
 // +build microbit_v2
 
 package machine

--- a/src/machine/board_microbit.go
+++ b/src/machine/board_microbit.go
@@ -1,3 +1,4 @@
+//go:build microbit
 // +build microbit
 
 package machine

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -1,3 +1,4 @@
+//go:build nano_rp2040
 // +build nano_rp2040
 
 // This contains the pin mappings for the Arduino Nano RP2040 Connect board.

--- a/src/machine/board_nicenano.go
+++ b/src/machine/board_nicenano.go
@@ -1,3 +1,4 @@
+//go:build nicenano
 // +build nicenano
 
 package machine

--- a/src/machine/board_nodemcu.go
+++ b/src/machine/board_nodemcu.go
@@ -1,3 +1,4 @@
+//go:build nodemcu
 // +build nodemcu
 
 // Pinout for the NodeMCU dev kit.

--- a/src/machine/board_nrf52840-mdk-usb-dongle.go
+++ b/src/machine/board_nrf52840-mdk-usb-dongle.go
@@ -1,3 +1,4 @@
+//go:build nrf52840_mdk_usb_dongle
 // +build nrf52840_mdk_usb_dongle
 
 package machine

--- a/src/machine/board_nrf52840-mdk.go
+++ b/src/machine/board_nrf52840-mdk.go
@@ -1,3 +1,4 @@
+//go:build nrf52840_mdk
 // +build nrf52840_mdk
 
 package machine

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -1,3 +1,4 @@
+//go:build nucleof103rb
 // +build nucleof103rb
 
 package machine

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -1,3 +1,4 @@
+//go:build nucleof722ze
 // +build nucleof722ze
 
 package machine

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -1,3 +1,4 @@
+//go:build nucleol031k6
 // +build nucleol031k6
 
 package machine

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -1,3 +1,4 @@
+//go:build nucleol432kc
 // +build nucleol432kc
 
 package machine

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -1,3 +1,4 @@
+//go:build nucleol552ze
 // +build nucleol552ze
 
 package machine

--- a/src/machine/board_p1am-100.go
+++ b/src/machine/board_p1am-100.go
@@ -1,3 +1,4 @@
+//go:build p1am_100
 // +build p1am_100
 
 // This contains the pin mappings for the ProductivityOpen P1AM-100 board.

--- a/src/machine/board_particle_argon.go
+++ b/src/machine/board_particle_argon.go
@@ -1,3 +1,4 @@
+//go:build particle_argon
 // +build particle_argon
 
 package machine

--- a/src/machine/board_particle_boron.go
+++ b/src/machine/board_particle_boron.go
@@ -1,3 +1,4 @@
+//go:build particle_boron
 // +build particle_boron
 
 package machine

--- a/src/machine/board_particle_xenon.go
+++ b/src/machine/board_particle_xenon.go
@@ -1,3 +1,4 @@
+//go:build particle_xenon
 // +build particle_xenon
 
 package machine

--- a/src/machine/board_pca10031.go
+++ b/src/machine/board_pca10031.go
@@ -1,3 +1,4 @@
+//go:build pca10031
 // +build pca10031
 
 // pca10031 is a nrf51 based dongle, intended for use in wireless applications.

--- a/src/machine/board_pca10040.go
+++ b/src/machine/board_pca10040.go
@@ -1,3 +1,4 @@
+//go:build pca10040
 // +build pca10040
 
 package machine

--- a/src/machine/board_pca10056.go
+++ b/src/machine/board_pca10056.go
@@ -1,3 +1,4 @@
+//go:build pca10056
 // +build pca10056
 
 package machine

--- a/src/machine/board_pca10059.go
+++ b/src/machine/board_pca10059.go
@@ -1,3 +1,4 @@
+//go:build pca10059
 // +build pca10059
 
 package machine

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -1,3 +1,4 @@
+//go:build pico
 // +build pico
 
 package machine

--- a/src/machine/board_pinetime-devkit0.go
+++ b/src/machine/board_pinetime-devkit0.go
@@ -1,3 +1,4 @@
+//go:build pinetime_devkit0
 // +build pinetime_devkit0
 
 package machine

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -1,3 +1,4 @@
+//go:build pybadge
 // +build pybadge
 
 package machine

--- a/src/machine/board_pygamer.go
+++ b/src/machine/board_pygamer.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && pygamer
 // +build sam,atsamd51,pygamer
 
 package machine

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -1,3 +1,4 @@
+//go:build pyportal
 // +build pyportal
 
 package machine

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && qtpy
 // +build sam,atsamd21,qtpy
 
 package machine

--- a/src/machine/board_reelboard.go
+++ b/src/machine/board_reelboard.go
@@ -1,3 +1,4 @@
+//go:build reelboard
 // +build reelboard
 
 package machine

--- a/src/machine/board_stm32f469disco.go
+++ b/src/machine/board_stm32f469disco.go
@@ -1,3 +1,4 @@
+//go:build stm32f469disco
 // +build stm32f469disco
 
 package machine

--- a/src/machine/board_teensy36.go
+++ b/src/machine/board_teensy36.go
@@ -1,3 +1,4 @@
+//go:build nxp && mk66f18 && teensy36
 // +build nxp,mk66f18,teensy36
 
 package machine

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -1,3 +1,4 @@
+//go:build teensy40
 // +build teensy40
 
 package machine

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && trinket_m0
 // +build sam,atsamd21,trinket_m0
 
 package machine

--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -1,3 +1,4 @@
+//go:build wioterminal
 // +build wioterminal
 
 package machine

--- a/src/machine/board_x9pro.go
+++ b/src/machine/board_x9pro.go
@@ -1,3 +1,4 @@
+//go:build x9pro
 // +build x9pro
 
 package machine

--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && xiao
 // +build sam,atsamd21,xiao
 
 package machine

--- a/src/machine/i2s.go
+++ b/src/machine/i2s.go
@@ -1,3 +1,4 @@
+//go:build sam
 // +build sam
 
 // This is the definition for I2S bus functions.

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega
 // +build avr,atmega
 
 package machine

--- a/src/machine/machine_atmega1280.go
+++ b/src/machine/machine_atmega1280.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega1280
 // +build avr,atmega1280
 
 package machine

--- a/src/machine/machine_atmega1284p.go
+++ b/src/machine/machine_atmega1284p.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega1284p
 // +build avr,atmega1284p
 
 package machine

--- a/src/machine/machine_atmega2560.go
+++ b/src/machine/machine_atmega2560.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega2560
 // +build avr,atmega2560
 
 package machine

--- a/src/machine/machine_atmega328p.go
+++ b/src/machine/machine_atmega328p.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega328p
 // +build avr,atmega328p
 
 package machine

--- a/src/machine/machine_atmega328pb.go
+++ b/src/machine/machine_atmega328pb.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega328pb
 // +build avr,atmega328pb
 
 package machine

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21
 // +build sam,atsamd21
 
 // Peripheral abstraction layer for the atsamd21.

--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && atsamd21e18
 // +build sam,atsamd21,atsamd21e18
 
 // Peripheral abstraction layer for the atsamd21.

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && atsamd21g18
 // +build sam,atsamd21,atsamd21g18
 
 // Peripheral abstraction layer for the atsamd21.

--- a/src/machine/machine_atsamd51g19.go
+++ b/src/machine/machine_atsamd51g19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51g19
 // +build sam,atsamd51,atsamd51g19
 
 // Peripheral abstraction layer for the atsamd51.

--- a/src/machine/machine_atsamd51j19.go
+++ b/src/machine/machine_atsamd51j19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51j19
 // +build sam,atsamd51,atsamd51j19
 
 // Peripheral abstraction layer for the atsamd51.

--- a/src/machine/machine_atsamd51j20.go
+++ b/src/machine/machine_atsamd51j20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51j20
 // +build sam,atsamd51,atsamd51j20
 
 // Peripheral abstraction layer for the atsamd51.

--- a/src/machine/machine_atsamd51p19.go
+++ b/src/machine/machine_atsamd51p19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51p19
 // +build sam,atsamd51,atsamd51p19
 
 // Peripheral abstraction layer for the atsamd51.

--- a/src/machine/machine_atsamd51p20.go
+++ b/src/machine/machine_atsamd51p20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51p20
 // +build sam,atsamd51,atsamd51p20
 
 // Peripheral abstraction layer for the atsamd51.

--- a/src/machine/machine_atsame51j19.go
+++ b/src/machine/machine_atsame51j19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsame51 && atsame51j19
 // +build sam,atsame51,atsame51j19
 
 // Peripheral abstraction layer for the atsame51.

--- a/src/machine/machine_atsame54p20.go
+++ b/src/machine/machine_atsame54p20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsame5x && atsame54p20
 // +build sam,atsame5x,atsame54p20
 
 // Peripheral abstraction layer for the atsame54.

--- a/src/machine/machine_atsame5x_can.go
+++ b/src/machine/machine_atsame5x_can.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsame51) || (sam && atsame54)
 // +build sam,atsame51 sam,atsame54
 
 package machine

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -1,3 +1,4 @@
+//go:build attiny85
 // +build attiny85
 
 package machine

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -1,3 +1,4 @@
+//go:build esp32
 // +build esp32
 
 package machine

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -1,3 +1,4 @@
+//go:build esp32c3
 // +build esp32c3
 
 package machine

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -1,3 +1,4 @@
+//go:build esp8266
 // +build esp8266
 
 package machine

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -1,3 +1,4 @@
+//go:build fe310
 // +build fe310
 
 package machine

--- a/src/machine/machine_gameboyadvance.go
+++ b/src/machine/machine_gameboyadvance.go
@@ -1,3 +1,4 @@
+//go:build gameboyadvance
 // +build gameboyadvance
 
 package machine

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -1,3 +1,4 @@
+//go:build !baremetal
 // +build !baremetal
 
 package machine

--- a/src/machine/machine_generic_peripherals.go
+++ b/src/machine/machine_generic_peripherals.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !arduino_mkr1000 && !arduino_mkrwifi1010 && !arduino_nano33 && !arduino_zero && !circuitplay_express && !feather_m0 && !feather_m4 && !grandcentral_m4 && !itsybitsy_m0 && !itsybitsy_m4 && !matrixportal_m4 && !metro_m4_airlift && !p1am_100 && !pybadge && !pygamer && !pyportal && !qtpy && !trinket_m0 && !wioterminal && !xiao
 // +build !baremetal,!arduino_mkr1000,!arduino_mkrwifi1010,!arduino_nano33,!arduino_zero,!circuitplay_express,!feather_m0,!feather_m4,!grandcentral_m4,!itsybitsy_m0,!itsybitsy_m4,!matrixportal_m4,!metro_m4_airlift,!p1am_100,!pybadge,!pygamer,!pyportal,!qtpy,!trinket_m0,!wioterminal,!xiao
 
 package machine

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -1,3 +1,4 @@
+//go:build k210
 // +build k210
 
 package machine

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package machine

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package machine

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -1,3 +1,4 @@
+//go:build nrf51
 // +build nrf51
 
 package machine

--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -1,3 +1,4 @@
+//go:build nrf52
 // +build nrf52
 
 package machine

--- a/src/machine/machine_nrf52833.go
+++ b/src/machine/machine_nrf52833.go
@@ -1,3 +1,4 @@
+//go:build nrf52833
 // +build nrf52833
 
 package machine

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -1,3 +1,4 @@
+//go:build nrf52840
 // +build nrf52840
 
 package machine

--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -1,3 +1,4 @@
+//go:build nrf52840
 // +build nrf52840
 
 package machine

--- a/src/machine/machine_nrf52840_usb_reset_bossa.go
+++ b/src/machine/machine_nrf52840_usb_reset_bossa.go
@@ -1,3 +1,4 @@
+//go:build nrf52840 && nrf52840_reset_bossa
 // +build nrf52840,nrf52840_reset_bossa
 
 package machine

--- a/src/machine/machine_nrf52840_usb_reset_none.go
+++ b/src/machine/machine_nrf52840_usb_reset_none.go
@@ -1,3 +1,4 @@
+//go:build nrf52840 && !nrf52840_reset_uf2 && !nrf52840_reset_bossa
 // +build nrf52840,!nrf52840_reset_uf2,!nrf52840_reset_bossa
 
 package machine

--- a/src/machine/machine_nrf52840_usb_reset_uf2.go
+++ b/src/machine/machine_nrf52840_usb_reset_uf2.go
@@ -1,3 +1,4 @@
+//go:build nrf52840 && nrf52840_reset_uf2
 // +build nrf52840,nrf52840_reset_uf2
 
 package machine

--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -1,3 +1,4 @@
+//go:build nrf52 || nrf52840 || nrf52833
 // +build nrf52 nrf52840 nrf52833
 
 package machine

--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -27,6 +27,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build nxp && mk66f18
 // +build nxp,mk66f18
 
 package machine

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -27,6 +27,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build nxp && mk66f18
 // +build nxp,mk66f18
 
 package machine

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_i2c.go
+++ b/src/machine/machine_rp2040_i2c.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_pll.go
+++ b/src/machine/machine_rp2040_pll.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_resets.go
+++ b/src/machine/machine_rp2040_resets.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_spi.go
+++ b/src/machine/machine_rp2040_spi.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_timer.go
+++ b/src/machine/machine_rp2040_timer.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_watchdog.go
+++ b/src/machine/machine_rp2040_watchdog.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_rp2040_xosc.go
+++ b/src/machine/machine_rp2040_xosc.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package machine

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package machine

--- a/src/machine/machine_stm32_exti_afio.go
+++ b/src/machine/machine_stm32_exti_afio.go
@@ -1,3 +1,4 @@
+//go:build stm32f1
 // +build stm32f1
 
 package machine

--- a/src/machine/machine_stm32_exti_exti.go
+++ b/src/machine/machine_stm32_exti_exti.go
@@ -1,3 +1,4 @@
+//go:build stm32l5
 // +build stm32l5
 
 package machine

--- a/src/machine/machine_stm32_i2c_reva.go
+++ b/src/machine/machine_stm32_i2c_reva.go
@@ -1,3 +1,4 @@
+//go:build stm32f4 || stm32f1
 // +build stm32f4 stm32f1
 
 package machine

--- a/src/machine/machine_stm32_tim.go
+++ b/src/machine/machine_stm32_tim.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package machine

--- a/src/machine/machine_stm32_tim_moder.go
+++ b/src/machine/machine_stm32_tim_moder.go
@@ -1,3 +1,4 @@
+//go:build stm32 && !stm32f1
 // +build stm32,!stm32f1
 
 package machine

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package machine

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -1,3 +1,4 @@
+//go:build stm32 && stm32f103
 // +build stm32,stm32f103
 
 package machine

--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -1,3 +1,4 @@
+//go:build stm32f7x2
 // +build stm32f7x2
 
 package machine

--- a/src/machine/machine_stm32l0x1.go
+++ b/src/machine/machine_stm32l0x1.go
@@ -1,3 +1,4 @@
+//go:build stm32l0x1
 // +build stm32l0x1
 
 package machine

--- a/src/machine/machine_stm32l5x2.go
+++ b/src/machine/machine_stm32l5x2.go
@@ -1,3 +1,4 @@
+//go:build stm32l5x2
 // +build stm32l5x2
 
 package machine

--- a/src/machine/serial-none.go
+++ b/src/machine/serial-none.go
@@ -1,3 +1,4 @@
+//go:build baremetal && serial.none
 // +build baremetal,serial.none
 
 package machine

--- a/src/machine/serial-uart.go
+++ b/src/machine/serial-uart.go
@@ -1,3 +1,4 @@
+//go:build baremetal && serial.uart
 // +build baremetal,serial.uart
 
 package machine

--- a/src/machine/serial-usb.go
+++ b/src/machine/serial-usb.go
@@ -1,3 +1,4 @@
+//go:build baremetal && serial.usb
 // +build baremetal,serial.usb
 
 package machine

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -1,3 +1,4 @@
+//go:build atmega || esp || nrf || sam || sifive || stm32 || k210 || nxp || rp2040
 // +build atmega esp nrf sam sifive stm32 k210 nxp rp2040
 
 package machine

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -1,3 +1,4 @@
+//go:build sam || nrf52840
 // +build sam nrf52840
 
 package machine

--- a/src/os/dir.go
+++ b/src/os/dir.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 // Copyright 2016 The Go Authors. All rights reserved.

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,3 +1,4 @@
+//go:build (go1.16 && baremetal) || (go1.16 && js) || (go1.16 && wasi) || (go1.16 && windows)
 // +build go1.16,baremetal go1.16,js go1.16,wasi go1.16,windows
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/dir_other_go115.go
+++ b/src/os/dir_other_go115.go
@@ -1,3 +1,4 @@
+//go:build !go1.16
 // +build !go1.16
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/dir_test.go
+++ b/src/os/dir_test.go
@@ -1,3 +1,4 @@
+//go:build darwin || (linux && !baremetal && !js && !wasi && !386 && !arm)
 // +build darwin linux,!baremetal,!js,!wasi,!386,!arm
 
 package os_test

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !baremetal && !wasi
 // +build linux,!baremetal,!wasi
 
 package os

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !js && !wasi
 // +build !baremetal,!js,!wasi
 
 // Copyright 2020 The Go Authors. All rights reserved.

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build darwin linux
+//go:build darwin || linux
+// +build darwin linux
 
 package os_test
 

--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,3 +1,4 @@
+//go:build !linux || baremetal
 // +build !linux baremetal
 
 package os

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !baremetal
 // +build linux,!baremetal
 
 package os

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !js
 // +build !baremetal,!js
 
 package os_test

--- a/src/os/file_go_116.go
+++ b/src/os/file_go_116.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package os

--- a/src/os/file_go_116_test.go
+++ b/src/os/file_go_116_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.16 && !baremetal && !js && !wasi
 // +build go1.16,!baremetal,!js,!wasi
 
 // DirFS tests copied verbatim from upstream os_test.go, and adjusted minimally to fit tinygo.

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,3 +1,4 @@
+//go:build baremetal || (wasm && !wasi)
 // +build baremetal wasm,!wasi
 
 package os

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || (linux && !baremetal)
 // +build darwin linux,!baremetal
 
 // Portions copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,3 +1,4 @@
+//go:build windows || darwin || (linux && !baremetal)
 // +build windows darwin linux,!baremetal
 
 package os_test

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !js && !wasi
 // +build !baremetal,!js,!wasi
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,3 +1,4 @@
+//go:build !windows && !baremetal && !js && !wasi
 // +build !windows,!baremetal,!js,!wasi
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/path.go
+++ b/src/os/path.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !js
 // +build !baremetal,!js
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/seek_unix_bad.go
+++ b/src/os/seek_unix_bad.go
@@ -1,3 +1,4 @@
+//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi)
 // +build linux,!baremetal,386 linux,!baremetal,arm,!wasi
 
 package os

--- a/src/os/stat_linux.go
+++ b/src/os/stat_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && !baremetal
 // +build linux,!baremetal
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,5 @@
-//  +build baremetal wasm,!wasi
+//go:build baremetal || (wasm && !wasi)
+// +build baremetal wasm,!wasi
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || (linux && !baremetal)
 // +build darwin linux,!baremetal
 
 // Copyright 2016 The Go Authors. All rights reserved.

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !js
 // +build !baremetal,!js
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || (linux && !baremetal)
 // +build darwin linux,!baremetal
 
 // Copyright 2009 The Go Authors. All rights reserved.

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -1,3 +1,4 @@
+//go:build (arm && !baremetal && !tinygo.wasm) || (arm && arm7tdmi)
 // +build arm,!baremetal,!tinygo.wasm arm,arm7tdmi
 
 package runtime

--- a/src/runtime/arch_tinygoriscv32.go
+++ b/src/runtime/arch_tinygoriscv32.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv32
 // +build tinygo.riscv32
 
 package runtime

--- a/src/runtime/arch_tinygoriscv64.go
+++ b/src/runtime/arch_tinygoriscv64.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv64
 // +build tinygo.riscv64
 
 package runtime

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -1,3 +1,4 @@
+//go:build tinygo.wasm
 // +build tinygo.wasm
 
 package runtime

--- a/src/runtime/arch_xtensa.go
+++ b/src/runtime/arch_xtensa.go
@@ -1,3 +1,4 @@
+//go:build xtensa
 // +build xtensa
 
 package runtime

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -1,3 +1,4 @@
+//go:build baremetal
 // +build baremetal
 
 package runtime

--- a/src/runtime/cond.go
+++ b/src/runtime/cond.go
@@ -1,3 +1,4 @@
+//go:build !scheduler.none
 // +build !scheduler.none
 
 package runtime

--- a/src/runtime/cond_nosched.go
+++ b/src/runtime/cond_nosched.go
@@ -1,3 +1,4 @@
+//go:build scheduler.none
 // +build scheduler.none
 
 package runtime

--- a/src/runtime/env_linux.go
+++ b/src/runtime/env_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package runtime

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -1,3 +1,4 @@
+//go:build gc.leaking
 // +build gc.leaking
 
 package runtime

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -1,3 +1,4 @@
+//go:build gc.none
 // +build gc.none
 
 package runtime

--- a/src/runtime/hosted.go
+++ b/src/runtime/hosted.go
@@ -1,3 +1,4 @@
+//go:build !baremetal
 // +build !baremetal
 
 package runtime

--- a/src/runtime/interrupt/interrupt_avr.go
+++ b/src/runtime/interrupt/interrupt_avr.go
@@ -1,3 +1,4 @@
+//go:build avr
 // +build avr
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_cortexm.go
+++ b/src/runtime/interrupt/interrupt_cortexm.go
@@ -1,3 +1,4 @@
+//go:build cortexm
 // +build cortexm
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -1,3 +1,4 @@
+//go:build esp32c3
 // +build esp32c3
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_gameboyadvance.go
+++ b/src/runtime/interrupt/interrupt_gameboyadvance.go
@@ -1,3 +1,4 @@
+//go:build gameboyadvance
 // +build gameboyadvance
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_k210.go
+++ b/src/runtime/interrupt/interrupt_k210.go
@@ -1,3 +1,4 @@
+//go:build k210
 // +build k210
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_none.go
+++ b/src/runtime/interrupt/interrupt_none.go
@@ -1,3 +1,4 @@
+//go:build !baremetal
 // +build !baremetal
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_sifive.go
+++ b/src/runtime/interrupt/interrupt_sifive.go
@@ -1,3 +1,4 @@
+//go:build sifive
 // +build sifive
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_tinygoriscv.go
+++ b/src/runtime/interrupt/interrupt_tinygoriscv.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv
 // +build tinygo.riscv
 
 package interrupt

--- a/src/runtime/interrupt/interrupt_xtensa.go
+++ b/src/runtime/interrupt/interrupt_xtensa.go
@@ -1,3 +1,4 @@
+//go:build xtensa
 // +build xtensa
 
 package interrupt

--- a/src/runtime/mstats.go
+++ b/src/runtime/mstats.go
@@ -1,3 +1,4 @@
+//go:build gc.conservative
 // +build gc.conservative
 
 package runtime

--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -1,3 +1,4 @@
+//go:build baremetal || js
 // +build baremetal js
 
 package runtime

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package runtime

--- a/src/runtime/os_js.go
+++ b/src/runtime/os_js.go
@@ -1,3 +1,4 @@
+//go:build js
 // +build js
 
 package runtime

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package runtime

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -1,3 +1,4 @@
+//go:build arm7tdmi
 // +build arm7tdmi
 
 package runtime

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -1,3 +1,4 @@
+//go:build avr && atmega
 // +build avr,atmega
 
 package runtime

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21
 // +build sam,atsamd21
 
 package runtime

--- a/src/runtime/runtime_atsamd21e18.go
+++ b/src/runtime/runtime_atsamd21e18.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && atsamd21e18
 // +build sam,atsamd21,atsamd21e18
 
 package runtime

--- a/src/runtime/runtime_atsamd21g18.go
+++ b/src/runtime/runtime_atsamd21g18.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd21 && atsamd21g18
 // +build sam,atsamd21,atsamd21g18
 
 package runtime

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsamd51) || (sam && atsame5x)
 // +build sam,atsamd51 sam,atsame5x
 
 package runtime

--- a/src/runtime/runtime_atsamd51g19.go
+++ b/src/runtime/runtime_atsamd51g19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51g19
 // +build sam,atsamd51,atsamd51g19
 
 package runtime

--- a/src/runtime/runtime_atsamd51j19.go
+++ b/src/runtime/runtime_atsamd51j19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51j19
 // +build sam,atsamd51,atsamd51j19
 
 package runtime

--- a/src/runtime/runtime_atsamd51j20.go
+++ b/src/runtime/runtime_atsamd51j20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51j20
 // +build sam,atsamd51,atsamd51j20
 
 package runtime

--- a/src/runtime/runtime_atsamd51p19.go
+++ b/src/runtime/runtime_atsamd51p19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51p19
 // +build sam,atsamd51,atsamd51p19
 
 package runtime

--- a/src/runtime/runtime_atsamd51p20.go
+++ b/src/runtime/runtime_atsamd51p20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsamd51 && atsamd51p20
 // +build sam,atsamd51,atsamd51p20
 
 package runtime

--- a/src/runtime/runtime_atsame51j19.go
+++ b/src/runtime/runtime_atsame51j19.go
@@ -1,3 +1,4 @@
+//go:build sam && atsame51 && atsame51j19
 // +build sam,atsame51,atsame51j19
 
 package runtime

--- a/src/runtime/runtime_atsame54p20.go
+++ b/src/runtime/runtime_atsame54p20.go
@@ -1,3 +1,4 @@
+//go:build sam && atsame5x && atsame54p20
 // +build sam,atsame5x,atsame54p20
 
 package runtime

--- a/src/runtime/runtime_atsame5x_can.go
+++ b/src/runtime/runtime_atsame5x_can.go
@@ -1,3 +1,4 @@
+//go:build (sam && atsame51) || (sam && atsame54)
 // +build sam,atsame51 sam,atsame54
 
 package runtime

--- a/src/runtime/runtime_attiny.go
+++ b/src/runtime/runtime_attiny.go
@@ -1,3 +1,4 @@
+//go:build avr && attiny
 // +build avr,attiny
 
 package runtime

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -1,3 +1,4 @@
+//go:build cortexm
 // +build cortexm
 
 package runtime

--- a/src/runtime/runtime_cortexm_abort.go
+++ b/src/runtime/runtime_cortexm_abort.go
@@ -1,3 +1,4 @@
+//go:build cortexm && !nxp && !qemu
 // +build cortexm,!nxp,!qemu
 
 package runtime

--- a/src/runtime/runtime_cortexm_hardfault.go
+++ b/src/runtime/runtime_cortexm_hardfault.go
@@ -1,3 +1,4 @@
+//go:build atsamd21 || nrf51
 // +build atsamd21 nrf51
 
 package runtime

--- a/src/runtime/runtime_cortexm_hardfault_debug.go
+++ b/src/runtime/runtime_cortexm_hardfault_debug.go
@@ -1,3 +1,4 @@
+//go:build cortexm && !atsamd21 && !nrf51
 // +build cortexm,!atsamd21,!nrf51
 
 package runtime

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -1,3 +1,4 @@
+//go:build cortexm && qemu
 // +build cortexm,qemu
 
 package runtime

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -1,3 +1,4 @@
+//go:build esp32
 // +build esp32
 
 package runtime

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -1,3 +1,4 @@
+//go:build esp32c3
 // +build esp32c3
 
 package runtime

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -1,3 +1,4 @@
+//go:build esp32 || esp32c3
 // +build esp32 esp32c3
 
 package runtime

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -1,3 +1,4 @@
+//go:build esp8266
 // +build esp8266
 
 package runtime

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -1,3 +1,4 @@
+//go:build fe310
 // +build fe310
 
 // This file implements target-specific things for the FE310 chip as used in the

--- a/src/runtime/runtime_fe310_baremetal.go
+++ b/src/runtime/runtime_fe310_baremetal.go
@@ -1,3 +1,4 @@
+//go:build fe310 && !qemu
 // +build fe310,!qemu
 
 package runtime

--- a/src/runtime/runtime_fe310_qemu.go
+++ b/src/runtime/runtime_fe310_qemu.go
@@ -1,3 +1,4 @@
+//go:build fe310 && qemu
 // +build fe310,qemu
 
 package runtime

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -1,3 +1,4 @@
+//go:build k210
 // +build k210
 
 // This file implements target-specific things for the K210 chip as used in the

--- a/src/runtime/runtime_k210_baremetal.go
+++ b/src/runtime/runtime_k210_baremetal.go
@@ -1,3 +1,4 @@
+//go:build k210 && !qemu
 // +build k210,!qemu
 
 package runtime

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package runtime

--- a/src/runtime/runtime_mimxrt1062_clock.go
+++ b/src/runtime/runtime_mimxrt1062_clock.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package runtime

--- a/src/runtime/runtime_mimxrt1062_mpu.go
+++ b/src/runtime/runtime_mimxrt1062_mpu.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package runtime

--- a/src/runtime/runtime_mimxrt1062_time.go
+++ b/src/runtime/runtime_mimxrt1062_time.go
@@ -1,3 +1,4 @@
+//go:build mimxrt1062
 // +build mimxrt1062
 
 package runtime

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -1,3 +1,4 @@
+//go:build nintendoswitch
 // +build nintendoswitch
 
 package runtime

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -1,3 +1,4 @@
+//go:build nrf
 // +build nrf
 
 package runtime

--- a/src/runtime/runtime_nrf_bare.go
+++ b/src/runtime/runtime_nrf_bare.go
@@ -1,3 +1,4 @@
+//go:build nrf && !softdevice
 // +build nrf,!softdevice
 
 package runtime

--- a/src/runtime/runtime_nrf_softdevice.go
+++ b/src/runtime/runtime_nrf_softdevice.go
@@ -1,3 +1,4 @@
+//go:build nrf && softdevice
 // +build nrf,softdevice
 
 package runtime

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -27,6 +27,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build nxp && mk66f18
 // +build nxp,mk66f18
 
 package runtime

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -1,3 +1,4 @@
+//go:build rp2040
 // +build rp2040
 
 package runtime

--- a/src/runtime/runtime_stm32.go
+++ b/src/runtime/runtime_stm32.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package runtime

--- a/src/runtime/runtime_stm32_timers.go
+++ b/src/runtime/runtime_stm32_timers.go
@@ -1,3 +1,4 @@
+//go:build stm32
 // +build stm32
 
 package runtime

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -1,3 +1,4 @@
+//go:build stm32 && stm32f103
 // +build stm32,stm32f103
 
 package runtime

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -1,3 +1,4 @@
+//go:build stm32f405
 // +build stm32f405
 
 package runtime

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -1,3 +1,4 @@
+//go:build stm32 && stm32f7x2
 // +build stm32,stm32f7x2
 
 package runtime

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -1,3 +1,4 @@
+//go:build stm32l0
 // +build stm32l0
 
 package runtime

--- a/src/runtime/runtime_stm32l0x1.go
+++ b/src/runtime/runtime_stm32l0x1.go
@@ -1,3 +1,4 @@
+//go:build stm32l0x1
 // +build stm32l0x1
 
 package runtime

--- a/src/runtime/runtime_stm32l0x2.go
+++ b/src/runtime/runtime_stm32l0x2.go
@@ -1,3 +1,4 @@
+//go:build stm32l0x2
 // +build stm32l0x2
 
 package runtime

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -1,3 +1,4 @@
+//go:build stm32 && stm32l5x2
 // +build stm32,stm32l5x2
 
 package runtime

--- a/src/runtime/runtime_tinygoriscv.go
+++ b/src/runtime/runtime_tinygoriscv.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv32
 // +build tinygo.riscv32
 
 package runtime

--- a/src/runtime/runtime_tinygoriscv64.go
+++ b/src/runtime/runtime_tinygoriscv64.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv64
 // +build tinygo.riscv64
 
 package runtime

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -1,3 +1,4 @@
+//go:build tinygo.riscv && virt && qemu
 // +build tinygo.riscv,virt,qemu
 
 package runtime

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,3 +1,4 @@
+//go:build tinygo.wasm
 // +build tinygo.wasm
 
 package runtime

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,3 +1,4 @@
+//go:build tinygo.wasm && wasi
 // +build tinygo.wasm,wasi
 
 package runtime

--- a/src/runtime/scheduler_tasks.go
+++ b/src/runtime/scheduler_tasks.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks
 // +build scheduler.tasks
 
 package runtime

--- a/src/runtime/time_nxpmk66f18.go
+++ b/src/runtime/time_nxpmk66f18.go
@@ -27,6 +27,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build nxp && mk66f18
 // +build nxp,mk66f18
 
 package runtime

--- a/src/runtime/volatile/bitband_nxpmk66f18.go
+++ b/src/runtime/volatile/bitband_nxpmk66f18.go
@@ -1,3 +1,4 @@
+//go:build nxp && mk66f18
 // +build nxp,mk66f18
 
 package volatile

--- a/src/runtime/wait_other.go
+++ b/src/runtime/wait_other.go
@@ -1,5 +1,5 @@
-// +build !tinygo.riscv
-// +build !cortexm
+//go:build !tinygo.riscv && !cortexm
+// +build !tinygo.riscv,!cortexm
 
 package runtime
 

--- a/src/syscall/errno_other.go
+++ b/src/syscall/errno_other.go
@@ -1,3 +1,4 @@
+//go:build !wasi && !darwin
 // +build !wasi,!darwin
 
 package syscall

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,3 +1,4 @@
+//go:build baremetal || wasm
 // +build baremetal wasm
 
 // This file emulates some file-related functions that are only available

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !wasm
 // +build !baremetal,!wasm
 
 // This file assumes there is a libc available that runs on a real operating

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,3 +1,4 @@
+//go:build baremetal || wasi || wasm
 // +build baremetal wasi wasm
 
 // This file emulates some process-related functions that are only available

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,3 +1,4 @@
+//go:build !baremetal && !wasi && !wasm
 // +build !baremetal,!wasi,!wasm
 
 // This file assumes there is a libc available that runs on a real operating

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -1,3 +1,4 @@
+//go:build darwin || nintendoswitch || wasi
 // +build darwin nintendoswitch wasi
 
 package syscall

--- a/src/syscall/syscall_libc_darwin.go
+++ b/src/syscall/syscall_libc_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package syscall

--- a/src/syscall/syscall_libc_nintendoswitch.go
+++ b/src/syscall/syscall_libc_nintendoswitch.go
@@ -1,3 +1,4 @@
+//go:build nintendoswitch
 // +build nintendoswitch
 
 package syscall

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -1,3 +1,4 @@
+//go:build wasi
 // +build wasi
 
 package syscall

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,3 +1,4 @@
+//go:build baremetal || js
 // +build baremetal js
 
 package syscall

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build baremetal || nintendoswitch || js
 // +build baremetal nintendoswitch js
 
 package syscall

--- a/util_unix.go
+++ b/util_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main


### PR DESCRIPTION
Do it all at once in preparation for Go 1.18 support.

To make this commit, I've simply modified the `fmt-check` Makefile target to rewrite files instead of listing the differences. So this is a fully mechanical change, it should not have introduced any errors.