### PR TITLE
rp2040: add usb settings

### DIFF
--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -60,3 +60,14 @@ const (
 	// Default Serial In Bus 1 for SPI communications
 	SPI1_SDI_PIN = GPIO12 // Rx
 )
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "Feather RP2040"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x80F1
+)

--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -64,3 +64,14 @@ const (
 	SPI0_SDO_PIN = 31 // not pinned out
 	SPI0_SDI_PIN = 31 // not pinned out
 )
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "MacroPad RP2040"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x8107
+)

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -64,3 +64,14 @@ const (
 	// Default Serial In Bus 1 for SPI communications
 	SPI1_SDI_PIN = GPIO12 // Rx
 )
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "Pico"
+	usb_STRING_MANUFACTURER = "Raspberry Pi"
+)
+
+var (
+	usb_VID uint16 = 0x2E8A
+	usb_PID uint16 = 0x000A
+)

--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -79,3 +79,14 @@ const (
 	// Default Serial In Bus 1 for SPI communications to muSDcard
 	SPI1_SDI_PIN = GPIO12 // Rx
 )
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "Thing Plus RP2040"
+	usb_STRING_MANUFACTURER = "SparkFun"
+)
+
+var (
+	usb_VID uint16 = 0x1B4F
+	usb_PID uint16 = 0x0026
+)

--- a/targets/feather-rp2040.json
+++ b/targets/feather-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial": "uart",
+    "serial-port": ["acm:239a:80f1"],
     "build-tags": ["feather_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",
     "extra-files": [

--- a/targets/macropad-rp2040.json
+++ b/targets/macropad-rp2040.json
@@ -4,6 +4,7 @@
     ],
     "build-tags": ["macropad_rp2040"],
     "serial": "none",
+    "serial-port": ["acm:239a:8107"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [
         "targets/pico-boot-stage2.S"

--- a/targets/pico.json
+++ b/targets/pico.json
@@ -4,6 +4,7 @@
     ],
     "build-tags": ["pico"],
     "serial": "uart",
+    "serial-port": ["acm:2e8a:000A"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [
         "targets/pico-boot-stage2.S"

--- a/targets/thingplus-rp2040.json
+++ b/targets/thingplus-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial": "uart",
+    "serial-port": ["acm:1b4f:0026"],
     "build-tags": ["thingplus_rp2040"],
     "linkerscript": "targets/thingplus-rp2040.ld",
     "extra-files": [


### PR DESCRIPTION
Add the settings listed below.

https://github.com/earlephilhower/arduino-pico/blob/master/boards.txt

The following boards were already set up.

* badger2040
* nano-rp2040