### PR TITLE
boards: Add XIAO ESP32C3 board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,6 +681,8 @@ endif
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=m5stamp-c3          examples/serial
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=xiao-esp32c3        examples/serial
+	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.hex -target=hifive1b            examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=hifive1-qemu        examples/serial

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 89 microcontroller boards are currently supported:
+The following 90 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -118,6 +118,7 @@ The following 89 microcontroller boards are currently supported:
 * [Raytac MDBT50Q-RX Dongle (with TinyUF2 bootloader)](https://www.adafruit.com/product/5199)
 * [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
 * [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html)
+* [Seeed XIAO ESP32C3](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)
 * [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html)
 * [Seeed LoRa-E5 Development Kit](https://www.seeedstudio.com/LoRa-E5-Dev-Kit-p-4868.html)
 * [Seeed Sipeed MAix BiT](https://www.seeedstudio.com/Sipeed-MAix-BiT-for-RISC-V-AI-IoT-p-2872.html)

--- a/src/machine/board_xiao-esp32c3.go
+++ b/src/machine/board_xiao-esp32c3.go
@@ -1,0 +1,54 @@
+//go:build xiao_esp32c3
+// +build xiao_esp32c3
+
+// This file contains the pin mappings for the Seeed XIAO ESP32C3 boards.
+//
+// Seeed Studio XIAO ESP32C3 is an IoT mini development board based on
+// the Espressif ESP32-C3 WiFi/Bluetooth dual-mode chip.
+//
+// - https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html
+// - https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started/
+
+package machine
+
+// Digital Pins
+const (
+	D0  = GPIO2
+	D1  = GPIO3
+	D2  = GPIO4
+	D3  = GPIO5
+	D4  = GPIO6
+	D5  = GPIO7
+	D6  = GPIO21
+	D7  = GPIO20
+	D8  = GPIO8
+	D9  = GPIO9
+	D10 = GPIO10
+)
+
+// Analog pins
+const (
+	A0 = GPIO2
+	A1 = GPIO3
+	A2 = GPIO4
+	A3 = GPIO5
+)
+
+// UART pins
+const (
+	UART_RX_PIN = GPIO20
+	UART_TX_PIN = GPIO21
+)
+
+// I2C pins
+const (
+	SDA_PIN = GPIO6
+	SCL_PIN = GPIO7
+)
+
+// SPI pins
+const (
+	SPI_SCK_PIN = GPIO8
+	SPI_SDI_PIN = GPIO9
+	SPI_SDO_PIN = GPIO10
+)

--- a/targets/xiao-esp32c3.json
+++ b/targets/xiao-esp32c3.json
@@ -1,0 +1,4 @@
+{
+	"inherits": ["esp32c3"],
+	"build-tags": ["xiao_esp32c3"]
+}


### PR DESCRIPTION
Seeed Studio [XIAO ESP32C3](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html) is an IoT mini development board based on the Espressif ESP32-C3 WiFi/Bluetooth dual-mode chip.
