### PR TITLE
cgo: implement support for static functions

### DIFF
--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -48,7 +48,7 @@ func TestCGo(t *testing.T) {
 			}
 
 			// Process the AST with CGo.
-			cgoAST, _, _, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", fset, cflags, "")
+			cgoAST, _, _, _, _, cgoErrors := Process([]*ast.File{f}, "testdata", "main", fset, cflags, "")
 
 			// Check the AST for type errors.
 			var typecheckErrors []error

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -17,6 +17,14 @@ CXString tinygo_clang_getCursorSpelling(CXCursor c) {
 	return clang_getCursorSpelling(c);
 }
 
+CXString tinygo_clang_getCursorPrettyPrinted(CXCursor c, CXPrintingPolicy policy) {
+	return clang_getCursorPrettyPrinted(c, policy);
+}
+
+CXPrintingPolicy tinygo_clang_getCursorPrintingPolicy(CXCursor c) {
+	return clang_getCursorPrintingPolicy(c);
+}
+
 enum CXCursorKind tinygo_clang_getCursorKind(CXCursor c) {
 	return clang_getCursorKind(c);
 }
@@ -43,6 +51,10 @@ int tinygo_clang_Cursor_getNumArguments(CXCursor c) {
 
 CXCursor tinygo_clang_Cursor_getArgument(CXCursor c, unsigned i) {
 	return clang_Cursor_getArgument(c, i);
+}
+
+enum CX_StorageClass tinygo_clang_Cursor_getStorageClass(CXCursor c) {
+	return clang_Cursor_getStorageClass(c);
 }
 
 CXSourceLocation tinygo_clang_getCursorLocation(CXCursor c) {

--- a/cgo/testdata/symbols.go
+++ b/cgo/testdata/symbols.go
@@ -5,6 +5,7 @@ package main
 int foo(int a, int b);
 void variadic0();
 void variadic2(int x, int y, ...);
+static void staticfunc(int x);
 
 // Global variable signatures.
 extern int someValue;
@@ -16,6 +17,7 @@ func accessFunctions() {
 	C.foo(3, 4)
 	C.variadic0()
 	C.variadic2(3, 5)
+	C.staticfunc(3)
 }
 
 func accessGlobals() {

--- a/cgo/testdata/symbols.out.go
+++ b/cgo/testdata/symbols.out.go
@@ -55,5 +55,10 @@ func C.variadic2(x C.int, y C.int)
 
 var C.variadic2$funcaddr unsafe.Pointer
 
+//export _Cgo_static_173c95a79b6df1980521_staticfunc
+func C.staticfunc!symbols.go(x C.int)
+
+var C.staticfunc!symbols.go$funcaddr unsafe.Pointer
+
 //go:extern someValue
 var C.someValue C.int

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -440,7 +440,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags()...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
-		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.program.fset, initialCFlags, p.program.clangHeaders)
+		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.clangHeaders)
 		p.CFlags = append(initialCFlags, cflags...)
 		p.CGoHeaders = headerCode
 		for path, hash := range accessedFiles {

--- a/testdata/cgo/extra.go
+++ b/testdata/cgo/extra.go
@@ -3,4 +3,18 @@ package main
 // Make sure CGo supports multiple files.
 
 // int fortytwo(void);
+// static float headerfunc_static(float a) { return a - 1; }
+// static void headerfunc_void(int a, int *ptr) { *ptr = a; }
 import "C"
+
+func headerfunc_2() {
+	// Call headerfunc_static that is different from the headerfunc_static in
+	// the main.go file.
+	// The upstream CGo implementation does not handle this case correctly.
+	println("static headerfunc 2:", C.headerfunc_static(5))
+
+	// Test function without return value.
+	var n C.int
+	C.headerfunc_void(3, &n)
+	println("static headerfunc void:", n)
+}

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -12,6 +12,7 @@ int mul(int, int);
 import "C"
 
 // int headerfunc(int a) { return a + 1; }
+// static int headerfunc_static(int a) { return a - 1; }
 import "C"
 
 import "unsafe"
@@ -47,6 +48,8 @@ func main() {
 
 	// functions in the header C snippet
 	println("headerfunc:", C.headerfunc(5))
+	println("static headerfunc:", C.headerfunc_static(5))
+	headerfunc_2()
 
 	// equivalent types
 	var goInt8 int8 = 5

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -16,6 +16,9 @@ callback 2: 600
 variadic0: 1
 variadic2: 15
 headerfunc: 6
+static headerfunc: 4
+static headerfunc 2: +4.000000e+000
+static headerfunc void: 3
 bool: true true
 float: +3.100000e+000
 double: +3.200000e+000


### PR DESCRIPTION
This depends on #2774.

Static functions are used in tinygo.org/x/bluetooth but so far we've mostly just worked around them. This implements proper support for static functions.