### PR TITLE
targets: make leveldb runtime hash default for wasi

### DIFF
--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -2,7 +2,7 @@
 	"llvm-target":   "wasm32-unknown-wasi",
 	"cpu":           "generic",
 	"features":      "+bulk-memory,+nontrapping-fptoint,+sign-ext",
-	"build-tags":    ["tinygo.wasm", "wasi"],
+	"build-tags":    ["tinygo.wasm", "wasi", "runtime_memhash_leveldb"],
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",


### PR DESCRIPTION
Arguably we should adjust other targets, but lets start small...