### PR TITLE
Pico adc input ch support

### DIFF
--- a/src/examples/adc_rp2040/adc.go
+++ b/src/examples/adc_rp2040/adc.go
@@ -1,0 +1,65 @@
+/*
+Read 3 rp2040 ADC channels
+   ADC0_CH     - GPIO26 Raw reading every 100ms
+   ADC1_CH     - GPIO27 Voltage reading every 3s
+   ADC_TEMP_CH - Temperature sensor reading every serial output (I.e. every second)
+*/
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+)
+
+type celsius float32
+
+func (c celsius) String() string {
+	return fmt.Sprintf("%4.1f℃", c)
+}
+
+type volts float32
+
+func (v volts) String() string {
+	return fmt.Sprintf("%2.1fV", v)
+}
+
+var (
+	adc0Raw   uint16
+	adc1Volts volts
+)
+
+func readRawOften(c machine.ADCChannel) {
+	for {
+		adc0Raw = c.GetOnce()
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func readVoltsInfrequently(c machine.ADCChannel) {
+	for {
+		adc1Volts = volts(c.GetVoltage())
+		time.Sleep(3000 * time.Millisecond)
+	}
+}
+
+func main() {
+	machine.InitADC()
+	a0 := machine.ADC0_CH    // GPIO26 input
+	a1 := machine.ADC1_CH    // GPIO27 input
+	t := machine.ADC_TEMP_CH // Internal Temperature sensor
+	// Configure sets the GPIOs to PinAnalog mode
+	a0.Configure(machine.ADCChConfig{})
+	a1.Configure(machine.ADCChConfig{})
+	// Configure powers on the temperature sensor
+	t.Configure(machine.ADCChConfig{})
+
+	// Safe to read concurrently
+	go readRawOften(a0)
+	go readVoltsInfrequently(a1)
+
+	for {
+		fmt.Printf("ADC0: %5d ADC1: %v Temp: %v\n\r", adc0Raw, adc1Volts, celsius(t.GetTemp()))
+		time.Sleep(1000 * time.Millisecond)
+	}
+}

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -39,11 +39,12 @@ func InitADC() {
 }
 
 // Configure sets the ADC pin to analog input mode.
-// Does nothing if the GPIO is not an ADC muxed pin.
-func (a ADC) Configure(config ADCConfig) {
-	if c, err := a.GetADCChannel(); err == nil {
-		c.Configure(config)
+func (a ADC) Configure(config ADCConfig) error {
+	c, err := a.GetADCChannel()
+	if err != nil {
+		return err
 	}
+	return c.Configure(config)
 }
 
 // Get returns a one-shot ADC sample reading.
@@ -75,7 +76,7 @@ func (a ADC) GetADCChannel() (c ADCChannel, err error) {
 
 // Configure sets the channel's associated pin to analog input mode or powers on the temperature sensor for ADC_TEMP_SENSOR.
 // The powered on temperature sensor increases ADC_AVDD current by approximately 40 μA.
-func (c ADCChannel) Configure(config ADCConfig) {
+func (c ADCChannel) Configure(config ADCConfig) error {
 	if config.Reference != 0 {
 		adcAref = config.Reference
 	}
@@ -86,6 +87,7 @@ func (c ADCChannel) Configure(config ADCConfig) {
 		// Enable temperature sensor bias source
 		rp.ADC.CS.SetBits(rp.ADC_CS_TS_EN)
 	}
+	return nil
 }
 
 // getOnce returns a one-shot ADC sample reading from an ADC channel.

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -5,10 +5,29 @@ package machine
 
 import (
 	"device/rp"
+	"sync"
 )
 
+// ADC peripheral mux channel. 0-4.
+// Use channel constants to access valid channels.
+type ADCChannel uint8
+
+const (
+	ADC0_CH ADCChannel = iota
+	ADC1_CH
+	ADC2_CH
+	ADC3_CH     // Note: GPIO29 not broken out on pico board
+	ADC_TEMP_CH // Internal temperature sensor
+)
+
+// Will be needed for round robin config when implemented
+type ADCChConfig struct{}
+
+// Used to serialise ADC sampling
+var adcLock sync.Mutex
+
+// Reset the ADC peripheral.
 func InitADC() {
-	// reset ADC
 	rp.RESETS.RESET.SetBits(rp.RESETS_RESET_ADC)
 	rp.RESETS.RESET.ClearBits(rp.RESETS_RESET_ADC)
 	for !rp.RESETS.RESET_DONE.HasBits(rp.RESETS_RESET_ADC) {
@@ -20,43 +39,112 @@ func InitADC() {
 	waitForReady()
 }
 
-// Configure configures a ADC pin to be able to be used to read data.
+// Below methods are for standard tinygo, ADC{} pin based access to the ADC peripheral.
+
+// The Configure method sets the ADC pin to analog input mode.
+// Note the ADCConfig parameter is ignored.
+// Does nothing if the GPIO is not an ADC muxed pin.
 func (a ADC) Configure(config ADCConfig) {
-	switch a.Pin {
-	case ADC0, ADC1, ADC2, ADC3:
-		a.Pin.Configure(PinConfig{Mode: PinAnalog})
-	default:
-		// invalid ADC
-		return
+	if c, ok := a.GetADCChannel(); ok {
+		c.Configure(ADCChConfig{})
 	}
 }
 
+// The Get method returns a one-shot ADC sample reading.
 func (a ADC) Get() uint16 {
-	rp.ADC.CS.SetBits(uint32(a.getADCChannel()) << rp.ADC_CS_AINSEL_Pos)
+	if c, ok := a.GetADCChannel(); ok {
+		return c.GetOnce()
+	}
+	// Not an ADC pin!
+	return 0
+}
+
+// The GetADCChannel method returns the channel associated with the ADC pin.
+// Returns !ok if the pin is not an ADC pin
+func (a ADC) GetADCChannel() (c ADCChannel, ok bool) {
+	ok = true
+	switch a.Pin {
+	case ADC0:
+		c = ADC0_CH
+	case ADC1:
+		c = ADC1_CH
+	case ADC2:
+		c = ADC2_CH
+	case ADC3:
+		c = ADC3_CH
+	default:
+		// Invalid ADC pin
+		ok = false
+	}
+	return c, ok
+}
+
+// Below methods are rp2040 specific, channel based access to the ADC peripheral.
+// The adcChannel methods provide access to the temperature sensor. As well as the pin based channels.
+
+// The Configure method sets the channel's associated pin to analog input mode.
+// Configuring the ADC_TEMP_CH channel will power on the temperature sensor.
+// The powered on temperature sensor increases ADC_AVDD current by approximately 40 μA.
+func (c ADCChannel) Configure(config ADCChConfig) {
+	if p, ok := c.Pin(); ok {
+		p.Configure(PinConfig{Mode: PinAnalog})
+	}
+	if c == ADC_TEMP_CH {
+		// Enable temperature sensor bias source
+		rp.ADC.CS.SetBits(rp.ADC_CS_TS_EN)
+	}
+}
+
+// The GetOnce method returns a one-shot ADC sample reading
+func (c ADCChannel) GetOnce() uint16 {
+	// Make it safe to sample multiple ADC channels in separate go routines.
+	adcLock.Lock()
+	rp.ADC.CS.ReplaceBits(uint32(c), 0b111, rp.ADC_CS_AINSEL_Pos)
 	rp.ADC.CS.SetBits(rp.ADC_CS_START_ONCE)
 
 	waitForReady()
+	adcLock.Unlock()
 
-	// rp2040 uses 12-bit sampling, so scale to 16-bit
-	return uint16(rp.ADC.RESULT.Get() << 4)
+	// rp2040 is a 12-bit ADC, scale raw reading to 16-bits.
+	return uint16(rp.ADC.RESULT.Get()) << 4
 }
 
+// The GetVoltage method does a one-shot sample and returns the reading as a voltage between 0.0 and 3.3V
+func (c ADCChannel) GetVoltage() (volts float32) {
+	return float32(c.GetOnce()>>4) * float32(3.3) / float32(1<<12)
+}
+
+// The GetTemp method does a one-shot sample of the internal temperature sensor.
+// Only works on the ADC_TEMP_CH channel. aka AINSEL=4. Other channels will return 0.0.
+func (c ADCChannel) GetTemp() (celsius float32) {
+	if c == ADC_TEMP_CH {
+		// T = 27 - (ADC_voltage - 0.706)/0.001721
+		return float32(27) - (c.GetVoltage()-float32(0.706))/float32(0.001721)
+	}
+	return 0.0
+}
+
+// The waitForReady function spins waiting for the ADC peripheral to become ready
 func waitForReady() {
 	for !rp.ADC.CS.HasBits(rp.ADC_CS_READY) {
 	}
 }
 
-func (a ADC) getADCChannel() uint8 {
-	switch a.Pin {
-	case ADC0:
-		return 0
-	case ADC1:
-		return 1
-	case ADC2:
-		return 2
-	case ADC3:
-		return 3
+// The Pin method returns the GPIO Pin associated with the ADC mux channel, if it has one.
+// Returns !ok if the channel does not have an associated GPIO, or if the channel number is invalid.
+func (c ADCChannel) Pin() (p Pin, ok bool) {
+	ok = true
+	switch c {
+	case ADC0_CH:
+		p = ADC0
+	case ADC1_CH:
+		p = ADC1
+	case ADC2_CH:
+		p = ADC2
+	case ADC3_CH:
+		p = ADC3
 	default:
-		return 0
+		ok = false
 	}
+	return p, ok
 }

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -5,98 +5,91 @@ package machine
 
 import (
 	"device/rp"
+	"errors"
 	"sync"
 )
 
-// ADC peripheral mux channel. 0-4.
-// Use channel constants to access valid channels.
+// ADCChannel is the ADC peripheral mux channel. 0-4.
 type ADCChannel uint8
 
+// ADC channels. Only ADC_TEMP_SENSOR is public. The other channels are accessed via Machine.ADC objects
 const (
-	ADC0_CH ADCChannel = iota
-	ADC1_CH
-	ADC2_CH
-	ADC3_CH     // Note: GPIO29 not broken out on pico board
-	ADC_TEMP_CH // Internal temperature sensor
+	adc0_CH ADCChannel = iota
+	adc1_CH
+	adc2_CH
+	adc3_CH         // Note: GPIO29 not broken out on pico board
+	ADC_TEMP_SENSOR // Internal temperature sensor channel
 )
-
-// Will be needed for round robin config when implemented
-type ADCChConfig struct{}
 
 // Used to serialise ADC sampling
 var adcLock sync.Mutex
 
-// Reset the ADC peripheral.
+// ADC peripheral reference voltage (mV)
+var adcAref uint32 = 3300
+
+// InitADC resets the ADC peripheral.
 func InitADC() {
 	rp.RESETS.RESET.SetBits(rp.RESETS_RESET_ADC)
 	rp.RESETS.RESET.ClearBits(rp.RESETS_RESET_ADC)
 	for !rp.RESETS.RESET_DONE.HasBits(rp.RESETS_RESET_ADC) {
 	}
-
 	// enable ADC
 	rp.ADC.CS.Set(rp.ADC_CS_EN)
-
 	waitForReady()
 }
 
-// Below methods are for standard tinygo, ADC{} pin based access to the ADC peripheral.
-
-// The Configure method sets the ADC pin to analog input mode.
-// Note the ADCConfig parameter is ignored.
+// Configure sets the ADC pin to analog input mode.
 // Does nothing if the GPIO is not an ADC muxed pin.
 func (a ADC) Configure(config ADCConfig) {
-	if c, ok := a.GetADCChannel(); ok {
-		c.Configure(ADCChConfig{})
+	if c, err := a.GetADCChannel(); err == nil {
+		c.Configure(config)
 	}
 }
 
-// The Get method returns a one-shot ADC sample reading.
+// Get returns a one-shot ADC sample reading.
 func (a ADC) Get() uint16 {
-	if c, ok := a.GetADCChannel(); ok {
-		return c.GetOnce()
+	if c, err := a.GetADCChannel(); err == nil {
+		return c.getOnce()
 	}
 	// Not an ADC pin!
 	return 0
 }
 
-// The GetADCChannel method returns the channel associated with the ADC pin.
-// Returns !ok if the pin is not an ADC pin
-func (a ADC) GetADCChannel() (c ADCChannel, ok bool) {
-	ok = true
+// GetADCChannel returns the channel associated with the ADC pin.
+func (a ADC) GetADCChannel() (c ADCChannel, err error) {
+	err = nil
 	switch a.Pin {
 	case ADC0:
-		c = ADC0_CH
+		c = adc0_CH
 	case ADC1:
-		c = ADC1_CH
+		c = adc1_CH
 	case ADC2:
-		c = ADC2_CH
+		c = adc2_CH
 	case ADC3:
-		c = ADC3_CH
+		c = adc3_CH
 	default:
-		// Invalid ADC pin
-		ok = false
+		err = errors.New("no ADC channel for pin value")
 	}
-	return c, ok
+	return c, err
 }
 
-// Below methods are rp2040 specific, channel based access to the ADC peripheral.
-// The adcChannel methods provide access to the temperature sensor. As well as the pin based channels.
-
-// The Configure method sets the channel's associated pin to analog input mode.
-// Configuring the ADC_TEMP_CH channel will power on the temperature sensor.
+// Configure sets the channel's associated pin to analog input mode or powers on the temperature sensor for ADC_TEMP_SENSOR.
 // The powered on temperature sensor increases ADC_AVDD current by approximately 40 μA.
-func (c ADCChannel) Configure(config ADCChConfig) {
-	if p, ok := c.Pin(); ok {
+func (c ADCChannel) Configure(config ADCConfig) {
+	if config.Reference != 0 {
+		adcAref = config.Reference
+	}
+	if p, err := c.Pin(); err == nil {
 		p.Configure(PinConfig{Mode: PinAnalog})
 	}
-	if c == ADC_TEMP_CH {
+	if c == ADC_TEMP_SENSOR {
 		// Enable temperature sensor bias source
 		rp.ADC.CS.SetBits(rp.ADC_CS_TS_EN)
 	}
 }
 
-// The GetOnce method returns a one-shot ADC sample reading
-func (c ADCChannel) GetOnce() uint16 {
+// getOnce returns a one-shot ADC sample reading from an ADC channel.
+func (c ADCChannel) getOnce() uint16 {
 	// Make it safe to sample multiple ADC channels in separate go routines.
 	adcLock.Lock()
 	rp.ADC.CS.ReplaceBits(uint32(c), 0b111, rp.ADC_CS_AINSEL_Pos)
@@ -109,42 +102,42 @@ func (c ADCChannel) GetOnce() uint16 {
 	return uint16(rp.ADC.RESULT.Get()) << 4
 }
 
-// The GetVoltage method does a one-shot sample and returns the reading as a voltage between 0.0 and 3.3V
-func (c ADCChannel) GetVoltage() (volts float32) {
-	return float32(c.GetOnce()>>4) * float32(3.3) / float32(1<<12)
+// getVoltage does a one-shot sample and returns a millivolts reading.
+// Integer portion is stored in the high 16 bits and fractional in the low 16 bits.
+func (c ADCChannel) getVoltage() uint32 {
+	return (adcAref << 16) / (1 << 12) * uint32(c.getOnce()>>4)
 }
 
-// The GetTemp method does a one-shot sample of the internal temperature sensor.
-// Only works on the ADC_TEMP_CH channel. aka AINSEL=4. Other channels will return 0.0.
-func (c ADCChannel) GetTemp() (celsius float32) {
-	if c == ADC_TEMP_CH {
-		// T = 27 - (ADC_voltage - 0.706)/0.001721
-		return float32(27) - (c.GetVoltage()-float32(0.706))/float32(0.001721)
+// ReadTemperature does a one-shot sample of the internal temperature sensor and returns a milli-celsius reading.
+// Only works on the ADC_TEMP_SENSOR channel. aka AINSEL=4. Other channels will return 0
+func (c ADCChannel) ReadTemperature() (millicelsius uint32) {
+	if c != ADC_TEMP_SENSOR {
+		return
 	}
-	return 0.0
+	// T = 27 - (ADC_voltage - 0.706)/0.001721
+	return (27000<<16 - (c.getVoltage()-706<<16)*581) >> 16
 }
 
-// The waitForReady function spins waiting for the ADC peripheral to become ready
+// waitForReady spins waiting for the ADC peripheral to become ready.
 func waitForReady() {
 	for !rp.ADC.CS.HasBits(rp.ADC_CS_READY) {
 	}
 }
 
 // The Pin method returns the GPIO Pin associated with the ADC mux channel, if it has one.
-// Returns !ok if the channel does not have an associated GPIO, or if the channel number is invalid.
-func (c ADCChannel) Pin() (p Pin, ok bool) {
-	ok = true
+func (c ADCChannel) Pin() (p Pin, err error) {
+	err = nil
 	switch c {
-	case ADC0_CH:
+	case adc0_CH:
 		p = ADC0
-	case ADC1_CH:
+	case adc1_CH:
 		p = ADC1
-	case ADC2_CH:
+	case adc2_CH:
 		p = ADC2
-	case ADC3_CH:
+	case adc3_CH:
 		p = ADC3
 	default:
-		ok = false
+		err = errors.New("no associated pin for channel")
 	}
-	return p, ok
+	return p, err
 }

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -25,7 +25,7 @@ const (
 var adcLock sync.Mutex
 
 // ADC peripheral reference voltage (mV)
-var adcAref uint32 = 3300
+var adcAref uint32
 
 // InitADC resets the ADC peripheral.
 func InitADC() {
@@ -35,6 +35,7 @@ func InitADC() {
 	}
 	// enable ADC
 	rp.ADC.CS.Set(rp.ADC_CS_EN)
+	adcAref = 3300
 	waitForReady()
 }
 


### PR DESCRIPTION
Hi, This request adds ADC input channel support to the rp2040 ADC. This allows access to the ADC peripheral via the input mux channels as well as retaining the current access via machine.ADC pins. The enhancement includes:
1) Can now access the internal temperature sensor via channel 4. Which is not associated with a pin.
2) Fixes a bug. Could not use multiple ADC pins/channels before because the CS.AINSEL register bits where only getting set, not replaced. 
3) Added a Mutex to make it safe to read multiple ADC channels concurrently.
4) Added adc_rp2040 example to show off new features. 