### PR TITLE
cgo: refactor

### DIFF
--- a/cgo/testdata/basic.out.go
+++ b/cgo/testdata/basic.out.go
@@ -24,23 +24,16 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)

--- a/cgo/testdata/const.out.go
+++ b/cgo/testdata/const.out.go
@@ -24,26 +24,19 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
-const C.bar = C.foo
-const C.foo = 3
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)
 
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16
+const C.foo = 3
+const C.bar = C.foo

--- a/cgo/testdata/errors.go
+++ b/cgo/testdata/errors.go
@@ -27,7 +27,7 @@ import "C"
 //line errors.go:100
 var (
 	// constant too large
-	_ C.uint8_t = 2 << 10
+	_ C.char = 2 << 10
 
 	// z member does not exist
 	_ C.point_t = C.point_t{z: 3}

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -6,7 +6,7 @@
 //     testdata/errors.go:19:26: unexpected token ), expected end of expression
 
 // Type checking errors after CGo processing:
-//     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as uint8 value in variable declaration (overflows)
+//     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as C.char value in variable declaration (overflows)
 //     testdata/errors.go:105: unknown field z in struct literal
 //     testdata/errors.go:108: undeclared name: C.SOME_CONST_1
 //     testdata/errors.go:110: cannot use C.SOME_CONST_3 (untyped int constant 1234) as byte value in variable declaration (overflows)
@@ -38,29 +38,23 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
-const C.SOME_CONST_3 = 1234
-
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16
-type C.point_t = struct {
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)
+type C._Ctype_struct___0 struct {
 	x C.int
 	y C.int
 }
+type C.point_t = C._Ctype_struct___0
+
+const C.SOME_CONST_3 = 1234

--- a/cgo/testdata/flags.out.go
+++ b/cgo/testdata/flags.out.go
@@ -29,26 +29,19 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)
+
 const C.BAR = 3
 const C.FOO_H = 1
-
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16

--- a/cgo/testdata/symbols.out.go
+++ b/cgo/testdata/symbols.out.go
@@ -24,41 +24,36 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)
+
 //export foo
 func C.foo(a C.int, b C.int) C.int
+
+var C.foo$funcaddr unsafe.Pointer
 
 //export variadic0
 //go:variadic
 func C.variadic0()
 
+var C.variadic0$funcaddr unsafe.Pointer
+
 //export variadic2
 //go:variadic
 func C.variadic2(x C.int, y C.int)
 
-var C.foo$funcaddr unsafe.Pointer
-var C.variadic0$funcaddr unsafe.Pointer
 var C.variadic2$funcaddr unsafe.Pointer
 
 //go:extern someValue
 var C.someValue C.int
-
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -24,132 +24,126 @@ func C.GoBytes(ptr unsafe.Pointer, length C.int) []byte {
 	return C.__GoBytes(ptr, uintptr(length))
 }
 
-const C.option2A = 20
-const C.optionA = 0
-const C.optionB = 1
-const C.optionC = -5
-const C.optionD = -4
-const C.optionE = 10
-const C.optionF = 11
-const C.optionG = 12
-const C.unused1 = 5
-
-type C.int16_t = int16
-type C.int32_t = int32
-type C.int64_t = int64
-type C.int8_t = int8
-type C.uint16_t = uint16
-type C.uint32_t = uint32
-type C.uint64_t = uint64
-type C.uint8_t = uint8
-type C.uintptr_t = uintptr
-type C.char uint8
-type C.int int32
-type C.long int32
-type C.longlong int64
-type C.schar int8
-type C.short int16
-type C.uchar uint8
-type C.uint uint32
-type C.ulong uint32
-type C.ulonglong uint64
-type C.ushort uint16
-type C.bitfield_t = C.struct_4
-type C.myIntArray = [10]C.int
+type (
+	C.char      uint8
+	C.schar     int8
+	C.uchar     uint8
+	C.short     int16
+	C.ushort    uint16
+	C.int       int32
+	C.uint      uint32
+	C.long      int32
+	C.ulong     uint32
+	C.longlong  int64
+	C.ulonglong uint64
+)
 type C.myint = C.int
