### PR TITLE
src/runtime: add stub for debug.ReadBuildInfo()

### DIFF
--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -15,3 +15,28 @@ func SetMaxStack(n int) int {
 func Stack() []byte {
 	return nil
 }
+
+// ReadBuildInfo returns the build information embedded
+// in the running binary. The information is available only
+// in binaries built with module support.
+//
+// Not implemented.
+func ReadBuildInfo() (info *BuildInfo, ok bool) {
+	return nil, false
+}
+
+// BuildInfo represents the build information read from
+// the running binary.
+type BuildInfo struct {
+	Path string    // The main package path
+	Main Module    // The module containing the main package
+	Deps []*Module // Module dependencies
+}
+
+// Module represents a module.
+type Module struct {
+	Path    string  // module path
+	Version string  // module version
+	Sum     string  // checksum
+	Replace *Module // replaced by this module
+}


### PR DESCRIPTION
This adds the necessary structs and the `ReadBuildInfo()` function to
the runtime/debug module to allow to compile code that tries to access
it.
The stub itself returns ok=false, so that calling code should not try
to read from the nil pointer that is returned instead of the actual
BuildInfo struct.