### PR TITLE
main: add support for stlink-dap programmer

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -457,7 +457,14 @@ func (c *Config) OpenOCDConfiguration() (args []string, err error) {
 		args = append(args, "-c", cmd)
 	}
 	if c.Target.OpenOCDTransport != "" {
-		args = append(args, "-c", "transport select "+c.Target.OpenOCDTransport)
+		transport := c.Target.OpenOCDTransport
+		if transport == "swd" {
+			switch openocdInterface {
+			case "stlink-dap":
+				transport = "dapdirect_swd"
+			}
+		}
+		args = append(args, "-c", "transport select "+transport)
 	}
 	args = append(args, "-f", "target/"+c.Target.OpenOCDTarget+".cfg")
 	return args, nil


### PR DESCRIPTION
STLINK could not be used if swd was specified for `openocd-transport`.

```
$ tinygo flash --target wioterminal --size short --programmer stlink-dap -x ./b1
openocd -f interface/stlink-dap.cfg -c 'transport select swd' -f target/atsame5x.cfg -c 'program C:/Users/sago3/AppData/Local/Temp/tinygo3166121016/main.hex verify reset exit'
Open On-Chip Debugger 0.11.0-rc2+dev-gcafa0b5 (2021-02-20-22:09)
Error: Debug adapter doesn't support 'swd' transport
```

`-ocd-commands` allows additional configuration, but the existence of `transport select swd` will result in an error.

```
$ tinygo flash --target wioterminal --size short --programmer stlink-dap --ocd-commands "transport select dapdirect_swd" -x ./b1
openocd -f interface/stlink-dap.cfg -c 'transport select dapdirect_swd' -c 'transport select swd' -f target/atsame5x.cfg -c 'program C:/Users/sago3/AppData/Local/Temp/tinygo2520453502/main.hex verify reset exit'
Open On-Chip Debugger 0.11.0-rc2+dev-gcafa0b5 (2021-02-20-22:09)
dapdirect_swd
Error: Can't change session's transport after the initial selection was made
```

So, in this PR, it is first necessary to be able to override `openocd-transport` with `dapdirect_swd`, etc.
Previously, only `empty-string` or `swd` could be specified.

However, openocd allows `hla_swd` and `dapdirect_swd` to be specified, as shown in the following page.
https://openocd.org/doc/html/Debug-Adapter-Configuration.html

```
# ./wioterminal-stlink.json
{
    "inherits": ["wioterminal"],
    "openocd-transport": "dapdirect_swd"
}
```

```
$ tinygo flash --target ./wioterminal-stlink.json --size short --programmer stlink-dap -x ./b1
openocd -f interface/stlink-dap.cfg -c 'transport select dapdirect_swd' -f target/atsame5x.cfg -c 'program C:/Users/sago3/AppData/Local/Temp/tinygo4040189479/main.hex verify reset exit'
Open On-Chip Debugger 0.11.0-rc2+dev-gcafa0b5 (2021-02-20-22:09)
...
(OK)
```

This PR will allow the following cheap STLINK-V2 to be used with samd21, samd51, nrf, stm32f4 and others.
![image](https://user-images.githubusercontent.com/9251039/185516077-294795cd-77b4-432d-ad96-866541e231dd.png)
