### PR TITLE
wioterminal: add UART3 for RTL8720DN

### DIFF
--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -349,8 +349,11 @@ var (
 
 	UART1 = &sercomUSART2
 
-	// RTL8720D
+	// RTL8720D (tx: PC22, rx: PC23)
 	UART2 = &sercomUSART1
+
+	// RTL8720D (tx: PB24, rx: PC24)
+	UART3 = &sercomUSART0
 )
 
 // I2C pins


### PR DESCRIPTION
Currently, the RTL8270DN driver is complicated by the fact that the sercomUSARTx definition is not published.
In this PR, UART3 is defined as the UART that must be used when using the RTL8720DN.

https://github.com/tinygo-org/drivers/pull/453


