### PR TITLE
main: remove GOARM from `tinygo info`

### DIFF
--- a/main.go
+++ b/main.go
@@ -1668,7 +1668,6 @@ func main() {
 			fmt.Printf("LLVM triple:       %s\n", config.Triple())
 			fmt.Printf("GOOS:              %s\n", config.GOOS())
 			fmt.Printf("GOARCH:            %s\n", config.GOARCH())
-			fmt.Printf("GOARM:             %s\n", config.GOARM())
 			fmt.Printf("build tags:        %s\n", strings.Join(config.BuildTags(), " "))
 			fmt.Printf("garbage collector: %s\n", config.GC())
 			fmt.Printf("scheduler:         %s\n", config.Scheduler())


### PR DESCRIPTION
I think it is more confusing than helpful because it is only relevant when compiling an actual linux/arm binary (and in that case, it is also included in the LLVM triple).

Fixes #3034