### PR TITLE
fix: Define and inline atomic operations

### DIFF
--- a/compiler/atomic.go
+++ b/compiler/atomic.go
@@ -14,7 +14,7 @@ import (
 func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 	name := call.Value.(*ssa.Function).Name()
 	switch name {
-	case "AddInt32", "AddInt64", "AddUint32", "AddUint64", "AddUintptr":
+	case "llvm_AddInt32", "llvm_AddInt64", "llvm_AddUint32", "llvm_AddUint64", "llvm_AddUintptr":
 		ptr := b.getValue(call.Args[0])
 		val := b.getValue(call.Args[1])
 		if strings.HasPrefix(b.Triple, "avr") {
@@ -34,7 +34,7 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		oldVal := b.CreateAtomicRMW(llvm.AtomicRMWBinOpAdd, ptr, val, llvm.AtomicOrderingSequentiallyConsistent, true)
 		// Return the new value, not the original value returned by atomicrmw.
 		return b.CreateAdd(oldVal, val, ""), true
-	case "SwapInt32", "SwapInt64", "SwapUint32", "SwapUint64", "SwapUintptr", "SwapPointer":
+	case "llvm_SwapInt32", "llvm_SwapInt64", "llvm_SwapUint32", "llvm_SwapUint64", "llvm_SwapUintptr", "llvm_SwapPointer":
 		ptr := b.getValue(call.Args[0])
 		val := b.getValue(call.Args[1])
 		isPointer := val.Type().TypeKind() == llvm.PointerTypeKind
@@ -48,7 +48,7 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 			oldVal = b.CreateIntToPtr(oldVal, b.i8ptrType, "")
 		}
 		return oldVal, true
-	case "CompareAndSwapInt32", "CompareAndSwapInt64", "CompareAndSwapUint32", "CompareAndSwapUint64", "CompareAndSwapUintptr", "CompareAndSwapPointer":
+	case "llvm_CompareAndSwapInt32", "llvm_CompareAndSwapInt64", "llvm_CompareAndSwapUint32", "llvm_CompareAndSwapUint64", "llvm_CompareAndSwapUintptr", "llvm_CompareAndSwapPointer":
 		ptr := b.getValue(call.Args[0])
 		old := b.getValue(call.Args[1])
 		newVal := b.getValue(call.Args[2])
@@ -79,13 +79,13 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		tuple := b.CreateAtomicCmpXchg(ptr, old, newVal, llvm.AtomicOrderingSequentiallyConsistent, llvm.AtomicOrderingSequentiallyConsistent, true)
 		swapped := b.CreateExtractValue(tuple, 1, "")
 		return swapped, true
-	case "LoadInt32", "LoadInt64", "LoadUint32", "LoadUint64", "LoadUintptr", "LoadPointer":
+	case "llvm_LoadInt32", "llvm_LoadInt64", "llvm_LoadUint32", "llvm_LoadUint64", "llvm_LoadUintptr", "llvm_LoadPointer":
 		ptr := b.getValue(call.Args[0])
 		val := b.CreateLoad(ptr, "")
 		val.SetOrdering(llvm.AtomicOrderingSequentiallyConsistent)
 		val.SetAlignment(b.targetData.PrefTypeAlignment(val.Type())) // required
 		return val, true
-	case "StoreInt32", "StoreInt64", "StoreUint32", "StoreUint64", "StoreUintptr", "StorePointer":
+	case "llvm_StoreInt32", "llvm_StoreInt64", "llvm_StoreUint32", "llvm_StoreUint64", "llvm_StoreUintptr", "llvm_StorePointer":
 		ptr := b.getValue(call.Args[0])
 		val := b.getValue(call.Args[1])
 		if strings.HasPrefix(b.Triple, "avr") {

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -241,6 +241,7 @@ func pathsToOverride(needsSyscallPackage bool) map[string]bool {
 		"reflect/":              false,
 		"runtime/":              false,
 		"sync/":                 true,
+		"sync/atomic/":          true,
 		"testing/":              true,
 	}
 	if needsSyscallPackage {

--- a/src/sync/atomic/doc.go
+++ b/src/sync/atomic/doc.go
@@ -1,0 +1,144 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package atomic provides low-level atomic memory primitives
+// useful for implementing synchronization algorithms.
+//
+// These functions require great care to be used correctly.
+// Except for special, low-level applications, synchronization is better
+// done with channels or the facilities of the sync package.
+// Share memory by communicating;
+// don't communicate by sharing memory.
+//
+// The swap operation, implemented by the SwapT functions, is the atomic
+// equivalent of:
+//
+//	old = *addr
+//	*addr = new
+//	return old
+//
+// The compare-and-swap operation, implemented by the CompareAndSwapT
+// functions, is the atomic equivalent of:
+//
+//	if *addr == old {
+//		*addr = new
+//		return true
+//	}
+//	return false
+//
+// The add operation, implemented by the AddT functions, is the atomic
+// equivalent of:
+//
+//	*addr += delta
+//	return *addr
+//
+// The load and store operations, implemented by the LoadT and StoreT
+// functions, are the atomic equivalents of "return *addr" and
+// "*addr = val".
+//
+package atomic
+
+import (
+	"unsafe"
+)
+
+// BUG(rsc): On 386, the 64-bit functions use instructions unavailable before the Pentium MMX.
+//
+// On non-Linux ARM, the 64-bit functions use instructions unavailable before the ARMv6k core.
+//
+// On ARM, 386, and 32-bit MIPS, it is the caller's responsibility
+// to arrange for 64-bit alignment of 64-bit words accessed atomically.
+// The first word in a variable or in an allocated struct, array, or slice can
+// be relied upon to be 64-bit aligned.
+
+// SwapInt32 atomically stores new into *addr and returns the previous *addr value.
+func SwapInt32(addr *int32, new int32) (old int32) { return }
+
+// SwapInt64 atomically stores new into *addr and returns the previous *addr value.
+func SwapInt64(addr *int64, new int64) (old int64) { return }
+
+// SwapUint32 atomically stores new into *addr and returns the previous *addr value.
+func SwapUint32(addr *uint32, new uint32) (old uint32) { return }
+
+// SwapUint64 atomically stores new into *addr and returns the previous *addr value.
+func SwapUint64(addr *uint64, new uint64) (old uint64) { return }
+
+// SwapUintptr atomically stores new into *addr and returns the previous *addr value.
+func SwapUintptr(addr *uintptr, new uintptr) (old uintptr) { return }
+
+// SwapPointer atomically stores new into *addr and returns the previous *addr value.
+func SwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) (old unsafe.Pointer) { return }
+
+// CompareAndSwapInt32 executes the compare-and-swap operation for an int32 value.
+func CompareAndSwapInt32(addr *int32, old, new int32) (swapped bool) { return }
+
+// CompareAndSwapInt64 executes the compare-and-swap operation for an int64 value.
+func CompareAndSwapInt64(addr *int64, old, new int64) (swapped bool) { return }
+
+// CompareAndSwapUint32 executes the compare-and-swap operation for a uint32 value.
+func CompareAndSwapUint32(addr *uint32, old, new uint32) (swapped bool) { return }
+
+// CompareAndSwapUint64 executes the compare-and-swap operation for a uint64 value.
+func CompareAndSwapUint64(addr *uint64, old, new uint64) (swapped bool) { return }
+
+// CompareAndSwapUintptr executes the compare-and-swap operation for a uintptr value.
+func CompareAndSwapUintptr(addr *uintptr, old, new uintptr) (swapped bool) { return }
+
+// CompareAndSwapPointer executes the compare-and-swap operation for a unsafe.Pointer value.
+func CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) (swapped bool) { return }
+
+// AddInt32 atomically adds delta to *addr and returns the new value.
+func AddInt32(addr *int32, delta int32) (new int32) { return }
+
+// AddUint32 atomically adds delta to *addr and returns the new value.
+// To subtract a signed positive constant value c from x, do AddUint32(&x, ^uint32(c-1)).
+// In particular, to decrement x, do AddUint32(&x, ^uint32(0)).
+func AddUint32(addr *uint32, delta uint32) (new uint32) { return }
+
+// AddInt64 atomically adds delta to *addr and returns the new value.
+func AddInt64(addr *int64, delta int64) (new int64) { return }
+
+// AddUint64 atomically adds delta to *addr and returns the new value.
+// To subtract a signed positive constant value c from x, do AddUint64(&x, ^uint64(c-1)).
+// In particular, to decrement x, do AddUint64(&x, ^uint64(0)).
+func AddUint64(addr *uint64, delta uint64) (new uint64) { return }
+
+// AddUintptr atomically adds delta to *addr and returns the new value.
+func AddUintptr(addr *uintptr, delta uintptr) (new uintptr) { return }
+
+// LoadInt32 atomically loads *addr.
+func LoadInt32(addr *int32) (val int32) { return }
+
+// LoadInt64 atomically loads *addr.
+func LoadInt64(addr *int64) (val int64) { return }
+
+// LoadUint32 atomically loads *addr.
+func LoadUint32(addr *uint32) (val uint32) { return }
+
+// LoadUint64 atomically loads *addr.
+func LoadUint64(addr *uint64) (val uint64) { return }
+
+// LoadUintptr atomically loads *addr.
+func LoadUintptr(addr *uintptr) (val uintptr) { return }
+
+// LoadPointer atomically loads *addr.
+func LoadPointer(addr *unsafe.Pointer) (val unsafe.Pointer) { return }
+
+// StoreInt32 atomically stores val into *addr.
+func StoreInt32(addr *int32, val int32) {}
+
+// StoreInt64 atomically stores val into *addr.
+func StoreInt64(addr *int64, val int64) {}
+
+// StoreUint32 atomically stores val into *addr.
+func StoreUint32(addr *uint32, val uint32) {}
+
+// StoreUint64 atomically stores val into *addr.
+func StoreUint64(addr *uint64, val uint64) {}
+
+// StoreUintptr atomically stores val into *addr.
+func StoreUintptr(addr *uintptr, val uintptr) {}
+
+// StorePointer atomically stores val into *addr.
+func StorePointer(addr *unsafe.Pointer, val unsafe.Pointer) { return }

--- a/src/sync/atomic/doc.go
+++ b/src/sync/atomic/doc.go
@@ -53,92 +53,233 @@ import (
 // be relied upon to be 64-bit aligned.
 
 // SwapInt32 atomically stores new into *addr and returns the previous *addr value.
-func SwapInt32(addr *int32, new int32) (old int32) { return }
+// go:inline
+func SwapInt32(addr *int32, new int32) int32 {
+	return llvm_SwapInt32(addr, new)
+}
+
+func llvm_SwapInt32(addr *int32, new int32) (old int32)
 
 // SwapInt64 atomically stores new into *addr and returns the previous *addr value.
-func SwapInt64(addr *int64, new int64) (old int64) { return }
+// go:inline
+func SwapInt64(addr *int64, new int64) int64 {
+	return llvm_SwapInt64(addr, new)
+}
+
+func llvm_SwapInt64(addr *int64, new int64) (old int64)
 
 // SwapUint32 atomically stores new into *addr and returns the previous *addr value.
-func SwapUint32(addr *uint32, new uint32) (old uint32) { return }
+// go:inline
+func SwapUint32(addr *uint32, new uint32) uint32 {
+	return llvm_SwapUint32(addr, new)
+}
+
+func llvm_SwapUint32(addr *uint32, new uint32) (old uint32)
 
 // SwapUint64 atomically stores new into *addr and returns the previous *addr value.
-func SwapUint64(addr *uint64, new uint64) (old uint64) { return }
+// go:inline
+func SwapUint64(addr *uint64, new uint64) uint64 {
+	return llvm_SwapUint64(addr, new)
+}
+
+func llvm_SwapUint64(addr *uint64, new uint64) (old uint64)
 
 // SwapUintptr atomically stores new into *addr and returns the previous *addr value.
-func SwapUintptr(addr *uintptr, new uintptr) (old uintptr) { return }
+// go:inline
+func SwapUintptr(addr *uintptr, new uintptr) uintptr {
+	return llvm_SwapUintptr(addr, new)
+}
+
+func llvm_SwapUintptr(addr *uintptr, new uintptr) (old uintptr)
 
 // SwapPointer atomically stores new into *addr and returns the previous *addr value.
-func SwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) (old unsafe.Pointer) { return }
+func SwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) unsafe.Pointer {
+	return llvm_SwapPointer(addr, new)
+}
+
+func llvm_SwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) (old unsafe.Pointer)
 
 // CompareAndSwapInt32 executes the compare-and-swap operation for an int32 value.
