### PR TITLE
machine/usb/midi: correct reference to handler function

### DIFF
--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -32,7 +32,7 @@ func newMidi() *midi {
 	m := &midi{
 		buf: NewRingBuffer(),
 	}
-	machine.EnableMIDI(m.Handler, m.rxHandler, nil)
+	machine.EnableMIDI(m.Handler, m.RxHandler, nil)
 	return m
 }
 


### PR DESCRIPTION
This PR corrects the reference to the receive handler function in machine/usb/midi, as mentioned by @sago35 here https://github.com/tinygo-org/tinygo/pull/2981#discussion_r919470585