### PR TITLE
testdata: add russross/blackfriday markdown parser to corpus

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -280,3 +280,5 @@
 - repo: github.com/chewxy/math32
   tags: noasm
   version: master
+- repo: github.com/russross/blackfriday
+  version: v2


### PR DESCRIPTION
```
~/go/src/github.com/russross/blackfriday $ go test ./...
ok  	github.com/russross/blackfriday/v2	8.746s
~/go/src/github.com/russross/blackfriday $ tinygo test ./...
ok  	github.com/russross/blackfriday/v2	108.974s
```