### PR TITLE
Run ESP32 inside QEMU

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -37,8 +37,14 @@ import (
 // BuildResult is the output of a build. This includes the binary itself and
 // some other metadata that is obtained while building the binary.
 type BuildResult struct {
+	// The executable directly from the linker, usually including debug
+	// information. Used for GDB for example.
+	Executable string
+
 	// A path to the output binary. It will be removed after Build returns, so
 	// if it should be kept it must be copied or moved away.
+	// It is often the same as Executable, but differs if the output format is
+	// .hex for example (instead of the usual ELF).
 	Binary string
 
 	// The directory of the main package. This is useful for testing as the test
@@ -835,7 +841,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 		if err != nil {
 			return err
 		}
-	case "esp32", "esp32c3", "esp8266":
+	case "esp32", "esp32-img", "esp32c3", "esp8266":
 		// Special format for the ESP family of chips (parsed by the ROM
 		// bootloader).
 		tmppath = filepath.Join(dir, "main"+outext)
@@ -867,6 +873,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	}
 
 	return action(BuildResult{
+		Executable: executable,
 		Binary:     tmppath,
 		MainDir:    lprogram.MainPkg().Dir,
 		ModuleRoot: moduleroot,

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -395,6 +395,13 @@ func (c *Config) BinaryFormat(ext string) string {
 			return c.Target.BinaryFormat
 		}
 		return "bin"
+	case ".img":
+		// Image file. Only defined for the ESP32 at the moment, where it is a
+		// full (runnable) image that can be used in the Espressif QEMU fork.
+		if c.Target.BinaryFormat != "" {
+			return c.Target.BinaryFormat + "-img"
+		}
+		return "bin"
 	case ".hex":
 		// Similar to bin, but includes the start address and is thus usually a
 		// better format.
@@ -507,9 +514,14 @@ func (c *Config) EmulatorName() string {
 
 // EmulatorFormat returns the binary format for the emulator and the associated
 // file extension. An empty string means to pass directly whatever the linker
-// produces directly without conversion.
+// produces directly without conversion (usually ELF format).
 func (c *Config) EmulatorFormat() (format, fileExt string) {
-	return "", ""
+	switch {
+	case strings.Contains(c.Target.Emulator, "{img}"):
+		return "img", ".img"
+	default:
+		return "", ""
+	}
 }
 
 // Emulator returns a ready-to-run command to run the given binary in an

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -44,8 +44,8 @@ type TargetSpec struct {
 	LDFlags          []string `json:"ldflags"`
 	LinkerScript     string   `json:"linkerscript"`
 	ExtraFiles       []string `json:"extra-files"`
-	RP2040BootPatch  *bool    `json:"rp2040-boot-patch"`        // Patch RP2040 2nd stage bootloader checksum
-	Emulator         []string `json:"emulator" override:"copy"` // inherited Emulator must not be append
+	RP2040BootPatch  *bool    `json:"rp2040-boot-patch"` // Patch RP2040 2nd stage bootloader checksum
+	Emulator         string   `json:"emulator"`
 	FlashCommand     string   `json:"flash-command"`
 	GDB              []string `json:"gdb"`
 	PortReset        string   `json:"flash-1200-bps-reset"`
@@ -90,19 +90,8 @@ func (spec *TargetSpec) overrideProperties(child *TargetSpec) {
 			if !src.IsNil() {
 				dst.Set(src)
 			}
-		case reflect.Slice: // for slices...
-			if src.Len() > 0 { // ... if not empty ...
-				switch tag := field.Tag.Get("override"); tag {
-				case "copy":
-					// copy the field of child to spec
-					dst.Set(src)
-				case "append", "":
-					// or append the field of child to spec
-					dst.Set(reflect.AppendSlice(dst, src))
-				default:
-					panic("override mode must be 'copy' or 'append' (default). I don't know how to '" + tag + "'.")
-				}
-			}
+		case reflect.Slice: // for slices, append the field
+			dst.Set(reflect.AppendSlice(dst, src))
 		default:
 			panic("unknown field type : " + kind.String())
 		}
@@ -331,20 +320,20 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 			case "386":
 				// amd64 can _usually_ run 32-bit programs, so skip the emulator in that case.
 				if runtime.GOARCH != "amd64" {
-					spec.Emulator = []string{"qemu-i386"}
+					spec.Emulator = "qemu-i386 {}"
 				}
 			case "amd64":
-				spec.Emulator = []string{"qemu-x86_64"}
+				spec.Emulator = "qemu-x86_64 {}"
 			case "arm":
-				spec.Emulator = []string{"qemu-arm"}
+				spec.Emulator = "qemu-arm {}"
 			case "arm64":
-				spec.Emulator = []string{"qemu-aarch64"}
+				spec.Emulator = "qemu-aarch64 {}"
 			}
 		}
 	}
 	if goos != runtime.GOOS {
 		if goos == "windows" {
-			spec.Emulator = []string{"wine"}
+			spec.Emulator = "wine {}"
 		}
 	}
 	return &spec, nil

--- a/compileopts/target_test.go
+++ b/compileopts/target_test.go
@@ -29,7 +29,6 @@ func TestOverrideProperties(t *testing.T) {
 		CPU:              "baseCpu",
 		CFlags:           []string{"-base-foo", "-base-bar"},
 		BuildTags:        []string{"bt1", "bt2"},
-		Emulator:         []string{"be1", "be2"},
 		DefaultStackSize: 42,
 		AutoStackSize:    &baseAutoStackSize,
 	}
@@ -38,7 +37,6 @@ func TestOverrideProperties(t *testing.T) {
 		GOOS:             "",
 		CPU:              "chlidCpu",
 		CFlags:           []string{"-child-foo", "-child-bar"},
-		Emulator:         []string{"ce1", "ce2"},
 		AutoStackSize:    &childAutoStackSize,
 		DefaultStackSize: 64,
 	}
@@ -56,9 +54,6 @@ func TestOverrideProperties(t *testing.T) {
 	}
 	if !reflect.DeepEqual(base.BuildTags, []string{"bt1", "bt2"}) {
 		t.Errorf("Overriding failed : got %v", base.BuildTags)
-	}
-	if !reflect.DeepEqual(base.Emulator, []string{"ce1", "ce2"}) {
-		t.Errorf("Overriding failed : got %v", base.Emulator)
 	}
 	if *base.AutoStackSize != false {
 		t.Errorf("Overriding failed : got %v", base.AutoStackSize)

--- a/main.go
+++ b/main.go
@@ -634,7 +634,7 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 		// Construct and execute a gdb or lldb command.
 		// By default: gdb -ex run <binary>
 		// Exit the debugger with Ctrl-D.
-		params := []string{result.Binary}
+		params := []string{result.Executable}
 		switch debugger {
 		case "gdb":
 			if port != "" {
@@ -668,7 +668,7 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 		cmd.Stderr = os.Stderr
 		err = cmd.Run()
 		if err != nil {
-			return &commandError{"failed to run " + cmdName + " with", result.Binary, err}
+			return &commandError{"failed to run " + cmdName + " with", result.Executable, err}
 		}
 		return nil
 	})

--- a/targets/arduino-nano.json
+++ b/targets/arduino-nano.json
@@ -6,5 +6,5 @@
 		"-Wl,--defsym=_stack_size=512"
 	],
 	"flash-command": "avrdude -c arduino -p atmega328p -b 57600 -P {port} -U flash:w:{hex}:i",
-	"emulator": ["simavr", "-m", "atmega328p", "-f", "16000000"]
+	"emulator": "simavr -m atmega328p -f 16000000 {}"
 }

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -7,5 +7,5 @@
 	],
 	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
 	"serial-port": ["acm:2341:0043", "acm:2341:0001", "acm:2a03:0043", "acm:2341:0243"],
