### PR TITLE
feat: add basic WASI `net.Listener` via `sock_accept`

### DIFF
--- a/src/net/error_posix.go
+++ b/src/net/error_posix.go
@@ -1,0 +1,24 @@
+// The following is copied and adapted from Go 1.18 official implementation.
+
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || windows || wasi
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris windows wasi
+
+package net
+
+import (
+	"os"
+	"syscall"
+)
+
+// wrapSyscallError takes an error and a syscall name. If the error is
+// a syscall.Errno, it wraps it in a os.SyscallError using the syscall name.
+func wrapSyscallError(name string, err error) error {
+	if _, ok := err.(syscall.Errno); ok {
+		err = os.NewSyscallError(name, err)
+	}
+	return err
+}

--- a/src/net/fd_wasi.go
+++ b/src/net/fd_wasi.go
@@ -1,0 +1,57 @@
+//go:build wasi
+// +build wasi
+
+package net
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Network file descriptor.
+type netFD struct {
+	*os.File
+
+	net   string
+	laddr Addr
+	raddr Addr
+}
+
+// Read implements the Conn Read method.
+func (c *netFD) Read(b []byte) (int, error) {
+    // TODO: Handle EAGAIN and perform poll
+	return c.File.Read(b)
+}
+
+// Write implements the Conn Write method.
+func (c *netFD) Write(b []byte) (int, error) {
+    // TODO: Handle EAGAIN and perform poll
+	return c.File.Write(b)
+}
+
+// LocalAddr implements the Conn LocalAddr method.
+func (*netFD) LocalAddr() Addr {
+	return nil
+}
+
+// RemoteAddr implements the Conn RemoteAddr method.
+func (*netFD) RemoteAddr() Addr {
+	return nil
+}
+
+// SetDeadline implements the Conn SetDeadline method.
+func (*netFD) SetDeadline(t time.Time) error {
+	return ErrNotImplemented
+}
+
+// SetReadDeadline implements the Conn SetReadDeadline method.
+func (*netFD) SetReadDeadline(t time.Time) error {
+	return ErrNotImplemented
+}
+
+// SetWriteDeadline implements the Conn SetWriteDeadline method.
+func (*netFD) SetWriteDeadline(t time.Time) error {
+	return ErrNotImplemented
+}

--- a/src/net/file.go
+++ b/src/net/file.go
@@ -1,0 +1,31 @@
+//go:build wasi
+// +build wasi
+
+// The following is copied from Go 1.18 official implementation.
+
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+	"os"
+)
+
+type fileAddr string
+
+func (fileAddr) Network() string  { return "file+net" }
+func (f fileAddr) String() string { return string(f) }
+
+// FileListener returns a copy of the network listener corresponding
+// to the open file f.
+// It is the caller's responsibility to close ln when finished.
+// Closing ln does not affect f, and closing f does not affect ln.
+func FileListener(f *os.File) (ln Listener, err error) {
+	ln, err = fileListener(f)
+	if err != nil {
+		err = &OpError{Op: "file", Net: "file+net", Source: nil, Addr: fileAddr(f.Name()), Err: err}
+	}
+	return
+}

--- a/src/net/net_fake.go
+++ b/src/net/net_fake.go
@@ -6,6 +6,9 @@
 
 // Fake networking. It is intended to allow tests of other package to pass.
 
