### PR TITLE
syscall: stub mmap(), MAP_SHARED, PROT_READ, SIGBUS, etc. on nonhosted targets

### DIFF
--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -27,6 +27,12 @@ const (
 	SIGTRAP
 	SIGQUIT
 	SIGTERM
+	SIGILL
+	SIGABRT
+	SIGBUS
+	SIGFPE
+	SIGSEGV
+	SIGPIPE
 )
 
 func (s Signal) Signal() {}
@@ -64,6 +70,22 @@ const (
 	O_SYNC   = 010000
 
 	O_CLOEXEC = 0
+)
+
+// Dummy values to allow compiling tests
+// Dummy source: https://opensource.apple.com/source/xnu/xnu-7195.81.3/bsd/sys/mman.h.auto.html
+const (
+	PROT_NONE  = 0x00 // no permissions
+	PROT_READ  = 0x01 // pages can be read
+	PROT_WRITE = 0x02 // pages can be written
+	PROT_EXEC  = 0x04 // pages can be executed
+
+	MAP_SHARED  = 0x0001 // share changes
+	MAP_PRIVATE = 0x0002 // changes are private
+
+	MAP_FILE      = 0x0000 // map from file (default)
+	MAP_ANON      = 0x1000 // allocated from memory, swap space
+	MAP_ANONYMOUS = MAP_ANON
 )
 
 func runtime_envs() []string
@@ -166,6 +188,14 @@ func StartProcess(argv0 string, argv []string, attr *ProcAttr) (pid int, handle 
 }
 func Wait4(pid int, wstatus *WaitStatus, options int, rusage *Rusage) (wpid int, err error) {
 	return 0, ENOSYS
+}
+
+func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+	return nil, ENOSYS
+}
+
+func Munmap(b []byte) (err error) {
+	return ENOSYS
 }
 
 type Timeval struct {


### PR DESCRIPTION
Makes 1.18 tests a little happier.

Works around this error:

$ make test GOTESTFLAGS="-run TestTest/EmulatedCortexM3/Pass"
...
main_test.go:520: test error: could not compile: /usr/local/go/src/internal/fuzz/sys_posix.go:19:18: PROT_READ not declared by package syscall