### PR TITLE
reflect: add Value.UnsafePointer method

### DIFF
--- a/src/reflect/deepequal.go
+++ b/src/reflect/deepequal.go
@@ -76,7 +76,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]struct{}) bool {
 		if v1.Len() != v2.Len() {
 			return false
 		}
-		if v1.Pointer() == v2.Pointer() {
+		if v1.UnsafePointer() == v2.UnsafePointer() {
 			return true
 		}
 		for i := 0; i < v1.Len(); i++ {
@@ -91,7 +91,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]struct{}) bool {
 		}
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited)
 	case Ptr:
-		if v1.Pointer() == v2.Pointer() {
+		if v1.UnsafePointer() == v2.UnsafePointer() {
 			return true
 		}
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited)
@@ -109,7 +109,7 @@ func deepValueEqual(v1, v2 Value, visited map[visit]struct{}) bool {
 		if v1.Len() != v2.Len() {
 			return false
 		}
-		if v1.Pointer() == v2.Pointer() {
+		if v1.UnsafePointer() == v2.UnsafePointer() {
 			return true
 		}
 		for _, k := range v1.MapKeys() {

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -135,16 +135,22 @@ func (v Value) IsNil() bool {
 // Pointer returns the underlying pointer of the given value for the following
 // types: chan, map, pointer, unsafe.Pointer, slice, func.
 func (v Value) Pointer() uintptr {
+	return uintptr(v.UnsafePointer())
+}
+
+// UnsafePointer returns the underlying pointer of the given value for the
+// following types: chan, map, pointer, unsafe.Pointer, slice, func.
+func (v Value) UnsafePointer() unsafe.Pointer {
 	switch v.Kind() {
 	case Chan, Map, Ptr, UnsafePointer:
-		return uintptr(v.pointer())
+		return v.pointer()
 	case Slice:
 		slice := (*sliceHeader)(v.value)
-		return uintptr(slice.data)
+		return slice.data
 	case Func:
-		panic("unimplemented: (reflect.Value).Pointer()")
+		panic("unimplemented: (reflect.Value).UnsafePointer()")
 	default: // not implemented: Func
-		panic(&ValueError{Method: "Pointer"})
+		panic(&ValueError{Method: "UnsafePointer"})
 	}
 }
 

--- a/src/runtime/interface.go
+++ b/src/runtime/interface.go
@@ -59,7 +59,7 @@ func reflectValueEqual(x, y reflect.Value) bool {
 	case reflect.String:
 		return x.String() == y.String()
 	case reflect.Chan, reflect.Ptr, reflect.UnsafePointer:
-		return x.Pointer() == y.Pointer()
+		return x.UnsafePointer() == y.UnsafePointer()
 	case reflect.Array:
 		for i := 0; i < x.Len(); i++ {
 			if !reflectValueEqual(x.Index(i), y.Index(i)) {


### PR DESCRIPTION
This was added in Go 1.18.

There aren't really many tests here, because the `Value.Pointer()` function is so short I can't see how it goes wrong.

I've also changed some `.Pointer()` to `.UnsafePointer()` calls because I anticipate that will be useful in the future and might help LLVM a little bit.