### PR TITLE
darwin: scan globals by reading MachO header

### DIFF
--- a/interp/memory.go
+++ b/interp/memory.go
@@ -17,6 +17,7 @@ package interp
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"strconv"
@@ -104,28 +105,28 @@ func (mv *memoryView) revert() {
 // means that the interpreter can still read from it, but cannot write to it as
 // that would mean the external read (done at runtime) reads from a state that
 // would not exist had the whole initialization been done at runtime.
-func (mv *memoryView) markExternalLoad(llvmValue llvm.Value) {
-	mv.markExternal(llvmValue, 1)
+func (mv *memoryView) markExternalLoad(llvmValue llvm.Value) error {
+	return mv.markExternal(llvmValue, 1)
 }
 
 // markExternalStore marks the given LLVM value as having an external write.
 // This means that the interpreter can no longer read from it or write to it, as
 // that would happen in a different order than if all initialization were
 // happening at runtime.
-func (mv *memoryView) markExternalStore(llvmValue llvm.Value) {
-	mv.markExternal(llvmValue, 2)
+func (mv *memoryView) markExternalStore(llvmValue llvm.Value) error {
+	return mv.markExternal(llvmValue, 2)
 }
 
 // markExternal is a helper for markExternalLoad and markExternalStore, and
 // should not be called directly.
-func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) {
+func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 	if llvmValue.IsUndef() || llvmValue.IsNull() {
 		// Null and undef definitely don't contain (valid) pointers.
-		return
+		return nil
 	}
 	if !llvmValue.IsAInstruction().IsNil() || !llvmValue.IsAArgument().IsNil() {
 		// These are considered external by default, there is nothing to mark.
-		return
+		return nil
 	}
 
 	if !llvmValue.IsAGlobalValue().IsNil() {
@@ -144,7 +145,10 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) {
 					// Using mark '2' (which means read/write access) because
 					// even from an object that is only read from, the resulting
 					// loaded pointer can be written to.
-					mv.markExternal(initializer, 2)
+					err := mv.markExternal(initializer, 2)
+					if err != nil {
+						return err
+					}
 				}
 			} else {
 				// This is a function. Go through all instructions and mark all
@@ -170,7 +174,10 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) {
 						for i := 0; i < numOperands; i++ {
 							// Using mark '2' (which means read/write access)
 							// because this might be a store instruction.
-							mv.markExternal(inst.Operand(i), 2)
+							err := mv.markExternal(inst.Operand(i), 2)
+							if err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -179,9 +186,12 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) {
 	} else if !llvmValue.IsAConstantExpr().IsNil() {
 		switch llvmValue.Opcode() {
 		case llvm.IntToPtr, llvm.PtrToInt, llvm.BitCast, llvm.GetElementPtr:
-			mv.markExternal(llvmValue.Operand(0), mark)
+			err := mv.markExternal(llvmValue.Operand(0), mark)
+			if err != nil {
+				return err
+			}
 		default:
-			panic("interp: unknown constant expression")
+			return fmt.Errorf("interp: unknown constant expression '%s'", instructionNameMap[llvmValue.Opcode()])
 		}
 	} else if !llvmValue.IsAInlineAsm().IsNil() {
 		// Inline assembly can modify globals but only exported globals. Let's
@@ -196,18 +206,25 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) {
 			numElements := llvmType.StructElementTypesCount()
 			for i := 0; i < numElements; i++ {
 				element := llvm.ConstExtractValue(llvmValue, []uint32{uint32(i)})
-				mv.markExternal(element, mark)
+				err := mv.markExternal(element, mark)
+				if err != nil {
+					return err
+				}
 			}
 		case llvm.ArrayTypeKind:
 			numElements := llvmType.ArrayLength()
 			for i := 0; i < numElements; i++ {
 				element := llvm.ConstExtractValue(llvmValue, []uint32{uint32(i)})
-				mv.markExternal(element, mark)
+				err := mv.markExternal(element, mark)
+				if err != nil {
+					return err
+				}
 			}
 		default:
-			panic("interp: unknown type kind in markExternalValue")
+			return errors.New("interp: unknown type kind in markExternalValue")
 		}
 	}
+	return nil
 }
 
 // hasExternalLoadOrStore returns true if this object has an external load or

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -190,6 +190,16 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 			if err != nil {
 				return err
 			}
+		case llvm.Add, llvm.Sub, llvm.Mul, llvm.UDiv, llvm.SDiv, llvm.URem, llvm.SRem, llvm.Shl, llvm.LShr, llvm.AShr, llvm.And, llvm.Or, llvm.Xor:
+			// Integer binary operators. Mark both operands.
+			err := mv.markExternal(llvmValue.Operand(0), mark)
+			if err != nil {
+				return err
+			}
+			err = mv.markExternal(llvmValue.Operand(1), mark)
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("interp: unknown constant expression '%s'", instructionNameMap[llvmValue.Opcode()])
 		}

