### PR TITLE
rp2040: fix incorrect inline assembly

### DIFF
--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -149,16 +149,13 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 			// Note XOSC_COUNT is not helpful here because XOSC is not
 			// necessarily running, nor is timer... so, 3 cycles per loop:
 			delayCyc := configuredFreq[clkSys]/configuredFreq[clk.cix] + 1
-			arm.AsmFull(
-				`
-				ldr r0, {cyc}
-				1:
-				subs r0, #1
-				bne 1b 
-             	`,
-				map[string]interface{}{
-					"cyc": &delayCyc,
-				})
+			for delayCyc != 0 {
+				// This could be done more efficiently but TinyGo inline
+				// assembly is not yet capable enough to express that. In the
+				// meantime, this forces at least 3 cycles per loop.
+				delayCyc--
+				arm.Asm("nop\nnop\nnop")
+			}
 		}
 	}
 


### PR DESCRIPTION
The register r0 was used unconditionally. This is a bug: the compiler doesn't know it is clobbered and might consider it alive across the inline assembly expression.

The fix is simple. It could probably be optimized, but this should at least fix the bug. I discovered it while working on LLVM 14 support.

---

Note: this is UNTESTED. I don't have a rp2040 with me at the moment so can't test it myself.