### PR TITLE
build: run tests on drivers repo after successful docker dev build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,18 +55,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Trigger Drivers repo build on CircleCI
-        run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/drivers/pipeline' \
-            --header 'Content-Type: application/json' \
-            -d '{"branch": "dev"}' \
-            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
-      - name: Trigger Bluetooth repo build on CircleCI
-        run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/bluetooth/pipeline' \
-            --header 'Content-Type: application/json' \
-            -d '{"branch": "dev"}' \
-            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+      - name: Trigger Drivers repo build on Github Actions
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/drivers/actions/workflows/build.yml/dispatches \
+          -d '{"ref": "dev"}'
+      - name: Trigger Bluetooth repo build on Github Actions
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/bluetooth/actions/workflows/linux.yml/dispatches \
+          -d '{"ref": "dev"}'
       - name: Trigger TinyFS repo build on CircleCI
         run: |
           curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinyfs/pipeline' \


### PR DESCRIPTION
This PR switches the test of the drivers and bluetooth repos to use Github Actions after a successful Docker build.