### PR TITLE
src/os: add stubs for exec.ExitError and ProcessState.ExitCode

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -34,6 +34,12 @@ func (p *ProcessState) Success() bool {
 	return false // TODO
 }
 
+// ExitCode returns the exit code of the exited process, or -1
+// if the process hasn't exited or was terminated by a signal.
+func (p *ProcessState) ExitCode() int {
+	return -1 // TODO
+}
+
 type Process struct {
 	Pid int
 }

--- a/src/os/exec/exec.go
+++ b/src/os/exec/exec.go
@@ -1,0 +1,24 @@
+package exec
+
+import "os"
+
+// An ExitError reports an unsuccessful exit by a command.
+type ExitError struct {
+	*os.ProcessState
+
+	// Stderr holds a subset of the standard error output from the
+	// Cmd.Output method if standard error was not otherwise being
+	// collected.
+	//
+	// If the error output is long, Stderr may contain only a prefix
+	// and suffix of the output, with the middle replaced with
+	// text about the number of omitted bytes.
+	//
+	// Stderr is provided for debugging, for inclusion in error messages.
+	// Users with other needs should redirect Cmd.Stderr as needed.
+	Stderr []byte
+}
+
+func (e *ExitError) Error() string {
+	return e.ProcessState.String()
+}


### PR DESCRIPTION
This commit adds stubs for the `ExitError` struct of the `exec` package
and `ProcessState.ExitCode()` of the `os` package.

Since the `os/exec` is listed as unsupported, stubbing these methods
and structs should be enough to get programs that use these to compile.