### PR TITLE
machine: add DefaultUART to wioterminal

### DIFF
--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -345,6 +345,8 @@ const (
 )
 
 var (
+	DefaultUART = UART1
+
 	UART1 = &sercomUSART2
 
 	// RTL8720D


### PR DESCRIPTION
Activate the -serial option for tinygo.