### PR TITLE
all: run gofmt on all source code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,14 @@ commands:
           key: wasi-libc-sysroot-systemclang-v6
           paths:
             - lib/wasi-libc/sysroot
+      - when:
+          condition: <<parameters.fmt-check>>
+          steps:
+          - run:
+              # Do this before gen-device so that it doesn't check the
+              # formatting of generated files.
+              name: Check Go code formatting
+              command: make fmt-check
       - run: make gen-device -j4
       - run: make smoketest XTENSA=0
       - save_cache:
@@ -102,12 +110,6 @@ commands:
           paths:
             - ~/.cache/go-build
             - /go/pkg/mod
-      - when:
-          condition: <<parameters.fmt-check>>
-          steps:
-          - run:
-              name: Check Go code formatting
-              command: make fmt-check
 
 jobs:
   test-llvm13-go116:

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ endif
 clean:
 	@rm -rf build
 
-FMT_PATHS = ./*.go builder cgo compiler interp loader src/device/arm src/examples src/machine src/os src/reflect src/runtime src/sync src/syscall src/testing src/internal/reflectlite transform
+FMT_PATHS = ./*.go builder cgo/*.go compiler interp loader src transform
 fmt:
 	@gofmt -l -w $(FMT_PATHS)
 fmt-check:

--- a/src/crypto/rand/rand_arc4random.go
+++ b/src/crypto/rand/rand_arc4random.go
@@ -1,3 +1,4 @@
+//go:build darwin || tinygo.wasm
 // +build darwin tinygo.wasm
 
 // This implementation of crypto/rand uses the arc4random_buf function

--- a/src/crypto/rand/rand_urandom.go
+++ b/src/crypto/rand/rand_urandom.go
@@ -1,3 +1,4 @@
+//go:build linux && !baremetal && !wasi
 // +build linux,!baremetal,!wasi
 
 // This implementation of crypto/rand uses the /dev/urandom pseudo-file to

--- a/src/device/nxp/mimxrt1062_mpu.go
+++ b/src/device/nxp/mimxrt1062_mpu.go
@@ -193,12 +193,12 @@ func enableIcache(enable bool) {
 			arm.Asm("dsb 0xF")
 			arm.Asm("isb 0xF")
 		} else {
-		arm.Asm("dsb 0xF")
-		arm.Asm("isb 0xF")
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 			SystemControl.CCR.ClearBits(SCB_CCR_IC_Msk)
 			SystemControl.ICIALLU.Set(0)
-		arm.Asm("dsb 0xF")
-		arm.Asm("isb 0xF")
+			arm.Asm("dsb 0xF")
+			arm.Asm("isb 0xF")
 		}
 	}
 }

--- a/src/internal/fuzz/fuzz.go
+++ b/src/internal/fuzz/fuzz.go
@@ -115,7 +115,7 @@ func CheckCorpus(vals []any, types []reflect.Type) error {
 	return errors.New("not implemented")
 }
 
-func ResetCoverage() {}
+func ResetCoverage()    {}
 func SnapshotCoverage() {}
 
 // RunFuzzWorker is called in a worker process to communicate with the

--- a/src/internal/task/task_none.go
+++ b/src/internal/task/task_none.go
@@ -1,3 +1,4 @@
+//go:build scheduler.none
 // +build scheduler.none
 
 package task

--- a/src/internal/task/task_stack_386.go
+++ b/src/internal/task/task_stack_386.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && 386
 // +build scheduler.tasks,386
 
 package task

--- a/src/internal/task/task_stack_amd64.go
+++ b/src/internal/task/task_stack_amd64.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && amd64 && !windows
 // +build scheduler.tasks,amd64,!windows
 
 package task

--- a/src/internal/task/task_stack_amd64_windows.go
+++ b/src/internal/task/task_stack_amd64_windows.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && amd64 && windows
 // +build scheduler.tasks,amd64,windows
 
 package task

--- a/src/internal/task/task_stack_arm.go
+++ b/src/internal/task/task_stack_arm.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && arm && !cortexm && !avr && !xtensa && !tinygo.riscv
 // +build scheduler.tasks,arm,!cortexm,!avr,!xtensa,!tinygo.riscv
 
 package task

--- a/src/internal/task/task_stack_arm64.go
+++ b/src/internal/task/task_stack_arm64.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && arm64
 // +build scheduler.tasks,arm64
 
 package task

--- a/src/internal/task/task_stack_avr.go
+++ b/src/internal/task/task_stack_avr.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && avr
 // +build scheduler.tasks,avr
 
 package task

--- a/src/internal/task/task_stack_cortexm.go
+++ b/src/internal/task/task_stack_cortexm.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && cortexm
 // +build scheduler.tasks,cortexm
 
 package task

--- a/src/internal/task/task_stack_esp32.go
+++ b/src/internal/task/task_stack_esp32.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && esp32
 // +build scheduler.tasks,esp32
 
 package task

--- a/src/internal/task/task_stack_esp8266.go
+++ b/src/internal/task/task_stack_esp8266.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && esp8266
 // +build scheduler.tasks,esp8266
 
 package task

--- a/src/internal/task/task_stack_tinygoriscv.go
+++ b/src/internal/task/task_stack_tinygoriscv.go
@@ -1,3 +1,4 @@
+//go:build scheduler.tasks && tinygo.riscv
 // +build scheduler.tasks,tinygo.riscv
 
 package task

--- a/src/net/interface_tinygo.go
+++ b/src/net/interface_tinygo.go
@@ -1,3 +1,4 @@
+//go:build tinygo
 // +build tinygo
 
 package net


### PR DESCRIPTION
Some source code wasn't part of `FMT_PATHS` so wasn't checked for correct formatting. This change includes all this source code and excludes cgo/testdata because it contains files that can't be parsed.