### PR TITLE
os, runtime: enable os.Stdin for baremetal target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/echo
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/echo2
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=circuitplay-express examples/i2s
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/mcp3008

--- a/src/examples/echo2/echo2.go
+++ b/src/examples/echo2/echo2.go
@@ -1,0 +1,31 @@
+// This is a echo console running on the os.Stdin and os.Stdout.
+// Stdin and os.Stdout are connected to machine.Serial in the baremetal target.
+//
+// Serial can be switched with the -serial option as follows
+// 1. tinygo flash -target wioterminal -serial usb examples/echo2
+// 2. tinygo flash -target wioterminal -serial uart examples/echo2
+//
+// This example will also work with standard Go.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Printf("Echo console enabled. Type something then press enter:\r\n")
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for {
+		msg := ""
+		fmt.Scanf("%s\n", &msg)
+		fmt.Printf("You typed (scanf) : %s\r\n", msg)
+
+		if scanner.Scan() {
+			fmt.Printf("You typed (scanner) : %s\r\n", scanner.Text())
+		}
+	}
+}

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -14,6 +14,16 @@ func putchar(c byte) {
 	// dummy, TODO
 }
 
+func getchar() byte {
+	// dummy, TODO
+	return 0
+}
+
+func buffered() int {
+	// dummy, TODO
+	return 0
+}
+
 //go:extern _sbss
 var _sbss [0]byte
 

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -16,6 +16,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 // Sleep for a given period. The period is defined by the WDT peripheral, and is
 // on most chips (at least) 3 bits wide, in powers of two from 16ms to 2s
 // (0=16ms, 1=32ms, 2=64ms...). Note that the WDT is not very accurate: it can

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -39,6 +39,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initClocks() {
 	// Set 1 Flash Wait State for 48MHz, required for 3.3V operation according to SAMD21 Datasheet
 	sam.NVMCTRL.CTRLB.SetBits(sam.NVMCTRL_CTRLB_RWS_HALF << sam.NVMCTRL_CTRLB_RWS_Pos)

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -39,6 +39,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initClocks() {
 	// set flash wait state
 	sam.NVMCTRL.CTRLA.SetBits(0 << sam.NVMCTRL_CTRLA_RWS_Pos)

--- a/src/runtime/runtime_attiny.go
+++ b/src/runtime/runtime_attiny.go
@@ -14,6 +14,16 @@ func putchar(c byte) {
 	// UART is not supported.
 }
 
+func getchar() byte {
+	// UART is not supported.
+	return 0
+}
+
+func buffered() int {
+	// UART is not supported.
+	return 0
+}
+
 func sleepWDT(period uint8) {
 	// TODO: use the watchdog timer instead of a busy loop.
 	for i := 0x45; i != 0; i-- {

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -49,6 +49,16 @@ func putchar(c byte) {
 	stdoutWrite.Set(uint8(c))
 }
 
+func getchar() byte {
+	// dummy, TODO
+	return 0
+}
+
+func buffered() int {
+	// dummy, TODO
+	return 0
+}
+
 func waitForEvents() {
 	arm.Asm("wfe")
 }

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -15,6 +15,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 // Initialize .bss: zero-initialized global variables.
 // The .data section has already been loaded by the ROM bootloader.
 func clearbss() {

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -18,6 +18,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 // Write to the internal control bus (using I2C?).
 // Signature found here:
 // https://github.com/espressif/ESP8266_RTOS_SDK/blob/14171de0/components/esp8266/include/esp8266/rom_functions.h#L54

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -99,6 +99,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 var timerWakeup volatile.Register8
 
 func ticks() timeUnit {

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -111,6 +111,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 var timerWakeup volatile.Register8
 
 func ticks() timeUnit {

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -126,6 +126,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.UART1.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.UART1.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.UART1.Buffered()
+}
+
 func exit(code int) {
 	abort()
 }

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -66,6 +66,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks := uint32(d) & 0x7fffff // 23 bits (to be on the safe side)

--- a/src/runtime/runtime_nxpmk66f18.go
+++ b/src/runtime/runtime_nxpmk66f18.go
@@ -231,6 +231,16 @@ func putchar(c byte) {
 	machine.PutcharUART(machine.UART0, c)
 }
 
+func getchar() byte {
+	// dummy, TODO
+	return 0
+}
+
+func buffered() int {
+	// dummy, TODO
+	return 0
+}
+
 func exit(code int) {
 	abort()
 }

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -45,6 +45,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 // machineInit is provided by package machine.
 func machineInit()
 

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -20,6 +20,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 // initCLK sets clock to 72MHz using HSE 8MHz crystal w/ PLL X 9 (8MHz x 9 = 72MHz).
 func initCLK() {
 	stm32.FLASH.ACR.SetBits(stm32.FLASH_ACR_LATENCY_WS2)                          // Two wait states, per datasheet

--- a/src/runtime/runtime_stm32f4.go
+++ b/src/runtime/runtime_stm32f4.go
@@ -21,6 +21,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initCLK() {
 	// Reset clock registers
 	// Set HSION

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -163,3 +163,15 @@ func initCOM() {
 func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -38,6 +38,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initCLK() {
 	// PWR_CLK_ENABLE
 	stm32.RCC.APB1ENR.SetBits(stm32.RCC_APB1ENR_PWREN)

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -16,6 +16,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initCLK() {
 	// Set Power Regulator to enable max performance (1.8V)
 	stm32.PWR.CR.ReplaceBits(1<<stm32.PWR_CR_VOS_Pos, stm32.PWR_CR_VOS_Msk, 0)

--- a/src/runtime/runtime_stm32l4.go
+++ b/src/runtime/runtime_stm32l4.go
@@ -47,6 +47,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initCLK() {
 	// PWR_CLK_ENABLE
 	stm32.RCC.APB1ENR1.SetBits(stm32.RCC_APB1ENR1_PWREN)

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -39,6 +39,18 @@ func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
 
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
 func initCLK() {
 
 	// PWR_CLK_ENABLE

--- a/src/runtime/runtime_stm32wlx.go
+++ b/src/runtime/runtime_stm32wlx.go
@@ -102,3 +102,15 @@ func initCLK() {
 func putchar(c byte) {
 	machine.Serial.WriteByte(c)
 }
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -55,6 +55,16 @@ func putchar(c byte) {
 	stdoutWrite.Set(uint8(c))
 }
 
+func getchar() byte {
+	// dummy, TODO
+	return 0
+}
+
+func buffered() int {
+	// dummy, TODO
+	return 0
+}
+
 func abort() {
 	exit(1)
 }


### PR DESCRIPTION
This PR enables os.Stdin for the baremetal target.

There are two items that need to be discussed and agreement.

1. ~~Can an os package import a machine package?~~
    * solved: Could not import machine package from os package. I used go:link instead.
2. ~~There are changes that will *break compatibility*~~
    * ~~I've changed `src/machine/uart.go` and `src/machine/usb.go`, and the behavior changes significantly.~~
    * ~~`bufio.Scanner.Scan()` will not work without this change (error message is `multiple Read calls return no data or error`)~~
    * This PR only adds os.Stdin, so there are no compatibility-breaking changes.
