### PR TITLE
wasm,wasi: stub runtime.buffered, runtime.getchar

### DIFF
--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -49,6 +49,16 @@ func putchar(c byte) {
 	}
 }
 
+func getchar() byte {
+	// dummy, TODO
+	return 0
+}
+
+func buffered() int {
+	// dummy, TODO
+	return 0
+}
+
 //go:linkname now time.now
 func now() (sec int64, nsec int32, mono int64) {
 	mono = nanotime()


### PR DESCRIPTION
This PR adds runtime.buffered and runtime.getchar stubs to the wasm/wasi target.
Supported os.Stdin in #2625, but forgot to support the wasm/wasi target because it did not produce a link error.

With the code I am adding, it is not possible to use os.Stdin in wasm/wasi, but the error will no longer occur.
Note that os.Stdin is not supported by wasm/wasi from the original.