### PR TITLE
Attach USB DP to the correct pin on Matrix Portal M4

### DIFF
--- a/src/machine/board_matrixportal-m4.go
+++ b/src/machine/board_matrixportal-m4.go
@@ -49,7 +49,7 @@ const (
 	D36 = PA19  // ESP32 SPI SDO      1[3]   PWM  EXTI3
 	D37 = NoPin // USB Host enable
 	D38 = PA24  // USB DM
-	D39 = PA27  // USB DP
+	D39 = PA25  // USB DP
 	D40 = PA03  // DAC/VREFP
 	D41 = PB10  // Flash QSPI SCK
 	D42 = PB11  // Flash QSPI CS


### PR DESCRIPTION
USB DP wasn't connected to the right pin on Matrix Portal M4. This PR fixes it. I have verified the fix by running `examples/serial`.