### PR TITLE
compiler: update tests after adding new wasm features

### DIFF
--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -6,32 +6,32 @@ target triple = "wasm32-unknown-wasi"
 %main.kv = type { float }
 %main.kv.0 = type { i8 }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.addInt(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.addInt(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = add i32 %x, %y
   ret i32 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.equalInt(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.equalInt(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i32 %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.divInt(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.divInt(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -45,14 +45,14 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %5
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(i8* undef) #0
+  call void @runtime.divideByZeroPanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.divideByZeroPanic(i8*)
+declare void @runtime.divideByZeroPanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden i32 @main.divUint(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.divUint(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -62,12 +62,12 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %1
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(i8* undef) #0
+  call void @runtime.divideByZeroPanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.remInt(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.remInt(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -81,12 +81,12 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %5
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(i8* undef) #0
+  call void @runtime.divideByZeroPanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.remUint(i32 %x, i32 %y, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.remUint(i32 %x, i32 %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -96,66 +96,66 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %1
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(i8* undef) #0
+  call void @runtime.divideByZeroPanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatEQ(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatEQ(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp oeq float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatNE(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatNE(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp une float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatLower(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatLower(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp olt float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatLowerEqual(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatLowerEqual(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp ole float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatGreater(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatGreater(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp ogt float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatGreaterEqual(float %x, float %y, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.floatGreaterEqual(float %x, float %y, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fcmp oge float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.complexReal(float %x.r, float %x.i, i8* %context) unnamed_addr #0 {
+define hidden float @main.complexReal(float %x.r, float %x.i, i8* %context) unnamed_addr #1 {
 entry:
   ret float %x.r
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.complexImag(float %x.r, float %x.i, i8* %context) unnamed_addr #0 {
+define hidden float @main.complexImag(float %x.r, float %x.i, i8* %context) unnamed_addr #1 {
 entry:
   ret float %x.i
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #0 {
+define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fadd float %x.r, %y.r
   %1 = fadd float %x.i, %y.i
@@ -165,7 +165,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #0 {
+define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fsub float %x.r, %y.r
   %1 = fsub float %x.i, %y.i
@@ -175,7 +175,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #0 {
+define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, i8* %context) unnamed_addr #1 {
 entry:
   %0 = fmul float %x.r, %y.r
   %1 = fmul float %x.i, %y.i
@@ -189,16 +189,18 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.foo(%main.kv* dereferenceable_or_null(4) %a, i8* %context) unnamed_addr #0 {
+define hidden void @main.foo(%main.kv* dereferenceable_or_null(4) %a, i8* %context) unnamed_addr #1 {
 entry:
   call void @"main.foo$1"(%main.kv.0* null, i8* undef)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @"main.foo$1"(%main.kv.0* dereferenceable_or_null(1) %b, i8* %context) unnamed_addr #0 {
+define hidden void @"main.foo$1"(%main.kv.0* dereferenceable_or_null(1) %b, i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -11,18 +11,18 @@ target triple = "wasm32-unknown-wasi"
 %"internal/task.stackState" = type { i32, i32 }
 %runtime.chanSelectState = type { %runtime.channel*, i8* }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #0 {
+define hidden void @main.chanIntSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #1 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
@@ -31,22 +31,22 @@ entry:
   store i32 3, i32* %chan.value, align 4
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  call void @runtime.chanSend(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #0
+  call void @runtime.chanSend(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #3
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   ret void
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #2
 
-declare void @runtime.chanSend(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*)
+declare void @runtime.chanSend(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*) #0
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #2
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #0 {
+define hidden void @main.chanIntRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #1 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
@@ -54,41 +54,41 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #0
+  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* nonnull %chan.value.bitcast, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #3
   call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %chan.value.bitcast)
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
 }
 
-declare i1 @runtime.chanRecv(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*)
+declare i1 @runtime.chanRecv(%runtime.channel* dereferenceable_or_null(32), i8*, %runtime.channelBlockedList* dereferenceable_or_null(24), i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #0 {
+define hidden void @main.chanZeroSend(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #1 {
 entry:
   %complit = alloca {}, align 8
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %0 = bitcast {}* %complit to i8*
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #3
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  call void @runtime.chanSend(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #0
+  call void @runtime.chanSend(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #3
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #0 {
+define hidden void @main.chanZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #1 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.blockedList.bitcast = bitcast %runtime.channelBlockedList* %chan.blockedList to i8*
   call void @llvm.lifetime.start.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
-  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #0
+  %0 = call i1 @runtime.chanRecv(%runtime.channel* %ch, i8* null, %runtime.channelBlockedList* nonnull %chan.blockedList, i8* undef) #3
   call void @llvm.lifetime.end.p0i8(i64 24, i8* nonnull %chan.blockedList.bitcast)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.selectZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch1, %runtime.channel* dereferenceable_or_null(32) %ch2, i8* %context) unnamed_addr #0 {
+define hidden void @main.selectZeroRecv(%runtime.channel* dereferenceable_or_null(32) %ch1, %runtime.channel* dereferenceable_or_null(32) %ch2, i8* %context) unnamed_addr #1 {
 entry:
   %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
   %select.send.value = alloca i32, align 4
@@ -105,7 +105,7 @@ entry:
   %.repack4 = getelementptr inbounds [2 x %runtime.chanSelectState], [2 x %runtime.chanSelectState]* %select.states.alloca, i32 0, i32 1, i32 1
   store i8* null, i8** %.repack4, align 4
   %select.states = getelementptr inbounds [2 x %runtime.chanSelectState], [2 x %runtime.chanSelectState]* %select.states.alloca, i32 0, i32 0
-  %select.result = call { i32, i1 } @runtime.tryChanSelect(i8* undef, %runtime.chanSelectState* nonnull %select.states, i32 2, i32 2, i8* undef) #0
+  %select.result = call { i32, i1 } @runtime.tryChanSelect(i8* undef, %runtime.chanSelectState* nonnull %select.states, i32 2, i32 2, i8* undef) #3
   call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %select.states.alloca.bitcast)
   %1 = extractvalue { i32, i1 } %select.result, 0
   %2 = icmp eq i32 %1, 0
@@ -122,7 +122,9 @@ select.body:                                      ; preds = %select.next
   br label %select.done
 }
 
-declare { i32, i1 } @runtime.tryChanSelect(i8*, %runtime.chanSelectState*, i32, i32, i8*)
+declare { i32, i1 } @runtime.tryChanSelect(i8*, %runtime.chanSelectState*, i32, i32, i8*) #0
 
-attributes #0 = { nounwind }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { nounwind }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -3,18 +3,18 @@ source_filename = "float.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.f32tou32(float %v, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.f32tou32(float %v, i8* %context) unnamed_addr #1 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -26,25 +26,25 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.maxu32f(i8* %context) unnamed_addr #0 {
+define hidden float @main.maxu32f(i8* %context) unnamed_addr #1 {
 entry:
   ret float 0x41F0000000000000
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.maxu32tof32(i8* %context) unnamed_addr #0 {
+define hidden i32 @main.maxu32tof32(i8* %context) unnamed_addr #1 {
 entry:
   ret i32 -1
 }
 
 ; Function Attrs: nounwind
-define hidden { i32, i32, i32, i32 } @main.inftoi32(i8* %context) unnamed_addr #0 {
+define hidden { i32, i32, i32, i32 } @main.inftoi32(i8* %context) unnamed_addr #1 {
 entry:
   ret { i32, i32, i32, i32 } { i32 -1, i32 0, i32 2147483647, i32 -2147483648 }
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.u32tof32tou32(i32 %v, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.u32tof32tou32(i32 %v, i8* %context) unnamed_addr #1 {
 entry:
   %0 = uitofp i32 %v to float
   %withinmax = fcmp ole float %0, 0x41EFFFFFC0000000
@@ -54,7 +54,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.f32tou32tof32(float %v, i8* %context) unnamed_addr #0 {
+define hidden float @main.f32tou32tof32(float %v, i8* %context) unnamed_addr #1 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -67,7 +67,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.f32tou8(float %v, i8* %context) unnamed_addr #0 {
+define hidden i8 @main.f32tou8(float %v, i8* %context) unnamed_addr #1 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 2.550000e+02
@@ -79,7 +79,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.f32toi8(float %v, i8* %context) unnamed_addr #0 {
+define hidden i8 @main.f32toi8(float %v, i8* %context) unnamed_addr #1 {
 entry:
   %abovemin = fcmp oge float %v, -1.280000e+02
   %belowmax = fcmp ole float %v, 1.270000e+02
@@ -92,4 +92,5 @@ entry:
   ret i8 %0
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -3,45 +3,47 @@ source_filename = "func.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.foo(i8* %callback.context, void ()* %callback.funcptr, i8* %context) unnamed_addr #0 {
+define hidden void @main.foo(i8* %callback.context, void ()* %callback.funcptr, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq void ()* %callback.funcptr, null
   br i1 %0, label %fpcall.throw, label %fpcall.next
 
 fpcall.next:                                      ; preds = %entry
   %1 = bitcast void ()* %callback.funcptr to void (i32, i8*)*
-  call void %1(i32 3, i8* %callback.context) #0
+  call void %1(i32 3, i8* %callback.context) #2
   ret void
 
 fpcall.throw:                                     ; preds = %entry
-  call void @runtime.nilPanic(i8* undef) #0
+  call void @runtime.nilPanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.nilPanic(i8*)
+declare void @runtime.nilPanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.bar(i8* %context) unnamed_addr #0 {
+define hidden void @main.bar(i8* %context) unnamed_addr #1 {
 entry:
   call void @main.foo(i8* undef, void ()* bitcast (void (i32, i8*)* @main.someFunc to void ()*), i8* undef)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.someFunc(i32 %arg0, i8* %context) unnamed_addr #0 {
+define hidden void @main.someFunc(i32 %arg0, i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -26,91 +26,91 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.type:basic:complex128" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* null, i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* @"reflect/types.type:pointer:basic:complex128", i32 0 }
 @"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant %runtime.typecodeID { %runtime.typecodeID* @"reflect/types.type:basic:complex128", i32 0, %runtime.interfaceMethodInfo* null, %runtime.typecodeID* null, i32 0 }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newScalar(i8* %context) unnamed_addr #0 {
+define hidden void @main.newScalar(i8* %context) unnamed_addr #1 {
 entry:
-  %new = call i8* @runtime.alloc(i32 1, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #0
+  %new = call i8* @runtime.alloc(i32 1, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #2
   store i8* %new, i8** @main.scalar1, align 4
-  %new1 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #0
+  %new1 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #2
   store i8* %new1, i8** bitcast (i32** @main.scalar2 to i8**), align 4
-  %new2 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #0
+  %new2 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #2
   store i8* %new2, i8** bitcast (i64** @main.scalar3 to i8**), align 4
-  %new3 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new3, i8* undef) #0
+  %new3 = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new3, i8* undef) #2
   store i8* %new3, i8** bitcast (float** @main.scalar4 to i8**), align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newArray(i8* %context) unnamed_addr #0 {
+define hidden void @main.newArray(i8* %context) unnamed_addr #1 {
 entry:
-  %new = call i8* @runtime.alloc(i32 3, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #0
+  %new = call i8* @runtime.alloc(i32 3, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #2
   store i8* %new, i8** bitcast ([3 x i8]** @main.array1 to i8**), align 4
-  %new1 = call i8* @runtime.alloc(i32 71, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #0
+  %new1 = call i8* @runtime.alloc(i32 71, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #2
   store i8* %new1, i8** bitcast ([71 x i8]** @main.array2 to i8**), align 4
-  %new2 = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 67 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #0
+  %new2 = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 67 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #2
   store i8* %new2, i8** bitcast ([3 x i8*]** @main.array3 to i8**), align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newStruct(i8* %context) unnamed_addr #0 {
+define hidden void @main.newStruct(i8* %context) unnamed_addr #1 {
 entry:
-  %new = call i8* @runtime.alloc(i32 0, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #0
+  %new = call i8* @runtime.alloc(i32 0, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #2
   store i8* %new, i8** bitcast ({}** @main.struct1 to i8**), align 4
-  %new1 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #0
+  %new1 = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new1, i8* undef) #2
   store i8* %new1, i8** bitcast ({ i32, i32 }** @main.struct2 to i8**), align 4
-  %new2 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-2000000000000001" to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #0
+  %new2 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-2000000000000001" to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new2, i8* undef) #2
   store i8* %new2, i8** bitcast ({ i8*, [60 x i32], i8* }** @main.struct3 to i8**), align 4
-  %new3 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-0001" to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %new3, i8* undef) #0
+  %new3 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-0001" to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %new3, i8* undef) #2
   store i8* %new3, i8** bitcast ({ i8*, [61 x i32] }** @main.struct4 to i8**), align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden { i8*, void ()* }* @main.newFuncValue(i8* %context) unnamed_addr #0 {
+define hidden { i8*, void ()* }* @main.newFuncValue(i8* %context) unnamed_addr #1 {
 entry:
-  %new = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 197 to i8*), i8* undef) #0
+  %new = call i8* @runtime.alloc(i32 8, i8* nonnull inttoptr (i32 197 to i8*), i8* undef) #2
   %0 = bitcast i8* %new to { i8*, void ()* }*
-  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %new, i8* undef) #2
   ret { i8*, void ()* }* %0
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.makeSlice(i8* %context) unnamed_addr #0 {
+define hidden void @main.makeSlice(i8* %context) unnamed_addr #1 {
 entry:
-  %makeslice = call i8* @runtime.alloc(i32 5, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %makeslice, i8* undef) #0
+  %makeslice = call i8* @runtime.alloc(i32 5, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %makeslice, i8* undef) #2
   store i8* %makeslice, i8** getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 0), align 8
   store i32 5, i32* getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 1), align 4
   store i32 5, i32* getelementptr inbounds ({ i8*, i32, i32 }, { i8*, i32, i32 }* @main.slice1, i32 0, i32 2), align 8
-  %makeslice1 = call i8* @runtime.alloc(i32 20, i8* nonnull inttoptr (i32 67 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %makeslice1, i8* undef) #0
+  %makeslice1 = call i8* @runtime.alloc(i32 20, i8* nonnull inttoptr (i32 67 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %makeslice1, i8* undef) #2
   store i8* %makeslice1, i8** bitcast ({ i32**, i32, i32 }* @main.slice2 to i8**), align 8
   store i32 5, i32* getelementptr inbounds ({ i32**, i32, i32 }, { i32**, i32, i32 }* @main.slice2, i32 0, i32 1), align 4
   store i32 5, i32* getelementptr inbounds ({ i32**, i32, i32 }, { i32**, i32, i32 }* @main.slice2, i32 0, i32 2), align 8
-  %makeslice3 = call i8* @runtime.alloc(i32 60, i8* nonnull inttoptr (i32 71 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %makeslice3, i8* undef) #0
+  %makeslice3 = call i8* @runtime.alloc(i32 60, i8* nonnull inttoptr (i32 71 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %makeslice3, i8* undef) #2
   store i8* %makeslice3, i8** bitcast ({ { i8*, i32, i32 }*, i32, i32 }* @main.slice3 to i8**), align 8
   store i32 5, i32* getelementptr inbounds ({ { i8*, i32, i32 }*, i32, i32 }, { { i8*, i32, i32 }*, i32, i32 }* @main.slice3, i32 0, i32 1), align 4
   store i32 5, i32* getelementptr inbounds ({ { i8*, i32, i32 }*, i32, i32 }, { { i8*, i32, i32 }*, i32, i32 }* @main.slice3, i32 0, i32 2), align 8
@@ -118,18 +118,20 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.makeInterface(double %v.r, double %v.i, i8* %context) unnamed_addr #0 {
+define hidden %runtime._interface @main.makeInterface(double %v.r, double %v.i, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
   %.repack = bitcast i8* %0 to double*
   store double %v.r, double* %.repack, align 8
   %.repack1 = getelementptr inbounds i8, i8* %0, i32 8
   %1 = bitcast i8* %.repack1 to double*
   store double %v.i, double* %1, align 8
   %2 = insertvalue %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:complex128" to i32), i8* undef }, i8* %0, 1
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
   ret %runtime._interface %2
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/go1.17.ll
+++ b/compiler/testdata/go1.17.ll
@@ -3,35 +3,35 @@ source_filename = "go1.17.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.Add32(i8* %p, i32 %len, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.Add32(i8* %p, i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = getelementptr i8, i8* %p, i32 %len
-  call void @runtime.trackPointer(i8* %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* %0, i8* undef) #2
   ret i8* %0
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.Add64(i8* %p, i64 %len, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.Add64(i8* %p, i64 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = trunc i64 %len to i32
   %1 = getelementptr i8, i8* %p, i32 %0
-  call void @runtime.trackPointer(i8* %1, i8* undef) #0
+  call void @runtime.trackPointer(i8* %1, i8* undef) #2
   ret i8* %1
 }
 
 ; Function Attrs: nounwind
-define hidden [4 x i32]* @main.SliceToArray(i32* %s.data, i32 %s.len, i32 %s.cap, i8* %context) unnamed_addr #0 {
+define hidden [4 x i32]* @main.SliceToArray(i32* %s.data, i32 %s.len, i32 %s.cap, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp ult i32 %s.len, 4
   br i1 %0, label %slicetoarray.throw, label %slicetoarray.next
@@ -41,17 +41,17 @@ slicetoarray.next:                                ; preds = %entry
   ret [4 x i32]* %1
 
 slicetoarray.throw:                               ; preds = %entry
-  call void @runtime.sliceToArrayPointerPanic(i8* undef) #0
+  call void @runtime.sliceToArrayPointerPanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.sliceToArrayPointerPanic(i8*)
+declare void @runtime.sliceToArrayPointerPanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context) unnamed_addr #0 {
+define hidden [4 x i32]* @main.SliceToArrayConst(i8* %context) unnamed_addr #1 {
 entry:
-  %makeslice = call i8* @runtime.alloc(i32 24, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %makeslice, i8* undef) #0
+  %makeslice = call i8* @runtime.alloc(i32 24, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %makeslice, i8* undef) #2
   br i1 false, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.next:                                ; preds = %entry
@@ -63,7 +63,7 @@ slicetoarray.throw:                               ; preds = %entry
 }
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.SliceInt(i32* dereferenceable_or_null(4) %ptr, i32 %len, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.SliceInt(i32* dereferenceable_or_null(4) %ptr, i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp ugt i32 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -77,18 +77,18 @@ unsafe.Slice.next:                                ; preds = %entry
   %6 = insertvalue { i32*, i32, i32 } %5, i32 %len, 1
   %7 = insertvalue { i32*, i32, i32 } %6, i32 %len, 2
   %8 = bitcast i32* %ptr to i8*
-  call void @runtime.trackPointer(i8* %8, i8* undef) #0
+  call void @runtime.trackPointer(i8* %8, i8* undef) #2
   ret { i32*, i32, i32 } %7
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef) #0
+  call void @runtime.unsafeSlicePanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.unsafeSlicePanic(i8*)
+declare void @runtime.unsafeSlicePanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden { i8*, i32, i32 } @main.SliceUint16(i8* dereferenceable_or_null(1) %ptr, i16 %len, i8* %context) unnamed_addr #0 {
+define hidden { i8*, i32, i32 } @main.SliceUint16(i8* dereferenceable_or_null(1) %ptr, i16 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp eq i8* %ptr, null
   %1 = icmp ne i16 %len, 0
@@ -100,16 +100,16 @@ unsafe.Slice.next:                                ; preds = %entry
   %4 = insertvalue { i8*, i32, i32 } undef, i8* %ptr, 0
   %5 = insertvalue { i8*, i32, i32 } %4, i32 %3, 1
   %6 = insertvalue { i8*, i32, i32 } %5, i32 %3, 2
-  call void @runtime.trackPointer(i8* %ptr, i8* undef) #0
+  call void @runtime.trackPointer(i8* %ptr, i8* undef) #2
   ret { i8*, i32, i32 } %6
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef) #0
+  call void @runtime.unsafeSlicePanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.SliceUint64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.SliceUint64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp ugt i64 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -124,16 +124,16 @@ unsafe.Slice.next:                                ; preds = %entry
   %7 = insertvalue { i32*, i32, i32 } %6, i32 %5, 1
   %8 = insertvalue { i32*, i32, i32 } %7, i32 %5, 2
   %9 = bitcast i32* %ptr to i8*
-  call void @runtime.trackPointer(i8* %9, i8* undef) #0
+  call void @runtime.trackPointer(i8* %9, i8* undef) #2
   ret { i32*, i32, i32 } %8
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef) #0
+  call void @runtime.unsafeSlicePanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.SliceInt64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.SliceInt64(i32* dereferenceable_or_null(4) %ptr, i64 %len, i8* %context) unnamed_addr #1 {
 entry:
   %0 = icmp ugt i64 %len, 1073741823
   %1 = icmp eq i32* %ptr, null
@@ -148,12 +148,14 @@ unsafe.Slice.next:                                ; preds = %entry
   %7 = insertvalue { i32*, i32, i32 } %6, i32 %5, 1
   %8 = insertvalue { i32*, i32, i32 } %7, i32 %5, 2
   %9 = bitcast i32* %ptr to i8*
-  call void @runtime.trackPointer(i8* %9, i8* undef) #0
+  call void @runtime.trackPointer(i8* %9, i8* undef) #2
   ret { i32*, i32, i32 } %8
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(i8* undef) #0
+  call void @runtime.unsafeSlicePanic(i8* undef) #2
   unreachable
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -13,84 +13,84 @@ target triple = "wasm32-unknown-wasi"
 
 @"main$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.regularFunctionGoroutine(i8* %context) unnamed_addr #0 {
+define hidden void @main.regularFunctionGoroutine(i8* %context) unnamed_addr #1 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 16384, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.regularFunction$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 16384, i8* undef) #8
   ret void
 }
 
-declare void @main.regularFunction(i32, i8*)
+declare void @main.regularFunction(i32, i8*) #0
 
-declare void @runtime.deadlock(i8*)
+declare void @runtime.deadlock(i8*) #0
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.regularFunction$gowrapper"(i8* %0) unnamed_addr #1 {
+define linkonce_odr void @"main.regularFunction$gowrapper"(i8* %0) unnamed_addr #2 {
 entry:
   %unpack.int = ptrtoint i8* %0 to i32
-  call void @main.regularFunction(i32 %unpack.int, i8* undef) #0
-  call void @runtime.deadlock(i8* undef) #0
+  call void @main.regularFunction(i32 %unpack.int, i8* undef) #8
+  call void @runtime.deadlock(i8* undef) #8
   unreachable
 }
 
-declare void @"internal/task.start"(i32, i8*, i32, i8*)
+declare void @"internal/task.start"(i32, i8*, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.inlineFunctionGoroutine(i8* %context) unnamed_addr #0 {
+define hidden void @main.inlineFunctionGoroutine(i8* %context) unnamed_addr #1 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 16384, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.inlineFunctionGoroutine$1$gowrapper" to i32), i8* nonnull inttoptr (i32 5 to i8*), i32 16384, i8* undef) #8
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context) unnamed_addr #0 {
+define hidden void @"main.inlineFunctionGoroutine$1"(i32 %x, i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #2 {
+define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #3 {
 entry:
   %unpack.int = ptrtoint i8* %0 to i32
   call void @"main.inlineFunctionGoroutine$1"(i32 %unpack.int, i8* undef)
-  call void @runtime.deadlock(i8* undef) #0
+  call void @runtime.deadlock(i8* undef) #8
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.closureFunctionGoroutine(i8* %context) unnamed_addr #0 {
+define hidden void @main.closureFunctionGoroutine(i8* %context) unnamed_addr #1 {
 entry:
-  %n = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
+  %n = call i8* @runtime.alloc(i32 4, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #8
   %0 = bitcast i8* %n to i32*
-  call void @runtime.trackPointer(i8* nonnull %n, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %n, i8* undef) #8
   store i32 3, i32* %0, align 4
-  call void @runtime.trackPointer(i8* nonnull %n, i8* undef) #0
-  call void @runtime.trackPointer(i8* bitcast (void (i32, i8*)* @"main.closureFunctionGoroutine$1" to i8*), i8* undef) #0
-  %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %1, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %n, i8* undef) #8
+  call void @runtime.trackPointer(i8* bitcast (void (i32, i8*)* @"main.closureFunctionGoroutine$1" to i8*), i8* undef) #8
+  %1 = call i8* @runtime.alloc(i32 8, i8* null, i8* undef) #8
+  call void @runtime.trackPointer(i8* nonnull %1, i8* undef) #8
   %2 = bitcast i8* %1 to i32*
   store i32 5, i32* %2, align 4
   %3 = getelementptr inbounds i8, i8* %1, i32 4
   %4 = bitcast i8* %3 to i8**
   store i8* %n, i8** %4, align 4
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* nonnull %1, i32 16384, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"main.closureFunctionGoroutine$1$gowrapper" to i32), i8* nonnull %1, i32 16384, i8* undef) #8
   %5 = load i32, i32* %0, align 4
-  call void @runtime.printint32(i32 %5, i8* undef) #0
+  call void @runtime.printint32(i32 %5, i8* undef) #8
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context) unnamed_addr #0 {
+define hidden void @"main.closureFunctionGoroutine$1"(i32 %x, i8* %context) unnamed_addr #1 {
 entry:
   %unpack.ptr = bitcast i8* %context to i32*
   store i32 7, i32* %unpack.ptr, align 4
@@ -98,7 +98,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #3 {
+define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(i8* %0) unnamed_addr #4 {
 entry:
   %1 = bitcast i8* %0 to i32*
   %2 = load i32, i32* %1, align 4
@@ -106,17 +106,17 @@ entry:
   %4 = bitcast i8* %3 to i8**
   %5 = load i8*, i8** %4, align 4
   call void @"main.closureFunctionGoroutine$1"(i32 %2, i8* %5)
-  call void @runtime.deadlock(i8* undef) #0
+  call void @runtime.deadlock(i8* undef) #8
   unreachable
 }
 
-declare void @runtime.printint32(i32, i8*)
+declare void @runtime.printint32(i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.funcGoroutine(i8* %fn.context, void ()* %fn.funcptr, i8* %context) unnamed_addr #0 {
+define hidden void @main.funcGoroutine(i8* %fn.context, void ()* %fn.funcptr, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 12, i8* null, i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  %0 = call i8* @runtime.alloc(i32 12, i8* null, i8* undef) #8
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #8
   %1 = bitcast i8* %0 to i32*
   store i32 5, i32* %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4
@@ -125,12 +125,12 @@ entry:
   %4 = getelementptr inbounds i8, i8* %0, i32 8
   %5 = bitcast i8* %4 to void ()**
   store void ()* %fn.funcptr, void ()** %5, align 4
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* nonnull %0, i32 16384, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @main.funcGoroutine.gowrapper to i32), i8* nonnull %0, i32 16384, i8* undef) #8
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @main.funcGoroutine.gowrapper(i8* %0) unnamed_addr #4 {
+define linkonce_odr void @main.funcGoroutine.gowrapper(i8* %0) unnamed_addr #5 {
 entry:
   %1 = bitcast i8* %0 to i32*
   %2 = load i32, i32* %1, align 4
@@ -140,40 +140,40 @@ entry:
   %6 = getelementptr inbounds i8, i8* %0, i32 8
   %7 = bitcast i8* %6 to void (i32, i8*)**
   %8 = load void (i32, i8*)*, void (i32, i8*)** %7, align 4
-  call void %8(i32 %2, i8* %5) #0
-  call void @runtime.deadlock(i8* undef) #0
+  call void %8(i32 %2, i8* %5) #8
+  call void @runtime.deadlock(i8* undef) #8
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.recoverBuiltinGoroutine(i8* %context) unnamed_addr #0 {
+define hidden void @main.recoverBuiltinGoroutine(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context) unnamed_addr #0 {
+define hidden void @main.copyBuiltinGoroutine(i8* %dst.data, i32 %dst.len, i32 %dst.cap, i8* %src.data, i32 %src.len, i32 %src.cap, i8* %context) unnamed_addr #1 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef) #0
+  %copy.n = call i32 @runtime.sliceCopy(i8* %dst.data, i8* %src.data, i32 %dst.len, i32 %src.len, i32 1, i8* undef) #8
   ret void
 }
 
-declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*)
+declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #0 {
+define hidden void @main.closeBuiltinGoroutine(%runtime.channel* dereferenceable_or_null(32) %ch, i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef) #0
+  call void @runtime.chanClose(%runtime.channel* %ch, i8* undef) #8
   ret void
 }
 
-declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*)
+declare void @runtime.chanClose(%runtime.channel* dereferenceable_or_null(32), i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden void @main.startInterfaceMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  %0 = call i8* @runtime.alloc(i32 16, i8* null, i8* undef) #8
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #8
   %1 = bitcast i8* %0 to i8**
   store i8* %itf.value, i8** %1, align 4
   %2 = getelementptr inbounds i8, i8* %0, i32 4
@@ -185,14 +185,14 @@ entry:
   %4 = getelementptr inbounds i8, i8* %0, i32 12
   %5 = bitcast i8* %4 to i32*
   store i32 %itf.typecode, i32* %5, align 4
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), i8* nonnull %0, i32 16384, i8* undef) #0
+  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), i8* nonnull %0, i32 16384, i8* undef) #8
   ret void
 }
 
-declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8*, i8*, i32, i32, i8*) #5
+declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8*, i8*, i32, i32, i8*) #6
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(i8* %0) unnamed_addr #6 {
+define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(i8* %0) unnamed_addr #7 {
 entry:
   %1 = bitcast i8* %0 to i8**
   %2 = load i8*, i8** %1, align 4
@@ -205,15 +205,17 @@ entry:
   %9 = getelementptr inbounds i8, i8* %0, i32 12
   %10 = bitcast i8* %9 to i32*
   %11 = load i32, i32* %10, align 4
-  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8* %2, i8* %5, i32 %8, i32 %11, i8* undef) #0
-  call void @runtime.deadlock(i8* undef) #0
+  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(i8* %2, i8* %5, i32 %8, i32 %11, i8* undef) #8
+  call void @runtime.deadlock(i8* undef) #8
   unreachable
 }
 
-attributes #0 = { nounwind }
-attributes #1 = { nounwind "tinygo-gowrapper"="main.regularFunction" }
-attributes #2 = { nounwind "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
-attributes #3 = { nounwind "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
-attributes #4 = { nounwind "tinygo-gowrapper" }
-attributes #5 = { "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
-attributes #6 = { nounwind "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.regularFunction" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
+attributes #4 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper" }
+attributes #6 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
+attributes #7 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
+attributes #8 = { nounwind }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -22,52 +22,52 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.interface:interface{String() string}$interface" = linkonce_odr constant [1 x i8*] [i8* @"reflect/methods.String() string"]
 @"reflect/types.typeid:basic:int" = external constant i8
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.simpleType(i8* %context) unnamed_addr #0 {
+define hidden %runtime._interface @main.simpleType(i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* null, i8* undef) #0
+  call void @runtime.trackPointer(i8* null, i8* undef) #6
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:basic:int" to i32), i8* null }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.pointerType(i8* %context) unnamed_addr #0 {
+define hidden %runtime._interface @main.pointerType(i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* null, i8* undef) #0
+  call void @runtime.trackPointer(i8* null, i8* undef) #6
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:basic:int" to i32), i8* null }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.interfaceType(i8* %context) unnamed_addr #0 {
+define hidden %runtime._interface @main.interfaceType(i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* null, i8* undef) #0
+  call void @runtime.trackPointer(i8* null, i8* undef) #6
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:named:error" to i32), i8* null }
 }
 
-declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32) #1
+declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32) #2
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.anonymousInterfaceType(i8* %context) unnamed_addr #0 {
+define hidden %runtime._interface @main.anonymousInterfaceType(i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* null, i8* undef) #0
+  call void @runtime.trackPointer(i8* null, i8* undef) #6
   ret %runtime._interface { i32 ptrtoint (%runtime.typecodeID* @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" to i32), i8* null }
 }
 
-declare i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32) #2
+declare i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32) #3
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.isInt(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.typeid:basic:int", i8* undef) #0
+  %typecode = call i1 @runtime.typeAssert(i32 %itf.typecode, i8* nonnull @"reflect/types.typeid:basic:int", i8* undef) #6
   br i1 %typecode, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -77,12 +77,12 @@ typeassert.ok:                                    ; preds = %entry
   br label %typeassert.next
 }
 
-declare i1 @runtime.typeAssert(i32, i8* dereferenceable_or_null(1), i8*)
+declare i1 @runtime.typeAssert(i32, i8* dereferenceable_or_null(1), i8*) #0
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isError(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.isError(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #0
+  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #6
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -93,9 +93,9 @@ typeassert.ok:                                    ; preds = %entry
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isStringer(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.isStringer(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #0
+  %0 = call i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(i32 %itf.typecode) #6
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -106,27 +106,29 @@ typeassert.ok:                                    ; preds = %entry
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.callFooMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden i8 @main.callFooMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8* %itf.value, i32 3, i32 %itf.typecode, i8* undef) #0
+  %0 = call i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8* %itf.value, i32 3, i32 %itf.typecode, i8* undef) #6
   ret i8 %0
 }
 
-declare i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8*, i32, i32, i8*) #3
+declare i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(i8*, i32, i32, i8*) #4
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.callErrorMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #0 {
+define hidden %runtime._string @main.callErrorMethod(i32 %itf.typecode, i8* %itf.value, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8* %itf.value, i32 %itf.typecode, i8* undef) #0
+  %0 = call %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8* %itf.value, i32 %itf.typecode, i8* undef) #6
   %1 = extractvalue %runtime._string %0, 0
-  call void @runtime.trackPointer(i8* %1, i8* undef) #0
+  call void @runtime.trackPointer(i8* %1, i8* undef) #6
   ret %runtime._string %0
 }
 
-declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8*, i32, i8*) #4
+declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(i8*, i32, i8*) #5
 
-attributes #0 = { nounwind }
-attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }
-attributes #2 = { "tinygo-methods"="reflect/methods.String() string" }
-attributes #3 = { "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
-attributes #4 = { "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #3 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.String() string" }
+attributes #4 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
+attributes #5 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #6 = { nounwind }

--- a/compiler/testdata/intrinsics-wasm.ll
+++ b/compiler/testdata/intrinsics-wasm.ll
@@ -3,35 +3,36 @@ source_filename = "intrinsics.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden double @main.mySqrt(double %x, i8* %context) unnamed_addr #0 {
+define hidden double @main.mySqrt(double %x, i8* %context) unnamed_addr #1 {
 entry:
   %0 = call double @llvm.sqrt.f64(double %x)
   ret double %0
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.sqrt.f64(double) #1
+declare double @llvm.sqrt.f64(double) #2
 
 ; Function Attrs: nounwind
-define hidden double @main.myTrunc(double %x, i8* %context) unnamed_addr #0 {
+define hidden double @main.myTrunc(double %x, i8* %context) unnamed_addr #1 {
 entry:
   %0 = call double @llvm.trunc.f64(double %x)
   ret double %0
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.trunc.f64(double) #1
+declare double @llvm.trunc.f64(double) #2
 
-attributes #0 = { nounwind }
-attributes #1 = { nofree nosync nounwind readnone speculatable willreturn }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -3,76 +3,78 @@ source_filename = "pointer.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden [0 x i32] @main.pointerDerefZero([0 x i32]* %x, i8* %context) unnamed_addr #0 {
+define hidden [0 x i32] @main.pointerDerefZero([0 x i32]* %x, i8* %context) unnamed_addr #1 {
 entry:
   ret [0 x i32] zeroinitializer
 }
 
 ; Function Attrs: nounwind
-define hidden i32* @main.pointerCastFromUnsafe(i8* %x, i8* %context) unnamed_addr #0 {
+define hidden i32* @main.pointerCastFromUnsafe(i8* %x, i8* %context) unnamed_addr #1 {
 entry:
   %0 = bitcast i8* %x to i32*
-  call void @runtime.trackPointer(i8* %x, i8* undef) #0
+  call void @runtime.trackPointer(i8* %x, i8* undef) #2
   ret i32* %0
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.pointerCastToUnsafe(i32* dereferenceable_or_null(4) %x, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.pointerCastToUnsafe(i32* dereferenceable_or_null(4) %x, i8* %context) unnamed_addr #1 {
 entry:
   %0 = bitcast i32* %x to i8*
-  call void @runtime.trackPointer(i8* %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* %0, i8* undef) #2
   ret i8* %0
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.pointerCastToUnsafeNoop(i8* dereferenceable_or_null(1) %x, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.pointerCastToUnsafeNoop(i8* dereferenceable_or_null(1) %x, i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* %x, i8* undef) #0
+  call void @runtime.trackPointer(i8* %x, i8* undef) #2
   ret i8* %x
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.pointerUnsafeGEPFixedOffset(i8* dereferenceable_or_null(1) %ptr, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.pointerUnsafeGEPFixedOffset(i8* dereferenceable_or_null(1) %ptr, i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* %ptr, i8* undef) #0
+  call void @runtime.trackPointer(i8* %ptr, i8* undef) #2
   %0 = getelementptr inbounds i8, i8* %ptr, i32 10
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
   ret i8* %0
 }
 
 ; Function Attrs: nounwind
-define hidden i8* @main.pointerUnsafeGEPByteOffset(i8* dereferenceable_or_null(1) %ptr, i32 %offset, i8* %context) unnamed_addr #0 {
+define hidden i8* @main.pointerUnsafeGEPByteOffset(i8* dereferenceable_or_null(1) %ptr, i32 %offset, i8* %context) unnamed_addr #1 {
 entry:
-  call void @runtime.trackPointer(i8* %ptr, i8* undef) #0
+  call void @runtime.trackPointer(i8* %ptr, i8* undef) #2
   %0 = getelementptr inbounds i8, i8* %ptr, i32 %offset
-  call void @runtime.trackPointer(i8* %0, i8* undef) #0
-  call void @runtime.trackPointer(i8* %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* %0, i8* undef) #2
+  call void @runtime.trackPointer(i8* %0, i8* undef) #2
   ret i8* %0
 }
 
 ; Function Attrs: nounwind
-define hidden i32* @main.pointerUnsafeGEPIntOffset(i32* dereferenceable_or_null(4) %ptr, i32 %offset, i8* %context) unnamed_addr #0 {
+define hidden i32* @main.pointerUnsafeGEPIntOffset(i32* dereferenceable_or_null(4) %ptr, i32 %offset, i8* %context) unnamed_addr #1 {
 entry:
   %0 = bitcast i32* %ptr to i8*
-  call void @runtime.trackPointer(i8* %0, i8* undef) #0
+  call void @runtime.trackPointer(i8* %0, i8* undef) #2
   %1 = getelementptr i32, i32* %ptr, i32 %offset
   %2 = bitcast i32* %1 to i8*
-  call void @runtime.trackPointer(i8* %2, i8* undef) #0
+  call void @runtime.trackPointer(i8* %2, i8* undef) #2
   %3 = bitcast i32* %1 to i8*
-  call void @runtime.trackPointer(i8* %3, i8* undef) #0
+  call void @runtime.trackPointer(i8* %3, i8* undef) #2
   ret i32* %1
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -10,58 +10,59 @@ target triple = "wasm32-unknown-wasi"
 @undefinedGlobalNotInSection = external global i32, align 4
 @main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define void @extern_func() #1 {
+define void @extern_func() #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @somepkg.someFunction1(i8* %context) unnamed_addr #0 {
+define hidden void @somepkg.someFunction1(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
-declare void @somepkg.someFunction2(i8*)
+declare void @somepkg.someFunction2(i8*) #0
 
 ; Function Attrs: inlinehint nounwind
-define hidden void @main.inlineFunc(i8* %context) unnamed_addr #2 {
+define hidden void @main.inlineFunc(i8* %context) unnamed_addr #3 {
 entry:
   ret void
 }
 
 ; Function Attrs: noinline nounwind
-define hidden void @main.noinlineFunc(i8* %context) unnamed_addr #3 {
+define hidden void @main.noinlineFunc(i8* %context) unnamed_addr #4 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.functionInSection(i8* %context) unnamed_addr #0 section ".special_function_section" {
+define hidden void @main.functionInSection(i8* %context) unnamed_addr #1 section ".special_function_section" {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define void @exportedFunctionInSection() #4 section ".special_function_section" {
+define void @exportedFunctionInSection() #5 section ".special_function_section" {
 entry:
   ret void
 }
 
-declare void @main.undefinedFunctionNotInSection(i8*)
+declare void @main.undefinedFunctionNotInSection(i8*) #0
 
-attributes #0 = { nounwind }
-attributes #1 = { nounwind "wasm-export-name"="extern_func" }
-attributes #2 = { inlinehint nounwind }
-attributes #3 = { noinline nounwind }
-attributes #4 = { nounwind "wasm-export-name"="exportedFunctionInSection" }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" }
+attributes #3 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #4 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" }

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -3,30 +3,30 @@ source_filename = "slice.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceLen(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.sliceLen(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #1 {
 entry:
   ret i32 %ints.len
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceCap(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.sliceCap(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #1 {
 entry:
   ret i32 %ints.cap
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceElement(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.sliceElement(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, i8* %context) unnamed_addr #1 {
 entry:
   %.not = icmp ult i32 %index, %ints.len
   br i1 %.not, label %lookup.next, label %lookup.throw
@@ -37,17 +37,17 @@ lookup.next:                                      ; preds = %entry
   ret i32 %1
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(i8* undef) #0
+  call void @runtime.lookupPanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.lookupPanic(i8*)
+declare void @runtime.lookupPanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.sliceAppendValues(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i8* %context) unnamed_addr #1 {
 entry:
-  %varargs = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
-  call void @runtime.trackPointer(i8* nonnull %varargs, i8* undef) #0
+  %varargs = call i8* @runtime.alloc(i32 12, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
+  call void @runtime.trackPointer(i8* nonnull %varargs, i8* undef) #2
   %0 = bitcast i8* %varargs to i32*
   store i32 1, i32* %0, align 4
   %1 = getelementptr inbounds i8, i8* %varargs, i32 4
@@ -57,7 +57,7 @@ entry:
   %4 = bitcast i8* %3 to i32*
   store i32 3, i32* %4, align 4
   %append.srcPtr = bitcast i32* %ints.data to i8*
-  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, i8* undef) #0
+  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, i8* undef) #2
   %append.newPtr = extractvalue { i8*, i32, i32 } %append.new, 0
   %append.newBuf = bitcast i8* %append.newPtr to i32*
   %append.newLen = extractvalue { i8*, i32, i32 } %append.new, 1
@@ -65,18 +65,18 @@ entry:
   %5 = insertvalue { i32*, i32, i32 } undef, i32* %append.newBuf, 0
   %6 = insertvalue { i32*, i32, i32 } %5, i32 %append.newLen, 1
   %7 = insertvalue { i32*, i32, i32 } %6, i32 %append.newCap, 2
-  call void @runtime.trackPointer(i8* %append.newPtr, i8* undef) #0
+  call void @runtime.trackPointer(i8* %append.newPtr, i8* undef) #2
   ret { i32*, i32, i32 } %7
 }
 
-declare { i8*, i32, i32 } @runtime.sliceAppend(i8*, i8* nocapture readonly, i32, i32, i32, i32, i8*)
+declare { i8*, i32, i32 } @runtime.sliceAppend(i8*, i8* nocapture readonly, i32, i32, i32, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.sliceAppendSlice(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32* %added.data, i32 %added.len, i32 %added.cap, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.sliceAppendSlice(i32* %ints.data, i32 %ints.len, i32 %ints.cap, i32* %added.data, i32 %added.len, i32 %added.cap, i8* %context) unnamed_addr #1 {
 entry:
   %append.srcPtr = bitcast i32* %ints.data to i8*
   %append.srcPtr1 = bitcast i32* %added.data to i8*
-  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* %append.srcPtr1, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, i8* undef) #0
+  %append.new = call { i8*, i32, i32 } @runtime.sliceAppend(i8* %append.srcPtr, i8* %append.srcPtr1, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, i8* undef) #2
   %append.newPtr = extractvalue { i8*, i32, i32 } %append.new, 0
   %append.newBuf = bitcast i8* %append.newPtr to i32*
   %append.newLen = extractvalue { i8*, i32, i32 } %append.new, 1
@@ -84,103 +84,105 @@ entry:
   %0 = insertvalue { i32*, i32, i32 } undef, i32* %append.newBuf, 0
   %1 = insertvalue { i32*, i32, i32 } %0, i32 %append.newLen, 1
   %2 = insertvalue { i32*, i32, i32 } %1, i32 %append.newCap, 2
-  call void @runtime.trackPointer(i8* %append.newPtr, i8* undef) #0
+  call void @runtime.trackPointer(i8* %append.newPtr, i8* undef) #2
   ret { i32*, i32, i32 } %2
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceCopy(i32* %dst.data, i32 %dst.len, i32 %dst.cap, i32* %src.data, i32 %src.len, i32 %src.cap, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.sliceCopy(i32* %dst.data, i32 %dst.len, i32 %dst.cap, i32* %src.data, i32 %src.len, i32 %src.cap, i8* %context) unnamed_addr #1 {
 entry:
   %copy.dstPtr = bitcast i32* %dst.data to i8*
   %copy.srcPtr = bitcast i32* %src.data to i8*
-  %copy.n = call i32 @runtime.sliceCopy(i8* %copy.dstPtr, i8* %copy.srcPtr, i32 %dst.len, i32 %src.len, i32 4, i8* undef) #0
+  %copy.n = call i32 @runtime.sliceCopy(i8* %copy.dstPtr, i8* %copy.srcPtr, i32 %dst.len, i32 %src.len, i32 4, i8* undef) #2
   ret i32 %copy.n
 }
 
-declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*)
+declare i32 @runtime.sliceCopy(i8* nocapture writeonly, i8* nocapture readonly, i32, i32, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden { i8*, i32, i32 } @main.makeByteSlice(i32 %len, i8* %context) unnamed_addr #0 {
+define hidden { i8*, i32, i32 } @main.makeByteSlice(i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %slice.maxcap = icmp slt i32 %len, 0
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.next:                                       ; preds = %entry
-  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %len, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
   %0 = insertvalue { i8*, i32, i32 } undef, i8* %makeslice.buf, 0
   %1 = insertvalue { i8*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i8*, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #2
   ret { i8*, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef) #0
+  call void @runtime.slicePanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.slicePanic(i8*)
+declare void @runtime.slicePanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden { i16*, i32, i32 } @main.makeInt16Slice(i32 %len, i8* %context) unnamed_addr #0 {
+define hidden { i16*, i32, i32 } @main.makeInt16Slice(i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %slice.maxcap = icmp slt i32 %len, 0
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 1
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
   %makeslice.array = bitcast i8* %makeslice.buf to i16*
   %0 = insertvalue { i16*, i32, i32 } undef, i16* %makeslice.array, 0
   %1 = insertvalue { i16*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i16*, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #2
   ret { i16*, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef) #0
+  call void @runtime.slicePanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context) unnamed_addr #0 {
+define hidden { [3 x i8]*, i32, i32 } @main.makeArraySlice(i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %slice.maxcap = icmp ugt i32 %len, 1431655765
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = mul i32 %len, 3
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
   %makeslice.array = bitcast i8* %makeslice.buf to [3 x i8]*
   %0 = insertvalue { [3 x i8]*, i32, i32 } undef, [3 x i8]* %makeslice.array, 0
   %1 = insertvalue { [3 x i8]*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { [3 x i8]*, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #2
   ret { [3 x i8]*, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef) #0
+  call void @runtime.slicePanic(i8* undef) #2
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context) unnamed_addr #0 {
+define hidden { i32*, i32, i32 } @main.makeInt32Slice(i32 %len, i8* %context) unnamed_addr #1 {
 entry:
   %slice.maxcap = icmp ugt i32 %len, 1073741823
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 2
-  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #0
+  %makeslice.buf = call i8* @runtime.alloc(i32 %makeslice.cap, i8* nonnull inttoptr (i32 3 to i8*), i8* undef) #2
   %makeslice.array = bitcast i8* %makeslice.buf to i32*
   %0 = insertvalue { i32*, i32, i32 } undef, i32* %makeslice.array, 0
   %1 = insertvalue { i32*, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { i32*, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #0
+  call void @runtime.trackPointer(i8* nonnull %makeslice.buf, i8* undef) #2
   ret { i32*, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(i8* undef) #0
+  call void @runtime.slicePanic(i8* undef) #2
   unreachable
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -7,36 +7,36 @@ target triple = "wasm32-unknown-wasi"
 
 @"main$string" = internal unnamed_addr constant [3 x i8] c"foo", align 1
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*)
+declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*)
+declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #0 {
+define hidden void @main.init(i8* %context) unnamed_addr #1 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.someString(i8* %context) unnamed_addr #0 {
+define hidden %runtime._string @main.someString(i8* %context) unnamed_addr #1 {
 entry:
   ret %runtime._string { i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"main$string", i32 0, i32 0), i32 3 }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.zeroLengthString(i8* %context) unnamed_addr #0 {
+define hidden %runtime._string @main.zeroLengthString(i8* %context) unnamed_addr #1 {
 entry:
   ret %runtime._string zeroinitializer
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.stringLen(i8* %s.data, i32 %s.len, i8* %context) unnamed_addr #0 {
+define hidden i32 @main.stringLen(i8* %s.data, i32 %s.len, i8* %context) unnamed_addr #1 {
 entry:
   ret i32 %s.len
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.stringIndex(i8* %s.data, i32 %s.len, i32 %index, i8* %context) unnamed_addr #0 {
+define hidden i8 @main.stringIndex(i8* %s.data, i32 %s.len, i32 %index, i8* %context) unnamed_addr #1 {
 entry:
   %.not = icmp ult i32 %index, %s.len
   br i1 %.not, label %lookup.next, label %lookup.throw
@@ -47,40 +47,40 @@ lookup.next:                                      ; preds = %entry
   ret i8 %1
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(i8* undef) #0
+  call void @runtime.lookupPanic(i8* undef) #2
   unreachable
 }
 
-declare void @runtime.lookupPanic(i8*)
+declare void @runtime.lookupPanic(i8*) #0
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.stringCompareEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef) #0
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef) #2
   ret i1 %0
 }
 
-declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*)
+declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareUnequal(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.stringCompareUnequal(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef) #0
+  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* undef) #2
   %1 = xor i1 %0, true
   ret i1 %1
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareLarger(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #0 {
+define hidden i1 @main.stringCompareLarger(i8* %s1.data, i32 %s1.len, i8* %s2.data, i32 %s2.len, i8* %context) unnamed_addr #1 {
 entry:
-  %0 = call i1 @runtime.stringLess(i8* %s2.data, i32 %s2.len, i8* %s1.data, i32 %s1.len, i8* undef) #0
+  %0 = call i1 @runtime.stringLess(i8* %s2.data, i32 %s2.len, i8* %s1.data, i32 %s1.len, i8* undef) #2
   ret i1 %0
 }
 
-declare i1 @runtime.stringLess(i8*, i32, i8*, i32, i8*)
+declare i1 @runtime.stringLess(i8*, i32, i8*, i32, i8*) #0
 
 ; Function Attrs: nounwind
-define hidden i8 @main.stringLookup(i8* %s.data, i32 %s.len, i8 %x, i8* %context) unnamed_addr #0 {
+define hidden i8 @main.stringLookup(i8* %s.data, i32 %s.len, i8 %x, i8* %context) unnamed_addr #1 {
 entry:
   %0 = zext i8 %x to i32
   %.not = icmp ult i32 %0, %s.len
@@ -92,8 +92,10 @@ lookup.next:                                      ; preds = %entry
   ret i8 %2
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(i8* undef) #0
+  call void @runtime.lookupPanic(i8* undef) #2
   unreachable
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }


### PR DESCRIPTION
I don't understand why this wasn't caught in CI. It should have. In any case, because the llvm-features string was updated, these IR outputs were updated.