### PR TITLE
transform: fix poison value in heap-to-stack transform

### DIFF
--- a/transform/allocs.go
+++ b/transform/allocs.go
@@ -41,7 +41,7 @@ func OptimizeAllocs(mod llvm.Module, printAllocs *regexp.Regexp, logger func(tok
 
 	for _, heapalloc := range getUses(allocator) {
 		logAllocs := printAllocs != nil && printAllocs.MatchString(heapalloc.InstructionParent().Parent().Name())
-		if heapalloc.Operand(0).IsAConstant().IsNil() {
+		if heapalloc.Operand(0).IsAConstantInt().IsNil() {
 			// Do not allocate variable length arrays on the stack.
 			if logAllocs {
 				logAlloc(logger, heapalloc, "size is not constant")


### PR DESCRIPTION
In https://github.com/tinygo-org/tinygo/issues/2777, a poison value
ended up in `runtime.alloc`. This shouldn't happen, especially not for
well written code. So I'm not sure why it happens. But here is a fix
anyway.