### PR TITLE
xiao-ble: add support for flash-1200-bps-reset

### DIFF
--- a/targets/xiao-ble.json
+++ b/targets/xiao-ble.json
@@ -1,8 +1,9 @@
 {
 	"inherits": ["nrf52840"],
-	"build-tags": ["xiao_ble", "softdevice", "s140v7"],
-	"serial": "uart",
+	"build-tags": ["xiao_ble", "nrf52840_reset_uf2", "softdevice", "s140v7"],
+	"serial": "usb",
 	"serial-port": ["acm:2886:8045", "acm:2886:0045"],
+	"flash-1200-bps-reset": "true",
 	"flash-method": "msd",
 	"msd-volume-name": "XIAO-SENSE",
 	"msd-firmware-name": "firmware.uf2",


### PR DESCRIPTION
I had been flashing from openocd and was unaware of this.
I think it would be better to be able to write from usb like the regular nrf52840 board or xiao-samd21.

And, although not directly related to this change, the initial value of serial was changed to usb.
This is another change to match other boards.
However, it is important to note that **compatibility can be broken**.

@deadprogram @ysoldak 
What do you think?