### PR TITLE
makefile: add badger2040, nano-rp2040, thingplus-rp2040 to smoketest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,6 +557,10 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=macropad-rp2040 	examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=badger2040          examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=thingplus-rp2040    examples/blinky1
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex


### PR DESCRIPTION
We have probably forgotten to add.
I added this because I think it needs to be tested against the usb package update.