### PR TITLE
compiler: fix issue with methods on generic structs

### DIFF
--- a/testdata/generics.go
+++ b/testdata/generics.go
@@ -3,6 +3,9 @@ package main
 func main() {
 	println("add:", Add(3, 5))
 	println("add:", Add(int8(3), 5))
+
+	var c C[int]
+	c.F() // issue 2951
 }
 
 type Integer interface {
@@ -12,3 +15,8 @@ type Integer interface {
 func Add[T Integer](a, b T) T {
 	return a + b
 }
+
+// Test for https://github.com/tinygo-org/tinygo/issues/2951
+type C[V any] struct{}
+
+func (c *C[V]) F() {}


### PR DESCRIPTION
Testing the fix for #2951 as discussed in #2998 (using `typeutil.Map`).