### PR TITLE
m5stamp-c3: add pin setting of UART

### DIFF
--- a/src/machine/board_m5stamp_c3.go
+++ b/src/machine/board_m5stamp_c3.go
@@ -42,6 +42,9 @@ const (
 	SPIQ       = IO17
 	U0RXD      = IO20
 	U0TXD      = IO21
+
+	UART_TX_PIN = U0TXD
+	UART_RX_PIN = U0RXD
 )
 
 const (


### PR DESCRIPTION
It is better to have UART_TX_PIN defined in order to use `src/examples/echo`.

Unlike other ESP32C3 boards, the m5stamp has its UART pins connected to the Type-C connector via a serial conversion chip.
For this reason, it is very useful to define UART_TX_PIN.

https://docs.m5stack.com/en/core/stamp_c3