### PR TITLE
darwin: add support for ThinLTO

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -695,10 +695,15 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 			}
 			if config.UseThinLTO() {
 				ldflags = append(ldflags,
-					"--thinlto-cache-dir="+filepath.Join(cacheDir, "thinlto"),
-					"-plugin-opt=mcpu="+config.CPU(),
-					"-plugin-opt=O"+strconv.Itoa(optLevel),
-					"-plugin-opt=thinlto")
+					"-mllvm", "-mcpu="+config.CPU(),
+					"--lto-O"+strconv.Itoa(optLevel))
+				if config.GOOS() == "darwin" {
+					// Options for the ld64-compatible lld linker.
+					ldflags = append(ldflags, "-cache_path_lto", filepath.Join(cacheDir, "thinlto"))
+				} else {
+					// Options for the ELF linker.
+					ldflags = append(ldflags, "--thinlto-cache-dir="+filepath.Join(cacheDir, "thinlto"))
+				}
 				if config.CodeModel() != "default" {
 					ldflags = append(ldflags,
 						"-mllvm", "-code-model="+config.CodeModel())

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -192,10 +192,6 @@ func (c *Config) UseThinLTO() bool {
 		// through a plugin, but it's too much hassle to set up.
 		return false
 	}
-	if len(parts) >= 2 && strings.HasPrefix(parts[2], "macos") {
-		// We use an external linker here at the moment.
-		return false
-	}
 	if len(parts) >= 2 && parts[2] == "windows" {
 		// Linker error (undefined runtime.trackedGlobalsBitmap) when linking
 		// for Windows. Disable it for now until that's figured out and fixed.


### PR DESCRIPTION
Now that we use the lld linker (see #2586), we can add support for ThinLTO on MacOS. This allows some more optimizations at link time that aren't possible before that point. It also reduces executable sizes a bit, although that's not the main goal (verified using #2864).

The main motivation is that I eventually want to use ThinLTO on all platforms so that we can rely on ThinLTO for certain optimizations.