### PR TITLE
Add stub for runtime numcgocall and numgoroutine

### DIFF
--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -8,3 +8,17 @@ package runtime
 func NumCPU() int {
 	return 1
 }
+
+// NumCgoCall returns the number of cgo calls made by the current process.
+func NumCgoCall() int {
+	return 0
+}
+
+// NumGoroutine returns the number of goroutines that currently exist.
+func NumGoroutine() int {
+	return 1
+}
+
+func Version() string {
+	return "v0.1.0"
+}

--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -9,12 +9,12 @@ func NumCPU() int {
 	return 1
 }
 
-// NumCgoCall returns the number of cgo calls made by the current process.
+// Stub for NumCgoCall, does not return the real value
 func NumCgoCall() int {
 	return 0
 }
 
-// NumGoroutine returns the number of goroutines that currently exist.
+// Stub for NumGoroutine, does not return the real value
 func NumGoroutine() int {
 	return 1
 }

--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -18,7 +18,3 @@ func NumCgoCall() int {
 func NumGoroutine() int {
 	return 1
 }
-
-func Version() string {
-	return "v0.1.0"
-}


### PR DESCRIPTION
This adds a stub for `NumCgoCall`, `NumGoroutine` and `Version` functions from the runtime package.

Since the multi-threading is currently not supported, hard coding `NumGoroutine` value to 1 (main thread), `NumCgoCall` to 0 ~and lastly for the `Version` It is either the commit hash, date of the build or release tag but I have just put in `v0.1.0` for now~. From what I can see this change should not break anything since these functions don't already exist.