### PR TITLE
Support command line parameters in `tinygo run`

### DIFF
--- a/main.go
+++ b/main.go
@@ -709,13 +709,13 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 // the options, it will run the program directly on the host or will run it in
 // an emulator. For example, -target=wasm will cause the binary to be run inside
 // of a WebAssembly VM.
-func Run(pkgName string, options *compileopts.Options) error {
+func Run(pkgName string, options *compileopts.Options, cmdArgs []string) error {
 	config, err := builder.NewConfig(options)
 	if err != nil {
 		return err
 	}
 
-	return buildAndRun(pkgName, config, os.Stdout, nil, nil, 0)
+	return buildAndRun(pkgName, config, os.Stdout, cmdArgs, nil, 0)
 }
 
 // buildAndRun builds and runs the given program, writing output to stdout and
@@ -1495,13 +1495,13 @@ func main() {
 			handleCompilerError(err)
 		}
 	case "run":
-		if flag.NArg() != 1 {
+		if flag.NArg() < 1 {
 			fmt.Fprintln(os.Stderr, "No package specified.")
 			usage(command)
 			os.Exit(1)
 		}
 		pkgName := filepath.ToSlash(flag.Arg(0))
-		err := Run(pkgName, options)
+		err := Run(pkgName, options, flag.Args()[1:])
 		handleCompilerError(err)
 	case "test":
 		var pkgNames []string


### PR DESCRIPTION
This PR adds support for command line parameters to `tinygo run`. The biggest change is a refactor to make that possible.

Running normally:

```
$ tinygo run ./testdata/env.go foobar -asdf
[...]
arg: foobar
arg: -asdf
```

Running on an emulated Cortex-M chip:
```
$ tinygo run -target=cortex-m-qemu ./testdata/env.go foobar -asdf
[...]
arg: foobar
arg: -asdf
```

Running in wasmtime:

```
$ tinygo run -target=wasi ./testdata/env.go foobar -asdf
[...]
arg: foobar
arg: -asdf
```

(This is mostly just refactoring to make `tinygo run -target=esp32` easier to implement)