### PR TITLE
syscall: define more signal numbers

### DIFF
--- a/src/syscall/syscall_libc_darwin.go
+++ b/src/syscall/syscall_libc_darwin.go
@@ -74,13 +74,20 @@ const (
 
 type Signal int
 
+// Source: https://opensource.apple.com/source/xnu/xnu-7195.81.3/bsd/sys/signal.h
 const (
-	SIGCHLD Signal = 0x14
-	SIGINT  Signal = 0x2
-	SIGKILL Signal = 0x9
-	SIGTRAP Signal = 0x5
-	SIGQUIT Signal = 0x3
-	SIGTERM Signal = 0xf
+	SIGINT  Signal = 2  /* interrupt */
+	SIGQUIT Signal = 3  /* quit */
+	SIGILL  Signal = 4  /* illegal instruction (not reset when caught) */
+	SIGTRAP Signal = 5  /* trace trap (not reset when caught) */
+	SIGABRT Signal = 6  /* abort() */
+	SIGFPE  Signal = 8  /* floating point exception */
+	SIGKILL Signal = 9  /* kill (cannot be caught or ignored) */
+	SIGBUS  Signal = 10 /* bus error */
+	SIGSEGV Signal = 11 /* segmentation violation */
+	SIGPIPE Signal = 13 /* write on a pipe with no one to read it */
+	SIGTERM Signal = 15 /* software termination signal from kill */
+	SIGCHLD Signal = 20 /* to parent on child stop or exit */
 )
 
 func (s Signal) Signal() {}

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -9,16 +9,24 @@ import (
 )
 
 // https://github.com/WebAssembly/wasi-libc/blob/main/expected/wasm32-wasi/predefined-macros.txt
+// disagrees with ../../lib/wasi-libc/libc-top-half/musl/arch/wasm32/bits/signal.h for SIGCHLD?
+// https://github.com/WebAssembly/wasi-libc/issues/271
 
 type Signal int
 
 const (
-	SIGCHLD Signal = 16
 	SIGINT  Signal = 2
-	SIGKILL Signal = 9
-	SIGTRAP Signal = 5
 	SIGQUIT Signal = 3
+	SIGILL  Signal = 4
+	SIGTRAP Signal = 5
+	SIGABRT Signal = 6
+	SIGBUS  Signal = 7
+	SIGFPE  Signal = 8
+	SIGKILL Signal = 9
+	SIGSEGV Signal = 11
+	SIGPIPE Signal = 13
 	SIGTERM Signal = 15
+	SIGCHLD Signal = 17
 )
 
 func (s Signal) Signal() {}


### PR DESCRIPTION
Hoisted out of https://github.com/tinygo-org/tinygo/pull/2725
Makes tests happier under go 1.18