### PR TITLE
build: use Go 1.18.1 for all builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.18.1'
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.18.1'
       - name: Cache Go
         uses: actions/cache@v2
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.18.1'
       - name: Install wasmtime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
@@ -160,7 +160,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.18.1'
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.18.1'
       - uses: brechtm/setup-scoop@v2
       - name: Install Dependencies
         shell: bash


### PR DESCRIPTION
This PR is to ensure that we use Go 1.18.1 for all builds on GHA.

It also updates Windows build to use the `windows-2022` runner. 

See https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/