### PR TITLE
Fix for builds of tinygo using an Android host

### DIFF
--- a/builder/buildid.go
+++ b/builder/buildid.go
@@ -24,7 +24,7 @@ func ReadBuildID() ([]byte, error) {
 	defer f.Close()
 
 	switch runtime.GOOS {
-	case "linux", "freebsd":
+	case "linux", "freebsd", "android":
 		// Read the GNU build id section. (Not sure about FreeBSD though...)
 		file, err := elf.NewFile(f)
 		if err != nil {


### PR DESCRIPTION
As mentioned in https://github.com/tinygo-org/tinygo/issues/2975, it is possible to build and use tinygo under Termux (an Android app) after this small fix.

It also requires running `make llvm-source` even if using the installed LLVM (maybe this should be documented?).

I only tested it for building WebAssembly files using tinygo version 0.26.0-dev android/arm64 (using go version go1.18.3 and LLVM version 14.0.4)