### PR TITLE
Also disable asynchronous unwind tables

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -153,7 +153,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 		}
 	}
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
-		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft", "-fno-unwind-tables")
+		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables")
 	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -259,7 +259,7 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		spec.Features = "+cx8,+fxsr,+mmx,+sse,+sse2,+x87"
 	case "arm":
 		spec.CPU = "generic"
-		spec.CFlags = append(spec.CFlags, "-fno-unwind-tables")
+		spec.CFlags = append(spec.CFlags, "-fno-unwind-tables", "-fno-asynchronous-unwind-tables")
 		switch strings.Split(triple, "-")[0] {
 		case "armv5":
 			spec.Features = "+armv5t,+strict-align,-aes,-bf16,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-mve.fp,-neon,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -14,7 +14,7 @@
 		"-fshort-enums",
 		"-fomit-frame-pointer",
 		"-mfloat-abi=soft",
-		"-fno-exceptions", "-fno-unwind-tables",
+		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],
 	"ldflags": [

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -12,7 +12,7 @@
 		"-Werror",
 		"-fshort-enums",
 		"-fomit-frame-pointer",
-		"-fno-exceptions", "-fno-unwind-tables",
+		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],
 	"ldflags": [

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -18,7 +18,7 @@
     "-Werror",
     "-fshort-enums",
     "-fomit-frame-pointer",
-    "-fno-exceptions", "-fno-unwind-tables",
+    "-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
     "-ffunction-sections", "-fdata-sections"
   ],
   "ldflags": [

--- a/targets/riscv.json
+++ b/targets/riscv.json
@@ -9,7 +9,7 @@
 	"cflags": [
 		"-Werror",
 		"-mno-relax",
-		"-fno-exceptions", "-fno-unwind-tables",
+		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],
 	"ldflags": [

--- a/targets/xtensa.json
+++ b/targets/xtensa.json
@@ -9,7 +9,7 @@
 		"-Werror",
 		"-fshort-enums",
 		"-Wno-macro-redefined",
-		"-fno-exceptions", "-fno-unwind-tables",
+		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],
 	"ldflags": [


### PR DESCRIPTION
These seem to be enabled in LLVM 14, and cause undefined symbol errors. I don't know how old this flag is, so hopefully CI doesn't break on older versions.