### PR TITLE
avr: add full support for float64 and fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-14-v1
+            - llvm-source-14-v2
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-14-v1
+          key: llvm-source-14-v2
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-14-linux-v1
+          key: llvm-source-14-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -179,7 +179,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-14-linux-asserts-v1
+          key: llvm-source-14-linux-asserts-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -276,7 +276,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-14-linux-v1
+          key: llvm-source-14-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-source
         with:
-          key: llvm-source-14-windows-v1
+          key: llvm-source-14-windows-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -40,7 +40,6 @@ var genericBuiltins = []string{
 	"divdf3.c",
 	"divdi3.c",
 	"divmoddi4.c",
-	"divmodsi4.c",
 	"divsc3.c",
 	"divsf3.c",
 	"divsi3.c",
@@ -127,7 +126,6 @@ var genericBuiltins = []string{
 	"ucmpti2.c",
 	"udivdi3.c",
 	"udivmoddi4.c",
-	"udivmodsi4.c",
 	"udivmodti4.c",
 	"udivsi3.c",
 	"udivti3.c",
@@ -154,6 +152,14 @@ var aeabiBuiltins = []string{
 	"arm/aeabi_memset.S",
 	"arm/aeabi_uidivmod.S",
 	"arm/aeabi_uldivmod.S",
+
+	// These two are not technically EABI builtins but are used by them and only
+	// seem to be used on ARM. LLVM seems to use __divsi3 and __modsi3 on most
+	// other architectures.
+	// Most importantly, they have a different calling convention on AVR so
+	// should not be used on AVR.
+	"divmodsi4.c",
+	"udivmodsi4.c",
 }
 
 // CompilerRT is a library with symbols required by programs compiled with LLVM.

--- a/builder/library.go
+++ b/builder/library.go
@@ -148,12 +148,21 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 		// However, ARM has not done this.
 		if strings.HasPrefix(target, "i386") || strings.HasPrefix(target, "x86_64") {
 			args = append(args, "-march="+cpu)
+		} else if strings.HasPrefix(target, "avr") {
+			args = append(args, "-mmcu="+cpu)
 		} else {
 			args = append(args, "-mcpu="+cpu)
 		}
 	}
 	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
 		args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables")
+	}
+	if strings.HasPrefix(target, "avr") {
+		// AVR defaults to C float and double both being 32-bit. This deviates
+		// from what most code (and certainly compiler-rt) expects. So we need
+		// to force the compiler to use 64-bit floating point numbers for
+		// double.
+		args = append(args, "-mdouble=64")
 	}
 	if strings.HasPrefix(target, "riscv32-") {
 		args = append(args, "-march=rv32imac", "-mabi=ilp32", "-fforce-enable-int128")

--- a/main_test.go
+++ b/main_test.go
@@ -146,46 +146,7 @@ func TestBuild(t *testing.T) {
 		// LIBCLANG FATAL ERROR: Cannot select: t3: i16 = JumpTable<0>
 		// This bug is non-deterministic.
 		t.Skip("skipped due to non-deterministic backend bugs")
-
-		var avrTests []string
-		for _, t := range tests {
-			switch t {
-			case "atomic.go":
-				// Requires GCC 11.2.0 or above for interface comparison.
-				// https://github.com/gcc-mirror/gcc/commit/f30dd607669212de135dec1f1d8a93b8954c327c
-
-			case "reflect.go":
-				// Reflect tests do not work due to type code issues.
-
-			case "gc.go":
-				// Does not pass due to high mark false positive rate.
-
-			case "json.go", "stdlib.go", "testing.go":
-				// Breaks interp.
-
-			case "map.go":
-				// Reflect size calculation crashes.
-
-			case "binop.go":
-				// Interface comparison results are inverted.
-
-			case "channel.go":
-				// Freezes after recv from closed channel.
-
-			case "float.go", "math.go", "print.go":
-				// Stuck in runtime.printfloat64.
-
-			case "interface.go":
-				// Several comparison tests fail.
-
-			case "cgo/":
-				// CGo does not work on AVR.
-
-			default:
-				avrTests = append(avrTests, t)
-			}
-		}
-		runPlatTests(optionsFromTarget("simavr", sema), avrTests, t)
+		runPlatTests(optionsFromTarget("simavr", sema), tests, t)
 	})
 
 	if runtime.GOOS == "linux" {
@@ -217,6 +178,54 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 	}
 
 	for _, name := range tests {
+		if options.Target == "simavr" {
+			// Not all tests are currently supported on AVR.
+			// Skip the ones that aren't.
+			switch name {
+			case "atomic.go":
+				// Requires GCC 11.2.0 or above for interface comparison.
+				// https://github.com/gcc-mirror/gcc/commit/f30dd607669212de135dec1f1d8a93b8954c327c
+				continue
+
+			case "reflect.go":
+				// Reflect tests do not work due to type code issues.
+				continue
+
+			case "gc.go":
+				// Does not pass due to high mark false positive rate.
+				continue
+
+			case "json.go", "stdlib.go", "testing.go", "testing_go118.go":
+				// Breaks interp.
+				continue
+
+			case "map.go":
+				// Reflect size calculation crashes.
+				continue
+
+			case "binop.go":
+				// Interface comparison results are inverted.
+				continue
+
+			case "channel.go":
+				// Freezes after recv from closed channel.
+				continue
+
+			case "float.go", "math.go", "print.go":
+				// Stuck in runtime.printfloat64.
+				continue
+
+			case "interface.go":
+				// Several comparison tests fail.
+				continue
+
+			case "cgo/":
+				// CGo does not work on AVR.
+				continue
+
+			default:
+			}
+		}
 		name := name // redefine to avoid race condition
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/main_test.go
+++ b/main_test.go
@@ -182,11 +182,6 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 			// Not all tests are currently supported on AVR.
 			// Skip the ones that aren't.
 			switch name {
-			case "atomic.go":
-				// Requires GCC 11.2.0 or above for interface comparison.
-				// https://github.com/gcc-mirror/gcc/commit/f30dd607669212de135dec1f1d8a93b8954c327c
-				continue
-
 			case "reflect.go":
 				// Reflect tests do not work due to type code issues.
 				continue
@@ -203,20 +198,12 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 				// Reflect size calculation crashes.
 				continue
 
-			case "binop.go":
-				// Interface comparison results are inverted.
-				continue
-
 			case "channel.go":
 				// Freezes after recv from closed channel.
 				continue
 
-			case "float.go", "math.go", "print.go":
-				// Stuck in runtime.printfloat64.
-				continue
-
-			case "interface.go":
-				// Several comparison tests fail.
+			case "math.go":
+				// Stuck somewhere, not sure what's happening.
 				continue
 
 			case "cgo/":

--- a/main_test.go
+++ b/main_test.go
@@ -194,10 +194,6 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 				// Breaks interp.
 				continue
 
-			case "map.go":
-				// Reflect size calculation crashes.
-				continue
-
 			case "channel.go":
 				// Freezes after recv from closed channel.
 				continue

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -6,6 +6,7 @@
 	"gc": "conservative",
 	"linker": "avr-gcc",
 	"scheduler": "none",
+	"rtlib": "compiler-rt",
 	"default-stack-size": 256,
 	"cflags": [
 		"-Werror"

--- a/targets/simavr.json
+++ b/targets/simavr.json
@@ -1,5 +1,5 @@
 {
     "inherits": ["atmega1284p"],
     "scheduler": "tasks",
-    "default-stack-size": 512
+    "default-stack-size": 384
 }

--- a/testdata/map.go
+++ b/testdata/map.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sort"
+	"unsafe"
 )
 
 var testmap1 = map[string]int{"data": 3}
@@ -211,10 +212,12 @@ func testBigMap(squares map[int]int, n int) {
 func mapgrow() {
 	m := make(map[int]int)
 
-	const (
-		Delete = 500
-		N      = Delete * 2
-	)
+	var Delete = 500
+	if unsafe.Sizeof(uintptr(0)) < 4 {
+		// Reduce the number of iterations on low-memory devices like AVR.
+		Delete = 20
+	}
+	var N = Delete * 2
 
 	for i := 0; i < Delete; i++ {
 		m[i] = i
@@ -246,7 +249,7 @@ func mapgrow() {
 		println("bad length post grow/delete", len(m))
 	}
 
-	seen := make([]bool, 500)
+	seen := make([]bool, Delete)
 
 	var mcount int
 	for k, v := range m {


### PR DESCRIPTION
With this change, you can run most tests under AVR:

```
$ go test -target=simavr -run Build -v
[...]
--- PASS: TestBuild (0.00s)
    --- PASS: TestBuild/alias.go (1.71s)
    --- PASS: TestBuild/string.go (2.07s)
    --- PASS: TestBuild/init_multi.go (1.26s)
    --- PASS: TestBuild/goroutines.go (4.22s)
    --- PASS: TestBuild/init.go (1.40s)
    --- PASS: TestBuild/map.go (4.84s)
    --- PASS: TestBuild/interface.go (3.44s)
    --- PASS: TestBuild/slice.go (1.85s)
    --- PASS: TestBuild/print.go (1.93s)
    --- PASS: TestBuild/sort.go (2.56s)
    --- PASS: TestBuild/float.go (2.58s)
    --- PASS: TestBuild/calls.go (2.27s)
    --- PASS: TestBuild/zeroalloc.go (1.24s)
    --- PASS: TestBuild/binop.go (2.26s)
    --- PASS: TestBuild/atomic.go (2.44s)
    --- PASS: TestBuild/go1.17.go (0.99s)
    --- PASS: TestBuild/structs.go (0.96s)
PASS
ok      github.com/tinygo-org/tinygo    9.966s
```

This has taken a lot of work behind the scenes, this PR only shows a small part of it! A number of patches were needed to Clang and compiler-rt to make compiler-rt work for AVR.