### PR TITLE
compiler: implement deferred calls to sync/atomic.*

### DIFF
--- a/compiler/atomic.go
+++ b/compiler/atomic.go
@@ -11,12 +11,12 @@ import (
 // createAtomicOp lowers an atomic library call by lowering it as an LLVM atomic
 // operation. It returns the result of the operation and true if the call could
 // be lowered inline, and false otherwise.
-func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
-	name := call.Value.(*ssa.Function).Name()
+func (b *builder) createAtomicOp(call *ssa.Function, args []llvm.Value) (llvm.Value, bool) {
+	name := call.Name()
 	switch name {
 	case "AddInt32", "AddInt64", "AddUint32", "AddUint64", "AddUintptr":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := args[0]
+		val := args[1]
 		if strings.HasPrefix(b.Triple, "avr") {
 			// AtomicRMW does not work on AVR as intended:
 			// - There are some register allocation issues (fixed by https://reviews.llvm.org/D97127 which is not yet in a usable LLVM release)
@@ -35,8 +35,8 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		// Return the new value, not the original value returned by atomicrmw.
 		return b.CreateAdd(oldVal, val, ""), true
 	case "SwapInt32", "SwapInt64", "SwapUint32", "SwapUint64", "SwapUintptr", "SwapPointer":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := args[0]
+		val := args[1]
 		isPointer := val.Type().TypeKind() == llvm.PointerTypeKind
 		if isPointer {
 			// atomicrmw only supports integers, so cast to an integer.
@@ -49,21 +49,21 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		}
 		return oldVal, true
 	case "CompareAndSwapInt32", "CompareAndSwapInt64", "CompareAndSwapUint32", "CompareAndSwapUint64", "CompareAndSwapUintptr", "CompareAndSwapPointer":
-		ptr := b.getValue(call.Args[0])
-		old := b.getValue(call.Args[1])
-		newVal := b.getValue(call.Args[2])
+		ptr := args[0]
+		old := args[1]
+		newVal := args[2]
 		tuple := b.CreateAtomicCmpXchg(ptr, old, newVal, llvm.AtomicOrderingSequentiallyConsistent, llvm.AtomicOrderingSequentiallyConsistent, true)
 		swapped := b.CreateExtractValue(tuple, 1, "")
 		return swapped, true
 	case "LoadInt32", "LoadInt64", "LoadUint32", "LoadUint64", "LoadUintptr", "LoadPointer":
-		ptr := b.getValue(call.Args[0])
+		ptr := args[0]
 		val := b.CreateLoad(ptr, "")
 		val.SetOrdering(llvm.AtomicOrderingSequentiallyConsistent)
 		val.SetAlignment(b.targetData.PrefTypeAlignment(val.Type())) // required
 		return val, true
 	case "StoreInt32", "StoreInt64", "StoreUint32", "StoreUint64", "StoreUintptr", "StorePointer":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := args[0]
+		val := args[1]
 		if strings.HasPrefix(b.Triple, "avr") {
 			// SelectionDAGBuilder is currently missing the "are unaligned atomics allowed" check for stores.
 			vType := val.Type()

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1449,7 +1449,12 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 		case strings.HasPrefix(name, "runtime/volatile.Store"):
 			return b.createVolatileStore(instr)
 		case strings.HasPrefix(name, "sync/atomic."):
-			val, ok := b.createAtomicOp(instr)
+			var params []llvm.Value
+			for _, param := range instr.Args {
+				params = append(params, b.getValue(param))
+			}
+
+			val, ok := b.createAtomicOp(instr.StaticCallee(), params)
 			if ok {
 				// This call could be lowered as an atomic operation.
 				return val, nil

--- a/testdata/atomic.go
+++ b/testdata/atomic.go
@@ -431,25 +431,25 @@ func testUintptr() {
 	before = deferredSwapUintptr(&value, 100)
 	after = atomic.LoadUintptr(&value)
 	success = before == 7 && after == 100
-	println("deferred SwapUintptr:", success, before, after)
+	println("deferred SwapUintptr:", success)
 
 	value = 9
 	before = deferredCompareAndSwapUintptr(&value, 9, 58)
 	after = atomic.LoadUintptr(&value)
 	success = before == 9 && after == 58
-	println("deferred CompareAndSwapUintptr:", success, before, after)
+	println("deferred CompareAndSwapUintptr:", success)
 
 	value = 11
 	before = deferredLoadUintptr(&value)
 	after = atomic.LoadUintptr(&value)
 	success = before == 11 && after == 11
-	println("deferred LoadUintptr:", success, before, after)
+	println("deferred LoadUintptr:", success)
 
 	value = 11
 	before = deferredStoreUintptr(&value, 15)
 	after = atomic.LoadUintptr(&value)
 	success = before == 11 && after == 15
-	println("deferred StoreUintptr:", success, before, after)
+	println("deferred StoreUintptr:", success)
 }
 
 func deferredSwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) unsafe.Pointer {

--- a/testdata/atomic.go
+++ b/testdata/atomic.go
@@ -81,6 +81,9 @@ func main() {
 	// test atomic.Value load/store operations
 	testValue(int(3), int(-2))
 	testValue("", "foobar", "baz")
+
+	// test deferred calls to atomic operations
+	testDeferredAtomics()
 }
 
 func testValue(values ...interface{}) {
@@ -92,4 +95,430 @@ func testValue(values ...interface{}) {
 			println("val store/load didn't work, expected", val, "but got", loadedVal)
 		}
 	}
+}
+
+// testDeferredAtomics tests direct deferred calls to atomic/*
+//
+// For example:
+//   defer atomic.StoreUint32(&global, 1)
+//
+// Not:
+//   defer func () {
+//     // ...
+// 		 atomic.StoreUint32(&global, 1)`
+//     // ...
+// 	 }()
+func testDeferredAtomics() {
+	println("Int32 --")
+	testInt32()
+	println("Uint32 --")
+	testUint32()
+	println("Int64 --")
+	testInt64()
+	println("Uint64 --")
+	testUint64()
+	println("Uintptr --")
+	testUintptr()
+	println("Pointer --")
+	testPointer()
+}
+
+func deferredAddInt32(addr *int32, delta int32) int32 {
+	defer atomic.AddInt32(addr, delta)
+	return atomic.LoadInt32(addr)
+}
+
+func deferredSwapInt32(addr *int32, new int32) int32 {
+	defer atomic.SwapInt32(addr, new)
+	return atomic.LoadInt32(addr)
+}
+
+func deferredCompareAndSwapInt32(addr *int32, a, b int32) int32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapInt32(addr, a, b)
+	return atomic.LoadInt32(addr)
+}
+
+func deferredLoadInt32(addr *int32) int32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadInt32(addr)
+	return atomic.LoadInt32(addr)
+}
+
+func deferredStoreInt32(addr *int32, new int32) int32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StoreInt32(addr, new)
+	return atomic.LoadInt32(addr)
+}
+
+func testInt32() {
+	var value int32
+	var before int32
+	var after int32
+	var success bool
+
+	value = -9
+	before = deferredAddInt32(&value, 11)
+	after = atomic.LoadInt32(&value)
+	success = before == -9 && after == 2
+	println("deferred AddInt32:", success, before, after)
+
+	value = -7
+	before = deferredSwapInt32(&value, 100)
+	after = atomic.LoadInt32(&value)
+	success = before == -7 && after == 100
+	println("deferred SwapInt32:", success, before, after)
+
+	value = -9
+	before = deferredCompareAndSwapInt32(&value, -9, 58)
+	after = atomic.LoadInt32(&value)
+	success = before == -9 && after == 58
+	println("deferred CompareAndSwapInt32:", success, before, after)
+
+	value = -11
+	before = deferredLoadInt32(&value)
+	after = atomic.LoadInt32(&value)
+	success = before == -11 && after == -11
+	println("deferred LoadInt32:", success, before, after)
+
+	value = -11
+	before = deferredStoreInt32(&value, 15)
+	after = atomic.LoadInt32(&value)
+	success = before == -11 && after == 15
+	println("deferred StoreInt32:", success, before, after)
+}
+
+func deferredAddInt64(addr *int64, delta int64) int64 {
+	defer atomic.AddInt64(addr, delta)
+	return atomic.LoadInt64(addr)
+}
+
+func deferredSwapInt64(addr *int64, new int64) int64 {
+	defer atomic.SwapInt64(addr, new)
+	return atomic.LoadInt64(addr)
+}
+
+func deferredCompareAndSwapInt64(addr *int64, a, b int64) int64 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapInt64(addr, a, b)
+	return atomic.LoadInt64(addr)
+}
+
+func deferredLoadInt64(addr *int64) (old int64) {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadInt64(addr)
+	return atomic.LoadInt64(addr)
+}
+
+func deferredStoreInt64(addr *int64, new int64) int64 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StoreInt64(addr, new)
+	return atomic.LoadInt64(addr)
+}
+
+func testInt64() {
+	var value int64
+	var before int64
+	var after int64
+	var success bool
+
+	value = -9
+	before = deferredAddInt64(&value, 11)
+	after = atomic.LoadInt64(&value)
+	success = before == -9 && after == 2
+	println("deferred AddInt64:", success, before, after)
+
+	value = -7
+	before = deferredSwapInt64(&value, 100)
+	after = atomic.LoadInt64(&value)
+	success = before == -7 && after == 100
+	println("deferred SwapInt64:", success, before, after)
+
+	value = -9
+	before = deferredCompareAndSwapInt64(&value, -9, 58)
+	after = atomic.LoadInt64(&value)
+	success = before == -9 && after == 58
+	println("deferred CompareAndSwapInt64:", success, before, after)
+
+	value = -11
+	before = deferredLoadInt64(&value)
+	after = atomic.LoadInt64(&value)
+	success = before == -11 && after == -11
+	println("deferred LoadInt64:", success, before, after)
+
+	value = -11
+	before = deferredStoreInt64(&value, 15)
+	after = atomic.LoadInt64(&value)
+	success = before == -11 && after == 15
+	println("deferred StoreInt64:", success, before, after)
+}
+
+func deferredAddUint32(addr *uint32, delta uint32) uint32 {
+	defer atomic.AddUint32(addr, delta)
+	return atomic.LoadUint32(addr)
+}
+
+func deferredSwapUint32(addr *uint32, new uint32) uint32 {
+	defer atomic.SwapUint32(addr, new)
+	return atomic.LoadUint32(addr)
+}
+
+func deferredCompareAndSwapUint32(addr *uint32, a, b uint32) uint32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapUint32(addr, a, b)
+	return atomic.LoadUint32(addr)
+}
+
+func deferredLoadUint32(addr *uint32) uint32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadUint32(addr)
+	return atomic.LoadUint32(addr)
+}
+
+func deferredStoreUint32(addr *uint32, new uint32) uint32 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StoreUint32(addr, new)
+	return atomic.LoadUint32(addr)
+}
+
+func testUint32() {
+	var value uint32
+	var before uint32
+	var after uint32
+	var success bool
+
+	value = 9
+	before = deferredAddUint32(&value, 11)
+	after = atomic.LoadUint32(&value)
+	success = before == 9 && after == 20
+	println("deferred AddUint32:", success, before, after)
+
+	value = 7
+	before = deferredSwapUint32(&value, 100)
+	after = atomic.LoadUint32(&value)
+	success = before == 7 && after == 100
+	println("deferred SwapUint32:", success, before, after)
+
+	value = 9
+	before = deferredCompareAndSwapUint32(&value, 9, 58)
+	after = atomic.LoadUint32(&value)
+	success = before == 9 && after == 58
+	println("deferred CompareAndSwapUint32:", success, before, after)
+
+	value = 11
+	before = deferredLoadUint32(&value)
+	after = atomic.LoadUint32(&value)
+	success = before == 11 && after == 11
+	println("deferred LoadUint32:", success, before, after)
+
+	value = 11
+	before = deferredStoreUint32(&value, 15)
+	after = atomic.LoadUint32(&value)
+	success = before == 11 && after == 15
+	println("deferred StoreUint32:", success, before, after)
+}
+
+func deferredAddUint64(addr *uint64, delta uint64) uint64 {
+	defer atomic.AddUint64(addr, delta)
+	return atomic.LoadUint64(addr)
+}
+
+func deferredSwapUint64(addr *uint64, new uint64) uint64 {
+	defer atomic.SwapUint64(addr, new)
+	return atomic.LoadUint64(addr)
+}
+
+func deferredCompareAndSwapUint64(addr *uint64, a, b uint64) uint64 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapUint64(addr, a, b)
+	return atomic.LoadUint64(addr)
+}
+
+func deferredLoadUint64(addr *uint64) (old uint64) {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadUint64(addr)
+	return atomic.LoadUint64(addr)
+}
+
+func deferredStoreUint64(addr *uint64, new uint64) uint64 {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StoreUint64(addr, new)
+	return atomic.LoadUint64(addr)
+}
+
+func testUint64() {
+	var value uint64
+	var before uint64
+	var after uint64
+	var success bool
+
+	value = 9
+	before = deferredAddUint64(&value, 11)
+	after = atomic.LoadUint64(&value)
+	success = before == 9 && after == 20
+	println("deferred AddUint64:", success, before, after)
+
+	value = 7
+	before = deferredSwapUint64(&value, 100)
+	after = atomic.LoadUint64(&value)
+	success = before == 7 && after == 100
+	println("deferred SwapUint64:", success, before, after)
+
+	value = 9
+	before = deferredCompareAndSwapUint64(&value, 9, 58)
+	after = atomic.LoadUint64(&value)
+	success = before == 9 && after == 58
+	println("deferred CompareAndSwapUint64:", success, before, after)
+
+	value = 11
+	before = deferredLoadUint64(&value)
+	after = atomic.LoadUint64(&value)
+	success = before == 11 && after == 11
+	println("deferred LoadUint64:", success, before, after)
+
+	value = 11
+	before = deferredStoreUint64(&value, 15)
+	after = atomic.LoadUint64(&value)
+	success = before == 11 && after == 15
+	println("deferred StoreUint64:", success, before, after)
+}
+
+func deferredSwapUintptr(addr *uintptr, new uintptr) uintptr {
+	defer atomic.SwapUintptr(addr, new)
+	return atomic.LoadUintptr(addr)
+}
+
+func deferredCompareAndSwapUintptr(addr *uintptr, a, b uintptr) uintptr {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapUintptr(addr, a, b)
+	return atomic.LoadUintptr(addr)
+}
+
+func deferredLoadUintptr(addr *uintptr) uintptr {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadUintptr(addr)
+	return atomic.LoadUintptr(addr)
+}
+
+func deferredStoreUintptr(addr *uintptr, new uintptr) uintptr {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StoreUintptr(addr, new)
+	return atomic.LoadUintptr(addr)
+}
+
+func testUintptr() {
+	var value uintptr
+	var before uintptr
+	var after uintptr
+	var success bool
+
+	value = 7
+	before = deferredSwapUintptr(&value, 100)
+	after = atomic.LoadUintptr(&value)
+	success = before == 7 && after == 100
+	println("deferred SwapUintptr:", success, before, after)
+
+	value = 9
+	before = deferredCompareAndSwapUintptr(&value, 9, 58)
+	after = atomic.LoadUintptr(&value)
+	success = before == 9 && after == 58
+	println("deferred CompareAndSwapUintptr:", success, before, after)
+
+	value = 11
+	before = deferredLoadUintptr(&value)
+	after = atomic.LoadUintptr(&value)
+	success = before == 11 && after == 11
+	println("deferred LoadUintptr:", success, before, after)
+
+	value = 11
+	before = deferredStoreUintptr(&value, 15)
+	after = atomic.LoadUintptr(&value)
+	success = before == 11 && after == 15
+	println("deferred StoreUintptr:", success, before, after)
+}
+
+func deferredSwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) unsafe.Pointer {
+	defer atomic.SwapPointer(addr, new)
+	return atomic.LoadPointer(addr)
+}
+
+func deferredCompareAndSwapPointer(addr *unsafe.Pointer, a, b unsafe.Pointer) unsafe.Pointer {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value to compare, we test it for completeness
+	defer atomic.CompareAndSwapPointer(addr, a, b)
+	return atomic.LoadPointer(addr)
+}
+
+func deferredLoadPointer(addr *unsafe.Pointer) (old unsafe.Pointer) {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.LoadPointer(addr)
+	return atomic.LoadPointer(addr)
+}
+
+func deferredStorePointer(addr *unsafe.Pointer, new unsafe.Pointer) unsafe.Pointer {
+	// Even though this function doesn't make a lot of sense to be deferred, since you would
+	// not be able to use the value loaded, we test it for completeness
+	defer atomic.StorePointer(addr, new)
+	return atomic.LoadPointer(addr)
+}
+
+func testPointer() {
+	var value uint64
+	var valueP unsafe.Pointer
+	var after unsafe.Pointer
+	var success bool
+
+	valueIn := func(p unsafe.Pointer) uint64 {
+		return *(*uint64)(p)
+	}
+
+	value = 7
+	valueP = unsafe.Pointer(&value)
+	var swapTo uintptr = 100
+	swapToP := unsafe.Pointer(&swapTo)
+	deferredSwapPointer(&valueP, swapToP)
+	after = atomic.LoadPointer(&valueP)
+	success = value == 7 && after == swapToP && valueIn(swapToP) == 100
+	println("deferred SwapPointer:", success)
+
+	value = 9
+	valueP = unsafe.Pointer(&value)
+	swapTo = 58
+	swapToP = unsafe.Pointer(&swapTo)
+	deferredCompareAndSwapPointer(&valueP, valueP, swapToP)
+	after = atomic.LoadPointer(&valueP)
+	success = value == 9 && after == swapToP && valueIn(swapToP) == 58
+	println("deferred CompareAndSwapPointer:", success)
+
+	value = 11
+	valueP = unsafe.Pointer(&value)
+	deferredLoadPointer(&valueP)
+	after = atomic.LoadPointer(&valueP)
+	success = value == 11 && after == valueP && valueIn(valueP) == 11
+	println("deferred LoadPointer:", success)
+
+	value = 11
+	valueP = unsafe.Pointer(&value)
+	swapTo = 15
+	swapToP = unsafe.Pointer(&swapTo)
+	deferredStorePointer(&valueP, unsafe.Pointer(&swapTo))
+	after = atomic.LoadPointer(&valueP)
+	success = value == 11 && after == swapToP && valueIn(swapToP) == 15
+	println("deferred StorePointer:", success)
 }

