### PR TITLE
build: back to windows-2019 image, also Go 1.18.3

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,12 +13,12 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.1'
+          go-version: '1.18.3'
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'


### PR DESCRIPTION
Restore functioning build for Windows by dropping back to older `windows-2019` runner.

Also use latest Go release 1.18.3