### PR TITLE
build: trigger builds of dev branches of repos in TinyGo ecosystem

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,3 +57,27 @@ jobs:
             --header 'Content-Type: application/json' \
             -d '{"branch": "dev"}' \
             -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+      - name: Trigger Bluetooth repo build on CircleCI
+        run: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/bluetooth/pipeline' \
+            --header 'Content-Type: application/json' \
+            -d '{"branch": "dev"}' \
+            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+      - name: Trigger TinyFS repo build on CircleCI
+        run: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinyfs/pipeline' \
+            --header 'Content-Type: application/json' \
+            -d '{"branch": "dev"}' \
+            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+      - name: Trigger TinyFont repo build on CircleCI
+        run: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinyfont/pipeline' \
+            --header 'Content-Type: application/json' \
+            -d '{"branch": "dev"}' \
+            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+      - name: Trigger TinyDraw repo build on CircleCI
+        run: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinydraw/pipeline' \
+            --header 'Content-Type: application/json' \
+            -d '{"branch": "dev"}' \
+            -u "${{ secrets.CIRCLECI_API_TOKEN }}"


### PR DESCRIPTION
This PR triggers builds of `dev` branches of all the repos in the TinyGo ecosystem e.g. Bluetooth, TinyFS, TinyFont, TinyDraw.

The idea is to make it immediate that we know about breaking changes the same way that we currently do for the Drivers repo.