### PR TITLE
rp2040: change to ignore PortReset failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -350,16 +350,14 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 		// do we need port reset to put MCU into bootloader mode?
 		if config.Target.PortReset == "true" && flashMethod != "openocd" {
 			port, err := getDefaultPort(port, config.Target.SerialPort)
-			if err != nil {
-				return err
+			if err == nil {
+				err = touchSerialPortAt1200bps(port)
+				if err != nil {
+					return &commandError{"failed to reset port", result.Binary, err}
+				}
+				// give the target MCU a chance to restart into bootloader
+				time.Sleep(3 * time.Second)
 			}
-
-			err = touchSerialPortAt1200bps(port)
-			if err != nil {
-				return &commandError{"failed to reset port", result.Binary, err}
-			}
-			// give the target MCU a chance to restart into bootloader
-			time.Sleep(3 * time.Second)
 		}
 
 		// this flashing method copies the binary data to a Mass Storage Device (msd)


### PR DESCRIPTION
It should be merged after https://github.com/tinygo-org/tinygo/pull/2990

This PR fixes the tinygo-flash failure issue for rp2040 already in the bootloader.
In my environment, this does not occur on Windows, but on Linux (ubuntu20.04).

This becomes a problem when the following software is written.

```go
package main

import (
	"runtime/interrupt"
)

func main() {
	interrupt.Disable()
	panic("panic")
}
```

If you want to recover without having to make this PR change, you must make the following changes before tinygo flash

1. Set flash-1200-bps-reset in `targets/rp2040.json` to false
2. Press bootsel to start up.
3. tinygo flash