+//go:build !wasi
+// +build !wasi
+
 package net
 
 import (

--- a/src/net/net_fake.go
+++ b/src/net/net_fake.go
@@ -1,0 +1,215 @@
+// The following is copied from Go 1.18 official implementation.
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Fake networking. It is intended to allow tests of other package to pass.
+
+package net
+
+import (
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var listenersMu sync.Mutex
+var listeners = make(map[string]*netFD)
+
+var portCounterMu sync.Mutex
+var portCounter = 0
+
+func nextPort() int {
+	portCounterMu.Lock()
+	defer portCounterMu.Unlock()
+	portCounter++
+	return portCounter
+}
+
+// Network file descriptor.
+type netFD struct {
+	r        *bufferedPipe
+	w        *bufferedPipe
+	incoming chan *netFD
+
+	closedMu sync.Mutex
+	closed   bool
+
+	// immutable until Close
+	listener bool
+	family   int
+	sotype   int
+	net      string
+	laddr    Addr
+	raddr    Addr
+
+	isConnected bool // handshake completed or use of association with peer
+}
+
+func (fd *netFD) Read(p []byte) (n int, err error) {
+	return fd.r.Read(p)
+}
+
+func (fd *netFD) Write(p []byte) (nn int, err error) {
+	return fd.w.Write(p)
+}
+
+func (fd *netFD) Close() error {
+	fd.closedMu.Lock()
+	if fd.closed {
+		fd.closedMu.Unlock()
+		return nil
+	}
+	fd.closed = true
+	fd.closedMu.Unlock()
+
+	if fd.listener {
+		listenersMu.Lock()
+		delete(listeners, fd.laddr.String())
+		close(fd.incoming)
+		fd.listener = false
+		listenersMu.Unlock()
+		return nil
+	}
+
+	fd.r.Close()
+	fd.w.Close()
+	return nil
+}
+
+func (fd *netFD) closeRead() error {
+	fd.r.Close()
+	return nil
+}
+
+func (fd *netFD) closeWrite() error {
+	fd.w.Close()
+	return nil
+}
+
+func (fd *netFD) accept() (*netFD, error) {
+	c, ok := <-fd.incoming
+	if !ok {
+		return nil, syscall.EINVAL
+	}
+	return c, nil
+}
+
+func (fd *netFD) SetDeadline(t time.Time) error {
+	fd.r.SetReadDeadline(t)
+	fd.w.SetWriteDeadline(t)
+	return nil
+}
+
+func (fd *netFD) SetReadDeadline(t time.Time) error {
+	fd.r.SetReadDeadline(t)
+	return nil
+}
+
+func (fd *netFD) SetWriteDeadline(t time.Time) error {
+	fd.w.SetWriteDeadline(t)
+	return nil
+}
+
+func newBufferedPipe(softLimit int) *bufferedPipe {
+	p := &bufferedPipe{softLimit: softLimit}
+	p.rCond.L = &p.mu
+	p.wCond.L = &p.mu
+	return p
+}
+
+type bufferedPipe struct {
+	softLimit int
+	mu        sync.Mutex
+	buf       []byte
+	closed    bool
+	rCond     sync.Cond
+	wCond     sync.Cond
+	rDeadline time.Time
+	wDeadline time.Time
+}
+
+func (p *bufferedPipe) Read(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for {
+		if p.closed && len(p.buf) == 0 {
+			return 0, io.EOF
+		}
+		if !p.rDeadline.IsZero() {
+			d := time.Until(p.rDeadline)
+			if d <= 0 {
+				return 0, syscall.EAGAIN
+			}
+			time.AfterFunc(d, p.rCond.Broadcast)
+		}
+		if len(p.buf) > 0 {
+			break
+		}
+		p.rCond.Wait()
+	}
+
+	n := copy(b, p.buf)
+	p.buf = p.buf[n:]
+	p.wCond.Broadcast()
+	return n, nil
+}
+
+func (p *bufferedPipe) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for {
+		if p.closed {
+			return 0, syscall.ENOTCONN
+		}
+		if !p.wDeadline.IsZero() {
+			d := time.Until(p.wDeadline)
+			if d <= 0 {
+				return 0, syscall.EAGAIN
+			}
+			time.AfterFunc(d, p.wCond.Broadcast)
+		}
+		if len(p.buf) <= p.softLimit {
+			break
+		}
+		p.wCond.Wait()
+	}
+
+	p.buf = append(p.buf, b...)
+	p.rCond.Broadcast()
+	return len(b), nil
+}
+
+func (p *bufferedPipe) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	p.rCond.Broadcast()
+	p.wCond.Broadcast()
+}
+
+func (p *bufferedPipe) SetReadDeadline(t time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.rDeadline = t
+	p.rCond.Broadcast()
+}
+
+func (p *bufferedPipe) SetWriteDeadline(t time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.wDeadline = t
+	p.wCond.Broadcast()
+}
+
+func (fd *netFD) dup() (f *os.File, err error) {
+	return nil, syscall.ENOSYS
+}

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -309,6 +309,14 @@ func Getpagesize() int {
 	return 65536
 }
 
+func SockAccept(fd int, flags int) (nfd int, err error) {
+	var retptr0 __wasi_fd_t
+	if n := sock_accept(__wasi_fd_t(fd), __wasi_fdflags_t(flags), &retptr0); n != 0 {
+		return -1, Errno(n)
+	}
+	return int(retptr0), nil
+}
+
 // int stat(const char *path, struct stat * buf);
 //
 //export stat
