### PR TITLE
rp2040: make picoprobe default openocd interface

### DIFF
--- a/targets/rp2040.json
+++ b/targets/rp2040.json
@@ -12,6 +12,7 @@
     "extra-files": [
         "src/device/rp/rp2040.s"
     ],
+    "openocd-interface": "picoprobe",
     "openocd-transport": "swd",
     "openocd-target": "rp2040"
 }


### PR DESCRIPTION
This enables picoprobe to be easily used to flash and debug on rp2040.  From experimentation, this seems the most robust (an best documented) way to debug RP2040 at SWD level.

With this change, the following work:
```sh
tinygo flash -target pico -serial uart -programmer openocd ./src/examples/echo/
tinygo gdb -target pico -serial uart -programmer openocd ./src/examples/echo/
```

Picoprobe should be flashed and connected as-per the RP2040 'Getting Started Guide'.

I think this gives us best of both worlds - simple UF2 flashing with USB reset for most uses as default and SWD using picoprobe for low-level debugging using `-programmer openocd`