-func CompareAndSwapInt32(addr *int32, old, new int32) (swapped bool) { return }
+// go:inline
+func CompareAndSwapInt32(addr *int32, old, new int32) bool {
+	return llvm_CompareAndSwapInt32(addr, old, new)
+}
+
+func llvm_CompareAndSwapInt32(addr *int32, old, new int32) (swapped bool)
 
 // CompareAndSwapInt64 executes the compare-and-swap operation for an int64 value.
-func CompareAndSwapInt64(addr *int64, old, new int64) (swapped bool) { return }
+// go:inline
+func CompareAndSwapInt64(addr *int64, old, new int64) bool {
+	return llvm_CompareAndSwapInt64(addr, old, new)
+}
+
+func llvm_CompareAndSwapInt64(addr *int64, old, new int64) (swapped bool)
 
 // CompareAndSwapUint32 executes the compare-and-swap operation for a uint32 value.
-func CompareAndSwapUint32(addr *uint32, old, new uint32) (swapped bool) { return }
+// go:inline
+func CompareAndSwapUint32(addr *uint32, old, new uint32) bool {
+	return llvm_CompareAndSwapUint32(addr, old, new)
+}
+
+func llvm_CompareAndSwapUint32(addr *uint32, old, new uint32) (swapped bool)
 
 // CompareAndSwapUint64 executes the compare-and-swap operation for a uint64 value.
