### PR TITLE
compiler: remove support for memory references in AsmFull

### DIFF
--- a/compiler/inlineasm.go
+++ b/compiler/inlineasm.go
@@ -98,7 +98,10 @@ func (b *builder) createInlineAsmFull(instr *ssa.CallCommon) (llvm.Value, error)
 			case llvm.IntegerTypeKind:
 				constraints = append(constraints, "r")
 			case llvm.PointerTypeKind:
-				constraints = append(constraints, "*m")
+				// Memory references require a type in LLVM 14, probably as a
+				// preparation for opaque pointers.
+				err = b.makeError(instr.Pos(), "support for pointer operands was dropped in TinyGo 0.23")
+				return s
 			default:
 				err = b.makeError(instr.Pos(), "unknown type in inline assembly for value: "+name)
 				return s

--- a/src/device/nxp/mimxrt1062_mpu.go
+++ b/src/device/nxp/mimxrt1062_mpu.go
@@ -142,18 +142,14 @@ func (mpu *MPU_Type) Enable(enable bool) {
 	if enable {
 		mpu.CTRL.Set(MPU_CTRL_PRIVDEFENA_Msk | MPU_CTRL_ENABLE_Msk)
 		SystemControl.SHCSR.SetBits(SCB_SHCSR_MEMFAULTENA_Msk)
-		arm.AsmFull(`
-      dsb 0xF
-      isb 0xF
-    `, nil)
+		arm.Asm("dsb 0xF")
+		arm.Asm("isb 0xF")
 		enableDcache(true)
 		enableIcache(true)
 	} else {
 		enableIcache(false)
 		enableDcache(false)
-		arm.AsmFull(`
-      dmb 0xF
-    `, nil)
+		arm.Asm("dmb 0xF")
 		SystemControl.SHCSR.ClearBits(SCB_SHCSR_MEMFAULTENA_Msk)
 		mpu.CTRL.ClearBits(MPU_CTRL_ENABLE_Msk)
 	}
@@ -188,31 +184,21 @@ func (mpu *MPU_Type) SetRASR(size RegionSize, access AccessPerms, ext Extension,
 func enableIcache(enable bool) {
 	if enable != SystemControl.CCR.HasBits(SCB_CCR_IC_Msk) {
 		if enable {
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 			SystemControl.ICIALLU.Set(0)
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 			SystemControl.CCR.SetBits(SCB_CCR_IC_Msk)
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 		} else {
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+		arm.Asm("dsb 0xF")
+		arm.Asm("isb 0xF")
 			SystemControl.CCR.ClearBits(SCB_CCR_IC_Msk)
 			SystemControl.ICIALLU.Set(0)
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+		arm.Asm("dsb 0xF")
+		arm.Asm("isb 0xF")
 		}
 	}
 }
@@ -227,9 +213,7 @@ func enableDcache(enable bool) {
 	if enable != SystemControl.CCR.HasBits(SCB_CCR_DC_Msk) {
 		if enable {
 			SystemControl.CSSELR.Set(0)
-			arm.AsmFull(`
-        dsb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
 			ccsidr := SystemControl.CCSIDR.Get()
 			sets := (ccsidr & SCB_CCSIDR_NUMSETS_Msk) >> SCB_CCSIDR_NUMSETS_Pos
 			for sets != 0 {
@@ -242,23 +226,15 @@ func enableDcache(enable bool) {
 				}
 				sets--
 			}
-			arm.AsmFull(`
-        dsb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
 			SystemControl.CCR.SetBits(SCB_CCR_DC_Msk)
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 		} else {
 			SystemControl.CSSELR.Set(0)
-			arm.AsmFull(`
-        dsb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
 			SystemControl.CCR.ClearBits(SCB_CCR_DC_Msk)
-			arm.AsmFull(`
-        dsb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
 			dcacheCcsidr.Set(SystemControl.CCSIDR.Get())
 			dcacheSets.Set((dcacheCcsidr.Get() & SCB_CCSIDR_NUMSETS_Msk) >> SCB_CCSIDR_NUMSETS_Pos)
 			for dcacheSets.Get() != 0 {
@@ -271,10 +247,8 @@ func enableDcache(enable bool) {
 				}
 				dcacheSets.Set(dcacheSets.Get() - 1)
 			}
-			arm.AsmFull(`
-        dsb 0xF
-        isb 0xF
-      `, nil)
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 		}
 	}
 }

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -236,10 +236,10 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 			kendryte.GPIOHS.RISE_IE.ClearBits(1 << pin)
 			// Acknowledge interrupt atomically.
 			riscv.AsmFull(
-				"amoor.w {}, {mask}, {reg}",
+				"amoor.w {}, {mask}, ({reg})",
 				map[string]interface{}{
 					"mask": uint32(1 << pin),
-					"reg":  &kendryte.GPIOHS.RISE_IP.Reg,
+					"reg":  uintptr(unsafe.Pointer(&kendryte.GPIOHS.RISE_IP.Reg)),
 				})
 			kendryte.GPIOHS.RISE_IE.SetBits(1 << pin)
 		}
@@ -248,10 +248,10 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 			kendryte.GPIOHS.FALL_IE.ClearBits(1 << pin)
 			// Acknowledge interrupt atomically.
 			riscv.AsmFull(
-				"amoor.w {}, {mask}, {reg}",
+				"amoor.w {}, {mask}, ({reg})",
 				map[string]interface{}{
 					"mask": uint32(1 << pin),
-					"reg":  &kendryte.GPIOHS.FALL_IP.Reg,
+					"reg":  uintptr(unsafe.Pointer(&kendryte.GPIOHS.FALL_IP.Reg)),
 				})
 			kendryte.GPIOHS.FALL_IE.SetBits(1 << pin)
 		}


### PR DESCRIPTION
Memory references (`*m` in LLVM IR inline assembly) need a pointer type starting in LLVM 14. This is a bit inconvenient and requires a new API in the go-llvm package.

Instead of doing that, I'd like to remove support for memory references from AsmFull (and possibly AsmFull entirely if possible: it's hard to use correctly).

This breaks tinygo.org/x/drivers/ws2812 for AVR, ARM, and RISC-V which need to be updated. Probably using CGo.