### PR TITLE
src/os: implement os.File.Fd() method

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -179,9 +179,19 @@ func (f *File) SyscallConn() (syscall.RawConn, error) {
 	return nil, ErrNotImplemented
 }
 
+// fd is an internal interface that is used to try a type assertion in order to
+// call the Fd() method of the underlying file handle if it is implemented.
+type fd interface {
+	Fd() uintptr
+}
+
 // Fd returns the file handle referencing the open file.
 func (f *File) Fd() uintptr {
-	panic("unimplemented: os.file.Fd()")
+	handle, ok := f.handle.(fd)
+	if ok {
+		return handle.Fd()
+	}
+	return 0
 }
 
 // Truncate is a stub, not yet implemented

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -118,6 +118,10 @@ func (f unixFileHandle) Close() error {
 	return handleSyscallError(syscall.Close(syscallFd(f)))
 }
 
+func (f unixFileHandle) Fd() uintptr {
+	return uintptr(f)
+}
+
 // Chmod changes the mode of the named file to mode.
 // If the file is a symbolic link, it changes the mode of the link's target.
 // If there is an error, it will be of type *PathError.

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -68,3 +68,21 @@ func TestChdir(t *testing.T) {
 		t.Errorf("Remove %s: %s", dir, err)
 	}
 }
+
+func TestStandardFd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Log("TODO: TestFd fails on Windows, skipping")
+		return
+	}
+	if fd := Stdin.Fd(); fd != 0 {
+		t.Errorf("Stdin.Fd() = %d, want 0", fd)
+	}
+
+	if fd := Stdout.Fd(); fd != 1 {
+		t.Errorf("Stdout.Fd() = %d, want 1", fd)
+	}
+
+	if fd := Stderr.Fd(); fd != 2 {
+		t.Errorf("Stderr.Fd() = %d, want 2", fd)
+	}
+}

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -71,6 +71,10 @@ func (f stdioFileHandle) Seek(offset int64, whence int) (int64, error) {
 	return -1, ErrUnsupported
 }
 
+func (f stdioFileHandle) Fd() uintptr {
+	return uintptr(f)
+}
+
 //go:linkname putchar runtime.putchar
 func putchar(c byte)
 


### PR DESCRIPTION
This commits adds a OS-specific `Fd()` function for `file_anyos.go` and
`file_other.go`, which returns a uintptr to the underlying file
descriptor.

Creating this as a draft PR, because I'm unsure, if this is the correct way to go about implementing it.