### PR TITLE
avr: add support for `recover()`

### DIFF
--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -71,7 +71,7 @@ func (b *builder) deferInitFunc() {
 		// possibly broken by the C alloca function).
 		// The frame pointer is _not_ saved, because it is marked as clobbered
 		// in the setjmp-like inline assembly.
-		deferFrameType := b.getLLVMType(b.program.ImportedPackage("internal/task").Members["DeferFrame"].Type())
+		deferFrameType := b.getLLVMRuntimeType("deferFrame")
 		b.deferFrame = b.CreateAlloca(deferFrameType, "deferframe.buf")
 		stackPointer := b.readStackPointer()
 		b.createRuntimeCall("setupDeferFrame", []llvm.Value{b.deferFrame, stackPointer}, "")

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -5,12 +5,10 @@ target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }
-%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", %"internal/task.DeferFrame"* }
+%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", i8* }
 %"internal/task.gcData" = type { i8* }
 %"internal/task.state" = type { i32, i8*, %"internal/task.stackState", i1 }
 %"internal/task.stackState" = type { i32, i32 }
-%"internal/task.DeferFrame" = type { i8*, i8*, %"internal/task.DeferFrame"*, i1, %runtime._interface }
-%runtime._interface = type { i32, i8* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv7m-unknown-unknown-eabi"
 
 %runtime._defer = type { i32, %runtime._defer* }
-%runtime.deferFrame = type { i8*, i8*, %runtime.deferFrame*, i1, %runtime._interface }
+%runtime.deferFrame = type { i8*, i8*, [0 x i8*], %runtime.deferFrame*, i1, %runtime._interface }
 %runtime._interface = type { i32, i8* }
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv7m-unknown-unknown-eabi"
 
 %runtime._defer = type { i32, %runtime._defer* }
-%"internal/task.DeferFrame" = type { i8*, i8*, %"internal/task.DeferFrame"*, i1, %runtime._interface }
+%runtime.deferFrame = type { i8*, i8*, %runtime.deferFrame*, i1, %runtime._interface }
 %runtime._interface = type { i32, i8* }
 
 declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
@@ -23,16 +23,16 @@ entry:
   %defer.alloca = alloca { i32, %runtime._defer* }, align 4
   %deferPtr = alloca %runtime._defer*, align 4
   store %runtime._defer* null, %runtime._defer** %deferPtr, align 4
-  %deferframe.buf = alloca %"internal/task.DeferFrame", align 4
+  %deferframe.buf = alloca %runtime.deferFrame, align 4
   %0 = call i8* @llvm.stacksave()
-  call void @runtime.setupDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* %0, i8* undef) #3
+  call void @runtime.setupDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* %0, i8* undef) #3
   %defer.alloca.repack = getelementptr inbounds { i32, %runtime._defer* }, { i32, %runtime._defer* }* %defer.alloca, i32 0, i32 0
   store i32 0, i32* %defer.alloca.repack, align 4
   %defer.alloca.repack16 = getelementptr inbounds { i32, %runtime._defer* }, { i32, %runtime._defer* }* %defer.alloca, i32 0, i32 1
   store %runtime._defer* null, %runtime._defer** %defer.alloca.repack16, align 4
   %1 = bitcast %runtime._defer** %deferPtr to { i32, %runtime._defer* }**
   store { i32, %runtime._defer* }* %defer.alloca, { i32, %runtime._defer* }** %1, align 4
-  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result = icmp eq i32 %setjmp, 0
   br i1 %setjmp.result, label %2, label %lpad
 
@@ -56,7 +56,7 @@ rundefers.loop:                                   ; preds = %rundefers.loophead
   ]
 
 rundefers.callback0:                              ; preds = %rundefers.loop
-  %setjmp1 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp1 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result2 = icmp eq i32 %setjmp1, 0
   br i1 %setjmp.result2, label %4, label %lpad
 
@@ -68,11 +68,11 @@ rundefers.default:                                ; preds = %rundefers.loop
   unreachable
 
 rundefers.end:                                    ; preds = %rundefers.loophead
-  call void @runtime.destroyDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* undef) #3
+  call void @runtime.destroyDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* undef) #3
   ret void
 
 recover:                                          ; preds = %rundefers.end3
-  call void @runtime.destroyDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* undef) #3
+  call void @runtime.destroyDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* undef) #3
   ret void
 
 lpad:                                             ; preds = %rundefers.callback012, %rundefers.callback0, %entry
