### PR TITLE
Cross-build of TinyGo to 32-bit Linux ARM

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -84,7 +84,6 @@ jobs:
         run: make wasi-libc
       - name: Install fpm
         run: |
-          sudo apt-get install ruby ruby-dev
           sudo gem install --no-document fpm
       - name: Build TinyGo release
         run: |
@@ -94,7 +93,7 @@ jobs:
       - name: Publish release artifact
         uses: actions/upload-artifact@v2
         with:
-          name: release-double-zipped
+          name: linux-amd64-double-zipped
           path: |
             /tmp/tinygo.linux-amd64.tar.gz
             /tmp/tinygo_amd64.deb
@@ -116,7 +115,7 @@ jobs:
       - name: Download release artifact
         uses: actions/download-artifact@v2
         with:
-          name: release-double-zipped
+          name: linux-amd64-double-zipped
       - name: Extract release tarball
         run: |
           mkdir -p ~/lib
@@ -242,3 +241,108 @@ jobs:
       - run: make smoketest
       - run: make wasmtest
       - run: make tinygo-baremetal
+  build-linux-arm:
+    # Build ARM Linux binaries, ready for release.
+    # This intentionally uses an older Linux image, so that we compile against
+    # an older glibc version and therefore are compatible with a wide range of
+    # Linux distributions.
+    # It is set to "needs: build-linux" because it modifies the release created
+    # in that process to avoid doing lots of duplicate work and to avoid
+    # complications around precompiled libraries such as compiler-rt shipped as
+    # part of the release tarball.
+    runs-on: ubuntu-18.04
+    needs: build-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get install --no-install-recommends \
+              qemu-user \
+              g++-arm-linux-gnueabihf \
+              libc6-dev-armhf-cross
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - name: Cache Go
+        uses: actions/cache@v2
+        with:
+          key: go-cache-linux-arm-v2-${{ hashFiles('go.mod') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+      - name: Cache LLVM source
+        uses: actions/cache@v2
+        id: cache-llvm-source
+        with:
+          key: llvm-source-14-linux-v1
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Download LLVM source
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        run: make llvm-source
+      - name: Cache LLVM build
+        uses: actions/cache@v2
+        id: cache-llvm-build
+        with:
+          key: llvm-build-14-linux-arm-v1
+          path: llvm-build
+      - name: Build LLVM
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        run: |
+          # fetch LLVM source
+          rm -rf llvm-project
+          make llvm-source
+          # Install build dependencies.
+          sudo apt-get install --no-install-recommends ninja-build
+          # build!
+          make llvm-build CROSS=arm-linux-gnueabihf
+          # Remove unnecessary object files (to reduce cache size).
+          find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Cache Binaryen
+        uses: actions/cache@v2
+        id: cache-binaryen
+        with:
+          key: binaryen-linux-arm-v1
+          path: build/wasm-opt
+      - name: Build Binaryen
+        if: steps.cache-binaryen.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get install --no-install-recommends ninja-build
+          git submodule update --init lib/binaryen
+          make CROSS=arm-linux-gnueabihf binaryen
+      - name: Install fpm
+        run: |
+          sudo gem install --no-document fpm
+      - name: Build TinyGo binary
+        run: |
+          make CROSS=arm-linux-gnueabihf
+      - name: Download amd64 release
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-amd64-double-zipped
+      - name: Extract amd64 release
+        run: |
+          mkdir -p build/release
+          tar -xf tinygo.linux-amd64.tar.gz -C build/release tinygo
+      - name: Modify release
+        run: |
+          cp -p build/tinygo   build/release/tinygo/bin
+          cp -p build/wasm-opt build/release/tinygo/bin
+      - name: Create arm release
+        run: |
+          make release deb RELEASEONLY=1 DEB_ARCH=armhf
+          cp -p build/release.tar.gz /tmp/tinygo.linux-arm.tar.gz
+          cp -p build/release.deb    /tmp/tinygo_armhf.deb
+      - name: Publish release artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-arm-double-zipped
+          path: |
+            /tmp/tinygo.linux-arm.tar.gz
+            /tmp/tinygo_armhf.deb


### PR DESCRIPTION
Instead of me doing it on my Raspberry Pi at home, let's do it in CI! It needs some configuration so that cross compilation works well.

Unfortunately, `llvm-config` is a bit complicated. I'm now running it using `qemu-arm`, which is not pretty, but it works.

Eventually, these changes might allow for us to cross compile from X86 Macs to M1 Macs - until the CI situation for macOS arm64 has been sorted out.