### PR TITLE
compiler.go: createBuiltin: accept alias for slice.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1233,7 +1233,7 @@ func (b *builder) createBuiltin(argTypes []types.Type, argValues []llvm.Value, c
 	case "cap":
 		value := argValues[0]
 		var llvmCap llvm.Value
-		switch argTypes[0].(type) {
+		switch argTypes[0].Underlying().(type) {
 		case *types.Chan:
 			llvmCap = b.createRuntimeCall("chanCap", []llvm.Value{value}, "cap")
 		case *types.Slice:


### PR DESCRIPTION
Seems to get 1.18 tests closer to passing.

I don't know llvm, so this was a bit of a guess.

For https://github.com/tinygo-org/tinygo/pull/2515 / https://github.com/tinygo-org/tinygo/issues/2718