### PR TITLE
syscall: add WASI `sock_accept`

### DIFF
--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -309,6 +309,14 @@ func Getpagesize() int {
 	return 65536
 }
 
+func SockAccept(fd int, flags int) (nfd int, err error) {
+	var retptr0 __wasi_fd_t
+	if n := sock_accept(__wasi_fd_t(fd), __wasi_fdflags_t(flags), &retptr0); n != 0 {
+		return -1, Errno(n)
+	}
+	return int(retptr0), nil
+}
+
 // int stat(const char *path, struct stat * buf);
 //
 //export stat
@@ -323,3 +331,14 @@ func libc_fstat(fd int32, ptr unsafe.Pointer) int32
 //
 //export lstat
 func libc_lstat(pathname *byte, ptr unsafe.Pointer) int32
+
+type (
+	__wasi_errno_t = uint16
+
+	__wasi_fd_t      = int32
+	__wasi_fdflags_t = uint16
+)
+
+//go:wasm-module wasi_snapshot_preview1
+//export sock_accept
+func sock_accept(fd __wasi_fd_t, flags __wasi_fdflags_t, retptr0 *__wasi_fd_t) __wasi_errno_t


### PR DESCRIPTION
Extracted from #2748 
This PR adds functionality to be able to call the syscall directly. #2748 uses this syscall to implement `net.Listener` for WASI

Note that this calls into WASI directly without using libc. Note, also that this syscall is similar to, but different from standard Linux `accept{,4}`

Refs https://github.com/WebAssembly/WASI/pull/458