### PR TITLE
WIP: Support LLVM 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
 # Try to autodetect LLVM build tools.
 # Versions are listed here in descending priority order.
-LLVM_VERSIONS = 13 12 11
+LLVM_VERSIONS = 14 13 12 11
 errifempty = $(if $(1),$(1),$(error $(2)))
 detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
 toolSearchPathsVersion = $(1)-$(2)

--- a/cgo/libclang_config_llvm13.go
+++ b/cgo/libclang_config_llvm13.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && !llvm11 && !llvm12
-// +build !byollvm,!llvm11,!llvm12
+//go:build !byollvm && !llvm11 && !llvm12 && !llvm14
+// +build !byollvm,!llvm11,!llvm12,!llvm14
 
 package cgo
 

--- a/cgo/libclang_config_llvm14.go
+++ b/cgo/libclang_config_llvm14.go
@@ -1,0 +1,16 @@
+//go:build !byollvm && llvm14
+// +build !byollvm,llvm14
+
+package cgo
+
+/*
+#cgo linux        CFLAGS:  -I/usr/lib/llvm-14/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@14/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@14/include
+#cgo freebsd      CFLAGS:  -I/usr/local/llvm14/include
+#cgo linux        LDFLAGS: -L/usr/lib/llvm-14/lib -lclang
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@14/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@14/lib -lclang -lffi
+#cgo freebsd      LDFLAGS: -L/usr/local/llvm14/lib -lclang
+*/
+import "C"

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -957,10 +957,10 @@ func (b *builder) createFunction() {
 			} else {
 				fieldOffsets := b.expandFormalParamOffsets(llvmType)
 				for i, field := range fields {
-					expr := b.dibuilder.CreateExpression([]int64{
-						0x1000,                     // DW_OP_LLVM_fragment
-						int64(fieldOffsets[i]) * 8, // offset in bits
-						int64(b.targetData.TypeAllocSize(field.Type())) * 8, // size in bits
+					expr := b.dibuilder.CreateExpression([]uint64{
+						0x1000,                      // DW_OP_LLVM_fragment
+						uint64(fieldOffsets[i]) * 8, // offset in bits
+						uint64(b.targetData.TypeAllocSize(field.Type())) * 8, // size in bits
 					})
 					b.dibuilder.InsertValueAtEnd(field, dbgParam, expr, loc, entryBlock)
 				}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -226,9 +226,9 @@ func filterIrrelevantIRLines(lines []string) []string {
 			// Right now test outputs are for LLVM 12 and higher.
 			continue
 		}
-		if llvmVersion < 13 && strings.HasPrefix(line, "target datalayout = ") {
+		if llvmVersion < 14 && strings.HasPrefix(line, "target datalayout = ") {
 			// The datalayout string may vary betewen LLVM versions.
-			// Right now test outputs are for LLVM 13 and higher.
+			// Right now test outputs are for LLVM 14 and higher.
 			continue
 		}
 		out = append(out, line)

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'basic.go'
 source_filename = "basic.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %main.kv = type { float }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'channel.go'
 source_filename = "channel.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'float.go'
 source_filename = "float.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'func.go'
 source_filename = "func.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'gc.go'
 source_filename = "gc.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'go1.17.go'
 source_filename = "go1.17.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'interface.go'
 source_filename = "interface.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pointer.go'
 source_filename = "pointer.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pragma.go'
 source_filename = "pragma.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 @extern_global = external global [0 x i8], align 1

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'slice.go'
 source_filename = "slice.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'string.go'
 source_filename = "string.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime._string = type { i8*, i32 }

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1
+	tinygo.org/x/go-llvm v0.0.0-20220205113212-452041907258
 )

--- a/go.sum
+++ b/go.sum
@@ -80,5 +80,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+tinygo.org/x/go-llvm v0.0.0-20220205113212-452041907258 h1:eEMU4MnbHHV3LagJlYD34Gi3prZ06E4WhZcokaUMk5s=
+tinygo.org/x/go-llvm v0.0.0-20220205113212-452041907258/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
 tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1 h1:6G8AxueDdqobCEqQrmHPLaEH1AZ1p6Y7rGElDNT7N98=
 tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
Note, this requires tinygo-org/go-llvm#34 as well as WebAssembly/wasi-libc#265 (but I'm not sure how to apply that here, so I'm hoping it'll be merged soon). Also, this doesn't actually enable LLVM 14 in CI anywhere, as you appear to be using a fork, and I don't know how to update that.

This currently can run most of the tests, except wasm + cgo, which has some signature bugs:
```
wasm-ld: warning: function signature mismatch: variadic0
>>> defined as (i32) -> i32 in /tmp/tinygo1864163112/main.o
>>> defined as () -> i32 in /builddir/build/BUILD/tinygo-0.22.0/tinygo.5TXwE7/tinygo/obj-b143eb5902dc0a6118a040115ada1e1b0602a1976ff7ba7ff77f35b0.o
RuntimeError: unreachable
    at signature_mismatch:variadic0 (wasm://wasm/00080be2:wasm-function[4]:0x299)
    at runtime.run$1 (wasm://wasm/00080be2:wasm-function[50]:0x3990)
    at runtime.run$1$gowrapper (wasm://wasm/00080be2:wasm-function[48]:0x2ebf)
    at tinygo_launch (wasm://wasm/00080be2:wasm-function[67]:0x6f73)
    at (*internal/task.Task).Resume (wasm://wasm/00080be2:wasm-function[8]:0x4db)
    at runtime.scheduler (wasm://wasm/00080be2:wasm-function[49]:0x2f75)
    at _start (wasm://wasm/00080be2:wasm-function[47]:0x2e3a)
    at _start.command_export (wasm://wasm/00080be2:wasm-function[111]:0x95ff)
    at global.Go.run (/builddir/build/BUILDROOT/tinygo-0.22.0-8.fc37.x86_64/usr/lib64/tinygo/targets/wasm_exec.js:486:24)
    at /builddir/build/BUILDROOT/tinygo-0.22.0-8.fc37.x86_64/usr/lib64/tinygo/targets/wasm_exec.js:529:14
```

`make smoketest` builds everything up to `pico`, which fails with:
```
/builddir/build/BUILDROOT/tinygo-0.22.0-8.fc37.x86_64/usr/bin/tinygo build -size short -o test.hex -target=pico                examples/blinky1
Operand for indirect constraint must have elementtype attribute
  call void asm sideeffect "\0A\09\09\09\09ldr r0, ${0}\0A\09\09\09\091:\0A\09\09\09\09subs r0, #1\0A\09\09\09\09bne 1b \0A             \09", "*m"(i32* %15), !dbg !2249
error: verification error after compiling package machine
```