### PR TITLE
usb: rename callback to handler to keep consistent

### DIFF
--- a/src/examples/usb-midi/main.go
+++ b/src/examples/usb-midi/main.go
@@ -15,7 +15,7 @@ func main() {
 	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
 	m := midi.New()
-	m.SetCallback(func(b []byte) {
+	m.SetHandler(func(b []byte) {
 		led.Set(!led.Get())
 		fmt.Printf("% X\r\n", b)
 		m.Write(b)

--- a/src/machine/usb/hid/hid.go
+++ b/src/machine/usb/hid/hid.go
@@ -20,35 +20,35 @@ const (
 )
 
 type hidDevicer interface {
-	Callback() bool
+	Handler() bool
 }
 
 var devices [5]hidDevicer
 var size int
 
-// SetCallbackHandler sets the callback. Only the first time it is called, it
+// SetHandler sets the handler. Only the first time it is called, it
 // calls machine.EnableHID for USB configuration
-func SetCallbackHandler(d hidDevicer) {
+func SetHandler(d hidDevicer) {
 	if size == 0 {
-		machine.EnableHID(callback, nil, callbackSetup)
+		machine.EnableHID(handler, nil, setupHandler)
 	}
 
 	devices[size] = d
 	size++
 }
 
-func callback() {
+func handler() {
 	for _, d := range devices {
 		if d == nil {
 			continue
 		}
-		if done := d.Callback(); done {
+		if done := d.Handler(); done {
 			return
 		}
 	}
 }
 
-func callbackSetup(setup machine.USBSetup) bool {
+func setupHandler(setup machine.USBSetup) bool {
 	ok := false
 	if setup.BmRequestType == usb_SET_REPORT_TYPE && setup.BRequest == usb_SET_IDLE {
 		machine.SendZlp()

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -59,7 +59,7 @@ const (
 func init() {
 	if Keyboard == nil {
 		Keyboard = newKeyboard()
-		hid.SetCallbackHandler(Keyboard)
+		hid.SetHandler(Keyboard)
 	}
 }
 
@@ -74,7 +74,7 @@ func newKeyboard() *keyboard {
 	}
 }
 
-func (kb *keyboard) Callback() bool {
+func (kb *keyboard) Handler() bool {
 	kb.waitTxc = false
 	if b, ok := kb.buf.Get(); ok {
 		kb.waitTxc = true

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -23,7 +23,7 @@ type mouse struct {
 func init() {
 	if Mouse == nil {
 		Mouse = newMouse()
-		hid.SetCallbackHandler(Mouse)
+		hid.SetHandler(Mouse)
 	}
 }
 
@@ -38,7 +38,7 @@ func newMouse() *mouse {
 	}
 }
 
-func (m *mouse) Callback() bool {
+func (m *mouse) Handler() bool {
 	m.waitTxc = false
 	if b, ok := m.buf.Get(); ok {
 		m.waitTxc = true
@@ -82,7 +82,7 @@ func (m *mouse) Move(vx, vy int) {
 	})
 }
 
-// Cilck clicks the mouse button.
+// Click clicks the mouse button.
 func (m *mouse) Click(btn Button) {
 	m.Press(btn)
 	m.Release(btn)

--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -12,9 +12,9 @@ const (
 var Midi *midi
 
 type midi struct {
-	buf            *RingBuffer
-	callbackFuncRx func([]byte)
-	waitTxc        bool
+	buf       *RingBuffer
+	rxHandler func([]byte)
+	waitTxc   bool
 }
 
 func init() {
@@ -32,12 +32,12 @@ func newMidi() *midi {
 	m := &midi{
 		buf: NewRingBuffer(),
 	}
-	machine.EnableMIDI(m.Callback, m.CallbackRx, nil)
+	machine.EnableMIDI(m.Handler, m.rxHandler, nil)
 	return m
 }
 
-func (m *midi) SetCallback(callbackRx func([]byte)) {
-	m.callbackFuncRx = callbackRx
+func (m *midi) SetHandler(rxHandler func([]byte)) {
+	m.rxHandler = rxHandler
 }
 
 func (m *midi) Write(b []byte) (n int, err error) {
@@ -54,7 +54,7 @@ func (m *midi) sendUSBPacket(b []byte) {
 }
 
 // from BulkIn
-func (m *midi) Callback() {
+func (m *midi) Handler() {
 	m.waitTxc = false
 	if b, ok := m.buf.Get(); ok {
 		m.waitTxc = true
@@ -72,8 +72,8 @@ func (m *midi) tx(b []byte) {
 }
 
 // from BulkOut
-func (m *midi) CallbackRx(b []byte) {
-	if m.callbackFuncRx != nil {
-		m.callbackFuncRx(b)
+func (m *midi) RxHandler(b []byte) {
+	if m.rxHandler != nil {
+		m.rxHandler(b)
 	}
 }


### PR DESCRIPTION
This PR renames all of the USB "callbacks" to "handlers" to keep consistent.