### PR TITLE
Implement some missing Signal bits

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -55,3 +55,7 @@ func (p *Process) Wait() (*ProcessState, error) {
 func (p *Process) Kill() error {
 	return ErrNotImplemented
 }
+
+func (p *Process) Signal(sig Signal) error {
+	return ErrNotImplemented
+}

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -1,0 +1,22 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package os
+
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || windows
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris windows
+
+import (
+	"syscall"
+)
+
+// The only signal values guaranteed to be present in the os package on all
+// systems are os.Interrupt (send the process an interrupt) and os.Kill (force
+// the process to exit). On Windows, sending os.Interrupt to a process with
+// os.Process.Signal is not implemented; it will return an error instead of
+// sending a signal.
+var (
+	Interrupt Signal = syscall.SIGINT
+	Kill      Signal = syscall.SIGKILL
+)

--- a/src/syscall/syscall_libc_darwin.go
+++ b/src/syscall/syscall_libc_darwin.go
@@ -4,6 +4,7 @@
 package syscall
 
 import (
+	"internal/itoa"
 	"unsafe"
 )
 
@@ -81,6 +82,20 @@ const (
 	SIGQUIT Signal = 0x3
 	SIGTERM Signal = 0xf
 )
+
+func (s Signal) Signal() {}
+
+func (s Signal) String() string {
+	if 0 <= s && int(s) < len(signals) {
+		str := signals[s]
+		if str != "" {
+			return str
+		}
+	}
+	return "signal " + itoa.Itoa(int(s))
+}
+
+var signals = [...]string{}
 
 const (
 	Stdin  = 0

--- a/src/syscall/syscall_libc_nintendoswitch.go
+++ b/src/syscall/syscall_libc_nintendoswitch.go
@@ -3,6 +3,10 @@
 
 package syscall
 
+import (
+	"internal/itoa"
+)
+
 // A Signal is a number describing a process signal.
 // It implements the os.Signal interface.
 type Signal int
@@ -16,6 +20,20 @@ const (
 	SIGQUIT
 	SIGTERM
 )
+
+func (s Signal) Signal() {}
+
+func (s Signal) String() string {
+	if 0 <= s && int(s) < len(signals) {
+		str := signals[s]
+		if str != "" {
+			return str
+		}
+	}
+	return "signal " + itoa.Itoa(int(s))
+}
+
+var signals = [...]string{}
 
 // File system
 

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -4,6 +4,7 @@
 package syscall
 
 import (
+	"internal/itoa"
 	"unsafe"
 )
 
@@ -19,6 +20,20 @@ const (
 	SIGQUIT = 3
 	SIGTERM = 15
 )
+
+func (s Signal) Signal() {}
+
+func (s Signal) String() string {
+	if 0 <= s && int(s) < len(signals) {
+		str := signals[s]
+		if str != "" {
+			return str
+		}
+	}
+	return "signal " + itoa.Itoa(int(s))
+}
+
+var signals = [...]string{}
 
 const (
 	Stdin  = 0

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -13,12 +13,12 @@ import (
 type Signal int
 
 const (
-	SIGCHLD = 16
-	SIGINT  = 2
-	SIGKILL = 9
-	SIGTRAP = 5
-	SIGQUIT = 3
-	SIGTERM = 15
+	SIGCHLD Signal = 16
+	SIGINT  Signal = 2
+	SIGKILL Signal = 9
+	SIGTRAP Signal = 5
+	SIGQUIT Signal = 3
+	SIGTERM Signal = 15
 )
 
 func (s Signal) Signal() {}

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -3,6 +3,10 @@
 
 package syscall
 
+import (
+	"internal/itoa"
+)
+
 // Most code here has been copied from the Go sources:
 //   https://github.com/golang/go/blob/go1.12/src/syscall/syscall_js.go
 // It has the following copyright note:
@@ -24,6 +28,20 @@ const (
 	SIGQUIT
 	SIGTERM
 )
+
+func (s Signal) Signal() {}
+
+func (s Signal) String() string {
+	if 0 <= s && int(s) < len(signals) {
+		str := signals[s]
+		if str != "" {
+			return str
+		}
+	}
+	return "signal " + itoa.Itoa(int(s))
+}
+
+var signals = [...]string{}
 
 // File system
 


### PR DESCRIPTION
Some bits of the `os.Signal` interface were not implemented, so I copied them out of the `syscall_js.go` from upstream Go. Also added the "always-available" (but not really, because the build constraints) signal aliases to `os`.

These are needed for parts of the fuzzing implementation in Go 1.18.