### PR TITLE
samd21,samd51,nrf52840: refactor usb initialization

### DIFF
--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -22,7 +22,6 @@ type USBCDC struct {
 	waitTxc           bool
 	waitTxcRetryCount uint8
 	sent              bool
-	configured        bool
 }
 
 var (
@@ -150,26 +149,8 @@ const (
 	usb_DEVICE_PCKSIZE_MULTI_PACKET_SIZE_Mask = 0x3FFF
 )
 
-var (
-	usbEndpointDescriptors [8]usbDeviceDescriptor
-
-	udd_ep_in_cache_buffer  [7][128]uint8
-	udd_ep_out_cache_buffer [7][128]uint8
-
-	isEndpointHalt        = false
-	isRemoteWakeUpEnabled = false
-	endPoints             = []uint32{usb_ENDPOINT_TYPE_CONTROL,
-		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
-		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
-
-	usbConfiguration uint8
-	usbSetInterface  uint8
-	usbLineInfo      = cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
-)
-
-// Configure the USB CDC interface. The config is here for compatibility with the UART interface.
-func (usbcdc *USBCDC) Configure(config UARTConfig) {
+// Configure the USB peripheral. The config is here for compatibility with the UART interface.
+func (dev *USBDevice) Configure(config UARTConfig) {
 	// reset USB interface
 	sam.USB_DEVICE.CTRLA.SetBits(sam.USB_DEVICE_CTRLA_SWRST)
 	for sam.USB_DEVICE.SYNCBUSY.HasBits(sam.USB_DEVICE_SYNCBUSY_SWRST) ||
@@ -208,13 +189,10 @@ func (usbcdc *USBCDC) Configure(config UARTConfig) {
 	interrupt.New(sam.IRQ_USB_SOF_HSOF, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT0, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT1, handleUSBIRQ).Enable()
-
-	usbcdc.configured = true
 }
 
-// Configured returns whether usbcdc is configured or not.
-func (usbcdc *USBCDC) Configured() bool {
-	return usbcdc.configured
+func (usbcdc *USBCDC) Configure(config UARTConfig) {
+	// dummy
 }
 
 func handlePadCalibration() {

--- a/src/machine/serial-usb.go
+++ b/src/machine/serial-usb.go
@@ -7,5 +7,4 @@ package machine
 var Serial = USB
 
 func InitSerial() {
-	Serial.Configure(UARTConfig{})
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -8,6 +8,12 @@ import (
 	"runtime/volatile"
 )
 
+type USBDevice struct {
+}
+
+var (
+	USBDev = &USBDevice{}
+)
 var usbDescriptor = descriptorCDC
 
 var (
@@ -45,6 +51,24 @@ func strToUTF16LEDescriptor(in string, out []byte) {
 var (
 	// TODO: allow setting these
 	usb_STRING_LANGUAGE = [2]uint16{(3 << 8) | (2 + 2), 0x0409} // English
+)
+
+var (
+	usbEndpointDescriptors [8]usbDeviceDescriptor
+
+	udd_ep_in_cache_buffer  [7][128]uint8
+	udd_ep_out_cache_buffer [7][128]uint8
+
+	isEndpointHalt        = false
+	isRemoteWakeUpEnabled = false
+	endPoints             = []uint32{usb_ENDPOINT_TYPE_CONTROL,
+		(usb_ENDPOINT_TYPE_INTERRUPT | usbEndpointIn),
+		(usb_ENDPOINT_TYPE_BULK | usbEndpointOut),
+		(usb_ENDPOINT_TYPE_BULK | usbEndpointIn)}
+
+	usbConfiguration uint8
+	usbSetInterface  uint8
+	usbLineInfo      = cdcLineInfo{115200, 0x00, 0x00, 0x08, 0x00}
 )
 
 const (

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -28,11 +28,8 @@ func init() {
 	initUSBClock()
 	initADCClock()
 
-	// connect to USB CDC interface
+	machine.USBDev.Configure(machine.UARTConfig{})
 	machine.InitSerial()
-	if !machine.USB.Configured() {
-		machine.USB.Configure(machine.UARTConfig{})
-	}
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -28,11 +28,8 @@ func init() {
 	initUSBClock()
 	initADCClock()
 
-	// connect to USB CDC interface
+	machine.USBDev.Configure(machine.UARTConfig{})
 	machine.InitSerial()
-	if !machine.USB.Configured() {
-		machine.USB.Configure(machine.UARTConfig{})
-	}
 }
 
 func putchar(c byte) {

--- a/src/runtime/runtime_nrf52840.go
+++ b/src/runtime/runtime_nrf52840.go
@@ -1,5 +1,5 @@
-//go:build nrf && !nrf52840
-// +build nrf,!nrf52840
+//go:build nrf && nrf52840
+// +build nrf,nrf52840
 
 package runtime
 
@@ -28,6 +28,7 @@ func main() {
 }
 
 func init() {
+	machine.USBDev.Configure(machine.UARTConfig{})
 	machine.InitSerial()
 	initLFCLK()
 	initRTC()


### PR DESCRIPTION
This PR is intended to further break #2937 into smaller pieces for easier review.
This PR must be merged after #2963 

This PR separates USB Device initialization from USBCDC.
Also move some common items to usb.go.
Renames several functions with the same meaning.
Separate runtime for nrf52840

I have confirmed that examples/echo works on the following boards
* feather-m0
* feather-m4-can
* feather-nrf52840-sense