### PR TITLE
testing: implement testing.TempDir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,11 +261,13 @@ TEST_PACKAGES := \
 
 # archive/zip requires ReadAt, which is not yet supported on windows
 # io/fs requires os.ReadDir, which is not yet supported on windows or wasi
+# testing/fstest requires os.ReadDir, which is not yet supported on windows or wasi
 ifneq ($(OS),Windows_NT)
 TEST_PACKAGES := \
 	$(TEST_PACKAGES) \
 	archive/zip \
-	io/fs
+	io/fs \
+	testing/fstest
 endif
 
 # Standard library packages that pass tests on wasi

--- a/Makefile
+++ b/Makefile
@@ -260,10 +260,12 @@ TEST_PACKAGES := \
 	$(TEST_PACKAGES_BASE)
 
 # archive/zip requires ReadAt, which is not yet supported on windows
+# io/fs requires os.ReadDir, which is not yet supported on windows or wasi
 ifneq ($(OS),Windows_NT)
 TEST_PACKAGES := \
 	$(TEST_PACKAGES) \
-	archive/zip
+	archive/zip \
+	io/fs
 endif
 
 # Standard library packages that pass tests on wasi

--- a/src/testing/is_wasi_no_test.go
+++ b/src/testing/is_wasi_no_test.go
@@ -1,0 +1,10 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//go:build !wasi
+// +build !wasi
+
+package testing_test
+
+const isWASI = false

--- a/src/testing/is_wasi_test.go
+++ b/src/testing/is_wasi_test.go
@@ -1,0 +1,10 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//go:build wasi
+// +build wasi
+
+package testing_test
+
+const isWASI = true

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -103,6 +103,7 @@ func fmtDuration(d time.Duration) string {
 
 // TB is the interface common to T and B.
 type TB interface {
+	Cleanup(func())
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
 	Fail()
@@ -110,6 +111,7 @@ type TB interface {
 	Failed() bool
 	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
+	Helper()
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
 	Name() string
@@ -117,8 +119,7 @@ type TB interface {
 	SkipNow()
 	Skipf(format string, args ...interface{})
 	Skipped() bool
-	Helper()
-	Parallel()
+	TempDir() string
 }
 
 var _ TB = (*T)(nil)
@@ -345,7 +346,7 @@ func (c *common) runCleanup() {
 }
 
 // Parallel is not implemented, it is only provided for compatibility.
-func (c *common) Parallel() {
+func (t *T) Parallel() {
 	// Unimplemented.
 }
 

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Testing flags.
@@ -58,6 +60,10 @@ type common struct {
 	name     string    // Name of test or benchmark.
 	start    time.Time // Time test or benchmark started
 	duration time.Duration
+
+	tempDir    string
+	tempDirErr error
+	tempDirSeq int32
 }
 
 // Short reports whether the -test.short flag is set.
@@ -256,6 +262,70 @@ func (c *common) Helper() {
 // first called order.
 func (c *common) Cleanup(f func()) {
 	c.cleanups = append(c.cleanups, f)
+}
+
+// TempDir returns a temporary directory for the test to use.
+// The directory is automatically removed by Cleanup when the test and
+// all its subtests complete.
+// Each subsequent call to t.TempDir returns a unique directory;
+// if the directory creation fails, TempDir terminates the test by calling Fatal.
+func (c *common) TempDir() string {
+	// Use a single parent directory for all the temporary directories
+	// created by a test, each numbered sequentially.
+	var nonExistent bool
+	if c.tempDir == "" { // Usually the case with js/wasm
+		nonExistent = true
+	} else {
+		_, err := os.Stat(c.tempDir)
+		nonExistent = os.IsNotExist(err)
+		if err != nil && !nonExistent {
+			c.Fatalf("TempDir: %v", err)
+		}
+	}
+
+	if nonExistent {
+		c.Helper()
+
+		// Drop unusual characters (such as path separators or
+		// characters interacting with globs) from the directory name to
+		// avoid surprising os.MkdirTemp behavior.
+		mapper := func(r rune) rune {
+			if r < utf8.RuneSelf {
+				const allowed = "!#$%&()+,-.=@^_{}~ "
+				if '0' <= r && r <= '9' ||
+					'a' <= r && r <= 'z' ||
+					'A' <= r && r <= 'Z' {
+					return r
+				}
+				if strings.ContainsRune(allowed, r) {
+					return r
+				}
+			} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
+				return r
+			}
+			return -1
+		}
+		pattern := strings.Map(mapper, c.Name())
+		c.tempDir, c.tempDirErr = os.MkdirTemp("", pattern)
+		if c.tempDirErr == nil {
+			c.Cleanup(func() {
+				if err := os.RemoveAll(c.tempDir); err != nil {
+					c.Errorf("TempDir RemoveAll cleanup: %v", err)
+				}
+			})
+		}
+	}
+
+	if c.tempDirErr != nil {
+		c.Fatalf("TempDir: %v", c.tempDirErr)
+	}
+	seq := c.tempDirSeq
+	c.tempDirSeq++
+	dir := fmt.Sprintf("%s%c%03d", c.tempDir, os.PathSeparator, seq)
+	if err := os.Mkdir(dir, 0777); err != nil {
+		c.Fatalf("TempDir: %v", err)
+	}
+	return dir
 }
 
 // runCleanup is called at the end of the test.

--- a/src/testing/testing_test.go
+++ b/src/testing/testing_test.go
@@ -119,6 +119,13 @@ func testTempDir(t *testing.T) {
 	if !fi.IsDir() {
 		t.Errorf("dir %q is not a dir", dir)
 	}
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) > 0 {
+		t.Errorf("unexpected %d files in TempDir: %v", len(files), files)
+	}
 
 	glob := filepath.Join(dir, "*.txt")
 	if _, err := filepath.Glob(glob); err != nil {


### PR DESCRIPTION
Also enable testing/fstest and io/fs in "make tinygo-test" as first consumers.

Not supported yet on windows and wasi, where os.Readdir and os.RemoveAll are unimplemented.