-func CompareAndSwapUint64(addr *uint64, old, new uint64) (swapped bool) { return }
+// go:inline
+func CompareAndSwapUint64(addr *uint64, old, new uint64) bool {
+	return llvm_CompareAndSwapUint64(addr, old, new)
+}
+
+func llvm_CompareAndSwapUint64(addr *uint64, old, new uint64) (swapped bool)
 
 // CompareAndSwapUintptr executes the compare-and-swap operation for a uintptr value.
-func CompareAndSwapUintptr(addr *uintptr, old, new uintptr) (swapped bool) { return }
+// go:inline
+func CompareAndSwapUintptr(addr *uintptr, old, new uintptr) bool {
+	return llvm_CompareAndSwapUintptr(addr, old, new)
+}
+
+func llvm_CompareAndSwapUintptr(addr *uintptr, old, new uintptr) (swapped bool)
 
 // CompareAndSwapPointer executes the compare-and-swap operation for a unsafe.Pointer value.
-func CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) (swapped bool) { return }
+// go:inline
+func CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) bool {
+	return llvm_CompareAndSwapPointer(addr, old, new)
+}
+
+func llvm_CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) (swapped bool)
 
 // AddInt32 atomically adds delta to *addr and returns the new value.
-func AddInt32(addr *int32, delta int32) (new int32) { return }
+// go:inline
+func AddInt32(addr *int32, delta int32) int32 {
+	return llvm_AddInt32(addr, delta)
+}
+
+func llvm_AddInt32(addr *int32, delta int32) (new int32)
 
 // AddUint32 atomically adds delta to *addr and returns the new value.
 // To subtract a signed positive constant value c from x, do AddUint32(&x, ^uint32(c-1)).
 // In particular, to decrement x, do AddUint32(&x, ^uint32(0)).
