### PR TITLE
rp2040: change default for serial to usb

### DIFF
--- a/targets/badger2040.json
+++ b/targets/badger2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
+    "serial-port": ["acm:2e8a:0003"],
     "build-tags": ["badger2040"],
     "linkerscript": "targets/badger2040.ld",
     "extra-files": [

--- a/targets/challenger-rp2040.json
+++ b/targets/challenger-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
+    "serial-port": ["acm:2e8a:1023"],
     "build-tags": ["challenger_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",
     "extra-files": [

--- a/targets/feather-rp2040.json
+++ b/targets/feather-rp2040.json
@@ -2,7 +2,6 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
     "serial-port": ["acm:239a:80f1"],
     "build-tags": ["feather_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",

--- a/targets/macropad-rp2040.json
+++ b/targets/macropad-rp2040.json
@@ -3,7 +3,6 @@
         "rp2040"
     ],
     "build-tags": ["macropad_rp2040"],
-    "serial": "none",
     "serial-port": ["acm:239a:8107"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [

--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
+    "serial-port": ["acm:2341:005e"],
     "build-tags": ["nano_rp2040"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [

--- a/targets/pico.json
+++ b/targets/pico.json
@@ -3,7 +3,6 @@
         "rp2040"
     ],
     "build-tags": ["pico"],
-    "serial": "uart",
     "serial-port": ["acm:2e8a:000A"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [

--- a/targets/rp2040.json
+++ b/targets/rp2040.json
@@ -2,6 +2,7 @@
     "inherits": ["cortex-m0plus"],
     "build-tags": ["rp2040", "rp"],
     "flash-method": "msd",
+    "serial": "usb",
     "msd-volume-name": "RPI-RP2",
     "msd-firmware-name": "firmware.uf2",
     "binary-format": "uf2",

--- a/targets/thingplus-rp2040.json
+++ b/targets/thingplus-rp2040.json
@@ -2,7 +2,6 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
     "serial-port": ["acm:1b4f:0026"],
     "build-tags": ["thingplus_rp2040"],
     "linkerscript": "targets/thingplus-rp2040.ld",

--- a/targets/xiao-rp2040.json
+++ b/targets/xiao-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial": "uart",
+    "serial-port": ["acm:2e8a:000a"],
     "build-tags": ["xiao_rp2040"],
     "linkerscript": "targets/xiao-rp2040.ld",
     "extra-files": [


### PR DESCRIPTION
This change breaks compatibility.
However, in many cases it is better to default to USB rather than UART for serial.


An additional serial-port setting has been added.
This is a necessary parameter after the user is able to enter the bootloader via USBCDC.