### PR TITLE
Implement getpagesize and munmap.  For go 1.18.

### DIFF
--- a/src/syscall/mmap_unix_test.go
+++ b/src/syscall/mmap_unix_test.go
@@ -1,0 +1,23 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build darwin || linux
+// +build darwin linux
+
+package syscall_test
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestMmap(t *testing.T) {
+	b, err := syscall.Mmap(-1, 0, syscall.Getpagesize(), syscall.PROT_NONE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("Mmap: %v", err)
+	}
+	if err := syscall.Munmap(b); err != nil {
+		t.Fatalf("Munmap: %v", err)
+	}
+}

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -226,12 +226,24 @@ func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, e
 	return (*[1 << 30]byte)(addr)[:length:length], nil
 }
 
+func Munmap(b []byte) (err error) {
+	errCode := libc_munmap(unsafe.Pointer(&b[0]), uintptr(len(b)))
+	if errCode != 0 {
+		err = getErrno()
+	}
+	return err
+}
+
 func Mprotect(b []byte, prot int) (err error) {
 	errCode := libc_mprotect(unsafe.Pointer(&b[0]), uintptr(len(b)), int32(prot))
 	if errCode != 0 {
 		err = getErrno()
 	}
 	return
+}
+
+func Getpagesize() int {
+	return int(libc_getpagesize())
 }
 
 func Environ() []string {
@@ -343,9 +355,17 @@ func libc_dup(fd int32) int32
 //export mmap
 func libc_mmap(addr unsafe.Pointer, length uintptr, prot, flags, fd int32, offset uintptr) unsafe.Pointer
 
+// int munmap(void *addr, size_t length);
+//export munmap
+func libc_munmap(addr unsafe.Pointer, length uintptr) int32
+
 // int mprotect(void *addr, size_t len, int prot);
 //export mprotect
 func libc_mprotect(addr unsafe.Pointer, len uintptr, prot int32) int32
+
+// int getpagesize();
+//export getpagesize
+func libc_getpagesize() int32
 
 // int chdir(const char *pathname, mode_t mode);
 //export chdir


### PR DESCRIPTION
"make test" with go 1.18 installed fails with
```
    main_test.go:541: test error: could not compile: /usr/local/go/src/internal/fuzz/sys_posix.go:37:11: Munmap not declared b
```
See https://github.com/tinygo-org/tinygo/pull/2515#issuecomment-1031295016

