### PR TITLE
Start moving optimizations to the package build

### DIFF
--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -11,6 +11,34 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
+// OptimizePackage runs optimization passes over the LLVM module for the given
+// Go package.
+func OptimizePackage(mod llvm.Module, config *compileopts.Config) {
+	optLevel, sizeLevel, _ := config.OptLevels()
+
+	// Run function passes for each function in the module.
+	// These passes are intended to be run on each function right
+	// after they're created to reduce IR size (and maybe also for
+	// cache locality to improve performance), but for now they're
+	// run here for each function in turn. Maybe this can be
+	// improved in the future.
+	builder := llvm.NewPassManagerBuilder()
+	defer builder.Dispose()
+	builder.SetOptLevel(optLevel)
+	builder.SetSizeLevel(sizeLevel)
+	funcPasses := llvm.NewFunctionPassManagerForModule(mod)
+	defer funcPasses.Dispose()
+	builder.PopulateFunc(funcPasses)
+	funcPasses.InitializeFunc()
+	for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+		if fn.IsDeclaration() {
+			continue
+		}
+		funcPasses.RunFunc(fn)
+	}
+	funcPasses.FinalizeFunc()
+}
+
 // Optimize runs a number of optimization and transformation passes over the
 // given module. Some passes are specific to TinyGo, others are generic LLVM
 // passes. You can set a preferred performance (0-3) and size (0-2) level and

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -37,6 +37,11 @@ func OptimizePackage(mod llvm.Module, config *compileopts.Config) {
 		funcPasses.RunFunc(fn)
 	}
 	funcPasses.FinalizeFunc()
+
+	// Run TinyGo-specific optimization passes.
+	if optLevel > 0 {
+		OptimizeMaps(mod)
+	}
 }
 
 // Optimize runs a number of optimization and transformation passes over the
@@ -92,7 +97,6 @@ func Optimize(mod llvm.Module, config *compileopts.Config, optLevel, sizeLevel i
 		goPasses.Run(mod)
 
 		// Run TinyGo-specific optimization passes.
-		OptimizeMaps(mod)
 		OptimizeStringToBytes(mod)
 		OptimizeReflectImplements(mod)
 		OptimizeAllocs(mod, nil, nil)


### PR DESCRIPTION
This is for https://github.com/tinygo-org/tinygo/issues/2870.

I'd like to move optimization passes to the package build whenever possible, so that #2870 becomes easier. It should also improve compile time a little bit when the package is already cached although this is probably negligible with the current PR.

This is just a first step to get things going. More changes can be done in separate PRs.