--- a/testdata/atomic.txt
+++ b/testdata/atomic.txt
@@ -33,3 +33,37 @@ StoreUint32: 20
 StoreUint64: 20
 StoreUintptr: 20
 StorePointer: true
+Int32 --
+deferred AddInt32: true -9 2
+deferred SwapInt32: true -7 100
+deferred CompareAndSwapInt32: true -9 58
+deferred LoadInt32: true -11 -11
+deferred StoreInt32: true -11 15
+Uint32 --
+deferred AddUint32: true 9 20
+deferred SwapUint32: true 7 100
+deferred CompareAndSwapUint32: true 9 58
+deferred LoadUint32: true 11 11
+deferred StoreUint32: true 11 15
+Int64 --
+deferred AddInt64: true -9 2
+deferred SwapInt64: true -7 100
+deferred CompareAndSwapInt64: true -9 58
+deferred LoadInt64: true -11 -11
+deferred StoreInt64: true -11 15
+Uint64 --
+deferred AddUint64: true 9 20
+deferred SwapUint64: true 7 100
+deferred CompareAndSwapUint64: true 9 58
+deferred LoadUint64: true 11 11
+deferred StoreUint64: true 11 15
+Uintptr --
+deferred SwapUintptr: true 7 100
+deferred CompareAndSwapUintptr: true 9 58
+deferred LoadUintptr: true 11 11
+deferred StoreUintptr: true 11 15
+Pointer --
+deferred SwapPointer: true
+deferred CompareAndSwapPointer: true
+deferred LoadPointer: true
+deferred StorePointer: true

