### PR TITLE
RP2040 fix USB device reset

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -128,6 +128,8 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 	// Bus is reset
 	if (status & rp.USBCTRL_REGS_INTS_BUS_RESET) > 0 {
 		rp.USBCTRL_REGS.SIE_STATUS.Set(rp.USBCTRL_REGS_SIE_STATUS_BUS_RESET)
+		rp.USBCTRL_REGS.ADDR_ENDP.Set(0)
+
 		initEndpoint(0, usb.ENDPOINT_TYPE_CONTROL)
 	}
 }


### PR DESCRIPTION
This change makes the RP2040 USB much more reliable in the case where a bus fault occurs and the host tries to re-initialize the device.  In that case, the RP2040 should be expecting to respond to packets addressed to device '0'.

This fixes #3012 where a USB hub is failing to allow the initial USB setup packet handshake to complete in some cases (reason unknown).  When the host then tries to 'start-over', the RP2040 was failing to ACK USB packets (probably because it was expecting to respond to the original address).  This logic was borrowed from the Pico bootrom code, which always resets the device address on USB bus reset.

Before fix, bus can get in this state (notice, no ACK from RP2040 to packets on address 0):
![image](https://user-images.githubusercontent.com/509378/180827229-ca93dc03-ae64-49c5-8c09-c1747880c621.png)

After fix, although there are more USB resets that should be required, the bus does eventually get itself in a good state:
![image](https://user-images.githubusercontent.com/509378/180827397-2fcbc64e-ecc1-4f72-9075-1fb1685031a2.png)
