### PR TITLE
fixes `./...` syntax in `tinygo test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,8 @@ tinygo-baremetal:
 .PHONY: smoketest
 smoketest:
 	$(TINYGO) version
+	# regression test for #2892
+	cd tests/testing/recurse && ($(TINYGO) test ./... > recurse.log && cat recurse.log && test $$(wc -l < recurse.log) = 2 && rm recurse.log)
 	# compile-only platform-independent examples
 	cd tests/text/template/smoke && $(TINYGO) test -c && rm -f smoke.test
 	# regression test for #2563

--- a/builder/build.go
+++ b/builder/build.go
@@ -193,7 +193,7 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	defer machine.Dispose()
 
 	// Load entire program AST into memory.
-	lprogram, err := loader.Load(config, []string{pkgName}, config.ClangHeaders, types.Config{
+	lprogram, err := loader.Load(config, pkgName, config.ClangHeaders, types.Config{
 		Sizes: compiler.Sizes(machine),
 	})
 	if err != nil {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -109,7 +109,7 @@ func TestCompiler(t *testing.T) {
 			defer machine.Dispose()
 
 			// Load entire program AST into memory.
-			lprogram, err := loader.Load(config, []string{"./testdata/" + tc.file}, config.ClangHeaders, types.Config{
+			lprogram, err := loader.Load(config, "./testdata/"+tc.file, config.ClangHeaders, types.Config{
 				Sizes: Sizes(machine),
 			})
 			if err != nil {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -104,7 +104,7 @@ type EmbedFile struct {
 // Load loads the given package with all dependencies (including the runtime
 // package). Call .Parse() afterwards to parse all Go files (including CGo
 // processing, if necessary).
-func Load(config *compileopts.Config, inputPkgs []string, clangHeaders string, typeChecker types.Config) (*Program, error) {
+func Load(config *compileopts.Config, inputPkg string, clangHeaders string, typeChecker types.Config) (*Program, error) {
 	goroot, err := GetCachedGoroot(config)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func Load(config *compileopts.Config, inputPkgs []string, clangHeaders string, t
 	if config.TestConfig.CompileTestBinary {
 		extraArgs = append(extraArgs, "-test")
 	}
-	cmd, err := List(config, extraArgs, inputPkgs)
+	cmd, err := List(config, extraArgs, []string{inputPkg})
 	if err != nil {
 		return nil, err
 	}

--- a/tests/testing/recurse/subdir/subdir_test.go
+++ b/tests/testing/recurse/subdir/subdir_test.go
@@ -1,0 +1,6 @@
+package subdir
+
+import "testing"
+
+func TestSubdir(t *testing.T) {
+}

--- a/tests/testing/recurse/top_test.go
+++ b/tests/testing/recurse/top_test.go
@@ -1,0 +1,6 @@
+package top
+
+import "testing"
+
+func TestTop(t *testing.T) {
+}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -146,7 +146,7 @@ func compileGoFileForTesting(t *testing.T, filename string) llvm.Module {
 	defer machine.Dispose()
 
 	// Load entire program AST into memory.
-	lprogram, err := loader.Load(config, []string{filename}, config.ClangHeaders, types.Config{
+	lprogram, err := loader.Load(config, filename, config.ClangHeaders, types.Config{
 		Sizes: compiler.Sizes(machine),
 	})
 	if err != nil {


### PR DESCRIPTION
Adds proper support for `./...` syntax which was broken or maybe never intended to be supported and it only somehow worked because we use `go list` underneath. Allowing to use `./...` is actually a good experience in `go test`.

For example, running the tinygo@0.23.0 like:

```
$ tinygo test ./tests/testing/threedots/...
ok      github.com/tinygo-org/tinygo/tests/testing/threedots/pass       0.106s
```

whereas `./tests/testing/threedots` has two packages.

Closes #2892