### PR TITLE
ci: disable autocrlf on windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,11 @@ jobs:
         shell: bash
         run: |
           scoop install ninja binaryen
+      - name: git config
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The source code included in TinyGo, which is created with GitHub Actions, is in CRLF.
I suspect this is due to git autocrlf, so I changed the setting.

https://github.com/tinygo-org/tinygo/releases/download/v0.23.0/tinygo0.23.0.windows-amd64.zip

Maybe this change will make it LF.