### PR TITLE
Makefile: chmod before fpm. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -693,4 +693,7 @@ deb: build/release
 	@mkdir -p build/release-deb/usr/local/lib
 	cp -ar build/release/tinygo build/release-deb/usr/local/lib/tinygo
 	ln -sf ../lib/tinygo/bin/tinygo build/release-deb/usr/local/bin/tinygo
+	echo "Work around bad permissions set by tinygo build-library?"
+	find build/release-deb -type d -exec chmod +rx '{}' ';'
+	find build/release-deb -type f -exec chmod +r '{}' ';'
 	fpm -f -s dir -t deb -n tinygo -v $(shell grep "const Version = " goenv/version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb


### PR DESCRIPTION
This works around a likely permissions problem in "tinygo build-library"

(Originally removed a -j3, but testing on a hex core machine showed -j3 really does speed things up a bit.)

Fixes #2685