@@ -323,3 +331,14 @@ func libc_fstat(fd int32, ptr unsafe.Pointer) int32
 //
 //export lstat
 func libc_lstat(pathname *byte, ptr unsafe.Pointer) int32
+
+type (
+	__wasi_errno_t = uint16
+
+	__wasi_fd_t      = int32
+	__wasi_fdflags_t = uint16
+)
+
+//go:wasm-module wasi_snapshot_preview1
+//export sock_accept
+func sock_accept(fd __wasi_fd_t, flags __wasi_fdflags_t, retptr0 *__wasi_fd_t) __wasi_errno_t


### PR DESCRIPTION
# Description
Add support for `sock_accept` recently added to WASI https://github.com/WebAssembly/WASI/pull/458

The implementation still lacks polling support, but that is something best left for another PR, since that would be a magnitudes bigger change.

Relevant documentation on flags can be found here https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fdflags

I followed the upstream Go implementation as much as possible with minimal changes

# Testing

## Server
Save the following program to `main.go` in your working directory:
```go
package main

import (
	"fmt"
	"io"
	"log"
	"net"
	"os"
	"strconv"
	"time"
)

func handle(conn net.Conn) error {
	defer conn.Close()

	var b [128]byte
	n, err := conn.Read(b[:])
	if err != nil {
		if err == io.EOF {
			return nil
		}
		return fmt.Errorf("failed to read from connection: %s", err)
	}
	log.Printf("Read '%s'\n", b[:n])

	res := fmt.Sprintf("Hello, %s", b[:n])
	n, err = conn.Write([]byte(res))
	if err != nil {
		return fmt.Errorf("failed to write to connection: %s", err)
	}
	log.Printf("Wrote '%s'\n", res[:n])
	return nil
}

func run() error {
	fds, err := strconv.Atoi(os.Getenv("FD_COUNT"))
	if err != nil {
		return fmt.Errorf("failed to parse FD_COUNT: %w", err)
	}
	if fds != 4 {
		return fmt.Errorf("FD_COUNT must be 4, got %d", fds)
	}

	ln, err := net.FileListener(os.NewFile(uintptr(3), "socket"))
	if err != nil {
		return fmt.Errorf("failed to listen on fd 3: %w", err)
	}

	for {
		log.Println("Waiting for connection...")
		conn, err := ln.Accept()
		if err != nil {
			if err, ok := err.(*os.SyscallError); ok && err.Timeout() {
				log.Println("Accept timed out, retrying in a second...")
				time.Sleep(time.Second)
				continue
			}
			return fmt.Errorf("failed to accept connection: %w", err)
		}
		log.Println("Accepted connection")

		if err := handle(conn); err != nil {
			return fmt.Errorf("failed to handle connection: %w", err)
		}
		log.Println("---")
	}
}

func init() {
	log.SetOutput(os.Stderr)
	log.SetFlags(0)
}

func main() {
	if err := run(); err != nil {
		log.Fatalf("Failed to run: %s", err)
	}
}
```

Compile with:
```
$ tinygo build -target wasi main.go
```

### Wasmtime
Works on `wasmtime 0.38.0`:
```
$ wasmtime run --env FD_COUNT=4 --tcplisten 127.0.0.1:9000 main.wasm
Waiting for connection...
Accept timed out, retrying in a millisecond...
Waiting for connection...
Accept timed out, retrying in a millisecond...
Waiting for connection...
Accept timed out, retrying in a millisecond...
Waiting for connection...
Accepted connection
Read 'test
'
Wrote 'Hello, test
'
---
```

### Enarx
Works on https://github.com/enarx/enarx with the following config:
```toml
[[files]]
kind = "stdin"

[[files]]
kind = "stdout"

[[files]]
kind = "stderr"

[[files]]
kind = "listen"
prot = "tcp"
port = 9000
```

For example, on Linux:
```
$ curl -sL -o enarx https://github.com/enarx/enarx/releases/download/v0.6.0/enarx-x86_64-unknown-linux-musl
$ echo 26823747c19c21fc7c5a7a6d44337d731735c780044b9da90365e63aae15f68d enarx | sha256sum -c
$ chmod +x enarx
$ ./enarx run --wasmcfgfile Enarx.toml main.wasm
Waiting for connection...
Accepted connection
Read 'test
'
Wrote 'Hello, test
'
---
```

## Client
Start in a terminal window:
```
while :; do sleep 1 && echo test | nc 127.0.0.1 9000; done
Hello, test
```