@@ -94,7 +94,7 @@ rundefers.loop5:                                  ; preds = %rundefers.loophead6
   ]
 
 rundefers.callback012:                            ; preds = %rundefers.loop5
-  %setjmp14 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp14 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result15 = icmp eq i32 %setjmp14, 0
   br i1 %setjmp.result15, label %6, label %lpad
 
@@ -112,7 +112,7 @@ rundefers.end3:                                   ; preds = %rundefers.loophead6
 ; Function Attrs: nofree nosync nounwind willreturn
 declare i8* @llvm.stacksave() #2
 
-declare void @runtime.setupDeferFrame(%"internal/task.DeferFrame"* dereferenceable_or_null(24), i8*, i8*) #0
+declare void @runtime.setupDeferFrame(%runtime.deferFrame* dereferenceable_or_null(24), i8*, i8*) #0
 
 ; Function Attrs: nounwind
 define hidden void @"main.deferSimple$1"(i8* %context) unnamed_addr #1 {
@@ -121,7 +121,7 @@ entry:
   ret void
 }
 
-declare void @runtime.destroyDeferFrame(%"internal/task.DeferFrame"* dereferenceable_or_null(24), i8*) #0
+declare void @runtime.destroyDeferFrame(%runtime.deferFrame* dereferenceable_or_null(24), i8*) #0
 
 declare void @runtime.printint32(i32, i8*) #0
 
@@ -132,9 +132,9 @@ entry:
   %defer.alloca = alloca { i32, %runtime._defer* }, align 4
   %deferPtr = alloca %runtime._defer*, align 4
   store %runtime._defer* null, %runtime._defer** %deferPtr, align 4
-  %deferframe.buf = alloca %"internal/task.DeferFrame", align 4
+  %deferframe.buf = alloca %runtime.deferFrame, align 4
   %0 = call i8* @llvm.stacksave()
-  call void @runtime.setupDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* %0, i8* undef) #3
+  call void @runtime.setupDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* %0, i8* undef) #3
   %defer.alloca.repack = getelementptr inbounds { i32, %runtime._defer* }, { i32, %runtime._defer* }* %defer.alloca, i32 0, i32 0
   store i32 0, i32* %defer.alloca.repack, align 4
   %defer.alloca.repack26 = getelementptr inbounds { i32, %runtime._defer* }, { i32, %runtime._defer* }* %defer.alloca, i32 0, i32 1
@@ -148,7 +148,7 @@ entry:
   store { i32, %runtime._defer* }* %defer.alloca, { i32, %runtime._defer* }** %2, align 4
   %3 = bitcast %runtime._defer** %deferPtr to { i32, %runtime._defer* }**
   store { i32, %runtime._defer* }* %defer.alloca2, { i32, %runtime._defer* }** %3, align 4
-  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result = icmp eq i32 %setjmp, 0
   br i1 %setjmp.result, label %4, label %lpad
 
@@ -173,7 +173,7 @@ rundefers.loop:                                   ; preds = %rundefers.loophead
   ]
 
 rundefers.callback0:                              ; preds = %rundefers.loop
-  %setjmp4 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp4 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result5 = icmp eq i32 %setjmp4, 0
   br i1 %setjmp.result5, label %6, label %lpad
 
@@ -182,7 +182,7 @@ rundefers.callback0:                              ; preds = %rundefers.loop
   br label %rundefers.loophead
 
 rundefers.callback1:                              ; preds = %rundefers.loop
-  %setjmp7 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp7 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result8 = icmp eq i32 %setjmp7, 0
   br i1 %setjmp.result8, label %7, label %lpad
 
@@ -194,11 +194,11 @@ rundefers.default:                                ; preds = %rundefers.loop
   unreachable
 
 rundefers.end:                                    ; preds = %rundefers.loophead
-  call void @runtime.destroyDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* undef) #3
+  call void @runtime.destroyDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* undef) #3
   ret void
 
 recover:                                          ; preds = %rundefers.end9
-  call void @runtime.destroyDeferFrame(%"internal/task.DeferFrame"* nonnull %deferframe.buf, i8* undef) #3
+  call void @runtime.destroyDeferFrame(%runtime.deferFrame* nonnull %deferframe.buf, i8* undef) #3
   ret void
 
 lpad:                                             ; preds = %rundefers.callback122, %rundefers.callback018, %rundefers.callback1, %rundefers.callback0, %entry
