### PR TITLE
fix: flash-command for maixbit board

### DIFF
--- a/targets/maixbit.json
+++ b/targets/maixbit.json
@@ -3,5 +3,5 @@
 	"build-tags": ["maixbit"],
 	"serial": "uart",
 	"linkerscript": "targets/maixbit.ld",
-	"flash-command": "kflash -p {port} --noansi --verbose {bin}"
+	"flash-command": "kflash --Board bit -p {port} --noansi --verbose {bin}"
 }


### PR DESCRIPTION
 Latest version of kflash tool requires a --Board/-B argument to be able to run the tool