### PR TITLE
compiler: make sure zero-sized array types are as small as possible

### DIFF
--- a/compiler/sizes.go
+++ b/compiler/sizes.go
@@ -21,6 +21,12 @@ func (s *stdSizes) Alignof(T types.Type) int64 {
 	// of alignment of the elements and fields, respectively.
 	switch t := T.Underlying().(type) {
 	case *types.Array:
+		if t.Len() == 0 {
+			// 0-sized arrays, always have 0 size.
+			// And from the spec, should have an alignment of _at least_ 1
+			return 1
+		}
+
 		// spec: "For a variable x of array type: unsafe.Alignof(x)
 		// is the same as unsafe.Alignof(x[0]), but at least 1."
 		return s.Alignof(t.Elem())

--- a/testdata/reflect.go
+++ b/testdata/reflect.go
@@ -52,6 +52,12 @@ func main() {
 	println("\nvalues of interfaces")
 	var zeroSlice []byte
 	var zeroFunc func()
+	// by embedding a 0-array func type in your struct, it is not comparable
+	type doNotCompare [0]func()
+	type notComparable struct {
+		doNotCompare
+		data *int32
+	}
 	var zeroMap map[string]int
 	var zeroChan chan int
 	n := 42
@@ -169,6 +175,10 @@ func main() {
 	assertSize(reflect.TypeOf("").Size() == unsafe.Sizeof(""), "string")
 	assertSize(reflect.TypeOf(new(int)).Size() == unsafe.Sizeof(new(int)), "*int")
 	assertSize(reflect.TypeOf(zeroFunc).Size() == unsafe.Sizeof(zeroFunc), "func()")
+
+	// make sure embedding a zero-sized "not comparable" struct does not add size to a struct
+	assertSize(reflect.TypeOf(doNotCompare{}).Size() == unsafe.Sizeof(doNotCompare{}), "[0]func()")
+	assertSize(unsafe.Sizeof(notComparable{}) == unsafe.Sizeof((*int32)(nil)), "struct{[0]func(); *int32}")
 
 	// Test that offset is correctly calculated.
 	// This doesn't just test reflect but also (indirectly) that unsafe.Alignof


### PR DESCRIPTION
As part of an https://github.com/tinygo-org/tinygo/issues/2667 - an effort to use protobufs with tinygo (particularly with WASM):

Fixes https://github.com/tinygo-org/tinygo/issues/2806

**Context**
The protobuf lib at `google.golang.org/protobuf/runtime/protoimpl` includes some code includes some code that acts as a "non-comparable" static check.  I have simplified the code to its minimal repro:

```go
package main

import (
	"unsafe"
)

// DoNotCompare can be embedded in a struct to prevent comparability.
type DoNotCompare [0]func()

type MessageState struct {
	DoNotCompare
	data *int32
}

// Static check that MessageState does not exceed the size of a pointer.
const _ = unsafe.Sizeof(unsafe.Pointer(nil)) - unsafe.Sizeof((MessageState{}))

func main() {
	println("protoc minimal example")
}
```

**Problem**

`alignof([0]func())` was 2 words large, should have only been 1.