@@ -221,7 +221,7 @@ rundefers.loop11:                                 ; preds = %rundefers.loophead1
   ]
 
 rundefers.callback018:                            ; preds = %rundefers.loop11
-  %setjmp20 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp20 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result21 = icmp eq i32 %setjmp20, 0
   br i1 %setjmp.result21, label %9, label %lpad
 
@@ -230,7 +230,7 @@ rundefers.callback018:                            ; preds = %rundefers.loop11
   br label %rundefers.loophead12
 
 rundefers.callback122:                            ; preds = %rundefers.loop11
-  %setjmp24 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%"internal/task.DeferFrame"* nonnull %deferframe.buf) #4
+  %setjmp24 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(%runtime.deferFrame* nonnull %deferframe.buf) #4
   %setjmp.result25 = icmp eq i32 %setjmp24, 0
   br i1 %setjmp.result25, label %10, label %lpad
 

--- a/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
@@ -5,11 +5,9 @@ target triple = "thumbv7m-unknown-unknown-eabi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }
-%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", %"internal/task.DeferFrame"* }
+%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", i8* }
 %"internal/task.gcData" = type {}
 %"internal/task.state" = type { i32, i32* }
-%"internal/task.DeferFrame" = type { i8*, i8*, %"internal/task.DeferFrame"*, i1, %runtime._interface }
-%runtime._interface = type { i32, i8* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
 @"main$string" = internal unnamed_addr constant [4 x i8] c"test", align 1

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -5,12 +5,10 @@ target triple = "wasm32-unknown-wasi"
 
 %runtime.channel = type { i32, i32, i8, %runtime.channelBlockedList*, i32, i32, i32, i8* }
 %runtime.channelBlockedList = type { %runtime.channelBlockedList*, %"internal/task.Task"*, %runtime.chanSelectState*, { %runtime.channelBlockedList*, i32, i32 } }
-%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", %"internal/task.DeferFrame"* }
+%"internal/task.Task" = type { %"internal/task.Task"*, i8*, i64, %"internal/task.gcData", %"internal/task.state", i8* }
 %"internal/task.gcData" = type { i8* }
 %"internal/task.state" = type { i32, i8*, %"internal/task.stackState", i1 }
 %"internal/task.stackState" = type { i32, i32 }
-%"internal/task.DeferFrame" = type { i8*, i8*, %"internal/task.DeferFrame"*, i1, %runtime._interface }
-%runtime._interface = type { i32, i8* }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
 @"main$string" = internal unnamed_addr constant [4 x i8] c"test", align 1

--- a/main_test.go
+++ b/main_test.go
@@ -349,6 +349,7 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		actual = bytes.Replace(actual, []byte{0x1b, '[', '3', '2', 'm'}, nil, -1)
 		actual = bytes.Replace(actual, []byte{0x1b, '[', '0', 'm'}, nil, -1)
 		actual = bytes.Replace(actual, []byte{'.', '.', '\n'}, []byte{'\n'}, -1)
+		actual = bytes.Replace(actual, []byte{'\n', '.', '\n'}, []byte{'\n', '\n'}, -1)
 	}
 	if name == "testing.go" {
 		// Strip actual time.

--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -23,19 +23,7 @@ type Task struct {
 
 	// DeferFrame stores a pointer to the (stack allocated) defer frame of the
 	// goroutine that is used for the recover builtin.
-	DeferFrame *DeferFrame
-}
-
-// DeferFrame is a stack allocated object that stores information for the
-// current "defer frame", which is used in functions that use the `defer`
-// keyword.
-// The compiler knows the JumpPC struct offset.
-type DeferFrame struct {
-	JumpSP     unsafe.Pointer // stack pointer to return to
-	JumpPC     unsafe.Pointer // pc to return to
-	Previous   *DeferFrame    // previous recover buffer pointer
-	Panicking  bool           // true iff this defer frame is panicking
-	PanicValue interface{}    // panic value, might be nil for panic(nil) for example
+	DeferFrame unsafe.Pointer
 }
 
 // getGoroutineStackSize is a compiler intrinsic that returns the stack size for

--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -5,6 +5,8 @@ const GOARCH = "386"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
+const deferExtraRegs = 0
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 15) &^ 15

--- a/src/runtime/arch_amd64.go
+++ b/src/runtime/arch_amd64.go
@@ -5,6 +5,8 @@ const GOARCH = "amd64"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 64
 
