### PR TITLE
Update libclang installation comment to libclang-13-dev

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -16,7 +16,7 @@ import (
 )
 
 /*
-#include <clang-c/Index.h> // if this fails, install libclang-11-dev
+#include <clang-c/Index.h> // if this fails, install libclang-13-dev
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -3,7 +3,7 @@
 // are slightly different from the ones defined in libclang.go, but they
 // should be ABI compatible.
 
-#include <clang-c/Index.h> // if this fails, install libclang-11-dev
+#include <clang-c/Index.h> // if this fails, install libclang-13-dev
 
 CXCursor tinygo_clang_getTranslationUnitCursor(CXTranslationUnit tu) {
 	return clang_getTranslationUnitCursor(tu);


### PR DESCRIPTION
Tinygo bumped the default llvm version to v13 in:
tinygo-org/tinygo@3a4e0c9