### PR TITLE
debug: pyOCD support

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -370,7 +370,7 @@ func (c *Config) Programmer() (method, openocdInterface string) {
 	case "":
 		// No configuration supplied.
 		return c.Target.FlashMethod, c.Target.OpenOCDInterface
-	case "openocd", "msd", "command":
+	case "openocd", "pyocd", "msd", "command":
 		// The -programmer flag only specifies the flash method.
 		return c.Options.Programmer, c.Target.OpenOCDInterface
 	case "bmp":

--- a/main.go
+++ b/main.go
@@ -557,6 +557,20 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 				daemon.Stdout = w
 				daemon.Stderr = w
 			}
+		case "pyocd":
+			port = ":3333"
+			gdbCommands = append(gdbCommands, "monitor halt", "load", "monitor reset halt")
+			daemon = executeCommand(config.Options, "pyocd", "gdbserver", "--persist", "-t", config.Target.OpenOCDTarget)
+			if ocdOutput {
+				// Make it clear which output is from the daemon.
+				w := &ColorWriter{
+					Out:    colorable.NewColorableStderr(),
+					Prefix: "pyocd: ",
+					Color:  TermColorYellow,
+				}
+				daemon.Stdout = w
+				daemon.Stderr = w
+			}
 		case "jlink":
 			port = ":2331"
 			gdbCommands = append(gdbCommands, "load", "monitor reset halt")


### PR DESCRIPTION
This adds [pyOCD](https://pyocd.io) support, rudimentary, uses existing openocd target definitions.

Tested to work with [picoprobe](https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html#debugging-using-another-raspberry-pi-pico) debugging RP2040 board.
Download [picoprobe.uf2](https://datasheets.raspberrypi.com/soft/picoprobe.uf2) file and flash it to any RP2040 board to convert it to a debugger. 

Motivation:
This is the only straight way to debug RP2040 boards I was able to find.
`openocd` (0.11.0 or HEAD) would not work for me via `cmsis-dap` or `jlink` interfaces (and different debuggers, including Particle DAPLink, XIAO DAPLink and JLink EDU I've tried), while `picoprobe` interface is not available in official `openocd`, and `pyOCD` does have it.

To use `pyocd`, please specify `--programmer=pyocd` in `tinygo gdb` command.

`--persist` is there to keep pyOCD running when automatically launched gdb is detached by user to connect to pyOCD from another app, like an IDE.