-func AddUint32(addr *uint32, delta uint32) (new uint32) { return }
+// go:inline
+func AddUint32(addr *uint32, delta uint32) uint32 {
+	return llvm_AddUint32(addr, delta)
+}
+
+func llvm_AddUint32(addr *uint32, delta uint32) (new uint32)
 
 // AddInt64 atomically adds delta to *addr and returns the new value.
-func AddInt64(addr *int64, delta int64) (new int64) { return }
+// go:inline
+func AddInt64(addr *int64, delta int64) int64 {
+	return llvm_AddInt64(addr, delta)
+}
+
+func llvm_AddInt64(addr *int64, delta int64) (new int64)
 
 // AddUint64 atomically adds delta to *addr and returns the new value.
 // To subtract a signed positive constant value c from x, do AddUint64(&x, ^uint64(c-1)).
 // In particular, to decrement x, do AddUint64(&x, ^uint64(0)).
-func AddUint64(addr *uint64, delta uint64) (new uint64) { return }
+// go:inline
+func AddUint64(addr *uint64, delta uint64) uint64 {
+	return llvm_AddUint64(addr, delta)
+}
+
+func llvm_AddUint64(addr *uint64, delta uint64) (new uint64)
 
 // AddUintptr atomically adds delta to *addr and returns the new value.
-func AddUintptr(addr *uintptr, delta uintptr) (new uintptr) { return }
+// go:inline
+func AddUintptr(addr *uintptr, delta uintptr) uintptr {
+	return llvm_AddUintptr(addr, delta)
+}
+
+func llvm_AddUintptr(addr *uintptr, delta uintptr) (new uintptr)
 
 // LoadInt32 atomically loads *addr.
-func LoadInt32(addr *int32) (val int32) { return }
+// go:inline
+func LoadInt32(addr *int32) int32 {
+	return llvm_LoadInt32(addr)
+}
+
+func llvm_LoadInt32(addr *int32) (val int32)
 
 // LoadInt64 atomically loads *addr.
