### PR TITLE
compileopts: fix windows/arm target triple

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -202,11 +202,10 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 		// triples for historical reasons) have the form:
 		//   arch-vendor-os-environment
 		target := llvmarch + "-unknown-" + llvmos
-		if options.GOARCH == "arm" {
-			target += "-gnueabihf"
-		}
 		if options.GOOS == "windows" {
 			target += "-gnu"
+		} else if options.GOARCH == "arm" {
+			target += "-gnueabihf"
 		}
 		return defaultTarget(options.GOOS, options.GOARCH, target)
 	}


### PR DESCRIPTION
This is just a papercut, and not really something important. But I noticed something weird:

    $ GOOS=windows GOARCH=arm tinygo info ""
    LLVM triple:       armv7-unknown-windows-gnueabihf-gnu
    GOOS:              windows
    GOARCH:            arm

That `-gnueabihf-gnu` ending is weird, it should pick one of the two. I've fixed it as follows:

    $ GOOS=windows GOARCH=arm tinygo info ""
    LLVM triple:       armv7-unknown-windows-gnu
    GOOS:              windows
    GOARCH:            arm
    [...]

We're probably never going to support windows/arm (this is 32-bit arm, not arm64) so it doesn't really matter which one we pick. And this patch shouldn't affect any other system.