### PR TITLE
ci: Add linux/arm64 build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -346,3 +346,103 @@ jobs:
           path: |
             /tmp/tinygo.linux-arm.tar.gz
             /tmp/tinygo_armhf.deb
+  build-linux-arm64:
+    # Build ARM64 Linux binaries, ready for release.
+    # It is set to "needs: build-linux" because it modifies the release created
+    # in that process to avoid doing lots of duplicate work and to avoid
+    # complications around precompiled libraries such as compiler-rt shipped as
+    # part of the release tarball.
+    runs-on: ubuntu-18.04
+    needs: build-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get install --no-install-recommends \
+              qemu-user \
+              g++-aarch64-linux-gnu \
+              libc6-dev-arm64-cross \
+              ninja-build
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.18.1'
+      - name: Cache Go
+        uses: actions/cache@v2
+        with:
+          key: go-cache-linux-arm64-v2-${{ hashFiles('go.mod') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+      - name: Cache LLVM source
+        uses: actions/cache@v2
+        id: cache-llvm-source
+        with:
+          key: llvm-source-14-linux-v1
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Download LLVM source
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        run: make llvm-source
+      - name: Cache LLVM build
+        uses: actions/cache@v2
+        id: cache-llvm-build
+        with:
+          key: llvm-build-14-linux-arm64-v1
+          path: llvm-build
+      - name: Build LLVM
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        run: |
+          # fetch LLVM source
+          rm -rf llvm-project
+          make llvm-source
+          # build!
+          make llvm-build CROSS=aarch64-linux-gnu
+          # Remove unnecessary object files (to reduce cache size).
+          find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Cache Binaryen
+        uses: actions/cache@v2
+        id: cache-binaryen
+        with:
+          key: binaryen-linux-arm64-v1
+          path: build/wasm-opt
+      - name: Build Binaryen
+        if: steps.cache-binaryen.outputs.cache-hit != 'true'
+        run: |
+          git submodule update --init lib/binaryen
+          make CROSS=aarch64-linux-gnu binaryen
+      - name: Install fpm
+        run: |
+          sudo gem install --no-document fpm
+      - name: Build TinyGo binary
+        run: |
+          make CROSS=aarch64-linux-gnu
+      - name: Download amd64 release
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-amd64-double-zipped
+      - name: Extract amd64 release
+        run: |
+          mkdir -p build/release
+          tar -xf tinygo.linux-amd64.tar.gz -C build/release tinygo
+      - name: Modify release
+        run: |
+          cp -p build/tinygo   build/release/tinygo/bin
+          cp -p build/wasm-opt build/release/tinygo/bin
+      - name: Create arm64 release
+        run: |
+          make release deb RELEASEONLY=1 DEB_ARCH=arm64
+          cp -p build/release.tar.gz /tmp/tinygo.linux-arm64.tar.gz
+          cp -p build/release.deb    /tmp/tinygo_arm64.deb
+      - name: Publish release artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-arm64-double-zipped
+          path: |
+            /tmp/tinygo.linux-arm64.tar.gz
+            /tmp/tinygo_arm64.deb

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,15 @@ ifneq ($(CROSS),)
             -DLLVM_TARGET_ARCH=ARM
         GOENVFLAGS = GOARCH=arm CC=$(CC) CXX=$(CXX) CGO_ENABLED=1
         BINARYEN_OPTION += -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX)
+    else ifeq ($(CROSS), aarch64-linux-gnu)
+        # Assume we're building on a Debian-like distro, with QEMU installed.
+        LLVM_CONFIG_PREFIX = qemu-aarch64 -L /usr/aarch64-linux-gnu/
+        # The CMAKE_SYSTEM_NAME flag triggers cross compilation mode.
+        LLVM_OPTION += \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DLLVM_TARGET_ARCH=AArch64
+        GOENVFLAGS = GOARCH=arm64 CC=$(CC) CXX=$(CXX) CGO_ENABLED=1
+        BINARYEN_OPTION += -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX)
     else
         $(error Unknown cross compilation target: $(CROSS))
     endif


### PR DESCRIPTION
Based on the discussion in #2760, this PR adds an `arm64` cross target and test. 