### PR TITLE
samd21,samd51: fix usbcdc initialization when -serial=uart

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1742,6 +1742,7 @@ type USBCDC struct {
 	waitTxc           bool
 	waitTxcRetryCount uint8
 	sent              bool
+	configured        bool
 }
 
 var (
@@ -1923,6 +1924,13 @@ func (usbcdc *USBCDC) Configure(config UARTConfig) {
 	// enable IRQ
 	intr := interrupt.New(sam.IRQ_USB, handleUSB)
 	intr.Enable()
+
+	usbcdc.configured = true
+}
+
+// Configured returns whether usbcdc is configured or not.
+func (usbcdc *USBCDC) Configured() bool {
+	return usbcdc.configured
 }
 
 func handlePadCalibration() {

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1965,6 +1965,7 @@ type USBCDC struct {
 	waitTxc           bool
 	waitTxcRetryCount uint8
 	sent              bool
+	configured        bool
 }
 
 var (
@@ -2149,6 +2150,13 @@ func (usbcdc *USBCDC) Configure(config UARTConfig) {
 	interrupt.New(sam.IRQ_USB_SOF_HSOF, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT0, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT1, handleUSBIRQ).Enable()
+
+	usbcdc.configured = true
+}
+
+// Configured returns whether usbcdc is configured or not.
+func (usbcdc *USBCDC) Configured() bool {
+	return usbcdc.configured
 }
 
 func handlePadCalibration() {

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -7,7 +7,6 @@ import (
 	"device/arm"
 	"device/sam"
 	"machine"
-	"reflect"
 	"runtime/interrupt"
 	"runtime/volatile"
 	"unsafe"
@@ -31,7 +30,7 @@ func init() {
 
 	// connect to USB CDC interface
 	machine.Serial.Configure(machine.UARTConfig{})
-	if reflect.TypeOf(machine.Serial) != reflect.TypeOf(machine.USB) {
+	if !machine.USB.Configured() {
 		machine.USB.Configure(machine.UARTConfig{})
 	}
 }

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -7,6 +7,7 @@ import (
 	"device/arm"
 	"device/sam"
 	"machine"
+	"reflect"
 	"runtime/interrupt"
 	"runtime/volatile"
 	"unsafe"
@@ -30,6 +31,9 @@ func init() {
 
 	// connect to USB CDC interface
 	machine.Serial.Configure(machine.UARTConfig{})
+	if reflect.TypeOf(machine.Serial) != reflect.TypeOf(machine.USB) {
+		machine.USB.Configure(machine.UARTConfig{})
+	}
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -7,7 +7,6 @@ import (
 	"device/arm"
 	"device/sam"
 	"machine"
-	"reflect"
 	"runtime/interrupt"
 	"runtime/volatile"
 )
@@ -31,7 +30,7 @@ func init() {
 
 	// connect to USB CDC interface
 	machine.Serial.Configure(machine.UARTConfig{})
-	if reflect.TypeOf(machine.Serial) != reflect.TypeOf(machine.USB) {
+	if !machine.USB.Configured() {
 		machine.USB.Configure(machine.UARTConfig{})
 	}
 }

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -7,6 +7,7 @@ import (
 	"device/arm"
 	"device/sam"
 	"machine"
+	"reflect"
 	"runtime/interrupt"
 	"runtime/volatile"
 )
@@ -30,6 +31,9 @@ func init() {
 
 	// connect to USB CDC interface
 	machine.Serial.Configure(machine.UARTConfig{})
+	if reflect.TypeOf(machine.Serial) != reflect.TypeOf(machine.USB) {
+		machine.USB.Configure(machine.UARTConfig{})
+	}
 }
 
 func putchar(c byte) {


### PR DESCRIPTION
After writing with -serial=uart, tinygo flash will fail.
The reason for the failure is that the USBCDC initialization is not performed.
This PR will fix this problem.



I have confirmed that it works with the following targets:

* ~~nrf : feather-nrf52840-sense~~
* samd21 : qtpy
* samd51 : wioterminal