### PR TITLE
src/os: export correct values for os.DevNull for each OS

### DIFF
--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -26,8 +26,6 @@ var (
 	Stderr = NewFile(uintptr(syscall.Stderr), "/dev/stderr")
 )
 
-const DevNull = "/dev/null"
-
 // isOS indicates whether we're running on a real operating system with
 // filesystem support.
 const isOS = true

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -15,6 +15,8 @@ var (
 	Stderr = NewFile(2, "/dev/stderr")
 )
 
+const DevNull = "/dev/null"
+
 // isOS indicates whether we're running on a real operating system with
 // filesystem support.
 const isOS = false

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,6 +1,9 @@
 //go:build darwin || (linux && !baremetal)
 // +build darwin linux,!baremetal
 
+// target wasi sets GOOS=linux and thus the +linux build tag,
+// even though it doesn't show up in "tinygo info target -wasi"
+
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -11,6 +14,8 @@ import (
 	"io"
 	"syscall"
 )
+
+const DevNull = "/dev/null"
 
 type syscallFd = int
 

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -13,6 +13,8 @@ import (
 	"unicode/utf16"
 )
 
+const DevNull = "NUL"
+
 type syscallFd = syscall.Handle
 
 // Symlink is a stub, it is not implemented.


### PR DESCRIPTION
This commit introduces `os.DevNull` exports for all supported OS
targets.
I had to introduce a new file `file_wasi.go` in order to export a
different value for `file_windows.go` (`NUL`) and keep `/dev/null` for
all other targets.

I'll create this PR as draft, because I have a few open questions:
~~I'm not sure, if this works correctly with the build tags or if the `file_anyos.go` takes precedence over the `file_windows.go`.~~
Other options that I see:
1. export from `file_other.go`, `file_unix.go` and `file_windows.go`, ignoring WASI
  1.1 create a separate `file_wasi.go` to be able to export `DevNull` there too (seems overkill?)
2. export only from `file_anyos.go` and `file_other.go`, ignoring Windows