### PR TITLE
cgo: fix default LLVM version to LLVM 14

### DIFF
--- a/cgo/libclang_config_llvm13.go
+++ b/cgo/libclang_config_llvm13.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && !llvm14
-// +build !byollvm,!llvm14
+//go:build !byollvm && llvm13
+// +build !byollvm,llvm13
 
 package cgo
 

--- a/cgo/libclang_config_llvm14.go
+++ b/cgo/libclang_config_llvm14.go
@@ -1,5 +1,5 @@
-//go:build !byollvm && llvm14
-// +build !byollvm,llvm14
+//go:build !byollvm && !llvm13
+// +build !byollvm,!llvm13
 
 package cgo
 


### PR DESCRIPTION
Without extra flags, we would try to use LLVM 13 for cgo and LLVM 14 for other things since 873412b43a6384e74a63f1d7b95de6455fc76992. That isn't great. So fix this by only using LLVM 14 in the cgo package.

This was a regression introduced with 873412b43a6384e74a63f1d7b95de6455fc76992.