### PR TITLE
examples/wasm: improve Makefile

### DIFF
--- a/src/examples/wasm/Makefile
+++ b/src/examples/wasm/Makefile
@@ -24,7 +24,7 @@ main: clean wasm_exec
 	cp ./main/index.html ./html/
 
 wasm_exec:
-	cp ../../../targets/wasm_exec.js ./html/
+	cp `tinygo env TINYGOROOT`/targets/wasm_exec.js ./html/
 
 clean:
 	rm -rf ./html


### PR DESCRIPTION
A small improvement.
It works well even if we copy examples/wasm to a different location.
Also, the version of wasm_exec.js will not be mistaken.