### PR TITLE
build: pin public_suffix Ruby gem to version 4.0.7

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,6 +98,7 @@ jobs:
         run: make wasi-libc
       - name: Install fpm
         run: |
+          gem install --version 4.0.7 public_suffix
           gem install --version 2.7.6 dotenv
           gem install --no-document fpm
       - name: Build TinyGo release
@@ -334,6 +335,7 @@ jobs:
           make CROSS=arm-linux-gnueabihf binaryen
       - name: Install fpm
         run: |
+          sudo gem install --version 4.0.7 public_suffix
           sudo gem install --version 2.7.6 dotenv
           sudo gem install --no-document fpm
       - name: Build TinyGo binary
@@ -436,6 +438,7 @@ jobs:
           make CROSS=aarch64-linux-gnu binaryen
       - name: Install fpm
         run: |
+          sudo gem install --version 4.0.7 public_suffix
           sudo gem install --version 2.7.6 dotenv
           sudo gem install --no-document fpm
       - name: Build TinyGo binary


### PR DESCRIPTION
This PR pins the `public_suffix` Ruby gem to version 4.0.7 to avoid needing to update Ruby version for build.

Needed to fix the CI build on `dev` branch due to upstream changes in dependencies.