### PR TITLE
Align API of  PortMaskSet and PortMaskClear to the other MCU implementations 

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -88,8 +88,8 @@ const (
 	PinSPI
 )
 
-func (p Pin) PortMaskSet() (*volatile.Register32, uint32) {
-	return &rp.SIO.GPIO_OUT_SET, 1 << p
+func (p Pin) PortMaskSet() (*uint32, uint32) {
+	return (*uint32)(unsafe.Pointer(&rp.SIO.GPIO_OUT_SET)), 1 << p
 }
 
 // set drives the pin high
@@ -98,8 +98,8 @@ func (p Pin) set() {
 	rp.SIO.GPIO_OUT_SET.Set(mask)
 }
 
-func (p Pin) PortMaskClear() (*volatile.Register32, uint32) {
-	return &rp.SIO.GPIO_OUT_CLR, 1 << p
+func (p Pin) PortMaskClear() (*uint32, uint32) {
+	return (*uint32)(unsafe.Pointer(&rp.SIO.GPIO_OUT_CLR)), 1 << p
 }
 
 // clr drives the pin low


### PR DESCRIPTION
Because of https://github.com/tinygo-org/drivers/pull/407 . Align the API of PortMaskSet and PortMaskClear. Not too sure if this a good idea since data types are coming straight from the SVD files.