### PR TITLE
main: use tags parser from buildutil

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -73,9 +73,7 @@ func (c *Config) BuildTags() []string {
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}
-	if extraTags := strings.Fields(c.Options.Tags); len(extraTags) != 0 {
-		tags = append(tags, extraTags...)
-	}
+	tags = append(tags, c.Options.Tags...)
 	return tags
 }
 

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -38,7 +38,7 @@ type Options struct {
 	PrintSizes      string
 	PrintAllocs     *regexp.Regexp // regexp string
 	PrintStacks     bool
-	Tags            string
+	Tags            []string
 	WasmAbi         string
 	GlobalValues    map[string]map[string]string // map[pkgpath]map[varname]value
 	TestConfig      TestConfig

--- a/corpus_test.go
+++ b/corpus_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/tools/go/buildutil"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -111,7 +112,9 @@ func TestCorpus(t *testing.T) {
 
 				opts := optionsFromTarget(target, sema)
 				opts.Directory = dir
-				opts.Tags = repo.Tags
+				var tags buildutil.TagsFlag
+				tags.Set(repo.Tags)
+				opts.Tags = []string(tags)
 
 				passed, err := Test(path, out, out, &opts, false, testing.Verbose(), false, "", "", "", "")
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 	"github.com/tinygo-org/tinygo/interp"
 	"github.com/tinygo-org/tinygo/loader"
+	"golang.org/x/tools/go/buildutil"
 	"tinygo.org/x/go-llvm"
 
 	"go.bug.st/serial"
@@ -1299,7 +1300,8 @@ func main() {
 	printIR := flag.Bool("printir", false, "print LLVM IR")
 	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
-	tags := flag.String("tags", "", "a space-separated list of extra build tags")
+	var tags buildutil.TagsFlag
+	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
 	printSize := flag.String("size", "", "print sizes (none, short, full)")
 	printStacks := flag.Bool("print-stacks", false, "print stack sizes of goroutines")
@@ -1393,7 +1395,7 @@ func main() {
 		PrintSizes:      *printSize,
 		PrintStacks:     *printStacks,
 		PrintAllocs:     printAllocs,
-		Tags:            *tags,
+		Tags:            []string(tags),
 		GlobalValues:    globalVarValues,
 		WasmAbi:         *wasmAbi,
 		Programmer:      *programmer,


### PR DESCRIPTION
This should add support for things like quotes around tags, if they are ever needed.

Only making this change now because I happened to stumble across buildutil.TagsFlag.

I would prefer to merge this after the coming release. Not because I think it's risky but because it doesn't fix a particular bug and I'd like to avoid introducing a new bug.