### PR TITLE
LLVM 14 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-13-v3
+            - llvm-source-14-v1
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-13-v3
+          key: llvm-source-14-v1
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
@@ -86,10 +86,10 @@ commands:
       - run: go install -tags=llvm<<parameters.llvm>> .
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-systemclang-v4
+            - wasi-libc-sysroot-systemclang-v5
       - run: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-systemclang-v4
+          key: wasi-libc-sysroot-systemclang-v5
           paths:
             - lib/wasi-libc/sysroot
       - run: make gen-device -j4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-macos-v2
+          key: llvm-source-14-macos-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-13-macos-v3
+          key: llvm-build-14-macos-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v2
+          key: wasi-libc-sysroot-v3
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-linux-v2
+          key: llvm-source-14-linux-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-13-linux-v2
+          key: llvm-build-14-linux-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-asserts-v3
+          key: wasi-libc-sysroot-linux-asserts-v4
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
@@ -180,7 +180,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-linux-asserts-v2
+          key: llvm-source-14-linux-asserts-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -194,7 +194,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-13-linux-asserts-v2
+          key: llvm-build-14-linux-asserts-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -219,7 +219,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-asserts-v3
+          key: wasi-libc-sysroot-linux-asserts-v4
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-13-windows-v2
+          key: llvm-source-14-windows-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-13-windows-v2
+          key: llvm-build-14-windows-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v2
+          key: wasi-libc-sysroot-v3
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
 # Try to autodetect LLVM build tools.
 # Versions are listed here in descending priority order.
-LLVM_VERSIONS = 13 12 11
+LLVM_VERSIONS = 14 13 12 11
 errifempty = $(if $(1),$(1),$(error $(2)))
 detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
 toolSearchPathsVersion = $(1)-$(2)
@@ -91,11 +91,11 @@ CLANG_LIB_NAMES = clangAnalysis clangAST clangASTMatchers clangBasic clangCodeGe
 CLANG_LIBS = $(START_GROUP) $(addprefix -l,$(CLANG_LIB_NAMES)) $(END_GROUP) -lstdc++
 
 # Libraries that should be linked in for the statically linked LLD.
-LLD_LIB_NAMES = lldCOFF lldCommon lldCore lldDriver lldELF lldMachO2 lldMinGW lldReaderWriter lldWasm lldYAML
+LLD_LIB_NAMES = lldCOFF lldCommon lldELF lldMachO lldMinGW lldWasm
 LLD_LIBS = $(START_GROUP) $(addprefix -l,$(LLD_LIB_NAMES)) $(END_GROUP)
 
 # Other libraries that are needed to link TinyGo.
-EXTRA_LIB_NAMES = LLVMInterpreter
+EXTRA_LIB_NAMES = LLVMInterpreter LLVMMCA LLVMX86TargetMCA
 
 # All libraries to be built and linked with the tinygo binary (lib/lib*.a).
 LIB_NAMES = clang $(CLANG_LIB_NAMES) $(LLD_LIB_NAMES) $(EXTRA_LIB_NAMES)
@@ -175,7 +175,7 @@ gen-device-rp: build/gen-device-svd
 
 # Get LLVM sources.
 $(LLVM_PROJECTDIR)/llvm:
-	git clone -b xtensa_release_13.0.0 --depth=1 https://github.com/tinygo-org/llvm-project $(LLVM_PROJECTDIR)
+	git clone -b xtensa_release_14.0.0-patched --depth=1 https://github.com/tinygo-org/llvm-project $(LLVM_PROJECTDIR)
 llvm-source: $(LLVM_PROJECTDIR)/llvm
 
 # Configure LLVM.

--- a/builder/cc1as.cpp
+++ b/builder/cc1as.cpp
@@ -38,6 +38,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/OptTable.h"
@@ -51,7 +52,6 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -120,7 +120,6 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
         llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
             .Case("none", llvm::DebugCompressionType::None)
             .Case("zlib", llvm::DebugCompressionType::Z)
