### PR TITLE
os: PathError now alias for fs.PathError, fixes #2817

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ commands:
       - run: make fmt-check
 
 jobs:
-  test-llvm11-go115:
+  test-llvm11-go116:
     docker:
-      - image: circleci/golang:1.15-buster
+      - image: circleci/golang:1.16-buster
     steps:
       - test-linux:
           llvm: "11"
@@ -118,5 +118,5 @@ jobs:
 workflows:
   test-all:
     jobs:
-      - test-llvm11-go115
+      - test-llvm11-go116
       - test-llvm12-go117

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ TEST_PACKAGES_LINUX := \
 	debug/dwarf \
 	debug/plan9obj \
 	io/fs \
+	io/ioutil \
 	testing/fstest
 
 TEST_PACKAGES_DARWIN := $(TEST_PACKAGES_LINUX)

--- a/builder/config.go
+++ b/builder/config.go
@@ -33,8 +33,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 15 || minor > 18 {
-		return nil, fmt.Errorf("requires go version 1.15 through 1.18, got go%d.%d", major, minor)
+	if major != 1 || minor < 16 || minor > 18 {
+		return nil, fmt.Errorf("requires go version 1.16 through 1.18, got go%d.%d", major, minor)
 	}
 
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -12,6 +12,7 @@ package os
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"runtime"
 	"syscall"
 )
@@ -201,21 +202,7 @@ func (f *File) Truncate(size int64) error {
 }
 
 // PathError records an error and the operation and file path that caused it.
-// TODO: PathError moved to io/fs in go 1.16 and left an alias in os/errors.go.
-// Do the same once we drop support for go 1.15.
-type PathError struct {
-	Op   string
-	Path string
-	Err  error
-}
-
-func (e *PathError) Error() string {
-	return e.Op + " " + e.Path + ": " + e.Err.Error()
-}
-
-func (e *PathError) Unwrap() error {
-	return e.Err
-}
+type PathError = fs.PathError
 
 // LinkError records an error during a link or symlink or rename system call and
 // the paths that caused it.


### PR DESCRIPTION
This lets us add io/ioutil to "make test-tinygo" on linux and mac.

This requires dropping go 1.15 support.

Fixes https://github.com/tinygo-org/tinygo/issues/2817