-type C.option2_t = C.uint
-type C.option_t = C.enum_option
-type C.point2d_t = struct {
+type C._Ctype_struct___0 struct {
 	x C.int
 	y C.int
 }
-type C.point3d_t = C.struct_point3d
-type C.struct_nested_t = struct {
-	begin C.point2d_t
-	end   C.point2d_t
-	tag   C.int
-
-	coord C.union_2
-}
-type C.types_t = struct {
-	f   float32
-	d   float64
-	ptr *C.int
-}
-type C.union1_t = struct{ i C.int }
-type C.union2d_t = C.union_union2d
-type C.union3_t = C.union_1
-type C.union_nested_t = C.union_3
-type C.unionarray_t = struct{ arr [10]C.uchar }
-
-func (s *C.struct_4) bitfield_a() C.uchar { return s.__bitfield_1 & 0x1f }
-func (s *C.struct_4) set_bitfield_a(value C.uchar) {
-	s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0
-}
-func (s *C.struct_4) bitfield_b() C.uchar {
-	return s.__bitfield_1 >> 5 & 0x1
-}
-func (s *C.struct_4) set_bitfield_b(value C.uchar) {
-	s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5
-}
-func (s *C.struct_4) bitfield_c() C.uchar {
-	return s.__bitfield_1 >> 6
-}
-func (s *C.struct_4) set_bitfield_c(value C.uchar,
-
-) { s.__bitfield_1 = s.__bitfield_1&0x3f | value<<6 }
-
-type C.struct_4 struct {
-	start        C.uchar
-	__bitfield_1 C.uchar
-
-	d C.uchar
-	e C.uchar
-}
+type C.point2d_t = C._Ctype_struct___0
 type C.struct_point3d struct {
 	x C.int
 	y C.int
 	z C.int
 }
+type C.point3d_t = C.struct_point3d
 type C.struct_type1 struct {
 	_type   C.int
 	__type  C.int
 	___type C.int
 }
 type C.struct_type2 struct{ _type C.int }
+type C._Ctype_union___1 struct{ i C.int }
+type C.union1_t = C._Ctype_union___1
+type C._Ctype_union___2 struct{ $union uint64 }
 
-func (union *C.union_1) unionfield_i() *C.int   { return (*C.int)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_1) unionfield_d() *float64 { return (*float64)(unsafe.Pointer(&union.$union)) }
-func (union *C.union_1) unionfield_s() *C.short { return (*C.short)(unsafe.Pointer(&union.$union)) }
-
-type C.union_1 struct{ $union uint64 }
-
-func (union *C.union_2) unionfield_area() *C.point2d_t {
-	return (*C.point2d_t)(unsafe.Pointer(&union.$union))
+func (union *C._Ctype_union___2) unionfield_i() *C.int {
+	return (*C.int)(unsafe.Pointer(&union.$union))
 }
-func (union *C.union_2) unionfield_solid() *C.point3d_t {
-	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
+func (union *C._Ctype_union___2) unionfield_d() *float64 {
+	return (*float64)(unsafe.Pointer(&union.$union))
 }
-
-type C.union_2 struct{ $union [3]uint32 }
-
-func (union *C.union_3) unionfield_point() *C.point3d_t {
-	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
-}
-func (union *C.union_3) unionfield_array() *C.unionarray_t {
-	return (*C.unionarray_t)(unsafe.Pointer(&union.$union))
-}
-func (union *C.union_3) unionfield_thing() *C.union3_t {
-	return (*C.union3_t)(unsafe.Pointer(&union.$union))
+func (union *C._Ctype_union___2) unionfield_s() *C.short {
+	return (*C.short)(unsafe.Pointer(&union.$union))
 }
 
-type C.union_3 struct{ $union [2]uint64 }
+type C.union3_t = C._Ctype_union___2
+type C.union_union2d struct{ $union [2]uint64 }
 
 func (union *C.union_union2d) unionfield_i() *C.int { return (*C.int)(unsafe.Pointer(&union.$union)) }
 func (union *C.union_union2d) unionfield_d() *[2]float64 {
 	return (*[2]float64)(unsafe.Pointer(&union.$union))
 }
 
-type C.union_union2d struct{ $union [2]uint64 }
-type C.enum_option C.int
-type C.enum_unused C.uint
+type C.union2d_t = C.union_union2d
+type C._Ctype_union___3 struct{ arr [10]C.uchar }
+type C.unionarray_t = C._Ctype_union___3
+type C._Ctype_union___5 struct{ $union [3]uint32 }
+
+func (union *C._Ctype_union___5) unionfield_area() *C.point2d_t {
+	return (*C.point2d_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C._Ctype_union___5) unionfield_solid() *C.point3d_t {
+	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
+}
+
+type C._Ctype_struct___4 struct {
+	begin C.point2d_t
+	end   C.point2d_t
+	tag   C.int
+
+	coord C._Ctype_union___5
+}
+type C.struct_nested_t = C._Ctype_struct___4
+type C._Ctype_union___6 struct{ $union [2]uint64 }
+
+func (union *C._Ctype_union___6) unionfield_point() *C.point3d_t {
+	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C._Ctype_union___6) unionfield_array() *C.unionarray_t {
+	return (*C.unionarray_t)(unsafe.Pointer(&union.$union))
+}
+func (union *C._Ctype_union___6) unionfield_thing() *C.union3_t {
+	return (*C.union3_t)(unsafe.Pointer(&union.$union))
+}
+
+type C.union_nested_t = C._Ctype_union___6
+type C.enum_option = C.int
+type C.option_t = C.enum_option
+type C._Ctype_enum___7 = C.uint
+type C.option2_t = C._Ctype_enum___7
+type C._Ctype_struct___8 struct {
+	f   float32
+	d   float64
+	ptr *C.int
+}
+type C.types_t = C._Ctype_struct___8
+type C.myIntArray = [10]C.int
+type C._Ctype_struct___9 struct {
+	start        C.uchar
+	__bitfield_1 C.uchar
+
+	d C.uchar
+	e C.uchar
+}
+
+func (s *C._Ctype_struct___9) bitfield_a() C.uchar { return s.__bitfield_1 & 0x1f }
+func (s *C._Ctype_struct___9) set_bitfield_a(value C.uchar) {
+	s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0
+}
+func (s *C._Ctype_struct___9) bitfield_b() C.uchar {
+	return s.__bitfield_1 >> 5 & 0x1
+}
+func (s *C._Ctype_struct___9) set_bitfield_b(value C.uchar) {
+	s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5
+}
+func (s *C._Ctype_struct___9) bitfield_c() C.uchar {
+	return s.__bitfield_1 >> 6
+}
+func (s *C._Ctype_struct___9) set_bitfield_c(value C.uchar,
+
+) { s.__bitfield_1 = s.__bitfield_1&0x3f | value<<6 }
+
+type C.bitfield_t = C._Ctype_struct___9


### PR DESCRIPTION
This is a large refactor of the cgo package. It should fix a number of smaller problems and be a bit more strict (like upstream CGo): it for example requires every Go file in a package to include the header files it needs instead of piggybacking on imports in earlier files.

The main benefit is that it should be a bit more maintainable and easier to add new features in the future (like static functions).

This breaks the tinygo.org/x/bluetooth package (https://github.com/tinygo-org/bluetooth/pull/97), which should be updated before this change lands.