### PR TITLE
ci: fix CI failure due to missing apt-get update

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -261,6 +261,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install --no-install-recommends \
               qemu-user \
               g++-arm-linux-gnueabihf \
@@ -363,6 +364,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install --no-install-recommends \
               qemu-user \
               g++-aarch64-linux-gnu \


### PR DESCRIPTION
There are failures in #2928 and #2927. Hopefully this fixes them.