### PR TITLE
samd51: improve TRNG

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -2067,18 +2067,16 @@ func (dac DAC) syncDAC() {
 	}
 }
 
-var rngInitDone = false
-
 // GetRNG returns 32 bits of cryptographically secure random data
 func GetRNG() (uint32, error) {
-	if !rngInitDone {
+	if !sam.MCLK.APBCMASK.HasBits(sam.MCLK_APBCMASK_TRNG_) {
 		// Turn on clock for TRNG
 		sam.MCLK.APBCMASK.SetBits(sam.MCLK_APBCMASK_TRNG_)
 
 		// enable
 		sam.TRNG.CTRLA.Set(sam.TRNG_CTRLA_ENABLE)
-
-		rngInitDone = true
+	}
+	for !sam.TRNG.INTFLAG.HasBits(sam.TRNG_INTFLAG_DATARDY) {
 	}
 	ret := sam.TRNG.DATA.Get()
 	return ret, nil


### PR DESCRIPTION
Two improvements were implemented.

I stopped using the rngInitDone variable.
This determination can be made by whether MCLK is running or not.

I made sure to wait for DATARDY.
Before the change, the first 4 bytes of the following code would be 0x00000000.
Also, consecutive calls to machine.GetRNG() with --opt=s may take the same value.
I believe crypto/rand needs to be modified because it needs to take a different value each time.

```
package main

import (
	"crypto/rand"
	"encoding/hex"
	"time"
)

func main() {
	time.Sleep(3 * time.Second)
	var result [32]byte
	for {
		rand.Read(result[:])
		encodedString := hex.EncodeToString(result[:])
		println(encodedString[:])
		time.Sleep(time.Second)
	}
}
```