### PR TITLE
feather-rp2040,macropad-rp2040: fix qspi-flash settings

### DIFF
--- a/targets/macropad-rp2040-boot-stage2.S
+++ b/targets/macropad-rp2040-boot-stage2.S
@@ -1,17 +1,17 @@
-// Adafruit Feather RP2040 Stage 2 Bootloader
+// Adafruit MacroPad RP2040 Stage 2 Bootloader
 
 //
 // This file defines the parameters specific to the flash-chip found
-// on the Adafruit Feather RP2040.  The generic implementation is in
+// on the Adafruit MacroPad RP2040.  The generic implementation is in
 // rp2040-boot-stage2.S
 //
 
 #define BOARD_PICO_FLASH_SPI_CLKDIV   4
-#define BOARD_CMD_READ                0xe7
+#define BOARD_CMD_READ                0xeb
 #define BOARD_QUAD_OK                 1
 #define BOARD_QUAD_ENABLE_STATUS_BYTE 2
 #define BOARD_QUAD_ENABLE_BIT_MASK    2
-#define BOARD_SPLIT_STATUS_WRITE      1
-#define BOARD_WAIT_CYCLES             2
+#define BOARD_SPLIT_STATUS_WRITE      0
+#define BOARD_WAIT_CYCLES             4
 
 #include "rp2040-boot-stage2.S"

--- a/targets/macropad-rp2040.json
+++ b/targets/macropad-rp2040.json
@@ -7,6 +7,6 @@
     "serial-port": ["acm:239a:8107"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [
-        "targets/pico-boot-stage2.S"
+        "targets/macropad-rp2040-boot-stage2.S"
     ]
 }


### PR DESCRIPTION
This PR resolves the issue of #2938

feather-rp2040 and macropad-rp2040 seem to be configured differently because they use slightly slower qspi-flash.
It would be good to keep it together with the pico-sdk source code.

PICO_FLASH_SPI_CLKDIV == 4
https://github.com/raspberrypi/pico-sdk/blob/2e6142b15b8a75c1227dd3edbe839193b2bf9041/src/boards/include/boards/adafruit_feather_rp2040.h#L80-L82
https://github.com/raspberrypi/pico-sdk/blob/2e6142b15b8a75c1227dd3edbe839193b2bf9041/src/boards/include/boards/adafruit_macropad_rp2040.h#L170-L172

PICO_FLASH_SPI_CLKDIV == 2
https://github.com/raspberrypi/pico-sdk/blob/2e6142b15b8a75c1227dd3edbe839193b2bf9041/src/boards/include/boards/pico.h#L69-L71
(All other boards are CLKDIV==2)

When adding RP2040 boards in the future, it is better to check the following
https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards
