### PR TITLE
targets: fail fast on duplicate values in target field slices

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -88,8 +88,17 @@ func (spec *TargetSpec) overrideProperties(child *TargetSpec) {
 			if !src.IsNil() {
 				dst.Set(src)
 			}
-		case reflect.Slice: // for slices, append the field
+		case reflect.Slice: // for slices, append the field and check for duplicates
 			dst.Set(reflect.AppendSlice(dst, src))
+			for i := 0; i < dst.Len(); i++ {
+				v := dst.Index(i).String()
+				for j := i + 1; j < dst.Len(); j++ {
+					w := dst.Index(j).String()
+					if v == w {
+						panic("duplicate value '" + v + "' in field : " + field.Name)
+					}
+				}
+			}
 		default:
 			panic("unknown field type : " + kind.String())
 		}

--- a/targets/p1am-100.json
+++ b/targets/p1am-100.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
-    "build-tags": ["sam", "atsamd21g18a", "p1am_100"],
+    "build-tags": ["p1am_100"],
     "flash-command": "bossac -d -i -e -w -v -R --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }


### PR DESCRIPTION
This is how it fails now:
```
/Users/yursol/bin/tinygo build -size short -o test.hex -target=p1am-100            examples/blinky1
panic: duplicate value 'atsamd21g18a' in field : BuildTags

goroutine 1 [running]:
github.com/tinygo-org/tinygo/compileopts.(*TargetSpec).overrideProperties(0xc00028e2c0, 0xc00028e000)
	/Users/yursol/Private/code/tinygo/compileopts/target.go:98 +0x848
github.com/tinygo-org/tinygo/compileopts.(*TargetSpec).resolveInherits(0xc00028e000)
	/Users/yursol/Private/code/tinygo/compileopts/target.go:157 +0x4d
github.com/tinygo-org/tinygo/compileopts.LoadTarget(0xc00028c000)
	/Users/yursol/Private/code/tinygo/compileopts/target.go:223 +0x2b3
github.com/tinygo-org/tinygo/builder.NewConfig(0xc00028c000)
	/Users/yursol/Private/code/tinygo/builder/config.go:16 +0x33
main.Build({0x7ff7bfeff9a8, 0x10}, {0x7ff7bfeff98e, 0x8}, 0xc00028c000)
	/Users/yursol/Private/code/tinygo/main.go:143 +0x56
main.main()
	/Users/yursol/Private/code/tinygo/main.go:1443 +0x3c75
make: *** [smoketest] Error 2

```