### PR TITLE
interp: fix some buggy localValue handling

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -219,6 +219,9 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				if err != nil {
 					return nil, mem, err
 				}
+			case callFn.name == "internal/task.Pause":
+				// Task scheduling isn't possible at compile time.
+				return nil, mem, r.errorAt(inst, errUnsupportedRuntimeInst)
 			case callFn.name == "runtime.nanotime" && r.pkgName == "time":
 				// The time package contains a call to runtime.nanotime.
 				// This appears to be to work around a limitation in Windows


### PR DESCRIPTION
Bug:

 1. `fn.locals[v.value]` returns 0 (the default value) if `v.value` is not part of the fn.locals map.
 2. `locals[fn.locals[v.value]]` then returns the first local value, which is usually non-nil
 3. This incorrect value is then used as the operand value.

The manifestation of this convoluted bug was https://github.com/tinygo-org/tinygo/issues/2842. It didn't occur more often probably because it only seems to happen in practice with inline assembly.

Fixes https://github.com/tinygo-org/tinygo/issues/2842