### PR TITLE
Seeed XIAO BLE nRF52840 (Sense) board support

### DIFF
--- a/src/machine/board_xiao-ble.go
+++ b/src/machine/board_xiao-ble.go
@@ -1,0 +1,113 @@
+//go:build xiao_ble
+// +build xiao_ble
+
+// This file contains the pin mappings for the Seeed XIAO BLE nRF52840 [Sense] boards.
+//
+// Seeed XIAO BLE is an ultra-small size, ultra-low power Bluetooth development board based on the Nordic nRF52840.
+// It features an onboard Bluetooth antenna, onboard battery charging chip, and 21*17.5mm thumb size, which makes it ideal for IoT projects.
+//
+// Seeed XIAO BLE nRF52840 Sense is a tiny Bluetooth LE development board designed for IoT and AI applications.
+// It features an onboard antenna, 6 Dof IMU, microphone, all of which make it an ideal board to run AI using TinyML and TensorFlow Lite.
+//
+// SoftDevice (s140v7) is pre-flashed on this board already.
+// See https://github.com/tinygo-org/bluetooth
+//
+// - https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html
+// - https://www.seeedstudio.com/Seeed-XIAO-BLE-Sense-nRF52840-p-5253.html
+//
+// - https://wiki.seeedstudio.com/XIAO_BLE/
+// - https://github.com/Seeed-Studio/ArduinoCore-mbed/tree/master/variants/SEEED_XIAO_NRF52840_SENSE
+//
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// Digital Pins
+const (
+	D0  Pin = P0_02
+	D1  Pin = P0_03
+	D2  Pin = P0_28
+	D3  Pin = P0_29
+	D4  Pin = P0_04
+	D5  Pin = P0_05
+	D6  Pin = P1_11
+	D7  Pin = P1_12
+	D8  Pin = P1_13
+	D9  Pin = P1_14
+	D10 Pin = P1_15
+)
+
+// Analog pins
+const (
+	A0 Pin = P0_02
+	A1 Pin = P0_03
+	A2 Pin = P0_28
+	A3 Pin = P0_29
+	A4 Pin = P0_04
+	A5 Pin = P0_05
+)
+
+// Onboard LEDs
+const (
+	LED       = LED_CHG
+	LED1      = LED_RED
+	LED2      = LED_GREEN
+	LED3      = LED_BLUE
+	LED_CHG   = P0_17
+	LED_RED   = P0_26
+	LED_GREEN = P0_30
+	LED_BLUE  = P0_06
+)
+
+// UART0 pins
+const (
+	UART_RX_PIN = P1_12
+	UART_TX_PIN = P1_11
+)
+
+// I2C pins
+const (
+	// Defaults to internal
+	SDA_PIN = SDA1_PIN
+	SCL_PIN = SCL1_PIN
+
+	// I2C0 (external) pins
+	SDA0_PIN = P0_04
+	SCL0_PIN = P0_05
+
+	// I2C1 (internal) pins
+	SDA1_PIN = P0_07
+	SCL1_PIN = P0_27
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = P1_13
+	SPI0_SDO_PIN = P1_14
+	SPI0_SDI_PIN = P1_15
+)
+
+// Peripherals
+const (
+	LSM_PWR = P1_08 // IMU (LSM6DS3TR) power
+	LSM_INT = P0_11 // IMU (LSM6DS3TR) interrupt
+
+	MIC_PWR = P1_10 // Microphone (MSM261D3526H1CPM) power
+	MIC_CLK = P1_00
+	MIC_DIN = P0_16
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "XIAO nRF52840 Sense"
+	usb_STRING_MANUFACTURER = "Seeed"
+)
+
+var (
+	usb_VID uint16 = 0x2886
+	usb_PID uint16 = 0x0045
+)
+
+var (
+	DefaultUART = UART0
+)

