### PR TITLE
syscall: ensure correct C prototype WASI function signature

### DIFF
--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -306,7 +306,7 @@ func Getpagesize() int {
 //export stat
 func libc_stat(pathname *byte, ptr unsafe.Pointer) int32
 
-// int fstat(fd int, struct stat * buf);
+// int fstat(int fd, struct stat * buf);
 //
 //export fstat
 func libc_fstat(fd int32, ptr unsafe.Pointer) int32


### PR DESCRIPTION
It's `<type> <name>`, rather than `<name> <type>` in C

Extracted from #2748 