### PR TITLE
src/runtime: add stub for runtime.NumCPU()

### DIFF
--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -1,0 +1,10 @@
+package runtime
+
+// NumCPU returns the number of logical CPUs usable by the current process.
+//
+// The set of available CPUs is checked by querying the operating system
+// at process startup. Changes to operating system CPU allocation after
+// process startup are not reflected.
+func NumCPU() int {
+	return 1
+}


### PR DESCRIPTION
This adds a stub for the `NumCPU()` function from the `runtime`
package.
This change allows code to compile that tries to access this function.

I guess for most hardware boards and WASM setting this value to `1` is
fine. And as far as I can see it shouldn't break or change existing
applications, because the function previously did not exist at all.