### PR TITLE
compiler: fix incorrect DWARF type in some generic parameters

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -688,7 +688,7 @@ func (b *builder) getLocalVariable(variable *types.Var) llvm.Metadata {
 				Name:           param.Name(),
 				File:           b.getDIFile(pos.Filename),
 				Line:           pos.Line,
-				Type:           b.getDIType(variable.Type()),
+				Type:           b.getDIType(param.Type()),
 				AlwaysPreserve: true,
 				ArgNo:          i + 1,
 			})

--- a/testdata/generics.go
+++ b/testdata/generics.go
@@ -12,6 +12,8 @@ func main() {
 	var c C[int]
 	c.F() // issue 2951
 
+	SliceOp([]int(nil)) // issue 3002
+
 	testa.Test()
 	testb.Test()
 }
@@ -28,3 +30,6 @@ func Add[T Integer](a, b T) T {
 type C[V any] struct{}
 
 func (c *C[V]) F() {}
+
+// Test for https://github.com/tinygo-org/tinygo/issues/3002
+func SliceOp[S ~[]E, E any](s S) {}


### PR DESCRIPTION
For some reason, the type of a function parameter can sometimes be of interface type, while it should be the underlying type. This might be a bug in the x/tools/go/ssa package but this is a simple workaround.

This fixes https://github.com/tinygo-org/tinygo/issues/3002