### PR TITLE
nintendoswitch: scan globals conservatively

### DIFF
--- a/src/runtime/gc_globals_precise.go
+++ b/src/runtime/gc_globals_precise.go
@@ -1,5 +1,5 @@
-//go:build gc.conservative && !baremetal && !darwin && !tinygo.wasm && !windows
-// +build gc.conservative,!baremetal,!darwin,!tinygo.wasm,!windows
+//go:build gc.conservative && !baremetal && !darwin && !nintendoswitch && !tinygo.wasm && !windows
+// +build gc.conservative,!baremetal,!darwin,!nintendoswitch,!tinygo.wasm,!windows
 
 package runtime
 

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -233,6 +233,31 @@ func getHeapEnd() uintptr {
 	return heapEnd
 }
 
+//go:extern __data_start
+var dataStartSymbol [0]byte
+
+//go:extern __data_end
+var dataEndSymbol [0]byte
+
+//go:extern __bss_start
+var bssStartSymbol [0]byte
+
+//go:extern __bss_end
+var bssEndSymbol [0]byte
+
+// Mark global variables.
+// The linker script provides __*_start and __*_end symbols that can be used to
+// scan the given sections. They are already aligned so don't need to be
+// manually aligned here.
+func markGlobals() {
+	dataStart := uintptr(unsafe.Pointer(&dataStartSymbol))
+	dataEnd := uintptr(unsafe.Pointer(&dataEndSymbol))
+	markRoots(dataStart, dataEnd)
+	bssStart := uintptr(unsafe.Pointer(&bssStartSymbol))
+	bssEnd := uintptr(unsafe.Pointer(&bssEndSymbol))
+	markRoots(bssStart, bssEnd)
+}
+
 // getContextPtr returns the hblauncher context
 // this is externally linked by gonx
 func getContextPtr() uintptr {


### PR DESCRIPTION
This is a step towards #2870, similar to #2867 and #2869. After this, I think only Linux remains.

I did not test this patch, I don't know how to do it. I know there is `yuzu`, but I don't know how to get it to show `println` messages.
@racerxdl can you check that this change didn't break anything?