+const deferExtraRegs = 0
+
 // Align a pointer.
 // Note that some amd64 instructions (like movaps) expect 16-byte aligned
 // memory, thus the result must be 16-byte aligned.

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -8,6 +8,8 @@ const GOARCH = "arm"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
+const deferExtraRegs = 0
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 3) &^ 3

--- a/src/runtime/arch_arm64.go
+++ b/src/runtime/arch_arm64.go
@@ -5,6 +5,8 @@ const GOARCH = "arm64"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 64
 
+const deferExtraRegs = 0
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 7) &^ 7

--- a/src/runtime/arch_avr.go
+++ b/src/runtime/arch_avr.go
@@ -10,6 +10,8 @@ const GOARCH = "arm" // avr pretends to be arm
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 8
 
+const deferExtraRegs = 1 // the frame pointer (Y register) also needs to be stored
+
 // Align on a word boundary.
 func align(ptr uintptr) uintptr {
 	// No alignment necessary on the AVR.

--- a/src/runtime/arch_cortexm.go
+++ b/src/runtime/arch_cortexm.go
@@ -12,6 +12,8 @@ const GOARCH = "arm"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
+const deferExtraRegs = 0
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 3) &^ 3

--- a/src/runtime/arch_tinygoriscv.go
+++ b/src/runtime/arch_tinygoriscv.go
@@ -5,6 +5,8 @@ package runtime
 
 import "device/riscv"
 
+const deferExtraRegs = 0
+
 func getCurrentStackPointer() uintptr {
 	return uintptr(stacksave())
 }

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -12,6 +12,8 @@ const GOARCH = "wasm"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
+const deferExtraRegs = 0
+
 //go:extern __heap_base
 var heapStartSymbol [0]byte
 

--- a/src/runtime/arch_xtensa.go
+++ b/src/runtime/arch_xtensa.go
@@ -8,6 +8,8 @@ const GOARCH = "arm" // xtensa pretends to be arm
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
+const deferExtraRegs = 0
+
 // Align on a word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 3) &^ 3

--- a/src/runtime/asm_386.S
+++ b/src/runtime/asm_386.S
@@ -28,6 +28,7 @@ tinygo_scanCurrentStack:
 tinygo_longjmp:
     // Note: the code we jump to assumes eax is set to a non-zero value if we
     // jump from here.
-    movl 8(%esp), %eax // jumpPC (stash in volatile register)
-    movl 4(%esp), %esp // jumpSP
+    movl 4(%esp), %eax
+    movl 0(%eax), %esp // jumpSP
+    movl 4(%eax), %eax // jumpPC (stash in volatile register)
     jmpl *%eax

--- a/src/runtime/asm_amd64.S
+++ b/src/runtime/asm_amd64.S
@@ -37,11 +37,11 @@ tinygo_longjmp:
 .global _tinygo_longjmp
 _tinygo_longjmp:
 #endif
-    // Note: the code we jump to assumes rax is non-zero so we have to load it
-    // with some value here.
-    movq $1, %rax
-    movq %rdi, %rsp // jumpSP
-    jmpq *%rsi      // jumpPC
+    // Note: the code we jump to assumes rax is set to a non-zero value if we
+    // jump from here, so we use rax as the temporary value for jumpPC.
+    movq 0(%rdi), %rsp // jumpSP
+    movq 8(%rdi), %rax // jumpPC
+    jmpq *%rax
 
 
 #ifdef __MACH__ // Darwin

--- a/src/runtime/asm_amd64_windows.S
+++ b/src/runtime/asm_amd64_windows.S
@@ -24,8 +24,8 @@ tinygo_scanCurrentStack:
 .section .text.tinygo_longjmp,"ax"
 .global tinygo_longjmp
 tinygo_longjmp:
-    // Note: the code we jump to assumes rax is non-zero so we have to load it
-    // with some value here.
-    movq $1, %rax
-    movq %rcx, %rsp // jumpSP
-    jmpq *%rdx      // jumpPC
+    // Note: the code we jump to assumes rax is set to a non-zero value if we
+    // jump from here, so we use rax as the temporary value for jumpPC.
+    movq 0(%rcx), %rsp // jumpSP
+    movq 8(%rcx), %rax // jumpPC
+    jmpq *%rax

--- a/src/runtime/asm_arm.S
+++ b/src/runtime/asm_arm.S
@@ -40,6 +40,8 @@ tinygo_longjmp:
     .cfi_startproc
     // Note: the code we jump to assumes r0 is set to a non-zero value if we
     // jump from here (which is conveniently already the case).
