### PR TITLE
builder: free LLVM IR modules after use

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -301,6 +301,7 @@ func CompilePackage(moduleName string, pkg *loader.Package, ssaPkg *ssa.Package,
 			}),
 		)
 		c.dibuilder.Finalize()
+		c.dibuilder.Destroy()
 	}
 
 	return c.mod, c.diagnostics

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -106,6 +106,7 @@ func TestCompiler(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to create target machine:", err)
 			}
+			defer machine.Dispose()
 
 			// Load entire program AST into memory.
 			lprogram, err := loader.Load(config, []string{"./testdata/" + tc.file}, config.ClangHeaders, types.Config{

--- a/compiler/llvmutil/llvm.go
+++ b/compiler/llvmutil/llvm.go
@@ -34,6 +34,7 @@ func CreateEntryBlockAlloca(builder llvm.Builder, t llvm.Type, name string) llvm
 func CreateTemporaryAlloca(builder llvm.Builder, mod llvm.Module, t llvm.Type, name string) (alloca, bitcast, size llvm.Value) {
 	ctx := t.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	i8ptrType := llvm.PointerType(ctx.Int8Type(), 0)
 	alloca = CreateEntryBlockAlloca(builder, t, name)
 	bitcast = builder.CreateBitCast(alloca, i8ptrType, name+".bitcast")
@@ -46,6 +47,7 @@ func CreateTemporaryAlloca(builder llvm.Builder, mod llvm.Module, t llvm.Type, n
 func CreateInstructionAlloca(builder llvm.Builder, mod llvm.Module, t llvm.Type, inst llvm.Value, name string) llvm.Value {
 	ctx := mod.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	i8ptrType := llvm.PointerType(ctx.Int8Type(), 0)
 
 	alloca := CreateEntryBlockAlloca(builder, t, name)

--- a/compiler/llvmutil/wordpack.go
+++ b/compiler/llvmutil/wordpack.go
@@ -15,8 +15,9 @@ import (
 func EmitPointerPack(builder llvm.Builder, mod llvm.Module, prefix string, needsStackObjects bool, values []llvm.Value) llvm.Value {
 	ctx := mod.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	i8ptrType := llvm.PointerType(mod.Context().Int8Type(), 0)
-	uintptrType := ctx.IntType(llvm.NewTargetData(mod.DataLayout()).PointerSize() * 8)
+	uintptrType := ctx.IntType(targetData.PointerSize() * 8)
 
 	valueTypes := make([]llvm.Type, len(values))
 	for i, value := range values {
@@ -127,8 +128,9 @@ func EmitPointerPack(builder llvm.Builder, mod llvm.Module, prefix string, needs
 func EmitPointerUnpack(builder llvm.Builder, mod llvm.Module, ptr llvm.Value, valueTypes []llvm.Type) []llvm.Value {
 	ctx := mod.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	i8ptrType := llvm.PointerType(mod.Context().Int8Type(), 0)
-	uintptrType := ctx.IntType(llvm.NewTargetData(mod.DataLayout()).PointerSize() * 8)
+	uintptrType := ctx.IntType(targetData.PointerSize() * 8)
 
 	packedType := ctx.StructType(valueTypes, false)
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -50,10 +50,17 @@ func newRunner(mod llvm.Module, debug bool) *runner {
 	return &r
 }
 
+// Dispose deallocates all alloated LLVM resources.
+func (r *runner) dispose() {
+	r.targetData.Dispose()
+	r.targetData = llvm.TargetData{}
+}
+
 // Run evaluates runtime.initAll function as much as possible at compile time.
 // Set debug to true if it should print output while running.
 func Run(mod llvm.Module, debug bool) error {
 	r := newRunner(mod, debug)
+	defer r.dispose()
 
 	initAll := mod.NamedFunction("runtime.initAll")
 	bb := initAll.EntryBasicBlock()
@@ -196,6 +203,7 @@ func RunFunc(fn llvm.Value, debug bool) error {
 	// Create and initialize *runner object.
 	mod := fn.GlobalParent()
 	r := newRunner(mod, debug)
+	defer r.dispose()
 	initName := fn.Name()
 	if !strings.HasSuffix(initName, ".init") {
 		return errorAt(fn, "interp: unexpected function name (expected *.init)")

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -40,6 +40,7 @@ func TestInterp(t *testing.T) {
 func runTest(t *testing.T, pathPrefix string) {
 	// Read the input IR.
 	ctx := llvm.NewContext()
+	defer ctx.Dispose()
 	buf, err := llvm.NewMemoryBufferFromFile(pathPrefix + ".ll")
 	os.Stat(pathPrefix + ".ll") // make sure this file is tracked by `go test` caching
 	if err != nil {
@@ -49,6 +50,7 @@ func runTest(t *testing.T, pathPrefix string) {
 	if err != nil {
 		t.Fatalf("could not load module:\n%v", err)
 	}
+	defer mod.Dispose()
 
 	// Perform the transform.
 	err = Run(mod, false)

--- a/transform/allocs.go
+++ b/transform/allocs.go
@@ -36,8 +36,10 @@ func OptimizeAllocs(mod llvm.Module, printAllocs *regexp.Regexp, logger func(tok
 	}
 
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	i8ptrType := llvm.PointerType(mod.Context().Int8Type(), 0)
 	builder := mod.Context().NewBuilder()
+	defer builder.Dispose()
 
 	for _, heapalloc := range getUses(allocator) {
 		logAllocs := printAllocs != nil && printAllocs.MatchString(heapalloc.InstructionParent().Parent().Name())

--- a/transform/gc.go
+++ b/transform/gc.go
@@ -33,7 +33,9 @@ func MakeGCStackSlots(mod llvm.Module) bool {
 
 	ctx := mod.Context()
 	builder := ctx.NewBuilder()
+	defer builder.Dispose()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	uintptrType := ctx.IntType(targetData.PointerSize() * 8)
 
 	// Look at *all* functions to see whether they are free of function pointer
@@ -326,6 +328,7 @@ func AddGlobalsBitmap(mod llvm.Module) bool {
 
 	ctx := mod.Context()
 	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
 	uintptrType := ctx.IntType(targetData.PointerSize() * 8)
 
 	// Collect all globals that contain pointers (and thus must be scanned by

--- a/transform/reflect.go
+++ b/transform/reflect.go
@@ -161,10 +161,12 @@ func LowerReflect(mod llvm.Module) {
 	})
 
 	// Assign typecodes the way the reflect package expects.
-	uintptrType := mod.Context().IntType(llvm.NewTargetData(mod.DataLayout()).PointerSize() * 8)
+	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
+	uintptrType := mod.Context().IntType(targetData.PointerSize() * 8)
 	state := typeCodeAssignmentState{
 		fallbackIndex:                    1,
-		uintptrLen:                       llvm.NewTargetData(mod.DataLayout()).PointerSize() * 8,
+		uintptrLen:                       targetData.PointerSize() * 8,
 		namedBasicTypes:                  make(map[string]int),
 		namedNonBasicTypes:               make(map[string]int),
 		arrayTypes:                       make(map[string]int),

--- a/transform/rtcalls.go
+++ b/transform/rtcalls.go
@@ -114,7 +114,9 @@ func OptimizeReflectImplements(mod llvm.Module) {
 	defer builder.Dispose()
 
 	// Get a few useful object for use later.
-	uintptrType := mod.Context().IntType(llvm.NewTargetData(mod.DataLayout()).PointerSize() * 8)
+	targetData := llvm.NewTargetData(mod.DataLayout())
+	defer targetData.Dispose()
+	uintptrType := mod.Context().IntType(targetData.PointerSize() * 8)
 
 	// Look up the (reflect.Value).Implements() method.
 	var implementsFunc llvm.Value

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -32,6 +32,7 @@ var defaultTestConfig = &compileopts.Config{
 func testTransform(t *testing.T, pathPrefix string, transform func(mod llvm.Module)) {
 	// Read the input IR.
 	ctx := llvm.NewContext()
+	defer ctx.Dispose()
 	buf, err := llvm.NewMemoryBufferFromFile(pathPrefix + ".ll")
 	os.Stat(pathPrefix + ".ll") // make sure this file is tracked by `go test` caching
 	if err != nil {
@@ -41,6 +42,7 @@ func testTransform(t *testing.T, pathPrefix string, transform func(mod llvm.Modu
 	if err != nil {
 		t.Fatalf("could not load module:\n%v", err)
 	}
+	defer mod.Dispose()
 
 	// Perform the transform.
 	transform(mod)
@@ -141,6 +143,7 @@ func compileGoFileForTesting(t *testing.T, filename string) llvm.Module {
 	if err != nil {
 		t.Fatal("failed to create target machine:", err)
 	}
+	defer machine.Dispose()
 
 	// Load entire program AST into memory.
 	lprogram, err := loader.Load(config, []string{filename}, config.ClangHeaders, types.Config{


### PR DESCRIPTION
This reduces the TinyGo memory consumption when running `make tinygo-test` from 5.8GB to 5GB on my laptop. This means there are still memory leaks, but some leaks have been fixed.