### PR TITLE
build/windows: use fork with updated permissions for new Scoop

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
-      - uses: MinoruSekine/setup-scoop@v1
+      - uses: brechtm/setup-scoop@v2
       - name: Install Dependencies
         shell: bash
         run: |


### PR DESCRIPTION
This PR switches to a fork with required permissions for new Scoop update for the GHA build. Needed to pass CI.