### PR TITLE
compiler: fix unsafe.Sizeof for chan and map values

### DIFF
--- a/compiler/sizes.go
+++ b/compiler/sizes.go
@@ -152,7 +152,7 @@ func (s *stdSizes) Sizeof(T types.Type) int64 {
 		return align(offsets[n-1]+s.Sizeof(fields[n-1].Type()), maxAlign)
 	case *types.Interface:
 		return s.PtrSize * 2
-	case *types.Pointer:
+	case *types.Pointer, *types.Chan, *types.Map:
 		return s.PtrSize
 	case *types.Signature:
 		// Func values in TinyGo are two words in size.

--- a/testdata/reflect.go
+++ b/testdata/reflect.go
@@ -175,6 +175,8 @@ func main() {
 	assertSize(reflect.TypeOf("").Size() == unsafe.Sizeof(""), "string")
 	assertSize(reflect.TypeOf(new(int)).Size() == unsafe.Sizeof(new(int)), "*int")
 	assertSize(reflect.TypeOf(zeroFunc).Size() == unsafe.Sizeof(zeroFunc), "func()")
+	assertSize(reflect.TypeOf(zeroChan).Size() == unsafe.Sizeof(zeroChan), "chan int")
+	assertSize(reflect.TypeOf(zeroMap).Size() == unsafe.Sizeof(zeroMap), "map[string]int")
 
 	// make sure embedding a zero-sized "not comparable" struct does not add size to a struct
 	assertSize(reflect.TypeOf(doNotCompare{}).Size() == unsafe.Sizeof(doNotCompare{}), "[0]func()")


### PR DESCRIPTION
These types are simply pointers. For some reason, they were never implemented.

Fixes https://github.com/tinygo-org/tinygo/issues/3083.