### PR TITLE
machine: Add support for Adafruit QT2040 board.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,6 +597,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=challenger-rp2040    examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=trinkey-qt2040      examples/adc_rp2040
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [getting started instructions](https://tinygo.org/getting-started/) for 
 
 You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
 
-The following 90 microcontroller boards are currently supported:
+The following 91 microcontroller boards are currently supported:
 
 * [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
 * [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
@@ -67,6 +67,7 @@ The following 90 microcontroller boards are currently supported:
 * [Adafruit PyPortal](https://www.adafruit.com/product/4116)
 * [Adafruit QT Py](https://www.adafruit.com/product/4600)
 * [Adafruit Trinket M0](https://www.adafruit.com/product/3500)
+* [Adafruit Trinkey QT2040](https://adafruit.com/product/5056)
 * [Arduino Mega 1280](https://www.arduino.cc/en/Main/arduinoBoardMega/)
 * [Arduino Mega 2560](https://store.arduino.cc/arduino-mega-2560-rev3)
 * [Arduino MKR1000](https://store.arduino.cc/arduino-mkr1000-wifi)

--- a/src/machine/board_trinkey_qt2040.go
+++ b/src/machine/board_trinkey_qt2040.go
@@ -1,0 +1,63 @@
+//go:build trinkey_qt2040
+// +build trinkey_qt2040
+
+// This file contains the pin mappings for the Adafruit Trinkey QT2040 board.
+//
+// The Trinkey QT2040 is a small development board based on the RP2040 which
+// plugs into a USB A port. The board has a minimal pinout: an integrated
+// NeoPixel LED and a STEMMA QT I2C port.
+//
+// - Product:    https://www.adafruit.com/product/5056
+// - Overview:   https://learn.adafruit.com/adafruit-trinkey-qt2040
+// - Pinouts:    https://learn.adafruit.com/adafruit-trinkey-qt2040/pinouts
+// - Datasheets: https://learn.adafruit.com/adafruit-trinkey-qt2040/downloads
+
+package machine
+
+// Onboard crystal oscillator frequency, in MHz
+const xoscFreq = 12 // MHz
+
+// Onboard LEDs
+const (
+	NEOPIXEL = GPIO27
+	WS2812   = NEOPIXEL
+)
+
+// I2C pins
+const (
+	I2C0_SDA_PIN = GPIO16
+	I2C0_SCL_PIN = GPIO17
+
+	I2C1_SDA_PIN = NoPin
+	I2C1_SCL_PIN = NoPin
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = NoPin
+	SPI0_SDO_PIN = NoPin
+	SPI0_SDI_PIN = NoPin
+
+	SPI1_SCK_PIN = NoPin
+	SPI1_SDO_PIN = NoPin
+	SPI1_SDI_PIN = NoPin
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = NoPin
+	UART0_RX_PIN = NoPin
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "Trinkey QT2040"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239a
+	usb_PID uint16 = 0x8109
+)

--- a/targets/trinkey-qt2040-boot-stage2.S
+++ b/targets/trinkey-qt2040-boot-stage2.S
@@ -1,0 +1,17 @@
+// Adafruit Trinkey QT2040 Stage 2 Bootloader
+
+//
+// This file defines the parameters specific to the flash-chip found
+// on the Adafruit Trinkey QT2040.  The generic implementation is in
+// rp2040-boot-stage2.S
+//
+
+#define BOARD_PICO_FLASH_SPI_CLKDIV   4
+#define BOARD_CMD_READ                0xe7
+#define BOARD_QUAD_OK                 1
+#define BOARD_QUAD_ENABLE_STATUS_BYTE 2
+#define BOARD_QUAD_ENABLE_BIT_MASK    2
+#define BOARD_SPLIT_STATUS_WRITE      1
+#define BOARD_WAIT_CYCLES             2
+
+#include "rp2040-boot-stage2.S"

--- a/targets/trinkey-qt2040.json
+++ b/targets/trinkey-qt2040.json
@@ -1,0 +1,11 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial-port": ["acm:239a:8109"],
+    "build-tags": ["trinkey_qt2040"],
+    "linkerscript": "targets/trinkey-qt2040.ld",
+    "extra-files": [
+        "targets/trinkey-qt2040-boot-stage2.S"
+    ]
+}

--- a/targets/trinkey-qt2040.ld
+++ b/targets/trinkey-qt2040.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    /* Reserve exactly 256 bytes at start of flash for second stage bootloader */
+    BOOT2_TEXT (rx) : ORIGIN = 0x10000000, LENGTH = 256
+    FLASH_TEXT (rx) : ORIGIN = 0x10000000 + 256, LENGTH = 8192K - 256
+    RAM (rwx)       : ORIGIN = 0x20000000, LENGTH = 256k
+}
+
+INCLUDE "targets/rp2040.ld"


### PR DESCRIPTION
This adds support for the Adafruit QT2040 board, based on the RP2040. The board shares a few properties with the already-supported Adafruit Feather RP2040: both use an 8MB QSPI flash chip, a 12MHz oscillator, and have a STEMMA QT port for I2C. However the QT2040 appears intended mainly for I2C development, and doesn't provide any pin mapping outside of its integrated NeoPixel LED and QT port. Due to the lack of a simple onboard LED, the smoke test I've included is the RP2040 ADC example, but I'm happy to change that to something else if y'all would prefer.

Thanks y'all!

EDIT: Forgot to mention that I pulled the USB VID/PID from the [Arduino library](https://github.com/earlephilhower/arduino-pico/blob/a97dc38e8778f531ec4d7eddfe66f464d8be434a/tools/json/adafruit_trinkeyrp2040qt.json#L6-L7) recommended in Adafruit's documentation.