### PR TITLE
Define intrinsic functions

### DIFF
--- a/compiler/atomic.go
+++ b/compiler/atomic.go
@@ -4,19 +4,17 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/tools/go/ssa"
 	"tinygo.org/x/go-llvm"
 )
 
-// createAtomicOp lowers an atomic library call by lowering it as an LLVM atomic
-// operation. It returns the result of the operation and true if the call could
-// be lowered inline, and false otherwise.
-func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
-	name := call.Value.(*ssa.Function).Name()
+// createAtomicOp lowers a sync/atomic function by lowering it as an LLVM atomic
+// operation. It returns the result of the operation, or a zero llvm.Value if
+// the result is void.
+func (b *builder) createAtomicOp(name string) llvm.Value {
 	switch name {
 	case "AddInt32", "AddInt64", "AddUint32", "AddUint64", "AddUintptr":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := b.getValue(b.fn.Params[0])
+		val := b.getValue(b.fn.Params[1])
 		if strings.HasPrefix(b.Triple, "avr") {
 			// AtomicRMW does not work on AVR as intended:
 			// - There are some register allocation issues (fixed by https://reviews.llvm.org/D97127 which is not yet in a usable LLVM release)
@@ -29,17 +27,18 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 			}
 			oldVal := b.createCall(fn, []llvm.Value{ptr, val}, "")
 			// Return the new value, not the original value returned.
-			return b.CreateAdd(oldVal, val, ""), true
+			return b.CreateAdd(oldVal, val, "")
 		}
 		oldVal := b.CreateAtomicRMW(llvm.AtomicRMWBinOpAdd, ptr, val, llvm.AtomicOrderingSequentiallyConsistent, true)
 		// Return the new value, not the original value returned by atomicrmw.
-		return b.CreateAdd(oldVal, val, ""), true
+		return b.CreateAdd(oldVal, val, "")
 	case "SwapInt32", "SwapInt64", "SwapUint32", "SwapUint64", "SwapUintptr", "SwapPointer":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := b.getValue(b.fn.Params[0])
+		val := b.getValue(b.fn.Params[1])
 		isPointer := val.Type().TypeKind() == llvm.PointerTypeKind
 		if isPointer {
 			// atomicrmw only supports integers, so cast to an integer.
+			// TODO: this is fixed in LLVM 15.
 			val = b.CreatePtrToInt(val, b.uintptrType, "")
 			ptr = b.CreateBitCast(ptr, llvm.PointerType(val.Type(), 0), "")
 		}
@@ -47,23 +46,23 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 		if isPointer {
 			oldVal = b.CreateIntToPtr(oldVal, b.i8ptrType, "")
 		}
-		return oldVal, true
+		return oldVal
 	case "CompareAndSwapInt32", "CompareAndSwapInt64", "CompareAndSwapUint32", "CompareAndSwapUint64", "CompareAndSwapUintptr", "CompareAndSwapPointer":
-		ptr := b.getValue(call.Args[0])
-		old := b.getValue(call.Args[1])
-		newVal := b.getValue(call.Args[2])
+		ptr := b.getValue(b.fn.Params[0])
+		old := b.getValue(b.fn.Params[1])
+		newVal := b.getValue(b.fn.Params[2])
 		tuple := b.CreateAtomicCmpXchg(ptr, old, newVal, llvm.AtomicOrderingSequentiallyConsistent, llvm.AtomicOrderingSequentiallyConsistent, true)
 		swapped := b.CreateExtractValue(tuple, 1, "")
-		return swapped, true
+		return swapped
 	case "LoadInt32", "LoadInt64", "LoadUint32", "LoadUint64", "LoadUintptr", "LoadPointer":
-		ptr := b.getValue(call.Args[0])
+		ptr := b.getValue(b.fn.Params[0])
 		val := b.CreateLoad(ptr, "")
 		val.SetOrdering(llvm.AtomicOrderingSequentiallyConsistent)
 		val.SetAlignment(b.targetData.PrefTypeAlignment(val.Type())) // required
-		return val, true
+		return val
 	case "StoreInt32", "StoreInt64", "StoreUint32", "StoreUint64", "StoreUintptr", "StorePointer":
-		ptr := b.getValue(call.Args[0])
-		val := b.getValue(call.Args[1])
+		ptr := b.getValue(b.fn.Params[0])
+		val := b.getValue(b.fn.Params[1])
 		if strings.HasPrefix(b.Triple, "avr") {
 			// SelectionDAGBuilder is currently missing the "are unaligned atomics allowed" check for stores.
 			vType := val.Type()
@@ -79,13 +78,15 @@ func (b *builder) createAtomicOp(call *ssa.CallCommon) (llvm.Value, bool) {
 			if fn.IsNil() {
 				fn = llvm.AddFunction(b.mod, name, llvm.FunctionType(vType, []llvm.Type{ptr.Type(), vType, b.uintptrType}, false))
 			}
-			return b.createCall(fn, []llvm.Value{ptr, val, llvm.ConstInt(b.uintptrType, 5, false)}, ""), true
+			b.createCall(fn, []llvm.Value{ptr, val, llvm.ConstInt(b.uintptrType, 5, false)}, "")
+			return llvm.Value{}
 		}
 		store := b.CreateStore(val, ptr)
 		store.SetOrdering(llvm.AtomicOrderingSequentiallyConsistent)
 		store.SetAlignment(b.targetData.PrefTypeAlignment(val.Type())) // required
-		return store, true
+		return llvm.Value{}
 	default:
-		return llvm.Value{}, false
+		b.addError(b.fn.Pos(), "unknown atomic operation: "+b.fn.Name())
+		return llvm.Value{}
 	}
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1619,10 +1619,6 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 		// applied) function call. If it is anonymous, it may be a closure.
 		name := fn.RelString(nil)
 		switch {
-		case name == "runtime.memcpy" || name == "runtime.memmove" || name == "reflect.memcpy":
-			return b.createMemoryCopyCall(fn, instr.Args)
-		case name == "runtime.memzero":
-			return b.createMemoryZeroCall(instr.Args)
 		case name == "math.Ceil" || name == "math.Floor" || name == "math.Sqrt" || name == "math.Trunc":
 			result, ok := b.createMathOp(instr)
 			if ok {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1642,10 +1642,6 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.createSyscall(instr)
 		case strings.HasPrefix(name, "syscall.rawSyscallNoError"):
 			return b.createRawSyscallNoError(instr)
-		case strings.HasPrefix(name, "runtime/volatile.Load"):
-			return b.createVolatileLoad(instr)
-		case strings.HasPrefix(name, "runtime/volatile.Store"):
-			return b.createVolatileStore(instr)
 		case name == "runtime.supportsRecover":
 			supportsRecover := uint64(0)
 			if b.supportsRecover() {

--- a/compiler/intrinsics.go
+++ b/compiler/intrinsics.go
@@ -20,6 +20,10 @@ import (
 func (b *builder) defineIntrinsicFunction() {
 	name := b.fn.RelString(nil)
 	switch {
+	case name == "runtime.memcpy" || name == "runtime.memmove":
+		b.createMemoryCopyImpl()
+	case name == "runtime.memzero":
+		b.createMemoryZeroImpl()
 	case strings.HasPrefix(name, "runtime/volatile.Load"):
 		b.createVolatileLoad()
 	case strings.HasPrefix(name, "runtime/volatile.Store"):
@@ -35,30 +39,32 @@ func (b *builder) defineIntrinsicFunction() {
 	}
 }
 
-// createMemoryCopyCall creates a call to a builtin LLVM memcpy or memmove
+// createMemoryCopyImpl creates a call to a builtin LLVM memcpy or memmove
 // function, declaring this function if needed. These calls are treated
 // specially by optimization passes possibly resulting in better generated code,
 // and will otherwise be lowered to regular libc memcpy/memmove calls.
-func (b *builder) createMemoryCopyCall(fn *ssa.Function, args []ssa.Value) (llvm.Value, error) {
-	fnName := "llvm." + fn.Name() + ".p0i8.p0i8.i" + strconv.Itoa(b.uintptrType.IntTypeWidth())
+func (b *builder) createMemoryCopyImpl() {
+	b.createFunctionStart()
+	fnName := "llvm." + b.fn.Name() + ".p0i8.p0i8.i" + strconv.Itoa(b.uintptrType.IntTypeWidth())
 	llvmFn := b.mod.NamedFunction(fnName)
 	if llvmFn.IsNil() {
 		fnType := llvm.FunctionType(b.ctx.VoidType(), []llvm.Type{b.i8ptrType, b.i8ptrType, b.uintptrType, b.ctx.Int1Type()}, false)
 		llvmFn = llvm.AddFunction(b.mod, fnName, fnType)
 	}
 	var params []llvm.Value
-	for _, param := range args {
+	for _, param := range b.fn.Params {
 		params = append(params, b.getValue(param))
 	}
 	params = append(params, llvm.ConstInt(b.ctx.Int1Type(), 0, false))
 	b.CreateCall(llvmFn, params, "")
-	return llvm.Value{}, nil
+	b.CreateRetVoid()
 }
 
-// createMemoryZeroCall creates calls to llvm.memset.* to zero a block of
+// createMemoryZeroImpl creates calls to llvm.memset.* to zero a block of
 // memory, declaring the function if needed. These calls will be lowered to
 // regular libc memset calls if they aren't optimized out in a different way.
-func (b *builder) createMemoryZeroCall(args []ssa.Value) (llvm.Value, error) {
+func (b *builder) createMemoryZeroImpl() {
+	b.createFunctionStart()
 	fnName := "llvm.memset.p0i8.i" + strconv.Itoa(b.uintptrType.IntTypeWidth())
 	llvmFn := b.mod.NamedFunction(fnName)
 	if llvmFn.IsNil() {
@@ -66,13 +72,13 @@ func (b *builder) createMemoryZeroCall(args []ssa.Value) (llvm.Value, error) {
 		llvmFn = llvm.AddFunction(b.mod, fnName, fnType)
 	}
 	params := []llvm.Value{
-		b.getValue(args[0]),
+		b.getValue(b.fn.Params[0]),
 		llvm.ConstInt(b.ctx.Int8Type(), 0, false),
-		b.getValue(args[1]),
+		b.getValue(b.fn.Params[1]),
 		llvm.ConstInt(b.ctx.Int1Type(), 0, false),
 	}
 	b.CreateCall(llvmFn, params, "")
-	return llvm.Value{}, nil
+	b.CreateRetVoid()
 }
 
 var mathToLLVMMapping = map[string]string{

--- a/compiler/intrinsics.go
+++ b/compiler/intrinsics.go
@@ -20,6 +20,10 @@ import (
 func (b *builder) defineIntrinsicFunction() {
 	name := b.fn.RelString(nil)
 	switch {
+	case strings.HasPrefix(name, "runtime/volatile.Load"):
+		b.createVolatileLoad()
+	case strings.HasPrefix(name, "runtime/volatile.Store"):
+		b.createVolatileStore()
 	case strings.HasPrefix(name, "sync/atomic.") && token.IsExported(b.fn.Name()):
 		b.createFunctionStart()
 		returnValue := b.createAtomicOp(b.fn.Name())

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -3,28 +3,25 @@ package compiler
 // This file implements volatile loads/stores in runtime/volatile.LoadT and
 // runtime/volatile.StoreT as compiler builtins.
 
-import (
-	"golang.org/x/tools/go/ssa"
-	"tinygo.org/x/go-llvm"
-)
-
 // createVolatileLoad is the implementation of the intrinsic function
 // runtime/volatile.LoadT().
-func (b *builder) createVolatileLoad(instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := b.getValue(instr.Args[0])
-	b.createNilCheck(instr.Args[0], addr, "deref")
+func (b *builder) createVolatileLoad() {
+	b.createFunctionStart()
+	addr := b.getValue(b.fn.Params[0])
+	b.createNilCheck(b.fn.Params[0], addr, "deref")
 	val := b.CreateLoad(addr, "")
 	val.SetVolatile(true)
-	return val, nil
+	b.CreateRet(val)
 }
 
 // createVolatileStore is the implementation of the intrinsic function
 // runtime/volatile.StoreT().
-func (b *builder) createVolatileStore(instr *ssa.CallCommon) (llvm.Value, error) {
-	addr := b.getValue(instr.Args[0])
-	val := b.getValue(instr.Args[1])
-	b.createNilCheck(instr.Args[0], addr, "deref")
+func (b *builder) createVolatileStore() {
+	b.createFunctionStart()
+	addr := b.getValue(b.fn.Params[0])
+	val := b.getValue(b.fn.Params[1])
+	b.createNilCheck(b.fn.Params[0], addr, "deref")
 	store := b.CreateStore(val, addr)
 	store.SetVolatile(true)
-	return llvm.Value{}, nil
+	b.CreateRetVoid()
 }

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -808,8 +808,7 @@ func (e *ValueError) Error() string {
 	return "reflect: call of " + e.Method + " on " + e.Kind.String() + " Value"
 }
 
-// Calls to this function are converted to LLVM intrinsic calls such as
-// llvm.memcpy.p0i8.p0i8.i32().
+//go:linkname memcpy runtime.memcpy
 func memcpy(dst, src unsafe.Pointer, size uintptr)
 
 //go:linkname alloc runtime.alloc

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -26,19 +26,19 @@ func GOROOT() string {
 }
 
 // Copy size bytes from src to dst. The memory areas must not overlap.
-// Calls to this function are converted to LLVM intrinsic calls such as
-// llvm.memcpy.p0i8.p0i8.i32(dst, src, size, false).
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memcpy.p0i8.p0i8.i32(dst, src, size, false).
 func memcpy(dst, src unsafe.Pointer, size uintptr)
 
 // Copy size bytes from src to dst. The memory areas may overlap and will do the
 // correct thing.
-// Calls to this function are converted to LLVM intrinsic calls such as
-// llvm.memmove.p0i8.p0i8.i32(dst, src, size, false).
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memmove.p0i8.p0i8.i32(dst, src, size, false).
 func memmove(dst, src unsafe.Pointer, size uintptr)
 
 // Set the given number of bytes to zero.
-// Calls to this function are converted to LLVM intrinsic calls such as
-// llvm.memset.p0i8.i32(ptr, 0, size, false).
+// This function is implemented by the compiler as a call to a LLVM intrinsic
+// like llvm.memset.p0i8.i32(ptr, 0, size, false).
 func memzero(ptr unsafe.Pointer, size uintptr)
 
 // This intrinsic returns the current stack pointer.

--- a/testdata/atomic.go
+++ b/testdata/atomic.go
@@ -3,6 +3,8 @@ package main
 import (
 	"sync/atomic"
 	"unsafe"
+
+	"runtime/volatile"
 )
 
 func main() {
@@ -82,7 +84,7 @@ func main() {
 	testValue(int(3), int(-2))
 	testValue("", "foobar", "baz")
 
-	// Test atomic operations as deferred values.
+	// Test atomic and volatile operations as deferred values.
 	testDefer()
 }
 
@@ -99,8 +101,11 @@ func testValue(values ...interface{}) {
 
 func testDefer() {
 	n1 := int32(5)
+	n2 := uint32(6)
 	defer func() {
 		println("deferred atomic add:", n1)
+		println("deferred volatile store:", n2)
 	}()
 	defer atomic.AddInt32(&n1, 3)
+	defer volatile.StoreUint32(&n2, 22)
 }

--- a/testdata/atomic.go
+++ b/testdata/atomic.go
@@ -81,6 +81,9 @@ func main() {
 	// test atomic.Value load/store operations
 	testValue(int(3), int(-2))
 	testValue("", "foobar", "baz")
+
+	// Test atomic operations as deferred values.
+	testDefer()
 }
 
 func testValue(values ...interface{}) {
@@ -92,4 +95,12 @@ func testValue(values ...interface{}) {
 			println("val store/load didn't work, expected", val, "but got", loadedVal)
 		}
 	}
+}
+
+func testDefer() {
+	n1 := int32(5)
+	defer func() {
+		println("deferred atomic add:", n1)
+	}()
+	defer atomic.AddInt32(&n1, 3)
 }

--- a/testdata/atomic.txt
+++ b/testdata/atomic.txt
@@ -34,3 +34,4 @@ StoreUint64: 20
 StoreUintptr: 20
 StorePointer: true
 deferred atomic add: 8
+deferred volatile store: 22

--- a/testdata/atomic.txt
+++ b/testdata/atomic.txt
@@ -33,3 +33,4 @@ StoreUint32: 20
 StoreUint64: 20
 StoreUintptr: 20
 StorePointer: true
+deferred atomic add: 8


### PR DESCRIPTION
This fixes #2652 by implementing various compiler intrinsics as real functions. Also see https://github.com/tinygo-org/tinygo/pull/2821#issuecomment-1136287242 and #2805.
I think it makes sense to move a few more functions over if possible, like the system call functions and `runtime.supportsRecover`. But this can be done at a later time.