-func LoadInt64(addr *int64) (val int64) { return }
+// go:inline
+func LoadInt64(addr *int64) int64 {
+	return llvm_LoadInt64(addr)
+}
+
+func llvm_LoadInt64(addr *int64) (val int64)
 
 // LoadUint32 atomically loads *addr.
-func LoadUint32(addr *uint32) (val uint32) { return }
+// go:inline
+func LoadUint32(addr *uint32) (val uint32) {
+	return llvm_LoadUint32(addr)
+}
+
+func llvm_LoadUint32(addr *uint32) (val uint32)
 
 // LoadUint64 atomically loads *addr.
-func LoadUint64(addr *uint64) (val uint64) { return }
+// go:inline
+func LoadUint64(addr *uint64) uint64 {
+	return llvm_LoadUint64(addr)
+}
+
+func llvm_LoadUint64(addr *uint64) (val uint64)
 
 // LoadUintptr atomically loads *addr.
-func LoadUintptr(addr *uintptr) (val uintptr) { return }
+// go:inline
+func LoadUintptr(addr *uintptr) uintptr {
+	return llvm_LoadUintptr(addr)
+}
+
+func llvm_LoadUintptr(addr *uintptr) (val uintptr)
 
 // LoadPointer atomically loads *addr.
-func LoadPointer(addr *unsafe.Pointer) (val unsafe.Pointer) { return }
+// go:inline
+func LoadPointer(addr *unsafe.Pointer) unsafe.Pointer {
+	return llvm_LoadPointer(addr)
+}
+
+func llvm_LoadPointer(addr *unsafe.Pointer) (val unsafe.Pointer)
 
 // StoreInt32 atomically stores val into *addr.
-func StoreInt32(addr *int32, val int32) {}
+// go:inline
+func StoreInt32(addr *int32, val int32) {
+	llvm_StoreInt32(addr, val)
+}
+
+func llvm_StoreInt32(addr *int32, val int32)
 
 // StoreInt64 atomically stores val into *addr.
-func StoreInt64(addr *int64, val int64) {}
+// go:inline
+func StoreInt64(addr *int64, val int64) {
+	llvm_StoreInt64(addr, val)
+}
+
+func llvm_StoreInt64(addr *int64, val int64)
 
 // StoreUint32 atomically stores val into *addr.
-func StoreUint32(addr *uint32, val uint32) {}
+// go:inline
+func StoreUint32(addr *uint32, val uint32) {
+	llvm_StoreUint32(addr, val)
+}
+
+func llvm_StoreUint32(addr *uint32, val uint32)
 
 // StoreUint64 atomically stores val into *addr.
-func StoreUint64(addr *uint64, val uint64) {}
+func StoreUint64(addr *uint64, val uint64) {
+	llvm_StoreUint64(addr, val)
+}
+
+func llvm_StoreUint64(addr *uint64, val uint64)
 
 // StoreUintptr atomically stores val into *addr.
-func StoreUintptr(addr *uintptr, val uintptr) {}
+func StoreUintptr(addr *uintptr, val uintptr) {
+	llvm_StoreUintptr(addr, val)
+}
+
+func llvm_StoreUintptr(addr *uintptr, val uintptr)
 
 // StorePointer atomically stores val into *addr.
-func StorePointer(addr *unsafe.Pointer, val unsafe.Pointer) { return }
+func StorePointer(addr *unsafe.Pointer, val unsafe.Pointer) {
+	llvm_StorePointer(addr, val)
+}
+
+func llvm_StorePointer(addr *unsafe.Pointer, val unsafe.Pointer)