--- a/testdata/atomic.txt
+++ b/testdata/atomic.txt
@@ -58,10 +58,10 @@ deferred CompareAndSwapUint64: true 9 58
 deferred LoadUint64: true 11 11
 deferred StoreUint64: true 11 15
 Uintptr --
-deferred SwapUintptr: true 7 100
-deferred CompareAndSwapUintptr: true 9 58
-deferred LoadUintptr: true 11 11
-deferred StoreUintptr: true 11 15
+deferred SwapUintptr: true
+deferred CompareAndSwapUintptr: true
+deferred LoadUintptr: true
+deferred StoreUintptr: true
 Pointer --
 deferred SwapPointer: true
 deferred CompareAndSwapPointer: true


### PR DESCRIPTION
Fixes: https://github.com/tinygo-org/tinygo/issues/2652 , https://github.com/tinygo-org/tinygo/pull/2805
And is part of a larger effort to get Protobufs working with tinygo. https://github.com/tinygo-org/tinygo/issues/2667

Previously discussed [here](https://github.com/tinygo-org/tinygo/issues/2652), and [here](https://github.com/tinygo-org/tinygo/pull/2805).

**Problem**
Deferrred calls to the sync/atomic package would fail with a linker error, since those _functions_ don't really exist in the LLVM representation.

```go
package main

import (
	"sync/atomic"
)

var global uint32

func foo() {
	defer atomic.StoreUint32(&global, 2) // the offending line
	atomic.StoreUint32(&global, 1)
	println(atomic.LoadUint32(&global))
}

func main() {
	foo()
	println(atomic.LoadUint32(&global))
}

```

![image](https://user-images.githubusercontent.com/592178/166161782-0a0f4d7a-0867-46bc-8e34-42050670be6d.png)

**Solution**
After some discussion in the referenced issues, the solution I pursued is to share the previous rewrite code with `createRunDefers`.  (In effect the deferred calls to atomic.* are inlined in exactly the same way).

![image](https://user-images.githubusercontent.com/592178/166162161-9bfac49e-2bc1-455a-96f3-d7d5a8b15a13.png)


**Next Steps**
The amount of code changed is small, and easy to understand, and given this has never worked before - I am fairly confident it won't break anything. The tests 'prove' it works, but given the "run defers" code seems particularly hairy (I would love a second set of eyes on it).

@aykevl this is a slight modification of your original idea [here](https://github.com/tinygo-org/tinygo/pull/2805#pullrequestreview-957580759), do you mind taking a look?

_Please feel free to hack away at my code if you'd find that faster than coordinating the work with me over comments._