### PR TITLE
Fix STM32 adc common

### DIFF
--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -238,7 +238,7 @@ func readSVD(path, sourceURL string) (*Device, error) {
 					groupName = "ADC_Common"
 				}
 				// Fix some group name with wrong case
-				periphEl.Name = "ADC_Common"
+				periphEl.Name = reAdcCommon.ReplaceAllString(periphEl.Name, "ADC_Common")
 			}
 		}
 


### PR DESCRIPTION
Currently, some generated files from STM32's svd file have some problems:

1. `ADC*` and `ADC_Common` has the same type, because they have the same group name `ADC`, `ADC_Common` should has a different type. For example in `src/device/stm32/stm32f429.go`:
```go
	// Analog-to-digital converter
	ADC1 = (*ADC_Type)(unsafe.Pointer(uintptr(0x40012000)))

	......

	// Common ADC registers
	ADC_Common = (*ADC_Type)(unsafe.Pointer(uintptr(0x40012300)))
```

2. `ADC_Type` used ADC_Common's structure, because `ADC_Common` be described before `ADC*` in the svd file, for example in `src/device/stm32/stm32f410.go`:
```go
// ADC common registers
type ADC_Type struct {
	CSR volatile.Register32 // 0x0
	CCR volatile.Register32 // 0x4
}
```

3. Some `ADC_Common` used wrong case like `ADC_common`, for example in `src/device/stm32/stm32mp153.svd`:
```xml
<name>ADC_common</name>
```

This PR just fix those problems before a better way.