### PR TITLE
test: fix assertion for multiple packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -1411,8 +1411,8 @@ func main() {
 		if len(pkgNames) == 0 {
 			pkgNames = []string{"."}
 		}
-		if *testCompileOnlyFlag && len(pkgNames) > 1 {
-			fmt.Println("cannot use -c flag with multiple packages")
+		if outpath != "" && len(pkgNames) > 1 {
+			fmt.Println("cannot use -o flag with multiple packages")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
I see no reason why it isn't possible to run `tinygo test -c` with multiple packages. It'll just create multiple test outputs. I think the intended flag was the `-o` flag, which indeed doesn't make much sense with multiple packages.