### PR TITLE
cgo: slightly improve error messages

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -16,7 +16,7 @@ import (
 )
 
 /*
-#include <clang-c/Index.h> // if this fails, install libclang-13-dev
+#include <clang-c/Index.h> // If this fails, libclang headers aren't available. Please take a look here: https://tinygo.org/docs/guides/build/
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -3,7 +3,7 @@
 // are slightly different from the ones defined in libclang.go, but they
 // should be ABI compatible.
 
-#include <clang-c/Index.h> // if this fails, install libclang-13-dev
+#include <clang-c/Index.h> // If this fails, libclang headers aren't available. Please take a look here: https://tinygo.org/docs/guides/build/
 
 CXCursor tinygo_clang_getTranslationUnitCursor(CXTranslationUnit tu) {
 	return clang_getTranslationUnitCursor(tu);


### PR DESCRIPTION
Updating them to libclang-13-dev was a good change, but we can go even further:

  * The suggestion didn't apply to MacOS.
  * The suggestion would need to be updated with every LLVM release, which is a maintenance burden.
  * The suggestion is wrong when compiling with `-tags=llvm12` for example to choose a different LLVM version.

Therefore, link to the build documentation instead.