### PR TITLE
Initial support for board XIAO RP2040

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=thingplus-rp2040    examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=xiao-rp2040         examples/blinky1
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 85 microcontroller boards are currently supported:
+The following 86 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -114,6 +114,7 @@ The following 85 microcontroller boards are currently supported:
 * [Raytac MDBT50Q-RX Dongle (with TinyUF2 bootloader)](https://www.adafruit.com/product/5199)
 * [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
 * [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html)
+* [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html)
 * [Seeed LoRa-E5 Development Kit](https://www.seeedstudio.com/LoRa-E5-Dev-Kit-p-4868.html)
 * [Seeed Sipeed MAix BiT](https://www.seeedstudio.com/Sipeed-MAix-BiT-for-RISC-V-AI-IoT-p-2872.html)
 * [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html)

--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -1,0 +1,79 @@
+//go:build xiao_rp2040
+// +build xiao_rp2040
+
+// This file contains the pin mappings for the Seeed XIAO RP2040 boards.
+//
+// XIAO RP2040 is a microcontroller using the Raspberry Pi RP2040 chip.
+//
+// - https://wiki.seeedstudio.com/XIAO-RP2040/
+//
+package machine
+
+// Digital Pins
+const (
+	D0  Pin = GPIO26
+	D1  Pin = GPIO27
+	D2  Pin = GPIO28
+	D3  Pin = GPIO29
+	D4  Pin = GPIO6
+	D5  Pin = GPIO7
+	D6  Pin = GPIO0
+	D7  Pin = GPIO1
+	D8  Pin = GPIO2
+	D9  Pin = GPIO3
+	D10 Pin = GPIO4
+)
+
+// Analog pins
+const (
+	A0 Pin = D0
+	A1 Pin = D1
+	A2 Pin = D2
+	A3 Pin = D3
+)
+
+// Onboard LEDs
+const (
+	NEOPIXEL = GPIO12
+
+	LED       = GPIO17
+	LED_RED   = GPIO17
+	LED_GREEN = GPIO16
+	LED_BLUE  = GPIO25
+)
+
+// I2C pins
+const (
+	I2C0_SDA_PIN Pin = D4
+	I2C0_SCL_PIN Pin = D5
+
+	I2C1_SDA_PIN Pin = NoPin
+	I2C1_SCL_PIN Pin = NoPin
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN Pin = D8
+	SPI0_SDO_PIN Pin = D9
+	SPI0_SDI_PIN Pin = D10
+
+	SPI1_SCK_PIN Pin = NoPin
+	SPI1_SDO_PIN Pin = NoPin
+	SPI1_SDI_PIN Pin = NoPin
+)
+
+// Onboard crystal oscillator frequency, in MHz.
+const (
+	xoscFreq = 12 // MHz
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "XIAO RP2040"
+	usb_STRING_MANUFACTURER = "Seeed"
+)
+
+var (
+	usb_VID uint16 = 0x2e8a
+	usb_PID uint16 = 0x000a
+)

--- a/targets/xiao-rp2040.json
+++ b/targets/xiao-rp2040.json
@@ -1,0 +1,11 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial": "uart",
+    "build-tags": ["xiao_rp2040"],
+    "linkerscript": "targets/xiao-rp2040.ld",
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}

--- a/targets/xiao-rp2040.ld
+++ b/targets/xiao-rp2040.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    /* Reserve exactly 256 bytes at start of flash for second stage bootloader */
+    BOOT2_TEXT (rx) : ORIGIN = 0x10000000, LENGTH = 256
+    FLASH_TEXT (rx) : ORIGIN = 0x10000000 + 256, LENGTH = 1020K - 256
+    RAM (rwx)       : ORIGIN = 0x20000000, LENGTH = 256k
+}
+
+INCLUDE "targets/rp2040.ld"


### PR DESCRIPTION
Looks like lib/wasi-libc was modified/updated, not sure why/how. Don't know how to drop it from the commit either.


Initial support, onboard RED led works, need to check all other pins.