### PR TITLE
Fix cross-Linux setup on non-amd64 arches

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -317,11 +317,20 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 	if goarch != runtime.GOARCH {
 		// Some educated guesses as to how to invoke helper programs.
 		spec.GDB = []string{"gdb-multiarch"}
-		if goarch == "arm" && goos == "linux" {
-			spec.Emulator = []string{"qemu-arm"}
-		}
-		if goarch == "arm64" && goos == "linux" {
-			spec.Emulator = []string{"qemu-aarch64"}
+		if goos == "linux" {
+			switch goarch {
+			case "386":
+				// amd64 can _usually_ run 32-bit programs, so skip the emulator in that case.
+				if runtime.GOARCH != "amd64" {
+					spec.Emulator = []string{"qemu-i386"}
+				}
+			case "amd64":
+				spec.Emulator = []string{"qemu-x86_64"}
+			case "arm":
+				spec.Emulator = []string{"qemu-arm"}
+			case "arm64":
+				spec.Emulator = []string{"qemu-aarch64"}
+			}
 		}
 	}
 	if goos != runtime.GOOS {


### PR DESCRIPTION
In that case, an emulator is needed for amd64, and tests should be run for amd64 as a _cross_ test.

I'm not 100% on the 386 and arm sides as it turns out qemu is broken there for some arches, but it works to put amd64 in qemu.