### PR TITLE
usb: adjust buffer alignment (samd21, samd51, nrf52840)

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -56,16 +56,21 @@ var (
 var (
 	usbEndpointDescriptors [usb.NumberOfEndpoints]usb.DeviceDescriptor
 
-	udd_ep_control_cache_buffer [256]uint8
-	udd_ep_in_cache_buffer      [7][64]uint8
-	udd_ep_out_cache_buffer     [7][64]uint8
-
 	isEndpointHalt        = false
 	isRemoteWakeUpEnabled = false
 
 	usbConfiguration uint8
 	usbSetInterface  uint8
 )
+
+//go:align 4
+var udd_ep_control_cache_buffer [256]uint8
+
+//go:align 4
+var udd_ep_in_cache_buffer [7][64]uint8
+
+//go:align 4
+var udd_ep_out_cache_buffer [7][64]uint8
 
 var (
 	usbTxHandler    [usb.NumberOfEndpoints]func()


### PR DESCRIPTION
This PR solves the USB Buffer align problem for samd21 and samd51 and nrf52840.
(#3004)


* samd51
    * Bits 31:0 – ADDR[31:0] Data Pointer Address Value These bits define the data pointer address as an absolute word address in RAM. The two least significant bits must be zero to ensure the start address is 32-bit aligned.
* samd21
    * Bits 31:0 – ADDR[31:0]: Data Pointer Address Value These bits define the data pointer address as an absolute word address in RAM.The two least significant bits must be zero to ensure the start address is 32-bit aligned.
* nrf52840
    * Note: The control endpoint buffer size in Data RAM can be of any size in bytes, and there is no constraint to keep it 32-bit aligned.
    * The maximum size of a bulk/interrupt transaction in USB full-speed is 64 bytes, and it has to be a multiple of 4 bytes and 32-bit aligned in Data RAM. However, the amount of data bytes transmitted on the USB data endpoint can be of any size (up to 64 bytes).
* rp2040
    * Already aligned.
	usbDPSRAM = (*USBDPSRAM)(unsafe.Pointer(uintptr(0x50100000)))
