### PR TITLE
atsamd21,atsamd51,nrf52840: improve usb-device initialization

### DIFF
--- a/src/machine/machine_atsamd21_usb.go
+++ b/src/machine/machine_atsamd21_usb.go
@@ -150,6 +150,10 @@ const (
 
 // Configure the USB peripheral. The config is here for compatibility with the UART interface.
 func (dev *USBDevice) Configure(config UARTConfig) {
+	if dev.initcomplete {
+		return
+	}
+
 	// reset USB interface
 	sam.USB_DEVICE.CTRLA.SetBits(sam.USB_DEVICE_CTRLA_SWRST)
 	for sam.USB_DEVICE.SYNCBUSY.HasBits(sam.USB_DEVICE_SYNCBUSY_SWRST) ||
@@ -185,6 +189,8 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 
 	// enable IRQ
 	interrupt.New(sam.IRQ_USB, handleUSBIRQ).Enable()
+
+	dev.initcomplete = true
 }
 
 func (usbcdc *USBCDC) Configure(config UARTConfig) {

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -151,6 +151,10 @@ const (
 
 // Configure the USB peripheral. The config is here for compatibility with the UART interface.
 func (dev *USBDevice) Configure(config UARTConfig) {
+	if dev.initcomplete {
+		return
+	}
+
 	// reset USB interface
 	sam.USB_DEVICE.CTRLA.SetBits(sam.USB_DEVICE_CTRLA_SWRST)
 	for sam.USB_DEVICE.SYNCBUSY.HasBits(sam.USB_DEVICE_SYNCBUSY_SWRST) ||
@@ -189,6 +193,8 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	interrupt.New(sam.IRQ_USB_SOF_HSOF, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT0, handleUSBIRQ).Enable()
 	interrupt.New(sam.IRQ_USB_TRCPT1, handleUSBIRQ).Enable()
+
+	dev.initcomplete = true
 }
 
 func (usbcdc *USBCDC) Configure(config UARTConfig) {

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -9,6 +9,7 @@ import (
 )
 
 type USBDevice struct {
+	initcomplete bool
 }
 
 var (


### PR DESCRIPTION
This PR is intended to further break https://github.com/tinygo-org/tinygo/pull/2937 into smaller pieces for easier review.
This PR must be merged after https://github.com/tinygo-org/tinygo/pull/2968

This PR fixes the following issues

* Fixed problem when configure is called multiple times (-> dev.initcomplete)
* Add workaround to errata 187 in nrf52840

> the problem is that I erased this part of nrf52840, which makes it easy for initialization to fail.
> And I think this part is needed for samd21 and samd51 as well.
> 
> https://github.com/tinygo-org/tinygo/blob/1b2e764835fb5278de144caf059cb094bad4db23/src/machine/machine_nrf52840_usb.go#L172-L174
> 
> For example, the following cases can cause exactly the problem
> 
> https://github.com/tinygo-org/tinygo/blob/b65447c7d567eea495805656f45472cc3c483e03/src/examples/echo/echo.go#L18