### PR TITLE
Revert "all: move stm32 files to separate repository"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,13 @@ src/device/sam/*.go
 src/device/sam/*.s
 src/device/sifive/*.go
 src/device/sifive/*.s
+src/device/stm32/*.go
+src/device/stm32/*.s
 src/device/kendryte/*.go
 src/device/kendryte/*.s
 src/device/rp/*.go
 src/device/rp/*.s
+vendor
 llvm-build
 llvm-project
 build/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,6 +20,9 @@
 [submodule "lib/picolibc"]
 	path = lib/picolibc
 	url = https://github.com/keith-packard/picolibc.git
+[submodule "lib/stm32-svd"]
+	path = lib/stm32-svd
+	url = https://github.com/tinygo-org/stm32-svd
 [submodule "lib/musl"]
 	path = lib/musl
 	url = git://git.musl-libc.org/musl
@@ -32,6 +35,3 @@
 [submodule "lib/macos-minimal-sdk"]
 	path = lib/macos-minimal-sdk
 	url = https://github.com/aykevl/macos-minimal-sdk.git
-[submodule "src/vendor/tinygo.org/x/device"]
-	path = src/vendor/tinygo.org/x/device
-	url = https://github.com/tinygo-org/device.git

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ fmt-check:
 
 
 gen-device: gen-device-avr gen-device-esp gen-device-nrf gen-device-sam gen-device-sifive gen-device-kendryte gen-device-nxp gen-device-rp
+ifneq ($(STM32), 0)
+gen-device: gen-device-stm32
+endif
 
 gen-device-avr:
 	@if [ ! -e lib/avr/README.md ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
@@ -161,6 +164,10 @@ gen-device-sifive: build/gen-device-svd
 gen-device-kendryte: build/gen-device-svd
 	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Kendryte-Community -interrupts=software lib/cmsis-svd/data/Kendryte-Community/ src/device/kendryte/
 	GO111MODULE=off $(GO) fmt ./src/device/kendryte
+
+gen-device-stm32: build/gen-device-svd
+	./build/gen-device-svd -source=https://github.com/tinygo-org/stm32-svd lib/stm32-svd/svd src/device/stm32/
+	GO111MODULE=off $(GO) fmt ./src/device/stm32
 
 gen-device-rp: build/gen-device-svd
 	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/RaspberryPi lib/cmsis-svd/data/RaspberryPi/ src/device/rp/

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -241,8 +241,6 @@ func pathsToOverride(needsSyscallPackage bool) map[string]bool {
 		"runtime/":              false,
 		"sync/":                 true,
 		"testing/":              true,
-		"vendor/":               true,
-		"vendor/tinygo.org/":    false,
 	}
 	if needsSyscallPackage {
 		paths["syscall/"] = true // include syscall/js

--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_gnse.go
+++ b/src/machine/board_gnse.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_lorae5.go
+++ b/src/machine/board_lorae5.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_nucleowl55jc.go
+++ b/src/machine/board_nucleowl55jc.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_stm32f469disco.go
+++ b/src/machine/board_stm32f469disco.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/board_swan.go
+++ b/src/machine/board_swan.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/machine/machine_stm32.go
+++ b/src/machine/machine_stm32.go
@@ -3,7 +3,7 @@
 
 package machine
 
-import "tinygo.org/x/device/stm32"
+import "device/stm32"
 
 const deviceName = stm32.Device
 

--- a/src/machine/machine_stm32_adc_f1.go
+++ b/src/machine/machine_stm32_adc_f1.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32_adc_f4.go
+++ b/src/machine/machine_stm32_adc_f4.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32_exti_afio.go
+++ b/src/machine/machine_stm32_exti_afio.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 func getEXTIConfigRegister(pin uint8) *volatile.Register32 {

--- a/src/machine/machine_stm32_exti_exti.go
+++ b/src/machine/machine_stm32_exti_exti.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 func getEXTIConfigRegister(pin uint8) *volatile.Register32 {

--- a/src/machine/machine_stm32_exti_syscfg.go
+++ b/src/machine/machine_stm32_exti_syscfg.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 func getEXTIConfigRegister(pin uint8) *volatile.Register32 {

--- a/src/machine/machine_stm32_exti_syscfg_noenable.go
+++ b/src/machine/machine_stm32_exti_syscfg_noenable.go
@@ -4,8 +4,8 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 func getEXTIConfigRegister(pin uint8) *volatile.Register32 {

--- a/src/machine/machine_stm32_gpio_reva.go
+++ b/src/machine/machine_stm32_gpio_reva.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 // This variant of the GPIO input interrupt logic is for

--- a/src/machine/machine_stm32_gpio_revb.go
+++ b/src/machine/machine_stm32_gpio_revb.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 // This variant of the GPIO input interrupt logic is for

--- a/src/machine/machine_stm32_gpio_revb_mp.go
+++ b/src/machine/machine_stm32_gpio_revb_mp.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 //

--- a/src/machine/machine_stm32_i2c_reva.go
+++ b/src/machine/machine_stm32_i2c_reva.go
@@ -7,7 +7,7 @@ package machine
 // of MCUs.
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32_i2c_revb.go
+++ b/src/machine/machine_stm32_i2c_revb.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 // GPIO for the stm32 families except the stm32f1xx which uses a simpler but

--- a/src/machine/machine_stm32_rng.go
+++ b/src/machine/machine_stm32_rng.go
@@ -3,7 +3,7 @@
 
 package machine
 
-import "tinygo.org/x/device/stm32"
+import "device/stm32"
 
 var rngInitDone = false
 

--- a/src/machine/machine_stm32_spi.go
+++ b/src/machine/machine_stm32_spi.go
@@ -6,8 +6,8 @@ package machine
 // Peripheral abstraction layer for SPI on the stm32 family
 
 import (
+	"device/stm32"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32_tim.go
+++ b/src/machine/machine_stm32_tim.go
@@ -7,9 +7,9 @@ package machine
 // depending on the size of that register in the MCU's TIM_Type structure.
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 const PWM_MODE1 = 0x6

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for UARTs on the stm32 family.
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for the stm32.
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -6,10 +6,10 @@ package machine
 // Peripheral abstraction layer for the stm32f4
 
 import (
+	"device/stm32"
 	"math/bits"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32f7.go
+++ b/src/machine/machine_stm32f7.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for the stm32f4
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -6,7 +6,7 @@ package machine
 // Peripheral abstraction layer for the stm32f407
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 func CPUFrequency() uint32 {

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -6,8 +6,8 @@ package machine
 // Peripheral abstraction layer for the stm32l0
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
-	"tinygo.org/x/device/stm32"
 )
 
 func CPUFrequency() uint32 {

--- a/src/machine/machine_stm32l0x1.go
+++ b/src/machine/machine_stm32l0x1.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for the stm32l0
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32l0x2.go
+++ b/src/machine/machine_stm32l0x2.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for the stm32l0
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -4,9 +4,9 @@
 package machine
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32l5.go
+++ b/src/machine/machine_stm32l5.go
@@ -6,9 +6,9 @@ package machine
 // Peripheral abstraction layer for the stm32l5
 
 import (
+	"device/stm32"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/machine/machine_stm32l5x2.go
+++ b/src/machine/machine_stm32l5x2.go
@@ -6,7 +6,7 @@ package machine
 // Peripheral abstraction layer for the stm32f407
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 func CPUFrequency() uint32 {

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -6,10 +6,10 @@ package machine
 // Peripheral abstraction layer for the stm32wle5
 
 import (
+	"device/stm32"
 	"math/bits"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 	"unsafe"
 )
 

--- a/src/runtime/runtime_stm32_timers.go
+++ b/src/runtime/runtime_stm32_timers.go
@@ -11,10 +11,10 @@ package runtime
 // Output Comparator used for fine-grained sleeps.
 
 import (
+	"device/stm32"
 	"machine"
 	"runtime/interrupt"
 	"runtime/volatile"
-	"tinygo.org/x/device/stm32"
 )
 
 type timerInfo struct {

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 func init() {

--- a/src/runtime/runtime_stm32f4.go
+++ b/src/runtime/runtime_stm32f4.go
@@ -5,8 +5,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 func init() {

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/runtime/runtime_stm32f407.go
+++ b/src/runtime/runtime_stm32f407.go
@@ -3,7 +3,7 @@
 
 package runtime
 
-import "tinygo.org/x/device/stm32"
+import "device/stm32"
 
 /*
    clock settings

--- a/src/runtime/runtime_stm32f469.go
+++ b/src/runtime/runtime_stm32f469.go
@@ -3,7 +3,7 @@
 
 package runtime
 
-import "tinygo.org/x/device/stm32"
+import "device/stm32"
 
 /*
    clock settings

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 /*

--- a/src/runtime/runtime_stm32l0.go
+++ b/src/runtime/runtime_stm32l0.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/runtime/runtime_stm32l0x1.go
+++ b/src/runtime/runtime_stm32l0x1.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/runtime/runtime_stm32l0x2.go
+++ b/src/runtime/runtime_stm32l0x2.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/runtime/runtime_stm32l4.go
+++ b/src/runtime/runtime_stm32l4.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/src/runtime/runtime_stm32l4x2.go
+++ b/src/runtime/runtime_stm32l4x2.go
@@ -4,7 +4,7 @@
 package runtime
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 /*

--- a/src/runtime/runtime_stm32l4x5.go
+++ b/src/runtime/runtime_stm32l4x5.go
@@ -4,7 +4,7 @@
 package runtime
 
 import (
-	"tinygo.org/x/device/stm32"
+	"device/stm32"
 )
 
 /*

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 /*

--- a/src/runtime/runtime_stm32wlx.go
+++ b/src/runtime/runtime_stm32wlx.go
@@ -4,8 +4,8 @@
 package runtime
 
 import (
+	"device/stm32"
 	"machine"
-	"tinygo.org/x/device/stm32"
 )
 
 const (

--- a/targets/bluepill.json
+++ b/targets/bluepill.json
@@ -4,7 +4,7 @@
 	"serial": "uart",
 	"linkerscript": "targets/stm32.ld",
 	"extra-files": [
-		"src/vendor/tinygo.org/x/device/stm32/stm32f103.s"
+		"src/device/stm32/stm32f103.s"
 	],
 	"flash-method": "openocd",
 	"openocd-interface": "stlink-v2",

--- a/targets/feather-stm32f405.json
+++ b/targets/feather-stm32f405.json
@@ -5,7 +5,7 @@
   "automatic-stack-size": false,
   "linkerscript": "targets/stm32f405.ld",
   "extra-files": [
-    "src/vendor/tinygo.org/x/device/stm32/stm32f405.s"
+    "src/device/stm32/stm32f405.s"
   ],
   "flash-method": "command",
   "flash-command": "dfu-util --alt 0 --dfuse-address 0x08000000 --download {bin}",

--- a/targets/nucleo-f103rb.json
+++ b/targets/nucleo-f103rb.json
@@ -4,7 +4,7 @@
   "serial": "uart",
   "linkerscript": "targets/stm32f103rb.ld",
   "extra-files": [
-    "src/vendor/tinygo.org/x/device/stm32/stm32f103.s"
+    "src/device/stm32/stm32f103.s"
   ],
   "flash-method": "openocd",
   "openocd-interface": "stlink-v2-1",

--- a/targets/nucleo-f722ze.json
+++ b/targets/nucleo-f722ze.json
@@ -4,7 +4,7 @@
   "serial": "uart",
   "linkerscript": "targets/stm32f7x2zetx.ld",
   "extra-files": [
-    "src/vendor/tinygo.org/x/device/stm32/stm32f7x2.s"
+    "src/device/stm32/stm32f7x2.s"
   ],
   "flash-method": "openocd",
   "openocd-interface": "stlink-v2-1",

--- a/targets/nucleo-l031k6.json
+++ b/targets/nucleo-l031k6.json
@@ -4,7 +4,7 @@
     "serial": "uart",
     "linkerscript": "targets/stm32l031k6.ld",
     "extra-files": [
-        "src/vendor/tinygo.org/x/device/stm32/stm32l0x1.s"
+        "src/device/stm32/stm32l0x1.s"
     ],
     "flash-method": "openocd",
     "openocd-interface": "stlink",

--- a/targets/nucleo-l432kc.json
+++ b/targets/nucleo-l432kc.json
@@ -4,7 +4,7 @@
     "serial": "uart",
     "linkerscript": "targets/stm32l4x2.ld",
     "extra-files": [
-      "src/vendor/tinygo.org/x/device/stm32/stm32l4x2.s"
+      "src/device/stm32/stm32l4x2.s"
     ],
     "flash-method": "openocd",
     "openocd-interface": "stlink-v2-1",

--- a/targets/nucleo-l552ze.json
+++ b/targets/nucleo-l552ze.json
@@ -4,7 +4,7 @@
     "serial": "uart",
     "linkerscript": "targets/stm32l5x2xe.ld",
     "extra-files": [
-      "src/vendor/tinygo.org/x/device/stm32/stm32l552.s"
+      "src/device/stm32/stm32l552.s"
     ],
     "flash-method": "openocd",
     "openocd-interface": "stlink",

--- a/targets/stm32f469disco.json
+++ b/targets/stm32f469disco.json
@@ -4,7 +4,7 @@
   "serial": "uart",
   "linkerscript": "targets/stm32f469.ld",
   "extra-files": [
-    "src/vendor/tinygo.org/x/device/stm32/stm32f469.s"
+    "src/device/stm32/stm32f469.s"
   ],
   "flash-method": "openocd",
   "openocd-interface": "stlink",

--- a/targets/stm32f4disco.json
+++ b/targets/stm32f4disco.json
@@ -4,7 +4,7 @@
   "serial": "uart",
   "linkerscript": "targets/stm32f407.ld",
   "extra-files": [
-    "src/vendor/tinygo.org/x/device/stm32/stm32f407.s"
+    "src/device/stm32/stm32f407.s"
   ],
   "flash-method": "openocd",
   "openocd-interface": "stlink-v2",

--- a/targets/stm32l0x2.json
+++ b/targets/stm32l0x2.json
@@ -8,6 +8,6 @@
         "stm32"
     ],
     "extra-files": [
-        "src/vendor/tinygo.org/x/device/stm32/stm32l0x2.s"
+        "src/device/stm32/stm32l0x2.s"
     ]
 }

--- a/targets/stm32wl5x_cm4.json
+++ b/targets/stm32wl5x_cm4.json
@@ -2,7 +2,7 @@
     "inherits": ["cortex-m4"],
     "build-tags": [ "stm32wl5x_cm4","stm32wlx", "stm32"],
     "extra-files": [
-      "src/vendor/tinygo.org/x/device/stm32/stm32wl5x_cm4.s"
+      "src/device/stm32/stm32wl5x_cm4.s"
     ],
     "linkerscript": "targets/stm32wlx.ld"
 }

--- a/targets/stm32wle5.json
+++ b/targets/stm32wle5.json
@@ -2,7 +2,7 @@
     "inherits": ["cortex-m4"],
     "build-tags": [ "stm32wle5","stm32wlx", "stm32"],
     "extra-files": [
-      "src/vendor/tinygo.org/x/device/stm32/stm32wle5.s"
+      "src/device/stm32/stm32wle5.s"
     ],
     "linkerscript": "targets/stm32wlx.ld"
 }

--- a/targets/swan.json
+++ b/targets/swan.json
@@ -4,7 +4,7 @@
     "serial": "uart",
     "linkerscript": "targets/stm32l4x5.ld",
     "extra-files": [
-      "src/vendor/tinygo.org/x/device/stm32/stm32l4x5.s"
+      "src/device/stm32/stm32l4x5.s"
     ],
     "flash-method": "command",
     "flash-command": "dfu-util --alt 0 --dfuse-address 0x08000000 --download {bin}",


### PR DESCRIPTION
This PR is to revert #2634.


Since the problem is reproduced in the local environment, I think it is better to revert and then PR again after the countermeasure is completed.
More information about the problem can be found below.

https://github.com/tinygo-org/drivers/pull/379