### PR TITLE
machine/rp2040: turn off pullup/down when not input type not specified

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -181,6 +181,7 @@ func (p Pin) Configure(config PinConfig) {
 		rp.SIO.GPIO_OE_SET.Set(mask)
 	case PinInput:
 		p.setFunc(fnSIO)
+		p.pulloff()
 	case PinInputPulldown:
 		p.setFunc(fnSIO)
 		p.pulldown()


### PR DESCRIPTION
This PR turns off the pullup/pulldown resistor when the input type has not specified it.

This is needed to leave the input pin in a floating mode such as that needed by the Makeybutton driver.