### PR TITLE
main: ignore ports with VID/PID if not candidates

### DIFF
--- a/main.go
+++ b/main.go
@@ -978,8 +978,7 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 			preferredPortIDs = append(preferredPortIDs, [2]uint16{uint16(vid), uint16(pid)})
 		}
 
-		var primaryPorts []string   // ports picked from preferred USB VID/PID
-		var secondaryPorts []string // other ports (as a fallback)
+		var primaryPorts []string // ports picked from preferred USB VID/PID
 		for _, p := range portsList {
 			if !p.IsUSB {
 				continue
@@ -1001,8 +1000,6 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 					continue
 				}
 			}
-
-			secondaryPorts = append(secondaryPorts, p.Name)
 		}
 		if len(primaryPorts) == 1 {
 			// There is exactly one match in the set of preferred ports. Use
@@ -1014,10 +1011,6 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 			// one device of the same type are connected (e.g. two Arduino
 			// Unos).
 			ports = primaryPorts
-		} else {
-			// No preferred ports found. Fall back to other serial ports
-			// available in the system.
-			ports = secondaryPorts
 		}
 
 		if len(ports) == 0 {


### PR DESCRIPTION
Fall-back using `secondaryPorts` can cause uf2 to be written to the wrong device.
For example, the problem occurs in the following cases

* XIAO and WioTerminal are connected to the PC
* While developing WioTerminal, wrote a program that caused panic
* Ran `tinygo flash -target wioterminal` in this state
* touchSerialPortAt1200bps() to XIAO and flash wrong UF2 for Wio Terminal

| json | msd-volume-name |
| -- | -- |
| targets/feather-m0.json |    "msd-volume-name": "FEATHERBOOT" |
| targets/feather-m4.json |    "msd-volume-name": "FEATHERBOOT" |
| targets/microbit-v2.json |    "msd-volume-name": "MICROBIT" |
| targets/microbit.json | "msd-volume-name": "MICROBIT" |
| targets/wioterminal.json |    "msd-volume-name": "Arduino" |
| targets/xiao.json |    "msd-volume-name": "Arduino" |


The following process is similar to that of secondaryPorts, but without the candidates.
This is the case when VID/PID is not defined in `targets/*.json`.
For now, I believe that this process is less problematic without any changes.
However, if changes are needed, please comment.

https://github.com/tinygo-org/tinygo/blob/d1baa392edeefe1ee9b7c4bd7287a1d554af8be8/main.go#L1039-L1045