### PR TITLE
esp: support CGo

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -287,6 +287,7 @@ func (c *Config) CFlags() []string {
 		path, _ := c.LibcPath("picolibc")
 		cflags = append(cflags,
 			"--sysroot="+path,
+			"-isystem", filepath.Join(path, "include"), // necessary for Xtensa
 			"-isystem", filepath.Join(picolibcDir, "include"),
 			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
 		)


### PR DESCRIPTION
Without this patch, the include directory isn't found and picolibc.h (used indirectly by stdint.h for example) can't be found.

I would like to add tests for this but we currently don't run Xtensa tests. This should be possible however using https://github.com/espressif/qemu/wiki (see also: https://github.com/tinygo-org/tinygo/pull/2780).

Simple way to verify this patch: `tinygo build -o test.bin -target=esp32 ./testdata/cgo/`