### PR TITLE
goenv: support GOOS=android

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -42,10 +42,14 @@ var TINYGOROOT string
 func Get(name string) string {
 	switch name {
 	case "GOOS":
-		if dir := os.Getenv("GOOS"); dir != "" {
-			return dir
+		goos := os.Getenv("GOOS")
+		if goos == "" {
+			goos = runtime.GOOS
 		}
-		return runtime.GOOS
+		if goos == "android" {
+			goos = "linux"
+		}
+		return goos
 	case "GOARCH":
 		if dir := os.Getenv("GOARCH"); dir != "" {
 			return dir


### PR DESCRIPTION
TinyGo doesn't currently support Android directly. However, GOOS=linux
works fine on Android. Therefore, force GOOS=linux on Android.

Tested in Termux.