### PR TITLE
main: use shared code for both run and test subcommands

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -332,7 +332,9 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 
 	// Build the test binary.
 	stdout := &bytes.Buffer{}
-	err = buildAndRun("./"+path, config, stdout, cmdArgs, environmentVars, time.Minute)
+	err = buildAndRun("./"+path, config, stdout, cmdArgs, environmentVars, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+		return cmd.Run()
+	})
 	if err != nil {
 		printCompilerError(t.Log, err)
 		t.Fail()


### PR DESCRIPTION
This means that we don't need duplicate code to pass parameters to wasmtime and that the following actually produces verbose output (it didn't before this PR):

    tinygo test -v -target=cortex-m-qemu math