### PR TITLE
Improve Go 1.19 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,6 @@ TEST_PACKAGES_FAST = \
 	container/list \
 	container/ring \
 	crypto/des \
-	crypto/elliptic/internal/fiat \
 	crypto/internal/subtle \
 	crypto/md5 \
 	crypto/rc4 \
@@ -317,6 +316,14 @@ TEST_PACKAGES_FAST = \
 	unicode \
 	unicode/utf16 \
 	unicode/utf8 \
+	$(nil)
+
+# Assume this will go away before Go2, so only check minor version.
+ifeq ($(filter $(shell $(GO) env GOVERSION | cut -f 2 -d.), 16 17 18), )
+TEST_PACKAGES_FAST += crypto/internal/nistec/fiat
+else
+TEST_PACKAGES_FAST += crypto/elliptic/internal/fiat
+endif
 
 # archive/zip requires os.ReadAt, which is not yet supported on windows
 # debug/plan9obj requires os.ReadAt, which is not yet supported on windows

--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -1,6 +1,9 @@
 package os
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 type Signal interface {
 	String() string
@@ -23,6 +26,9 @@ type ProcAttr struct {
 	Files []*File
 	Sys   *syscall.SysProcAttr
 }
+
+// ErrProcessDone indicates a Process has finished.
+var ErrProcessDone = errors.New("os: process already finished")
 
 type ProcessState struct {
 }


### PR DESCRIPTION
Fixes some issues running `make tinygo-test` against Go 1.19. It doesn't pass for me though because of #3057.