### PR TITLE
syscall: define MAP_SHARED and PROT_READ on wasi

### DIFF
--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -59,6 +59,19 @@ const (
 	O_SYNC   = __WASI_FDFLAGS_SYNC
 
 	O_CLOEXEC = 0
+
+	// ../../lib/wasi-libc/sysroot/include/sys/mman.h
+	MAP_FILE      = 0
+	MAP_SHARED    = 0x01
+	MAP_PRIVATE   = 0x02
+	MAP_ANON      = 0x20
+	MAP_ANONYMOUS = MAP_ANON
+
+	// ../../lib/wasi-libc/sysroot/include/sys/mman.h
+	PROT_NONE  = 0
+	PROT_READ  = 1
+	PROT_WRITE = 2
+	PROT_EXEC  = 4
 )
 
 //go:extern errno


### PR DESCRIPTION
Makes 1.18 tests a little happier.

Not sure mmap works on wasi, so these may be somewhat stubby.

For https://github.com/tinygo-org/tinygo/pull/2515 / https://github.com/tinygo-org/tinygo/issues/2718