-            .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
             .Default(llvm::DebugCompressionType::None);
   }
 
@@ -382,7 +381,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
         T, Ctx, std::move(MAB), std::move(OW), std::move(CE), *STI,
         Opts.RelaxAll, Opts.IncrementalLinkerCompatible,
         /*DWARFMustBeAtTheEnd*/ true));
-    Str.get()->InitSections(Opts.NoExecStack);
+    Str.get()->initSections(Opts.NoExecStack, *STI);
   }
 
   // When -fembed-bitcode is passed to clang_as, a 1-byte marker
@@ -442,7 +441,7 @@ bool ExecuteAssembler(AssemblerInvocation &Opts,
   return Failed;
 }
 
-static void LLVMErrorHandler(void *UserData, const std::string &Message,
+static void LLVMErrorHandler(void *UserData, const char *Message,
                              bool GenCrashDiag) {
   DiagnosticsEngine &Diags = *static_cast<DiagnosticsEngine*>(UserData);
 

--- a/builder/darwin-libsystem.go
+++ b/builder/darwin-libsystem.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
+	"tinygo.org/x/go-llvm"
 )
 
 // Create a job that builds a Darwin libSystem.dylib stub library. This library
@@ -38,8 +39,12 @@ func makeDarwinLibSystemJob(config *compileopts.Config, tmpdir string) *compileJ
 
 			// Link object file to dynamic library.
 			platformVersion := strings.TrimPrefix(strings.Split(config.Triple(), "-")[2], "macosx")
+			flavor := "darwin"
+			if strings.Split(llvm.Version, ".")[0] < "13" {
+				flavor = "darwinnew" // needed on LLVM 12 and below
+			}
 			flags = []string{
-				"-flavor", "darwinnew",
+				"-flavor", flavor,
 				"-demangle",
 				"-dynamic",
 				"-dylib",

--- a/builder/lld.cpp
+++ b/builder/lld.cpp
@@ -8,22 +8,22 @@ extern "C" {
 
 bool tinygo_link_elf(int argc, char **argv) {
 	std::vector<const char*> args(argv, argv + argc);
-	return lld::elf::link(args, false, llvm::outs(), llvm::errs());
+	return lld::elf::link(args, llvm::outs(), llvm::errs(), false, false);
 }
 
 bool tinygo_link_macho(int argc, char **argv) {
 	std::vector<const char*> args(argv, argv + argc);
-	return lld::macho::link(args, false, llvm::outs(), llvm::errs());
+	return lld::macho::link(args, llvm::outs(), llvm::errs(), false, false);
 }
 
 bool tinygo_link_mingw(int argc, char **argv) {
 	std::vector<const char*> args(argv, argv + argc);
-	return lld::mingw::link(args, false, llvm::outs(), llvm::errs());
+	return lld::mingw::link(args, llvm::outs(), llvm::errs(), false, false);
 }
 
 bool tinygo_link_wasm(int argc, char **argv) {
 	std::vector<const char*> args(argv, argv + argc);
-	return lld::wasm::link(args, false, llvm::outs(), llvm::errs());
+	return lld::wasm::link(args, llvm::outs(), llvm::errs(), false, false);
 }
 
 } // external "C"

--- a/builder/tools-builtin.go
+++ b/builder/tools-builtin.go
@@ -54,7 +54,7 @@ func RunTool(tool string, args ...string) error {
 		ok = C.tinygo_clang_driver(C.int(len(args)), (**C.char)(buf))
 	case "ld.lld":
 		switch linker {
-		case "darwinnew":
+		case "darwin", "darwinnew": // darwinnew is only needed for LLVM 12 and below
 			ok = C.tinygo_link_macho(C.int(len(args)), (**C.char)(buf))
 		case "elf":
 			ok = C.tinygo_link_elf(C.int(len(args)), (**C.char)(buf))

--- a/cgo/libclang_config_llvm13.go
+++ b/cgo/libclang_config_llvm13.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && !llvm11 && !llvm12
-// +build !byollvm,!llvm11,!llvm12
+//go:build !byollvm && !llvm11 && !llvm12 && !llvm14
+// +build !byollvm,!llvm11,!llvm12,!llvm14
 
 package cgo
 

--- a/cgo/libclang_config_llvm14.go
+++ b/cgo/libclang_config_llvm14.go
@@ -1,0 +1,16 @@
+//go:build !byollvm && llvm14
+// +build !byollvm,llvm14
+
+package cgo
+
+/*
+#cgo linux        CFLAGS:  -I/usr/lib/llvm-14/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@14/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@14/include
+#cgo freebsd      CFLAGS:  -I/usr/local/llvm14/include
+#cgo linux        LDFLAGS: -L/usr/lib/llvm-14/lib -lclang
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@14/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@14/lib -lclang -lffi
+#cgo freebsd      LDFLAGS: -L/usr/local/llvm14/lib -lclang
+*/
+import "C"

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -277,8 +277,12 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		spec.Libc = "darwin-libSystem"
 		arch := strings.Split(triple, "-")[0]
 		platformVersion := strings.TrimPrefix(strings.Split(triple, "-")[2], "macosx")
+		flavor := "darwin"
+		if strings.Split(llvm.Version, ".")[0] < "13" {
+			flavor = "darwinnew" // needed on LLVM 12 and below
+		}
 		spec.LDFlags = append(spec.LDFlags,
-			"-flavor", "darwinnew",
+			"-flavor", flavor,
 			"-dead_strip",
 			"-arch", arch,
 			"-platform_version", "macos", platformVersion, platformVersion,

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -226,9 +226,9 @@ func filterIrrelevantIRLines(lines []string) []string {
 			// Right now test outputs are for LLVM 12 and higher.
 			continue
 		}
-		if llvmVersion < 13 && strings.HasPrefix(line, "target datalayout = ") {
+		if llvmVersion < 14 && strings.HasPrefix(line, "target datalayout = ") {
 			// The datalayout string may vary betewen LLVM versions.
-			// Right now test outputs are for LLVM 13 and higher.
+			// Right now test outputs are for LLVM 14 and higher.
 			continue
 		}
 		out = append(out, line)

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'basic.go'
 source_filename = "basic.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %main.kv = type { float }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'channel.go'
 source_filename = "channel.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'float.go'
 source_filename = "float.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'func.go'
 source_filename = "func.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'gc.go'
 source_filename = "gc.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'go1.17.go'
 source_filename = "go1.17.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'goroutine.go'
 source_filename = "goroutine.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'interface.go'
 source_filename = "interface.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime.typecodeID = type { %runtime.typecodeID*, i32, %runtime.interfaceMethodInfo*, %runtime.typecodeID*, i32 }

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'intrinsics.go'
 source_filename = "intrinsics.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pointer.go'
 source_filename = "pointer.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'pragma.go'
 source_filename = "pragma.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 @extern_global = external global [0 x i8], align 1

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'slice.go'
 source_filename = "slice.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -1,6 +1,6 @@
 ; ModuleID = 'string.go'
 source_filename = "string.go"
-target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
 %runtime._string = type { i8*, i32 }

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1
+	tinygo.org/x/go-llvm v0.0.0-20220420140351-512c94c1e71f
 )

--- a/go.sum
+++ b/go.sum
@@ -80,5 +80,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1 h1:6G8AxueDdqobCEqQrmHPLaEH1AZ1p6Y7rGElDNT7N98=
-tinygo.org/x/go-llvm v0.0.0-20220211075103-ee4aad45c3a1/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20220420140351-512c94c1e71f h1:9/J+NpFTpAhYcbh1mC4dr9W/aAPnwrUh8dmq21xWdSM=
+tinygo.org/x/go-llvm v0.0.0-20220420140351-512c94c1e71f/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/interp/testdata/slice-copy.out.ll
+++ b/interp/testdata/slice-copy.out.ll
@@ -1,8 +1,6 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
-@"main$alloc.1" = internal unnamed_addr constant [6 x i8] c"\05\00{\00\00\04", align 8
-
 declare void @runtime.printuint8(i8) local_unnamed_addr
 
 declare void @runtime.printint16(i16) local_unnamed_addr
@@ -17,7 +15,6 @@ entry:
   call void @runtime.printuint8(i8 3)
   call void @runtime.printuint8(i8 3)
   call void @runtime.printint16(i16 5)
-  %int16SliceDst.val = load i16, i16* bitcast ([6 x i8]* @"main$alloc.1" to i16*), align 2
-  call void @runtime.printint16(i16 %int16SliceDst.val)
+  call void @runtime.printint16(i16 5)
   ret void
 }

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0",
-	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0plus",
-	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7m-unknown-unknown-eabi",
 	"cpu": "cortex-m3",
-	"features": "+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+	"features": "+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m4",
-	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -2,5 +2,5 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
-	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
+	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["xtensa"],
 	"cpu": "esp32",
+	"features": "+atomctl,+bool,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed",
 	"build-tags": ["esp32", "esp"],
 	"scheduler": "tasks",
 	"serial": "uart",

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
-	"features": "+c,+m,-relax,-save-restore",
+	"features": "+c,+m",
 	"build-tags": ["esp32c3", "esp"],
 	"serial": "uart",
 	"rtlib": "compiler-rt",

--- a/targets/esp8266.json
+++ b/targets/esp8266.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["xtensa"],
 	"cpu": "esp8266",
+	"features": "+debug,+density,+exception,+extendedl32r,+highpriinterrupts,+interrupt,+mul32,+nsa,+prid,+regprotect,+rvector,+timerint",
 	"build-tags": ["esp8266", "esp"],
 	"scheduler": "tasks",
 	"linker": "xtensa-esp32-elf-ld",

--- a/targets/fe310.json
+++ b/targets/fe310.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
 	"cpu": "sifive-e31",
-	"features": "+a,+c,+m,-64bit,-relax,-save-restore",
+	"features": "+a,+c,+m",
 	"build-tags": ["fe310", "sifive"]
 }

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "armv4t-unknown-unknown-eabi",
 	"cpu": "arm7tdmi",
-	"features": "+armv4t,+strict-align,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-ras,-sb,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
+	"features": "+armv4t,+strict-align,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-thumb-mode,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp",
 	"build-tags": ["gameboyadvance", "arm7tdmi", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",

--- a/targets/k210.json
+++ b/targets/k210.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv64"],
-	"features": "+64bit,+a,+c,+d,+f,+m,-relax,-save-restore",
+	"features": "+64bit,+a,+c,+d,+f,+m",
 	"build-tags": ["k210", "kendryte"],
 	"code-model": "medium"
 }

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -1,7 +1,7 @@
 {
   "llvm-target": "aarch64",
   "cpu": "cortex-a57",
-  "features": "+aes,+crc,+crypto,+fp-armv8,+neon,+sha2",
+  "features": "+aes,+crc,+crypto,+fp-armv8,+neon,+sha2,+v8a",
   "build-tags": ["nintendoswitch", "arm64"],
   "scheduler": "tasks",
   "goos": "linux",

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
-	"features": "+a,+c,+m,-relax,-save-restore",
+	"features": "+a,+c,+m",
 	"build-tags": ["virt", "qemu"],
 	"default-stack-size": 4096,
 	"linkerscript": "targets/riscv-qemu.ld",


### PR DESCRIPTION
This PR adds support for LLVM 14 without dropping support for older versions. It switches the LLVM version for static builds, but doesn't switch the default for system LLVM builds yet because Homebrew doesn't have LLVM 14 yet.

This PR is similar to #2766 but is more complete. I ran a bunch of tests locally and it seems to work fine.