### PR TITLE
docker: update Dockerfile to use Go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.17 AS tinygo-llvm
+FROM golang:1.18 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-11 binutils-avr gcc-avr avr-libc ninja-build


### PR DESCRIPTION
This PR updates the Dockerfile used for the `dev` build to use Go 1.18.1

It also updates the linker for Xtensa to the LLVM 14 version.