-	"emulator": ["simavr", "-m", "atmega328p", "-f", "16000000"]
+	"emulator": "simavr -m atmega328p -f 16000000 {}"
 }

--- a/targets/atmega1284p.json
+++ b/targets/atmega1284p.json
@@ -13,5 +13,5 @@
         "targets/avr.S",
         "src/device/avr/atmega1284p.s"
     ],
-    "emulator": ["simavr", "-m", "atmega1284p", "-f", "20000000"]
+    "emulator": "simavr -m atmega1284p -f 20000000 {}"
 }

--- a/targets/cortex-m-qemu.json
+++ b/targets/cortex-m-qemu.json
@@ -5,5 +5,5 @@
 	"extra-files": [
 		"targets/cortex-m-qemu.s"
 	],
-	"emulator": ["qemu-system-arm", "-machine", "lm3s6965evb", "-semihosting", "-nographic", "-kernel"]
+	"emulator": "qemu-system-arm -machine lm3s6965evb -semihosting -nographic -kernel {}"
 }

--- a/targets/digispark.json
+++ b/targets/digispark.json
@@ -6,5 +6,5 @@
 		"-Wl,--defsym=_stack_size=128"
 	],
 	"flash-command": "micronucleus --run {hex}",
-	"emulator": ["simavr", "-m", "attiny85", "-f", "16000000"]
+	"emulator": "simavr -m attiny85 -f 16000000 {}"
 }

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -14,5 +14,7 @@
 		"src/internal/task/task_stack_esp32.S"
 	],
 	"binary-format": "esp32",
