### PR TITLE
all: Go 1.19 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-14-v2
+            - llvm-source-14-v3
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-14-v2
+          key: llvm-source-14-v3
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include
@@ -45,29 +45,32 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - binaryen-linux-v1
+            - binaryen-linux-v2
       - run:
           name: "Build Binaryen"
           command: |
             make binaryen
       - save_cache:
-          key: binaryen-linux-v1
+          key: binaryen-linux-v2
           paths:
             - build/wasm-opt
   test-linux:
     parameters:
       llvm:
         type: string
+      fmt-check:
+        type: boolean
+        default: true
     steps:
       - checkout
       - submodules
       - run:
           name: "Install apt dependencies"
           command: |
-            echo 'deb https://apt.llvm.org/buster/ llvm-toolchain-buster-<<parameters.llvm>> main' | sudo tee /etc/apt/sources.list.d/llvm.list
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends \
+            echo 'deb https://apt.llvm.org/buster/ llvm-toolchain-buster-<<parameters.llvm>> main' > /etc/apt/sources.list.d/llvm.list
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+            apt-get update
+            apt-get install --no-install-recommends -y \
                 llvm-<<parameters.llvm>>-dev \
                 clang-<<parameters.llvm>> \
                 libclang-<<parameters.llvm>>-dev \
@@ -80,34 +83,46 @@ commands:
       - build-binaryen-linux
       - restore_cache:
           keys:
-            - go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
-            - go-cache-v2-{{ checksum "go.mod" }}
+            - go-cache-v3-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+            - go-cache-v3-{{ checksum "go.mod" }}
       - llvm-source-linux
       - run: go install -tags=llvm<<parameters.llvm>> .
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-systemclang-v5
+            - wasi-libc-sysroot-systemclang-v6
       - run: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-systemclang-v5
+          key: wasi-libc-sysroot-systemclang-v6
           paths:
             - lib/wasi-libc/sysroot
       - run: make gen-device -j4
       - run: make smoketest XTENSA=0
       - save_cache:
-          key: go-cache-v2-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
+          key: go-cache-v3-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - ~/.cache/go-build
             - /go/pkg/mod
-      - run: make fmt-check
+      - when:
+          condition: <<parameters.fmt-check>>
+          steps:
+          - run:
+              name: Check Go code formatting
+              command: make fmt-check
 
 jobs:
   test-llvm13-go116:
     docker:
-      - image: circleci/golang:1.16-buster
+      - image: golang:1.16-buster
     steps:
       - test-linux:
           llvm: "13"
+  test-llvm14-go119:
+    docker:
+      - image: golang:1.19beta1-buster
+    steps:
+      - test-linux:
+          llvm: "14"
+          fmt-check: false
 
 workflows:
   test-all:
@@ -115,3 +130,6 @@ workflows:
       # This tests our lowest supported versions of Go and LLVM, to make sure at
       # least the smoke tests still pass.
       - test-llvm13-go116
+      # This tests a beta version of Go. It should be removed once regular
+      # release builds are built using this version.
+      - test-llvm14-go119

--- a/builder/config.go
+++ b/builder/config.go
@@ -33,8 +33,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 16 || minor > 18 {
-		return nil, fmt.Errorf("requires go version 1.16 through 1.18, got go%d.%d", major, minor)
+	if major != 1 || minor < 16 || minor > 19 {
+		return nil, fmt.Errorf("requires go version 1.16 through 1.19, got go%d.%d", major, minor)
 	}
 
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))


### PR DESCRIPTION
This adds early Go 1.19 support. There are a number of things that don't work yet, but the smoke tests pass so it's at least working for a significant subset of programs.

This change also switches from CircleCI convenience images to upstream Go images. This makes it a bit easier to use the latest Go versions. Also, the convenience images are not updated anymore.