### PR TITLE
all: add -work flag

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -99,7 +99,11 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(dir)
+	if config.Options.Work {
+		fmt.Printf("WORK=%s\n", dir)
+	} else {
+		defer os.RemoveAll(dir)
+	}
 
 	// Check for a libc dependency.
 	// As a side effect, this also creates the headers for the given libc, if

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	PanicStrategy   string
 	Scheduler       string
 	Serial          string
+	Work            bool // -work flag to print temporary build directory
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool

--- a/main.go
+++ b/main.go
@@ -1187,6 +1187,7 @@ func main() {
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, tasks, asyncify)")
 	serial := flag.String("serial", "", "which serial output to use (none, uart, usb)")
+	work := flag.Bool("work", false, "print the name of the temporary build directory and do not delete this directory on exit")
 	printIR := flag.Bool("printir", false, "print LLVM IR")
 	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
@@ -1275,6 +1276,7 @@ func main() {
 		PanicStrategy:   *panicStrategy,
 		Scheduler:       *scheduler,
 		Serial:          *serial,
+		Work:            *work,
 		PrintIR:         *printIR,
 		DumpSSA:         *dumpSSA,
 		VerifyIR:        *verifyIR,


### PR DESCRIPTION
This flag has the same behavior as in upstream Go. It can be useful while debugging certain issues.