### PR TITLE
On baremetal platforms, use simpler test matcher.  Fixes #2666.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -239,3 +239,4 @@ jobs:
           rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
       - run: make smoketest
       - run: make wasmtest
+      - run: make tinygo-baremetal

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,10 @@ test-corpus-fast:
 test-corpus-wasi: wasi-libc
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags byollvm -run TestCorpus . -corpus=testdata/corpus.yaml -target=wasi
 
+tinygo-baremetal:
+	# Regression tests that run on a baremetal target and don't fit in either main_test.go or smoketest.
+	# regression test for #2666: e.g. encoding/hex must pass on baremetal
+	$(TINYGO) test -target cortex-m-qemu encoding/hex
 
 .PHONY: smoketest
 smoketest:

--- a/src/testing/is_baremetal.go
+++ b/src/testing/is_baremetal.go
@@ -1,0 +1,10 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//go:build baremetal
+// +build baremetal
+
+package testing
+
+const isBaremetal = true

--- a/src/testing/is_not_baremetal.go
+++ b/src/testing/is_not_baremetal.go
@@ -1,0 +1,10 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+//go:build !baremetal
+// +build !baremetal
+
+package testing
+
+const isBaremetal = false

--- a/testdata/testing.go
+++ b/testdata/testing.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func TestAllLowercase(t *testing.T) {
 		"alpha",
 		"BETA",
 		"gamma",
-		"DELTA",
+		"BELTA",
 	}
 
 	for _, name := range names {
@@ -56,23 +57,22 @@ var benchmarks = []testing.InternalBenchmark{}
 
 var examples = []testing.InternalExample{}
 
-// A fake regexp matcher that can only handle two patterns.
+// A fake regexp matcher.
 // Inflexible, but saves 50KB of flash and 50KB of RAM per -size full,
-// and lets tests pass on cortex-m3.
+// and lets tests pass on cortex-m.
+// Must match the one in src/testing/match.go that is substituted on bare-metal platforms,
+// or "make test" will fail there.
 func fakeMatchString(pat, str string) (bool, error) {
 	if pat == ".*" {
 		return true, nil
 	}
-	if pat == "[BD]" {
-		return (str[0] == 'B' || str[0] == 'D'), nil
-	}
-	println("BUG: fakeMatchString does not grok", pat)
-	return false, nil
+	matched := strings.Contains(str, pat)
+	return matched, nil
 }
 
 func main() {
 	testing.Init()
-	flag.Set("test.run", ".*/[BD]")
+	flag.Set("test.run", ".*/B")
 	m := testing.MainStart(matchStringOnly(fakeMatchString /*regexp.MatchString*/), tests, benchmarks, examples)
 
 	exitcode := m.Run()

--- a/testdata/testing.txt
+++ b/testdata/testing.txt
@@ -15,7 +15,7 @@
 --- FAIL: TestAllLowercase (0.00s)
     --- FAIL: TestAllLowercase/BETA (0.00s)
         expected lowercase name, got BETA
-    --- FAIL: TestAllLowercase/DELTA (0.00s)
-        expected lowercase name, got DELTA
+    --- FAIL: TestAllLowercase/BELTA (0.00s)
+        expected lowercase name, got BELTA
 FAIL
 exitcode: 1


### PR DESCRIPTION
On baremetal targets, there is no argv anyway, so even this minimal matcher is probably overkill... 
but it does work, in case anyone does jam arguments in somehow.