--- a/targets/xiao-ble.json
+++ b/targets/xiao-ble.json
@@ -1,0 +1,12 @@
+{
+	"inherits": ["nrf52840"],
+	"build-tags": ["xiao_ble", "softdevice", "s140v7"],
+	"serial": "uart",
+	"serial-port": ["acm:2886:8045", "acm:2886:0045"],
+	"flash-method": "msd",
+	"msd-volume-name": "XIAO-SENSE",
+	"msd-firmware-name": "firmware.uf2",
+	"binary-format": "uf2",
+	"uf2-family-id": "0xADA52840",
+	"linkerscript": "targets/xiao-ble.ld"
+}

--- a/targets/xiao-ble.ld
+++ b/targets/xiao-ble.ld
@@ -1,0 +1,18 @@
+
+/*
+  See also 
+  https://github.com/Seeed-Studio/ArduinoCore-mbed/blob/master/variants/SEEED_XIAO_NRF52840_SENSE/linker_script.ld
+*/
+MEMORY
+{
+    FLASH_TEXT (rx) : ORIGIN = 0x27000, LENGTH = 0xED000 - 0x27000
+    RAM (rwx) : ORIGIN = 0x20006000, LENGTH = 0x3A000
+}
+
+_stack_size = 4K + __softdevice_stack;
+
+/* This value is needed by the Nordic SoftDevice. */
+__app_ram_base = ORIGIN(RAM);
+__softdevice_stack = DEFINED(__softdevice_stack) ? __softdevice_stack : 0;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
This PR adds support for a new nrf52840 based boards from Seeed Studio.

Seeed XIAO BLE is an ultra-small size, ultra-low power Bluetooth development board based on the Nordic nRF52840.
It features an onboard Bluetooth antenna, onboard battery charging chip, and 21*17.5mm thumb size, which makes it ideal for IoT projects. "Sense" variant is designed for IoT and AI applications, it adds 6 Dof IMU and a microphone.

This nice board has NRF SoftDevice (s140v7) pre-flashed together with UF2 bootloader. This makes it an ideal first board to experiment with TinyGo and Bluetooth (no debug probe or soldering required).
Currently, I'm using it instead of Arduino Nano 33 BLE in my hobby TinyGo-based [Head Tracker](https://github.com/ysoldak/HeadTracker) project.

Wiring of on-board LSM6DS3TR IMU sensor is a bit odd. LSM_PWR pin must be set to an unusual mode (not just "Output" and is 32bit, instead of 8bit that's supported by TinyGo now). At first, I've added this code here in "init()" method, but moved it to "drivers" repository instead, in "xiao_ble" specific code for lsm6ds3 driver (PR soon).

Here is the pin mode code, that makes IMU usable on this board. Just for history and reference:
```
	// Following lines are XIAO BLE Sense specific, they have nothing to do with sensor per se
	// Implementation adapted from https://github.com/Seeed-Studio/Seeed_Arduino_LSM6DS3/blob/master/LSM6DS3.cpp#L68-L77

	// Special mode for IMU power pin on this board.
	// Can not use pin.Configure() directly due to special mode and 32 bit size
	pinConfig := uint32(nrf.GPIO_PIN_CNF_DIR_Output<<nrf.GPIO_PIN_CNF_DIR_Pos) |
		uint32(nrf.GPIO_PIN_CNF_INPUT_Disconnect<<nrf.GPIO_PIN_CNF_INPUT_Pos) |
		uint32(nrf.GPIO_PIN_CNF_PULL_Disabled<<nrf.GPIO_PIN_CNF_PULL_Pos) |
		uint32(nrf.GPIO_PIN_CNF_DRIVE_H0H1<<nrf.GPIO_PIN_CNF_DRIVE_Pos) |
		uint32(nrf.GPIO_PIN_CNF_SENSE_Disabled<<nrf.GPIO_PIN_CNF_SENSE_Pos)
	nrf.P1.PIN_CNF[8].Set(pinConfig) // LSM_PWR == P1_08

	// Enable IMU
	machine.LSM_PWR.High()
```