### PR TITLE
syscall/js: allow copyBytesTo(Go|JS) to use Uint8ClampedArray

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -424,7 +424,7 @@
 
 						const dst = loadSlice(dest_addr, dest_len);
 						const src = loadValue(source_addr);
-						if (!(src instanceof Uint8Array)) {
+						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
 							mem().setUint8(returned_status_addr, 0); // Return "not ok" status
 							return;
 						}
@@ -443,7 +443,7 @@
 
 						const dst = loadValue(dest_addr);
 						const src = loadSlice(source_addr, source_len);
-						if (!(dst instanceof Uint8Array)) {
+						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
 							mem().setUint8(returned_status_addr, 0); // Return "not ok" status
 							return;
 						}


### PR DESCRIPTION
This change allow the `js.CopyBytesToX` functions to also work with `Uint8ClampedArray`. The same change was made to Go: https://github.com/golang/go/commit/f0e8b81aa34120e21642c569912bde00ccd33393

I've tested that this change alone is enough to make it work. These types of arrays are common when working with the HTML Canvas.

Fixes https://github.com/tinygo-org/tinygo/issues/1941