--- a/src/sync/atomic/value.go
+++ b/src/sync/atomic/value.go
@@ -14,7 +14,7 @@ import (
 //
 // A Value must not be copied after first use.
 type Value struct {
-	v any
+	v interface{}
 }
 
 // ifaceWords is interface{} internal representation.
@@ -25,167 +25,59 @@ type ifaceWords struct {
 
 // Load returns the value set by the most recent Store.
 // It returns nil if there has been no call to Store for this Value.
-func (v *Value) Load() (val any) {
+func (v *Value) Load() (x interface{}) {
 	vp := (*ifaceWords)(unsafe.Pointer(v))
 	typ := LoadPointer(&vp.typ)
-	if typ == nil || typ == unsafe.Pointer(&firstStoreInProgress) {
+	if typ == nil || uintptr(typ) == ^uintptr(0) {
 		// First store not yet completed.
 		return nil
 	}
 	data := LoadPointer(&vp.data)
-	vlp := (*ifaceWords)(unsafe.Pointer(&val))
-	vlp.typ = typ
-	vlp.data = data
+	xp := (*ifaceWords)(unsafe.Pointer(&x))
+	xp.typ = typ
+	xp.data = data
 	return
 }
-
-var firstStoreInProgress byte
 
 // Store sets the value of the Value to x.
 // All calls to Store for a given Value must use values of the same concrete type.
 // Store of an inconsistent type panics, as does Store(nil).
-func (v *Value) Store(val any) {
-	if val == nil {
+func (v *Value) Store(x interface{}) {
+	if x == nil {
 		panic("sync/atomic: store of nil value into Value")
 	}
 	vp := (*ifaceWords)(unsafe.Pointer(v))
-	vlp := (*ifaceWords)(unsafe.Pointer(&val))
+	xp := (*ifaceWords)(unsafe.Pointer(&x))
 	for {
 		typ := LoadPointer(&vp.typ)
 		if typ == nil {
 			// Attempt to start first store.
 			// Disable preemption so that other goroutines can use
-			// active spin wait to wait for completion.
+			// active spin wait to wait for completion; and so that
+			// GC does not see the fake type accidentally.
 			runtime_procPin()
-			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(&firstStoreInProgress)) {
+			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(^uintptr(0))) {
 				runtime_procUnpin()
 				continue
 			}
 			// Complete first store.
-			StorePointer(&vp.data, vlp.data)
-			StorePointer(&vp.typ, vlp.typ)
+			StorePointer(&vp.data, xp.data)
+			StorePointer(&vp.typ, xp.typ)
 			runtime_procUnpin()
 			return
 		}
-		if typ == unsafe.Pointer(&firstStoreInProgress) {
+		if uintptr(typ) == ^uintptr(0) {
 			// First store in progress. Wait.
 			// Since we disable preemption around the first store,
 			// we can wait with active spinning.
 			continue
 		}
 		// First store completed. Check type and overwrite data.
-		if typ != vlp.typ {
+		if typ != xp.typ {
 			panic("sync/atomic: store of inconsistently typed value into Value")
 		}
-		StorePointer(&vp.data, vlp.data)
+		StorePointer(&vp.data, xp.data)
 		return
-	}
-}
-
-// Swap stores new into Value and returns the previous value. It returns nil if
-// the Value is empty.
-//
-// All calls to Swap for a given Value must use values of the same concrete
-// type. Swap of an inconsistent type panics, as does Swap(nil).
-func (v *Value) Swap(new any) (old any) {
-	if new == nil {
-		panic("sync/atomic: swap of nil value into Value")
-	}
-	vp := (*ifaceWords)(unsafe.Pointer(v))
-	np := (*ifaceWords)(unsafe.Pointer(&new))
-	for {
-		typ := LoadPointer(&vp.typ)
-		if typ == nil {
-			// Attempt to start first store.
-			// Disable preemption so that other goroutines can use
-			// active spin wait to wait for completion; and so that
-			// GC does not see the fake type accidentally.
-			runtime_procPin()
-			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(^uintptr(0))) {
-				runtime_procUnpin()
-				continue
-			}
-			// Complete first store.
-			StorePointer(&vp.data, np.data)
-			StorePointer(&vp.typ, np.typ)
-			runtime_procUnpin()
-			return nil
-		}
-		if uintptr(typ) == ^uintptr(0) {
-			// First store in progress. Wait.
-			// Since we disable preemption around the first store,
-			// we can wait with active spinning.
-			continue
-		}
-		// First store completed. Check type and overwrite data.
-		if typ != np.typ {
-			panic("sync/atomic: swap of inconsistently typed value into Value")
-		}
-		op := (*ifaceWords)(unsafe.Pointer(&old))
-		op.typ, op.data = np.typ, SwapPointer(&vp.data, np.data)
-		return old
-	}
-}
-
-// CompareAndSwap executes the compare-and-swap operation for the Value.
-//
-// All calls to CompareAndSwap for a given Value must use values of the same
-// concrete type. CompareAndSwap of an inconsistent type panics, as does
-// CompareAndSwap(old, nil).
-func (v *Value) CompareAndSwap(old, new any) (swapped bool) {
-	if new == nil {
-		panic("sync/atomic: compare and swap of nil value into Value")
-	}
-	vp := (*ifaceWords)(unsafe.Pointer(v))
-	np := (*ifaceWords)(unsafe.Pointer(&new))
-	op := (*ifaceWords)(unsafe.Pointer(&old))
-	if op.typ != nil && np.typ != op.typ {
-		panic("sync/atomic: compare and swap of inconsistently typed values")
-	}
-	for {
-		typ := LoadPointer(&vp.typ)
-		if typ == nil {
-			if old != nil {
-				return false
-			}
-			// Attempt to start first store.
-			// Disable preemption so that other goroutines can use
-			// active spin wait to wait for completion; and so that
-			// GC does not see the fake type accidentally.
-			runtime_procPin()
-			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(^uintptr(0))) {
-				runtime_procUnpin()
-				continue
-			}
-			// Complete first store.
-			StorePointer(&vp.data, np.data)
-			StorePointer(&vp.typ, np.typ)
-			runtime_procUnpin()
-			return true
-		}
-		if uintptr(typ) == ^uintptr(0) {
-			// First store in progress. Wait.
-			// Since we disable preemption around the first store,
-			// we can wait with active spinning.
-			continue
-		}
-		// First store completed. Check type and overwrite data.
-		if typ != np.typ {
-			panic("sync/atomic: compare and swap of inconsistently typed value into Value")
-		}
-		// Compare old and current via runtime equality check.
-		// This allows value types to be compared, something
-		// not offered by the package functions.
-		// CompareAndSwapPointer below only ensures vp.data
-		// has not changed since LoadPointer.
-		data := LoadPointer(&vp.data)
-		var i any
-		(*ifaceWords)(unsafe.Pointer(&i)).typ = typ
-		(*ifaceWords)(unsafe.Pointer(&i)).data = data
-		if i != old {
-			return false
-		}
-		return CompareAndSwapPointer(&vp.data, data, np.data)
 	}
 }
 

--- a/src/sync/atomic/value.go
+++ b/src/sync/atomic/value.go
@@ -1,0 +1,194 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package atomic
+
+import (
+	"unsafe"
+)
+
+// A Value provides an atomic load and store of a consistently typed value.
+// The zero value for a Value returns nil from Load.
+// Once Store has been called, a Value must not be copied.
+//
+// A Value must not be copied after first use.
+type Value struct {
+	v any
+}
+
+// ifaceWords is interface{} internal representation.
+type ifaceWords struct {
+	typ  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+// Load returns the value set by the most recent Store.
+// It returns nil if there has been no call to Store for this Value.
+func (v *Value) Load() (val any) {
+	vp := (*ifaceWords)(unsafe.Pointer(v))
+	typ := LoadPointer(&vp.typ)
+	if typ == nil || typ == unsafe.Pointer(&firstStoreInProgress) {
+		// First store not yet completed.
+		return nil
+	}
+	data := LoadPointer(&vp.data)
+	vlp := (*ifaceWords)(unsafe.Pointer(&val))
+	vlp.typ = typ
+	vlp.data = data
+	return
+}
+
+var firstStoreInProgress byte
+
+// Store sets the value of the Value to x.
+// All calls to Store for a given Value must use values of the same concrete type.
+// Store of an inconsistent type panics, as does Store(nil).
+func (v *Value) Store(val any) {
+	if val == nil {
+		panic("sync/atomic: store of nil value into Value")
+	}
+	vp := (*ifaceWords)(unsafe.Pointer(v))
+	vlp := (*ifaceWords)(unsafe.Pointer(&val))
+	for {
+		typ := LoadPointer(&vp.typ)
+		if typ == nil {
+			// Attempt to start first store.
+			// Disable preemption so that other goroutines can use
+			// active spin wait to wait for completion.
+			runtime_procPin()
+			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(&firstStoreInProgress)) {
+				runtime_procUnpin()
+				continue
+			}
+			// Complete first store.
+			StorePointer(&vp.data, vlp.data)
+			StorePointer(&vp.typ, vlp.typ)
+			runtime_procUnpin()
+			return
+		}
+		if typ == unsafe.Pointer(&firstStoreInProgress) {
+			// First store in progress. Wait.
+			// Since we disable preemption around the first store,
+			// we can wait with active spinning.
+			continue
+		}
+		// First store completed. Check type and overwrite data.
+		if typ != vlp.typ {
+			panic("sync/atomic: store of inconsistently typed value into Value")
+		}
+		StorePointer(&vp.data, vlp.data)
+		return
+	}
+}
+
+// Swap stores new into Value and returns the previous value. It returns nil if
+// the Value is empty.
+//
+// All calls to Swap for a given Value must use values of the same concrete
+// type. Swap of an inconsistent type panics, as does Swap(nil).
+func (v *Value) Swap(new any) (old any) {
+	if new == nil {
+		panic("sync/atomic: swap of nil value into Value")
+	}
+	vp := (*ifaceWords)(unsafe.Pointer(v))
+	np := (*ifaceWords)(unsafe.Pointer(&new))
+	for {
+		typ := LoadPointer(&vp.typ)
+		if typ == nil {
+			// Attempt to start first store.
+			// Disable preemption so that other goroutines can use
+			// active spin wait to wait for completion; and so that
+			// GC does not see the fake type accidentally.
+			runtime_procPin()
+			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(^uintptr(0))) {
+				runtime_procUnpin()
+				continue
+			}
+			// Complete first store.
+			StorePointer(&vp.data, np.data)
+			StorePointer(&vp.typ, np.typ)
+			runtime_procUnpin()
+			return nil
+		}
+		if uintptr(typ) == ^uintptr(0) {
+			// First store in progress. Wait.
+			// Since we disable preemption around the first store,
+			// we can wait with active spinning.
+			continue
+		}
+		// First store completed. Check type and overwrite data.
+		if typ != np.typ {
+			panic("sync/atomic: swap of inconsistently typed value into Value")
+		}
+		op := (*ifaceWords)(unsafe.Pointer(&old))
+		op.typ, op.data = np.typ, SwapPointer(&vp.data, np.data)
+		return old
+	}
+}
+
+// CompareAndSwap executes the compare-and-swap operation for the Value.
+//
+// All calls to CompareAndSwap for a given Value must use values of the same
+// concrete type. CompareAndSwap of an inconsistent type panics, as does
+// CompareAndSwap(old, nil).
+func (v *Value) CompareAndSwap(old, new any) (swapped bool) {
+	if new == nil {
+		panic("sync/atomic: compare and swap of nil value into Value")
+	}
+	vp := (*ifaceWords)(unsafe.Pointer(v))
+	np := (*ifaceWords)(unsafe.Pointer(&new))
+	op := (*ifaceWords)(unsafe.Pointer(&old))
+	if op.typ != nil && np.typ != op.typ {
+		panic("sync/atomic: compare and swap of inconsistently typed values")
+	}
+	for {
+		typ := LoadPointer(&vp.typ)
+		if typ == nil {
+			if old != nil {
+				return false
+			}
+			// Attempt to start first store.
+			// Disable preemption so that other goroutines can use
+			// active spin wait to wait for completion; and so that
+			// GC does not see the fake type accidentally.
+			runtime_procPin()
+			if !CompareAndSwapPointer(&vp.typ, nil, unsafe.Pointer(^uintptr(0))) {
+				runtime_procUnpin()
+				continue
+			}
+			// Complete first store.
+			StorePointer(&vp.data, np.data)
+			StorePointer(&vp.typ, np.typ)
+			runtime_procUnpin()
+			return true
+		}
+		if uintptr(typ) == ^uintptr(0) {
+			// First store in progress. Wait.
+			// Since we disable preemption around the first store,
+			// we can wait with active spinning.
+			continue
+		}
+		// First store completed. Check type and overwrite data.
+		if typ != np.typ {
+			panic("sync/atomic: compare and swap of inconsistently typed value into Value")
+		}
+		// Compare old and current via runtime equality check.
+		// This allows value types to be compared, something
+		// not offered by the package functions.
+		// CompareAndSwapPointer below only ensures vp.data
+		// has not changed since LoadPointer.
+		data := LoadPointer(&vp.data)
+		var i any
+		(*ifaceWords)(unsafe.Pointer(&i)).typ = typ
+		(*ifaceWords)(unsafe.Pointer(&i)).data = data
+		if i != old {
+			return false
+		}
+		return CompareAndSwapPointer(&vp.data, data, np.data)
+	}
+}
+
+// Disable/enable preemption, implemented in runtime.
+func runtime_procPin()
+func runtime_procUnpin()


### PR DESCRIPTION
Implement the atomic package in Go, but take advantage of the existing atomic methods defined using LLVM intrinsics. I picked the `llvm_` prefix quickly, so happy to change that to something else.

Fixes https://github.com/tinygo-org/tinygo/issues/2652

```
package main

import (
	"sync/atomic"
)

var global uint32

func foo() {
	defer atomic.StoreUint32(&global, 1)
	atomic.StoreUint32(&global, 2)
}

func main() {
	foo()
	println(atomic.LoadUint32(&global))
}
```