### PR TITLE
smoketest: add regression test for 'tinygo test ./...', see #2892

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,8 @@ tinygo-baremetal:
 .PHONY: smoketest
 smoketest:
 	$(TINYGO) version
+	# regression test for #2892
+	cd tests/testing/recurse && ($(TINYGO) test ./... > recurse.log && cat recurse.log && test $$(wc -l < recurse.log) = 2 && rm recurse.log)
 	# compile-only platform-independent examples
 	cd tests/text/template/smoke && $(TINYGO) test -c && rm -f smoke.test
 	# regression test for #2563

--- a/tests/testing/recurse/subdir/subdir_test.go
+++ b/tests/testing/recurse/subdir/subdir_test.go
@@ -1,0 +1,6 @@
+package subdir
+
+import "testing"
+
+func TestSubdir(t *testing.T) {
+}

--- a/tests/testing/recurse/top_test.go
+++ b/tests/testing/recurse/top_test.go
@@ -1,0 +1,6 @@
+package top
+
+import "testing"
+
+func TestTop(t *testing.T) {
+}


### PR DESCRIPTION
tests/testing/recurse has two directories with tests;
"make smoketest" now does "tinygo test ./..." in that directory
and fails if it does not run both directories' tests.

Currently fails because #2892 is not yet fixed.