+
+    ldm r0, {r0, r1}
     mov sp, r0 // jumpSP
     mov pc, r1 // jumpPC
     .cfi_endproc

--- a/src/runtime/asm_arm64.S
+++ b/src/runtime/asm_arm64.S
@@ -43,5 +43,6 @@ tinygo_longjmp:
 #endif
     // Note: the code we jump to assumes x0 is set to a non-zero value if we
     // jump from here (which is conveniently already the case).
-    mov sp, x0 // jumpSP
-    br  x1     // jumpPC
+    ldp x1, x2, [x0] // jumpSP, jumpPC
+    mov sp, x1
+    br  x2

--- a/src/runtime/asm_avr.S
+++ b/src/runtime/asm_avr.S
@@ -50,3 +50,33 @@ tinygo_scanCurrentStack:
     pop r17
     pop r28 // Y
     pop r29 // Y
+
+
+.section .text.tinygo_longjmp
+.global tinygo_longjmp
+tinygo_longjmp:
+    ; Move the *DeferFrame pointer to the X register.
+    mov r26, r24
+    mov r27, r25
+
+    ; Load the stack pointer
+    ld r24, X+
+    ld r25, X+
+
+    ; Switch to the given stack pointer.
+    in r0, 0x3f   ; SREG
+    cli           ; disable interrupts
+    out 0x3d, r24 ; SPL
+    out 0x3f, r0  ; re-enable interrupts (with one instruction delay)
+    out 0x3e, r25 ; SPH
+
+    ; Load the new PC
+    ld r30, X+
+    ld r31, X+
+
+    ; Load the new Y register
+    ld r28, X+
+    ld r29, X+
+
+    ; Jump to the PC (stored in the Z register)
+    icall

--- a/src/runtime/asm_riscv.S
+++ b/src/runtime/asm_riscv.S
@@ -46,6 +46,7 @@ tinygo_scanCurrentStack:
 .global tinygo_longjmp
 tinygo_longjmp:
     // Note: the code we jump to assumes a0 is non-zero, which is already the
-    // case because that's jumpSP (the stack pointer).
-    mv sp, a0 // jumpSP
-    jr a1     // jumpPC
+    // case because that's the defer frame pointer.
+    lw sp, 0(a0)       // jumpSP
+    lw a1, REGSIZE(a0) // jumpPC
+    jr a1

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -13,7 +13,7 @@ func trap()
 // Inline assembly stub. It is essentially C longjmp but modified a bit for the
 // purposes of TinyGo. It restores the stack pointer and jumps to the given pc.
 //export tinygo_longjmp
-func tinygo_longjmp(sp, pc unsafe.Pointer)
+func tinygo_longjmp(frame *task.DeferFrame)
 
 // Compiler intrinsic.
 // Returns whether recover is supported on the current architecture.
@@ -26,7 +26,7 @@ func _panic(message interface{}) {
 		if frame != nil {
 			frame.PanicValue = message
 			frame.Panicking = true
-			tinygo_longjmp(frame.JumpSP, frame.JumpPC)
+			tinygo_longjmp(frame)
 			// unreachable
 		}
 	}

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -25,11 +25,12 @@ func supportsRecover() bool
 // The compiler knows about the JumpPC struct offset, so it should not be moved
 // without also updating compiler/defer.go.
 type deferFrame struct {
-	JumpSP     unsafe.Pointer // stack pointer to return to
-	JumpPC     unsafe.Pointer // pc to return to
-	Previous   *deferFrame    // previous recover buffer pointer
-	Panicking  bool           // true iff this defer frame is panicking
-	PanicValue interface{}    // panic value, might be nil for panic(nil) for example
+	JumpSP     unsafe.Pointer                 // stack pointer to return to
+	JumpPC     unsafe.Pointer                 // pc to return to
+	ExtraRegs  [deferExtraRegs]unsafe.Pointer // extra registers (depending on the architecture)
+	Previous   *deferFrame                    // previous recover buffer pointer
+	Panicking  bool                           // true iff this defer frame is panicking
+	PanicValue interface{}                    // panic value, might be nil for panic(nil) for example
 }
 
 // Builtin function panic(msg), used as a compiler intrinsic.


### PR DESCRIPTION
You can see that it works with the following command:

    tinygo run -target=simavr ./testdata/recover.go

This also gets the following tests to pass again (which started failing since #2331):

    go test -run=Build -target=simavr -v

Adding support for AVR was a bit more compliated because it's also necessary to save and restore the Y register. That's why the first two commits move things around a bit.