### PR TITLE
darwin: add support for arm64 GOARCH (aka Apple Silicon)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -635,6 +635,7 @@ endif
 	GOOS=linux GOARCH=arm $(TINYGO) build -size short -o test.elf       ./testdata/cgo
 	GOOS=windows GOARCH=amd64 $(TINYGO) build -size short -o test.exe   ./testdata/cgo
 	GOOS=darwin GOARCH=amd64 $(TINYGO) build              -o test       ./testdata/cgo
+	GOOS=darwin GOARCH=arm64 $(TINYGO) build              -o test       ./testdata/cgo
 ifneq ($(OS),Windows_NT)
 	# TODO: this does not yet work on Windows. Somehow, unused functions are
 	# not garbage collected.

--- a/src/internal/task/task_stack_arm64.S
+++ b/src/internal/task/task_stack_arm64.S
@@ -1,7 +1,12 @@
+#ifdef __MACH__
+.global  _tinygo_startTask
+_tinygo_startTask:
+#else
 .section .text.tinygo_startTask
 .global  tinygo_startTask
 .type    tinygo_startTask, %function
 tinygo_startTask:
+#endif
     .cfi_startproc
     // Small assembly stub for starting a goroutine. This is already run on the
     // new stack, with the callee-saved registers already loaded.
@@ -23,13 +28,25 @@ tinygo_startTask:
     blr   x19
 
     // After return, exit this goroutine. This is a tail call.
+#ifdef __MACH__
+    b     _tinygo_pause
+#else
     b     tinygo_pause
+#endif
     .cfi_endproc
+#ifndef __MACH__
 .size tinygo_startTask, .-tinygo_startTask
+#endif
 
+
+#ifdef __MACH__
+.global _tinygo_swapTask
+_tinygo_swapTask:
+#else
 .global tinygo_swapTask
 .type tinygo_swapTask, %function
 tinygo_swapTask:
+#endif
     // This function gets the following parameters:
     // x0 = newStack uintptr
     // x1 = oldStack *uintptr

--- a/src/runtime/gc_arm64.S
+++ b/src/runtime/gc_arm64.S
@@ -1,7 +1,12 @@
+#ifdef __MACH__
+.global _tinygo_scanCurrentStack
+_tinygo_scanCurrentStack:
+#else
 .section .text.tinygo_scanCurrentStack
 .global tinygo_scanCurrentStack
 .type tinygo_scanCurrentStack, %function
 tinygo_scanCurrentStack:
+#endif
     // Sources:
     //   * https://developer.arm.com/architectures/learn-the-architecture/armv8-a-instruction-set-architecture/procedure-call-standard
     //   * https://godbolt.org/z/qrvrEh
@@ -16,7 +21,11 @@ tinygo_scanCurrentStack:
 
     // Scan the stack.
     mov     x0, sp
+#ifdef __MACH__
+    bl      _tinygo_scanstack
+#else
     bl      tinygo_scanstack
+#endif
 
     // Restore stack state and return.
     ldp     x29, x30, [sp], #96


### PR DESCRIPTION
This patch adds support for generating GOOS=darwin GOARCH=arm64 binaries. This means that it will become possible to run `go test` on recent Macs, for example.

Untested, except that it compiles and produces a MachO ARM64 binary. If someone with a M1 Mac can test it, that would be great.