-	"flash-command": "esptool.py --chip=esp32 --port {port} write_flash 0x1000 {bin} -ff 80m -fm dout"
+	"flash-command": "esptool.py --chip=esp32 --port {port} write_flash 0x1000 {bin} -ff 80m -fm dout",
+	"emulator": "qemu-system-xtensa -machine esp32 -nographic -drive file={img},if=mtd,format=raw",
+	"gdb": ["xtensa-esp32-elf-gdb"]
 }

--- a/targets/gameboy-advance.json
+++ b/targets/gameboy-advance.json
@@ -24,5 +24,5 @@
 		"src/runtime/gc_arm.S"
 	],
 	"gdb": ["gdb-multiarch"],
-	"emulator": ["mgba", "-3"]
+	"emulator": "mgba -3 {}"
 }

--- a/targets/hifive1-qemu.json
+++ b/targets/hifive1-qemu.json
@@ -4,5 +4,5 @@
 	"serial": "uart",
 	"default-stack-size": 4096,
 	"linkerscript": "targets/hifive1-qemu.ld",
-	"emulator": ["qemu-system-riscv32", "-machine", "sifive_e", "-nographic", "-kernel"]
+	"emulator": "qemu-system-riscv32 -machine sifive_e -nographic -kernel {}"
 }

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -4,5 +4,5 @@
 	"build-tags": ["virt", "qemu"],
 	"default-stack-size": 4096,
 	"linkerscript": "targets/riscv-qemu.ld",
-	"emulator": ["qemu-system-riscv32", "-machine", "virt", "-nographic", "-bios", "none", "-kernel"]
+	"emulator": "qemu-system-riscv32 -machine virt -nographic -bios none -kernel {}"
 }

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -13,6 +13,6 @@
 		"--stack-first",
 		"--no-demangle"
 	],
-	"emulator":      ["wasmtime"],
+	"emulator":      "wasmtime {}",
 	"wasm-abi":      "generic"
 }

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -13,6 +13,6 @@
 		"--stack-first",
 		"--no-demangle"
 	],
-	"emulator":      ["node", "{root}/targets/wasm_exec.js"],
+	"emulator":      "node {root}/targets/wasm_exec.js {}",
 	"wasm-abi":      "js"
 }


### PR DESCRIPTION
This should make it much easier to debug this chip:

![Screenshot_20220422_191206](https://user-images.githubusercontent.com/729697/164762971-5c7f9a91-937f-4158-8bd6-85d0ae7ec832.png)

The text "hello world!" is printed by the emulated firmware, and the startup messages ("ets Jul 29 2019 12:21:46" etc) are part of the built-in ROM, which is also emulated.

For this to work, you need:

 - `qemu-system-xtensa` from https://github.com/espressif/qemu/wiki (I built it from source)
 - `xtensa-esp32-elf-gdb`, optional (needed only if you want to debug). At least version esp-2021r2, otherwise you get [this error](https://stackoverflow.com/questions/70644426/build-gdb-for-esp32-and-qemu).