### PR TITLE
src/runtime: implement runtime.Version() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
 # Build the Go compiler.
 tinygo:
 	@if [ ! -f "$(LLVM_BUILDDIR)/bin/llvm-config" ]; then echo "Fetch and build LLVM first by running:"; echo "  make llvm-source"; echo "  make $(LLVM_BUILDDIR)"; exit 1; fi
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm -ldflags="-X main.gitSha1=`git rev-parse --short HEAD`" .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags byollvm -ldflags="-X github.com/tinygo-org/tinygo/goenv.GitSha1=`git rev-parse --short HEAD`" .
 
 test: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=20m -buildmode exe -tags byollvm ./builder ./cgo ./compileopts ./compiler ./interp ./transform .

--- a/builder/build.go
+++ b/builder/build.go
@@ -204,6 +204,21 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	var packageJobs []*compileJob
 	packageBitcodePaths := make(map[string]string)
 	packageActionIDs := make(map[string]string)
+
+	if config.Options.GlobalValues["runtime"]["buildVersion"] == "" {
+		version := goenv.Version
+		if strings.HasSuffix(goenv.Version, "-dev") && goenv.GitSha1 != "" {
+			version += "-" + goenv.GitSha1
+		}
+		if config.Options.GlobalValues == nil {
+			config.Options.GlobalValues = make(map[string]map[string]string)
+		}
+		if config.Options.GlobalValues["runtime"] == nil {
+			config.Options.GlobalValues["runtime"] = make(map[string]string)
+		}
+		config.Options.GlobalValues["runtime"]["buildVersion"] = version
+	}
+
 	for _, pkg := range lprogram.Sorted() {
 		pkg := pkg // necessary to avoid a race condition
 

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -14,6 +14,12 @@ import (
 // Update this value before release of new version of software.
 const Version = "0.23.0-dev"
 
+var (
+	// This variable is set at build time using -ldflags parameters.
+	// See: https://stackoverflow.com/a/11355611
+	GitSha1 string
+)
+
 // GetGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.
 func GetGorootVersion(goroot string) (major, minor int, err error) {

--- a/main.go
+++ b/main.go
@@ -36,12 +36,6 @@ import (
 	"go.bug.st/serial/enumerator"
 )
 
-var (
-	// This variable is set at build time using -ldflags parameters.
-	// See: https://stackoverflow.com/a/11355611
-	gitSha1 string
-)
-
 // commandError is an error type to wrap os/exec.Command errors. This provides
 // some more information regarding what went wrong while running a command.
 type commandError struct {
@@ -1023,8 +1017,8 @@ func getBMPPorts() (gdbPort, uartPort string, err error) {
 
 func usage(command string) {
 	version := goenv.Version
-	if strings.HasSuffix(version, "-dev") && gitSha1 != "" {
-		version += "-" + gitSha1
+	if strings.HasSuffix(version, "-dev") && goenv.GitSha1 != "" {
+		version += "-" + goenv.GitSha1
 	}
 
 	switch command {
@@ -1620,8 +1614,8 @@ func main() {
 			goversion = s
 		}
 		version := goenv.Version
-		if strings.HasSuffix(goenv.Version, "-dev") && gitSha1 != "" {
-			version += "-" + gitSha1
+		if strings.HasSuffix(goenv.Version, "-dev") && goenv.GitSha1 != "" {
+			version += "-" + goenv.GitSha1
 		}
 		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
 	case "env":

--- a/src/runtime/extern.go
+++ b/src/runtime/extern.go
@@ -3,3 +3,15 @@ package runtime
 func Callers(skip int, pc []uintptr) int {
 	return 0
 }
+
+// buildVersion is the Tinygo tree's version string at build time.
+//
+// This is set by the linker.
+var buildVersion string
+
+// Version returns the Tinygo tree's version string.
+// It is the same as goenv.Version, or in case of a development build,
+// it will be the concatenation of goenv.Version and the git commit hash.
+func Version() string {
+	return buildVersion
+}

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -11,7 +11,6 @@
 	"ldflags": [
 		"--allow-undefined",
 		"--stack-first",
-		"--export-dynamic",
 		"--no-demangle"
 	],
 	"emulator":      ["wasmtime"],


### PR DESCRIPTION
This adds the `Version()` function of the `runtime` package which embeds
the go version that was used to build tinygo.

For programs that are compiled with tinygo the version can be overriden
via the:
`tinygo build -ldflags="-X 'runtime.buildVersion=abc'"` flag.
Otherwise it will continue to use the go version with which tinygo was
compiled.