--- a/src/runtime/gc_globals_precise.go
+++ b/src/runtime/gc_globals_precise.go
@@ -1,5 +1,5 @@
-//go:build gc.conservative && !baremetal && !tinygo.wasm && !windows
-// +build gc.conservative,!baremetal,!tinygo.wasm,!windows
+//go:build gc.conservative && !baremetal && !darwin && !tinygo.wasm && !windows
+// +build gc.conservative,!baremetal,!darwin,!tinygo.wasm,!windows
 
 package runtime
 

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -3,6 +3,8 @@
 
 package runtime
 
+import "unsafe"
+
 const GOOS = "darwin"
 
 const (
@@ -18,3 +20,93 @@ const (
 	clock_REALTIME      = 0
 	clock_MONOTONIC_RAW = 4
 )
+
+// https://opensource.apple.com/source/xnu/xnu-7195.141.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
+type machHeader struct {
+	magic      uint32
+	cputype    uint32
+	cpusubtype uint32
+	filetype   uint32
+	ncmds      uint32
+	sizeofcmds uint32
+	flags      uint32
+	reserved   uint32
+}
+
+// Struct for the LC_SEGMENT_64 load command.
+type segmentLoadCommand struct {
+	cmd      uint32 // LC_SEGMENT_64
+	cmdsize  uint32
+	segname  [16]byte
+	vmaddr   uintptr
+	vmsize   uintptr
+	fileoff  uintptr
+	filesize uintptr
+	maxprot  uint32
+	initprot uint32
+	nsects   uint32
+	flags    uint32
+}
+
+// MachO header of the currently running process.
+//go:extern _mh_execute_header
+var libc_mh_execute_header machHeader
+
+// Mark global variables.
+// The MachO linker doesn't seem to provide symbols for the start and end of the
+// data section. There is get_etext, get_edata, and get_end, but these are
+// undocumented and don't work with ASLR (which is enabled by default).
+// Therefore, read the MachO header directly.
+func markGlobals() {
+	// Here is a useful blog post to understand the MachO file format:
+	// https://h3adsh0tzz.com/2020/01/macho-file-format/
+
+	const (
+		MH_MAGIC_64   = 0xfeedfacf
+		LC_SEGMENT_64 = 0x19
+		VM_PROT_WRITE = 0x02
+	)
+
+	// Sanity check that we're actually looking at a MachO header.
+	if gcAsserts && libc_mh_execute_header.magic != MH_MAGIC_64 {
+		runtimePanic("gc: unexpected MachO header")
+	}
+
+	// Iterate through the load commands.
+	// Because we're only interested in LC_SEGMENT_64 load commands, cast the
+	// pointer to that struct in advance.
+	var offset uintptr
+	var hasOffset bool
+	cmd := (*segmentLoadCommand)(unsafe.Pointer(uintptr(unsafe.Pointer(&libc_mh_execute_header)) + unsafe.Sizeof(machHeader{})))
+	for i := libc_mh_execute_header.ncmds; i != 0; i-- {
+		if cmd.cmd == LC_SEGMENT_64 {
+			if cmd.fileoff == 0 && cmd.nsects != 0 {
+				// Detect ASLR offset by checking fileoff and nsects. This
+				// locates the __TEXT segment. This matches getsectiondata:
+				// https://opensource.apple.com/source/cctools/cctools-973.0.1/libmacho/getsecbyname.c.auto.html
+				offset = uintptr(unsafe.Pointer(&libc_mh_execute_header)) - cmd.vmaddr
+				hasOffset = true
+			}
+			if cmd.maxprot&VM_PROT_WRITE != 0 {
+				// Found a writable segment, which may contain Go globals.
+				if gcAsserts && !hasOffset {
+					// No ASLR offset detected. Did the __TEXT segment come
+					// after the __DATA segment?
+					// Note that when ASLR is disabled (for example, when
+					// running inside lldb), the offset is zero. That's why we
+					// need a separate hasOffset for this assert.
+					runtimePanic("gc: did not detect ASLR offset")
+				}
+				// Scan this segment for GC roots.
+				// This could be improved by only reading the memory areas
+				// covered by sections. That would reduce the amount of memory
+				// scanned a little bit (up to a single VM page).
+				markRoots(offset+cmd.vmaddr, offset+cmd.vmaddr+cmd.vmsize)
+			}
+		}
+
+		// Move on to the next load command (wich may or may not be a
+		// LC_SEGMENT_64).
+		cmd = (*segmentLoadCommand)(unsafe.Pointer(uintptr(unsafe.Pointer(cmd)) + uintptr(cmd.cmdsize)))
+	}
+}


### PR DESCRIPTION
This replaces "precise" global scanning in LLVM with conservative scanning of writable MachO segments. Eventually I'd like to get rid of the `AddGlobalsBitmap` pass, and this is one step towards that goal.

Draft because it conflicts with #2867.