### PR TITLE
rp2040: support dormant mode

### DIFF
--- a/src/machine/machine_rp2040.go
+++ b/src/machine/machine_rp2040.go
@@ -97,3 +97,22 @@ func CurrentCore() int {
 
 // NumCores returns number of cores available on the device.
 func NumCores() int { return 2 }
+
+func Sleep(pin Pin, change PinChange) error {
+	if pin > 31 {
+		return ErrInvalidInputPin
+	}
+
+	base := &ioBank0.dormantWakeIRQctrl
+	pin.ctrlSetInterrupt(change, true, base) // gpio_set_dormant_irq_enabled
+
+	clocks.deinit() // Reconfigure clocks, disable PLLs etc
+
+	xosc.Dormant() // Execution stops here until woken up
+
+	clocks.init() // Re-initialize clocks
+
+	// Clear the irq so we can go back to dormant mode again if we want
+	pin.acknowledgeInterrupt(change)
+	return nil
+}

--- a/src/machine/machine_rp2040_pll.go
+++ b/src/machine/machine_rp2040_pll.go
@@ -99,3 +99,11 @@ func (pll *pll) init(refdiv, vcoFreq, postDiv1, postDiv2 uint32) {
 	pll.pwr.ClearBits(rp.PLL_SYS_PWR_POSTDIVPD)
 
 }
+
+func (pll *pll) deinit() {
+	// from Pico SDK pll.h
+	const PLL_PWR_BITS = 0x0000002d
+
+	// Set bits to disable
+	pll.pwr.Set(PLL_PWR_BITS)
+}

--- a/src/machine/machine_rp2040_xosc.go
+++ b/src/machine/machine_rp2040_xosc.go
@@ -41,3 +41,14 @@ func (osc *xoscType) init() {
 	for !osc.status.HasBits(rp.XOSC_STATUS_STABLE) {
 	}
 }
+
+// Dormant stops internal oscillator.
+// WARNING: This stops the xosc until woken up by an irq
+func (osc *xoscType) Dormant() {
+	const XOSC_DORMANT_VALUE_DORMANT = 0x636f6d61
+	osc.dormant.Set(XOSC_DORMANT_VALUE_DORMANT)
+
+	// Wait for it to become stable once woken up
+	for !osc.status.HasBits(rp.XOSC_STATUS_STABLE) {
+	}
+}


### PR DESCRIPTION
With this, I can get sub 1mA draw during idle (866uA) on a Challenger RP2040 LoRa board (I have to manually put the embedded LoRa chip into deep sleep).

The machine API is not final - it assumes Pin wake, when RP2040 also supports RTC-wake from dormant.