### PR TITLE
os: Use a uintptr for NewFile

### DIFF
--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -21,9 +21,9 @@ func init() {
 // Stdin, Stdout, and Stderr are open Files pointing to the standard input,
 // standard output, and standard error file descriptors.
 var (
-	Stdin  = NewFile(unixFileHandle(syscall.Stdin), "/dev/stdin")
-	Stdout = NewFile(unixFileHandle(syscall.Stdout), "/dev/stdout")
-	Stderr = NewFile(unixFileHandle(syscall.Stderr), "/dev/stderr")
+	Stdin  = NewFile(uintptr(syscall.Stdin), "/dev/stdin")
+	Stdout = NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+	Stderr = NewFile(uintptr(syscall.Stderr), "/dev/stderr")
 )
 
 const DevNull = "/dev/null"
@@ -87,9 +87,9 @@ func (fs unixFilesystem) Remove(path string) error {
 	return &PathError{Op: "remove", Path: path, Err: e}
 }
 
-func (fs unixFilesystem) OpenFile(path string, flag int, perm FileMode) (FileHandle, error) {
+func (fs unixFilesystem) OpenFile(path string, flag int, perm FileMode) (uintptr, error) {
 	fp, err := syscall.Open(path, flag, uint32(perm))
-	return unixFileHandle(fp), handleSyscallError(err)
+	return uintptr(fp), handleSyscallError(err)
 }
 
 // unixFileHandle is a Unix file pointer with associated methods that implement

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -10,9 +10,9 @@ import (
 // Stdin, Stdout, and Stderr are open Files pointing to the standard input,
 // standard output, and standard error file descriptors.
 var (
-	Stdin  = NewFile(stdioFileHandle(0), "/dev/stdin")
-	Stdout = NewFile(stdioFileHandle(1), "/dev/stdout")
-	Stderr = NewFile(stdioFileHandle(2), "/dev/stderr")
+	Stdin  = NewFile(0, "/dev/stdin")
+	Stdout = NewFile(1, "/dev/stdout")
+	Stderr = NewFile(2, "/dev/stderr")
 )
 
 // isOS indicates whether we're running on a real operating system with
@@ -32,8 +32,8 @@ type file struct {
 	name   string
 }
 
-func NewFile(fd FileHandle, name string) *File {
-	return &File{&file{fd, name}}
+func NewFile(fd uintptr, name string) *File {
+	return &File{&file{stdioFileHandle(fd), name}}
 }
 
 // Read is unsupported on this system.

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -38,8 +38,8 @@ type file struct {
 	dirinfo *dirInfo // nil unless directory being read
 }
 
-func NewFile(fd FileHandle, name string) *File {
-	return &File{&file{fd, name, nil}}
+func NewFile(fd uintptr, name string) *File {
+	return &File{&file{unixFileHandle(fd), name, nil}}
 }
 
 func Pipe() (r *File, w *File, err error) {
@@ -48,8 +48,8 @@ func Pipe() (r *File, w *File, err error) {
 	if err != nil {
 		return
 	}
-	r = NewFile(unixFileHandle(p[0]), "|0")
-	w = NewFile(unixFileHandle(p[1]), "|1")
+	r = NewFile(uintptr(p[0]), "|0")
+	w = NewFile(uintptr(p[1]), "|1")
 	return
 }
 

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -38,8 +38,8 @@ type file struct {
 	name   string
 }
 
-func NewFile(fd FileHandle, name string) *File {
-	return &File{&file{fd, name}}
+func NewFile(fd uintptr, name string) *File {
+	return &File{&file{unixFileHandle(fd), name}}
 }
 
 func Pipe() (r *File, w *File, err error) {
@@ -48,14 +48,8 @@ func Pipe() (r *File, w *File, err error) {
 	if e != nil {
 		return nil, nil, err
 	}
-	r = NewFile(
-		unixFileHandle(p[0]),
-		"|0",
-	)
-	w = NewFile(
-		unixFileHandle(p[1]),
-		"|1",
-	)
+	r = NewFile(uintptr(p[0]), "|0")
+	w = NewFile(uintptr(p[1]), "|1")
 	return
 }
 

--- a/src/os/filesystem.go
+++ b/src/os/filesystem.go
@@ -28,7 +28,7 @@ type mountPoint struct {
 // WARNING: this interface is not finalized and may change in a future version.
 type Filesystem interface {
 	// OpenFile opens the named file.
-	OpenFile(name string, flag int, perm FileMode) (FileHandle, error)
+	OpenFile(name string, flag int, perm FileMode) (uintptr, error)
 
 	// Mkdir creates a new directoy with the specified permission (before
 	// umask). Some filesystems may not support directories or permissions.


### PR DESCRIPTION
This appears to have been how it is upstream for about 10 years. Using an interface breaks if a file descriptor number is passed directly to `NewFile`, e.g., `NewFile(3, "fuzz_in")` as used in [Go 1.18 fuzzing code](https://github.com/golang/go/blob/d588f487703e773ba4a2f0a04f2d4141610bff6b/src/internal/fuzz/sys_posix.go#L61).