### PR TITLE
Refresh macos-minimal-sdk to fix regression; github: also run 'make tinygo-test' on mac

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -76,6 +76,8 @@ jobs:
         run: make test GOTESTFLAGS="-v -short"
       - name: Build TinyGo release tarball
         run: make release -j3
+      - name: Test stdlib packages
+        run: make tinygo-test
       - name: Make release artifact
         shell: bash
         run: cp -p build/release.tar.gz build/tinygo.darwin-amd64.tar.gz 

--- a/src/os/path.go
+++ b/src/os/path.go
@@ -1,6 +1,3 @@
-//go:build !baremetal
-// +build !baremetal
-
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
On my mac, "make tinygo-test" started complaining
```
ld.lld: error: undefined symbol: _readdir_r$INODE64
```
today.  Seems CI isn't running that test yet on Mac, so let's try adding it.