### PR TITLE
all: add support for ThinLTO

### DIFF
--- a/builder/cc.go
+++ b/builder/cc.go
@@ -56,7 +56,7 @@ import (
 //   depfile but without invalidating its name. For this reason, the depfile is
 //   written on each new compilation (even when it seems unnecessary). However, it
 //   could in rare cases lead to a stale file fetched from the cache.
-func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands func(string, ...string)) (string, error) {
+func compileAndCacheCFile(abspath, tmpdir string, cflags []string, thinlto bool, printCommands func(string, ...string)) (string, error) {
 	// Hash input file.
 	fileHash, err := hashFile(abspath)
 	if err != nil {
@@ -66,6 +66,11 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 	// Acquire a lock (if supported).
 	unlock := lock(filepath.Join(goenv.Get("GOCACHE"), fileHash+".c.lock"))
 	defer unlock()
+
+	ext := ".o"
+	if thinlto {
+		ext = ".bc"
+	}
 
 	// Create cache key for the dependencies file.
 	buf, err := json.Marshal(struct {
@@ -99,7 +104,7 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 		}
 
 		// Obtain hashes of all the files listed as a dependency.
-		outpath, err := makeCFileCachePath(dependencies, depfileNameHash)
+		outpath, err := makeCFileCachePath(dependencies, depfileNameHash, ext)
 		if err == nil {
 			if _, err := os.Stat(outpath); err == nil {
 				return outpath, nil
@@ -112,7 +117,7 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 		return "", err
 	}
 
-	objTmpFile, err := ioutil.TempFile(goenv.Get("GOCACHE"), "tmp-*.o")
+	objTmpFile, err := ioutil.TempFile(goenv.Get("GOCACHE"), "tmp-*"+ext)
 	if err != nil {
 		return "", err
 	}
@@ -124,6 +129,9 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 	depTmpFile.Close()
 	flags := append([]string{}, cflags...)                                   // copy cflags
 	flags = append(flags, "-MD", "-MV", "-MTdeps", "-MF", depTmpFile.Name()) // autogenerate dependencies
+	if thinlto {
+		flags = append(flags, "-flto=thin")
+	}
 	flags = append(flags, "-c", "-o", objTmpFile.Name(), abspath)
 	if strings.ToLower(filepath.Ext(abspath)) == ".s" {
 		// If this is an assembly file (.s or .S, lowercase or uppercase), then
@@ -181,7 +189,7 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 	}
 
 	// Move temporary object file to final location.
-	outpath, err := makeCFileCachePath(dependencySlice, depfileNameHash)
+	outpath, err := makeCFileCachePath(dependencySlice, depfileNameHash, ext)
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +204,7 @@ func compileAndCacheCFile(abspath, tmpdir string, cflags []string, printCommands
 // Create a cache path (a path in GOCACHE) to store the output of a compiler
 // job. This path is based on the dep file name (which is a hash of metadata
 // including compiler flags) and the hash of all input files in the paths slice.
-func makeCFileCachePath(paths []string, depfileNameHash string) (string, error) {
+func makeCFileCachePath(paths []string, depfileNameHash, ext string) (string, error) {
 	// Hash all input files.
 	fileHashes := make(map[string]string, len(paths))
 	for _, path := range paths {
@@ -221,7 +229,7 @@ func makeCFileCachePath(paths []string, depfileNameHash string) (string, error) 
 	outFileNameBuf := sha512.Sum512_224(buf)
 	cacheKey := hex.EncodeToString(outFileNameBuf[:])
 
-	outpath := filepath.Join(goenv.Get("GOCACHE"), "obj-"+cacheKey+".o")
+	outpath := filepath.Join(goenv.Get("GOCACHE"), "obj-"+cacheKey+ext)
 	return outpath, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20220121152956-4fa2ab2718f3
+	tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1
 )

--- a/go.sum
+++ b/go.sum
@@ -80,5 +80,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-tinygo.org/x/go-llvm v0.0.0-20220121152956-4fa2ab2718f3 h1:vQSFy0kNQegAfL/F6iyWQa4bF941Xc1gyJUkGy2m448=
-tinygo.org/x/go-llvm v0.0.0-20220121152956-4fa2ab2718f3/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1 h1:6G8AxueDdqobCEqQrmHPLaEH1AZ1p6Y7rGElDNT7N98=
+tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/stacksize/dwarf.go
+++ b/stacksize/dwarf.go
@@ -205,6 +205,10 @@ func (fi *frameInfo) exec(bytecode []byte) ([]frameInfoLine, error) {
 			if err != nil {
 				return nil, err
 			}
+		case 3: // DW_CFA_restore
+			// Restore a register. Used after an outlined function call.
+			// It should be possible to ignore this.
+			// TODO: check that this is not the stack pointer.
 		case 0:
 			switch lowBits {
 			case 0: // DW_CFA_nop
@@ -218,7 +222,22 @@ func (fi *frameInfo) exec(bytecode []byte) ([]frameInfoLine, error) {
 				}
 				fi.loc += uint64(offset) * fi.cie.codeAlignmentFactor
 				entries = append(entries, fi.newLine())
-				// TODO: DW_CFA_advance_loc2 etc
+			case 0x03: // DW_CFA_advance_loc2
+				var offset uint16
+				err := binary.Read(r, binary.LittleEndian, &offset)
+				if err != nil {
+					return nil, err
+				}
+				fi.loc += uint64(offset) * fi.cie.codeAlignmentFactor
+				entries = append(entries, fi.newLine())
+			case 0x04: // DW_CFA_advance_loc4
+				var offset uint32
+				err := binary.Read(r, binary.LittleEndian, &offset)
+				if err != nil {
+					return nil, err
+				}
+				fi.loc += uint64(offset) * fi.cie.codeAlignmentFactor
+				entries = append(entries, fi.newLine())
 			case 0x05: // DW_CFA_offset_extended
 				// Semantics are the same as DW_CFA_offset, but the encoding is
 				// different. Ignore it just like DW_CFA_offset.
@@ -236,6 +255,18 @@ func (fi *frameInfo) exec(bytecode []byte) ([]frameInfoLine, error) {
 				//     .cfi_undefined lr
 				// Ignore this directive.
 				_, err := readULEB128(r)
+				if err != nil {
+					return nil, err
+				}
+			case 0x09: // DW_CFA_register
+				// Copies a register. Emitted by the machine outliner, for example.
+				// It should be possible to ignore this.
+				// TODO: check that the stack pointer is not affected.
+				_, err := readULEB128(r)
+				if err != nil {
+					return nil, err
+				}
+				_, err = readULEB128(r)
 				if err != nil {
 					return nil, err
 				}

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -151,6 +151,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 	funcPasses.FinalizeFunc()
 
 	// Run module passes.
+	// TODO: somehow set the PrepareForThinLTO flag in the pass manager builder.
 	modPasses := llvm.NewPassManager()
 	defer modPasses.Dispose()
 	builder.Populate(modPasses)

--- a/transform/testdata/stacksize.out.ll
+++ b/transform/testdata/stacksize.out.ll
@@ -2,6 +2,7 @@ target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
 @"internal/task.stackSizes" = global [1 x i32] [i32 1024], section ".tinygo_stacksizes"
+@llvm.used = appending global [2 x i8*] [i8* bitcast ([1 x i32]* @"internal/task.stackSizes" to i8*), i8* bitcast (void (i8*)* @"runtime.run$1$gowrapper" to i8*)]
 
 declare i32 @"internal/task.getGoroutineStackSize"(i32, i8*, i8*)
 


### PR DESCRIPTION
ThinLTO optimizes across LLVM modules at link time. This means that
optimizations (such as inlining and const-propagation) are possible
between C and Go. This makes this change especially useful for CGo, but
not just for CGo. By doing some optimizations at link time, the linker
can discard some unused functions and this leads to a size reduction on
average. It does increase code size in some cases, but that's true for
most optimizations.

I've excluded a number of targets for now (wasm, avr, xtensa, windows,
macos). They can probably be supported with some more work, but that
should be done in separate PRs.

Overall, this change results in an average 3.24% size reduction over all
the tinygo.org/x/drivers smoke tests.

TODO: this commit runs part of the pass pipeline twice. We should set
the PrepareForThinLTO flag in the PassManagerBuilder for even further
reduced code size (0.7%) and improved compilation speed.

---

This PR took me a _long_ time to prepare. The change itself is pretty small, but it required a lot of investigation to avoid increases in code size.
Some day, I'd like to go further and compile every Go package in a separate LLVM module and rely on ThinLTO for optimizations across modules. That may result in a code size increase, but will likely be a huge improvement in compilation speed. As a preparation, this PR runs ThinLTO between C and Go files (and later possibly also including the C standard library).