### PR TITLE
target: add gopherbot and gopherbot2 aliases to simplify for newer users

### DIFF
--- a/targets/gopherbot.json
+++ b/targets/gopherbot.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["circuitplay-express"]
+}

--- a/targets/gopherbot2.json
+++ b/targets/gopherbot2.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["circuitplay-bluefruit"]
+}


### PR DESCRIPTION
This PR adds `gopherbot` and `gopherbot2` aliases to simplify flashing process for newer users.