### PR TITLE
ci: disable Ccache on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v2
         id: cache-llvm-build
         with:
-          key: llvm-build-14-windows-v1
+          key: llvm-build-14-windows-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -65,7 +65,7 @@ jobs:
           rm -rf llvm-project
           make llvm-source
           # build!
-          make llvm-build
+          make llvm-build CCACHE=OFF
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Cache wasi-libc sysroot

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,16 @@ MD5SUM = md5sum
 # tinygo binary for tests
 TINYGO ?= $(call detect,tinygo,tinygo $(CURDIR)/build/tinygo)
 
-# Use CCACHE for LLVM if possible
-ifneq (, $(shell command -v ccache 2> /dev/null))
-    LLVM_OPTION += '-DLLVM_CCACHE_BUILD=ON'
+# Check for ccache if the user hasn't set it to on or off.
+ifeq (, $(CCACHE))
+    # Use CCACHE for LLVM if possible
+    ifneq (, $(shell command -v ccache 2> /dev/null))
+        CCACHE := ON
+    else
+        CCACHE := OFF
+    endif
 endif
+LLVM_OPTION += '-DLLVM_CCACHE_BUILD=$(CCACHE)'
 
 # Allow enabling LLVM assertions
 ifeq (1, $(ASSERT))


### PR DESCRIPTION
Let's see whether this works.
Commented out the part after the LLVM build so we can get a cache. After LLVM finishes, that part should be uncommented to run all tests.