### PR TITLE
build: install scoop without update to avoid bug in ScoopInstaller

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           go-version: '1.18.1'
       - uses: brechtm/setup-scoop@v2
+        with:
+          scoop_update: 'false'
       - name: Install Dependencies
         shell: bash
         run: |


### PR DESCRIPTION
This PR in intended to provide a temporary work-around for https://github.com/ScoopInstaller/Scoop/issues/4917
