### PR TITLE
compiler: fix issue with methods on generic structs

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -390,6 +390,12 @@ func (c *compilerContext) makeLLVMType(goType types.Type) llvm.Type {
 			// LLVM. This is because it is otherwise impossible to create
 			// self-referencing types such as linked lists.
 			llvmName := typ.Obj().Pkg().Path() + "." + typ.Obj().Name()
+			if llvmType := c.mod.GetTypeByName(llvmName); !llvmType.IsNil() {
+				// For some reason, *types.Named isn't unique when working with
+				// generics. I'm not sure whether this is an upstream bug or
+				// not.
+				return llvmType
+			}
 			llvmType := c.ctx.StructCreateNamed(llvmName)
 			c.llvmTypes[goType] = llvmType // avoid infinite recursion
 			underlying := c.getLLVMType(st)

--- a/testdata/generics.go
+++ b/testdata/generics.go
@@ -3,6 +3,9 @@ package main
 func main() {
 	println("add:", Add(3, 5))
 	println("add:", Add(int8(3), 5))
+
+	var c C[int]
+	c.F() // issue 2951
 }
 
 type Integer interface {
@@ -12,3 +15,8 @@ type Integer interface {
 func Add[T Integer](a, b T) T {
 	return a + b
 }
+
+// Test for https://github.com/tinygo-org/tinygo/issues/2951
+type C[V any] struct{}
+
+func (c *C[V]) F() {}


### PR DESCRIPTION
This is a fix for https://github.com/tinygo-org/tinygo/issues/2951, which may or may not be an upstream Go bug.