### PR TITLE
darwin: support -size= flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,8 +634,8 @@ endif
 	@$(MD5SUM) test.hex
 	GOOS=linux GOARCH=arm $(TINYGO) build -size short -o test.elf       ./testdata/cgo
 	GOOS=windows GOARCH=amd64 $(TINYGO) build -size short -o test.exe   ./testdata/cgo
-	GOOS=darwin GOARCH=amd64 $(TINYGO) build              -o test       ./testdata/cgo
-	GOOS=darwin GOARCH=arm64 $(TINYGO) build              -o test       ./testdata/cgo
+	GOOS=darwin GOARCH=amd64 $(TINYGO) build  -size short -o test       ./testdata/cgo
+	GOOS=darwin GOARCH=arm64 $(TINYGO) build  -size short -o test       ./testdata/cgo
 ifneq ($(OS),Windows_NT)
 	# TODO: this does not yet work on Windows. Somehow, unused functions are
 	# not garbage collected.


### PR DESCRIPTION
This is just basic support. It doesn't add support for reading DWARF, because that's a bit complicated on MacOS (it isn't stored in the file itself but separately in the object files). But at least this change makes it possible to easily print executable sizes by section type like for other operating systems.