### PR TITLE
compiler: allow slices of empty structs.

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1554,7 +1554,11 @@ func (c *compilerContext) maxSliceSize(elementType llvm.Type) uint64 {
 	// Determine the maximum allowed size for a slice. The biggest possible
 	// pointer (starting from 0) would be maxPointerValue*sizeof(elementType) so
 	// divide by the element type to get the real maximum size.
-	maxSize := maxPointerValue / c.targetData.TypeAllocSize(elementType)
+	elementSize := c.targetData.TypeAllocSize(elementType)
+	if elementSize == 0 {
+		elementSize = 1
+	}
+	maxSize := maxPointerValue / elementSize
 
 	// len(slice) is an int. Make sure the length remains small enough to fit in
 	// an int.

--- a/testdata/slice.go
+++ b/testdata/slice.go
@@ -19,6 +19,9 @@ func main() {
 	printslice("foo[1:2]", foo[1:2])
 	println("sum foo:", sum(foo))
 
+	// creating a slice of uncommon base type
+	assert(len(make([]struct{}, makeInt(4))) == 4)
+
 	// creating a slice with uncommon len, cap types
 	assert(len(make([]int, makeInt(2), makeInt(3))) == 2)
 	assert(len(make([]int, makeInt8(2), makeInt8(3))) == 2)


### PR DESCRIPTION
Fixes https://github.com/tinygo-org/tinygo/issues/2749