### PR TITLE
machine/usb/midi: add NoteOn, NoteOff, and SendCC methods

### DIFF
--- a/src/examples/usb-midi/main.go
+++ b/src/examples/usb-midi/main.go
@@ -39,12 +39,12 @@ func main() {
 			led.Set(current)
 			if current {
 				for _, c := range chords[index].keys {
-					m.Write([]byte{0x08, 0x80, c, 0x40})
+					m.NoteOff(0, 0, c, 0x40)
 				}
 				index = (index + 1) % len(chords)
 			} else {
 				for _, c := range chords[index].keys {
-					m.Write([]byte{0x09, 0x90, c, 0x40})
+					m.NoteOn(0, 0, c, 0x40)
 				}
 			}
 			prev = current

--- a/src/machine/usb/midi/messages.go
+++ b/src/machine/usb/midi/messages.go
@@ -1,0 +1,19 @@
+package midi
+
+// NoteOn sends a note on message.
+func (m *midi) NoteOn(cable, channel, note, velocity uint8) {
+	m.msg[0], m.msg[1], m.msg[2], m.msg[3] = (cable&0xf<<4)|0x9, 0x90|(channel&0xf), note&0x7f, velocity&0x7f
+	m.Write(m.msg[:])
+}
+
+// NoteOff sends a note off message.
+func (m *midi) NoteOff(cable, channel, note, velocity uint8) {
+	m.msg[0], m.msg[1], m.msg[2], m.msg[3] = (cable&0xf<<4)|0x8, 0x80|(channel&0xf), note&0x7f, velocity&0x7f
+	m.Write(m.msg[:])
+}
+
+// SendCC sends a continuous controller message.
+func (m *midi) SendCC(cable, channel, control, value uint8) {
+	m.msg[0], m.msg[1], m.msg[2], m.msg[3] = (cable&0xf<<4)|0xB, 0xB0|(channel&0xf), control&0x7f, value&0x7f
+	m.Write(m.msg[:])
+}

--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -12,6 +12,7 @@ const (
 var Midi *midi
 
 type midi struct {
+	msg       [4]byte
 	buf       *RingBuffer
 	rxHandler func([]byte)
 	waitTxc   bool


### PR DESCRIPTION
This PR updates the `machine/usb/midi` package to add `NoteOn()`, `NoteOff()`, and `SendCC()` methods to have a more complete API.