### PR TITLE
serial: use common initialization for serial

### DIFF
--- a/src/machine/serial-none.go
+++ b/src/machine/serial-none.go
@@ -5,3 +5,7 @@ package machine
 
 // Serial is a null device: writes to it are ignored.
 var Serial = NullSerial{}
+
+func InitSerial() {
+	Serial.Configure(UARTConfig{})
+}

--- a/src/machine/serial-uart.go
+++ b/src/machine/serial-uart.go
@@ -5,3 +5,7 @@ package machine
 
 // Serial is implemented via the default (usually the first) UART on the chip.
 var Serial = DefaultUART
+
+func InitSerial() {
+	Serial.Configure(UARTConfig{})
+}

--- a/src/machine/serial-usb.go
+++ b/src/machine/serial-usb.go
@@ -5,3 +5,7 @@ package machine
 
 // Serial is implemented via USB (USB-CDC).
 var Serial = USB
+
+func InitSerial() {
+	Serial.Configure(UARTConfig{})
+}

--- a/src/runtime/runtime_atmega.go
+++ b/src/runtime/runtime_atmega.go
@@ -9,7 +9,7 @@ import (
 )
 
 func initUART() {
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -29,7 +29,7 @@ func init() {
 	initADCClock()
 
 	// connect to USB CDC interface
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 	if !machine.USB.Configured() {
 		machine.USB.Configure(machine.UARTConfig{})
 	}

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -29,7 +29,7 @@ func init() {
 	initADCClock()
 
 	// connect to USB CDC interface
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 	if !machine.USB.Configured() {
 		machine.USB.Configure(machine.UARTConfig{})
 	}

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -43,7 +43,7 @@ func main() {
 	clearbss()
 
 	// Initialize UART.
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	// Initialize main system timer used for time.Now.
 	initTimer()

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -48,7 +48,7 @@ func main() {
 	rom_i2c_writeReg(103, 4, 2, 145)
 
 	// Initialize UART.
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	// Initialize timer. Bits:
 	//  ENABLE:   timer enable

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -92,7 +92,7 @@ func initPeripherals() {
 	sifive.RTC.RTCCFG.Set(sifive.RTC_RTCCFG_ENALWAYS)
 
 	// Configure the UART.
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -104,7 +104,7 @@ func initPeripherals() {
 	// Enable FPIOA peripheral.
 	kendryte.SYSCTL.CLK_EN_PERI.SetBits(kendryte.SYSCTL_CLK_EN_PERI_FPIOA_CLK_EN)
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_mimxrt1062.go
+++ b/src/runtime/runtime_mimxrt1062.go
@@ -119,7 +119,7 @@ func initPins() {
 }
 
 func initUART() {
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -28,7 +28,7 @@ func main() {
 }
 
 func init() {
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 	initLFCLK()
 	initRTC()
 }

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -76,7 +76,7 @@ func machineInit()
 func init() {
 	machineInit()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 }
 
 //export Reset_Handler

--- a/src/runtime/runtime_stm32f103.go
+++ b/src/runtime/runtime_stm32f103.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM4)
 }

--- a/src/runtime/runtime_stm32f4.go
+++ b/src/runtime/runtime_stm32f4.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM2)
 }

--- a/src/runtime/runtime_stm32f405.go
+++ b/src/runtime/runtime_stm32f405.go
@@ -156,7 +156,7 @@ func initCLK() {
 
 func initCOM() {
 	if machine.NUM_UART_INTERFACES > 0 {
-		machine.Serial.Configure(machine.UARTConfig{})
+		machine.InitSerial()
 	}
 }
 

--- a/src/runtime/runtime_stm32f7x2.go
+++ b/src/runtime/runtime_stm32f7x2.go
@@ -29,7 +29,7 @@ const (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM3)
 }

--- a/src/runtime/runtime_stm32l0x1.go
+++ b/src/runtime/runtime_stm32l0x1.go
@@ -15,7 +15,7 @@ const (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM21)
 }

--- a/src/runtime/runtime_stm32l0x2.go
+++ b/src/runtime/runtime_stm32l0x2.go
@@ -15,7 +15,7 @@ const (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM3)
 }

--- a/src/runtime/runtime_stm32l4.go
+++ b/src/runtime/runtime_stm32l4.go
@@ -38,7 +38,7 @@ type arrtype = uint32
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM15)
 }

--- a/src/runtime/runtime_stm32l5x2.go
+++ b/src/runtime/runtime_stm32l5x2.go
@@ -30,7 +30,7 @@ const (
 func init() {
 	initCLK()
 
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	initTickTimer(&machine.TIM16)
 }

--- a/src/runtime/runtime_stm32wlx.go
+++ b/src/runtime/runtime_stm32wlx.go
@@ -23,7 +23,7 @@ func init() {
 	initCLK()
 
 	// UART init
-	machine.Serial.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	// Timers init
 	initTickTimer(&machine.TIM1)


### PR DESCRIPTION
This PR is intended to further break #2937 into smaller pieces for easier review.

This change is seemingly unnecessary, but is necessary to move usbcdc to machine/usb/cdc.
We can change it later if we find a better way.

After this PR, the final code will look like this

https://github.com/tinygo-org/tinygo/blob/0a54fad649c64e2a5e66dc9ffe561acb49c8e257/src/machine/serial-usb.go#L4-L10

https://github.com/tinygo-org/tinygo/blob/0a54fad649c64e2a5e66dc9ffe561acb49c8e257/src/machine/usb/cdc/usbcdc.go#L212-L215
