### PR TITLE
builder: use correct permission bits when creating a library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -693,7 +693,4 @@ deb: build/release
 	@mkdir -p build/release-deb/usr/local/lib
 	cp -ar build/release/tinygo build/release-deb/usr/local/lib/tinygo
 	ln -sf ../lib/tinygo/bin/tinygo build/release-deb/usr/local/bin/tinygo
-	echo "Work around bad permissions set by tinygo build-library?"
-	find build/release-deb -type d -exec chmod +rx '{}' ';'
-	find build/release-deb -type f -exec chmod +r '{}' ';'
 	fpm -f -s dir -t deb -n tinygo -v $(shell grep "const Version = " goenv/version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb

--- a/builder/library.go
+++ b/builder/library.go
@@ -103,6 +103,10 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 			if err != nil {
 				return nil, nil, err
 			}
+			err = os.Chmod(temporaryHeaderPath, 0o755) // TempDir uses 0o700 by default
+			if err != nil {
+				return nil, nil, err
+			}
 			err = os.Rename(temporaryHeaderPath, headerPath)
 			if err != nil {
 				switch {
@@ -179,6 +183,10 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 				return err
 			}
 			err = f.Close()
+			if err != nil {
+				return err
+			}
+			err = os.Chmod(f.Name(), 0o644) // TempFile uses 0o600 by default
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, the wrong permission bits were emitted by `tinygo build-library`. This commit fixes that, by `chmod`'ing to reasonable default permission bits.

See: https://github.com/tinygo-org/tinygo/issues/2685 and https://github.com/tinygo-org/tinygo/pull/2691.