### PR TITLE
Add aliases for ed25519 field.feMul and field.feSquare.

### DIFF
--- a/compiler/alias.go
+++ b/compiler/alias.go
@@ -16,6 +16,8 @@ import "tinygo.org/x/go-llvm"
 
 var stdlibAliases = map[string]string{
 	// crypto packages
+	"crypto/ed25519/internal/edwards25519/field.feMul":    "crypto/ed25519/internal/edwards25519/field.feMulGeneric",
+	"crypto/ed25519/internal/edwards25519/field.feSquare": "crypto/ed25519/internal/edwards25519/field.feSquareGeneric",
 	"crypto/md5.block":         "crypto/md5.blockGeneric",
 	"crypto/sha1.block":        "crypto/sha1.blockGeneric",
 	"crypto/sha1.blockAMD64":   "crypto/sha1.blockGeneric",


### PR DESCRIPTION
ed25519vectors_test.go still fails because:
* It relies on "go mod download" which doesn't work, as well as fork/exec.
* It relies on JSON parsing which has problems with reflection.

But, with the vectors hard coded in the test file the tests *do* succeed, so the encryption is working.