### PR TITLE
main: improve error handling when loading target/*.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,6 +419,7 @@ tinygo-baremetal:
 .PHONY: smoketest
 smoketest:
 	$(TINYGO) version
+	$(TINYGO) targets > /dev/null
 	# regression test for #2892
 	cd tests/testing/recurse && ($(TINYGO) test ./... > recurse.log && cat recurse.log && test $$(wc -l < recurse.log) = 2 && rm recurse.log)
 	# compile-only platform-independent examples

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -100,7 +100,7 @@ func (spec *TargetSpec) overrideProperties(child *TargetSpec) error {
 				}
 			}
 		default:
-			return fmt.Errorf("unknown field type : " + kind.String())
+			return fmt.Errorf("unknown field type: %s", kind)
 		}
 	}
 	return nil

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -95,7 +95,7 @@ func (spec *TargetSpec) overrideProperties(child *TargetSpec) error {
 				for j := i + 1; j < dst.Len(); j++ {
 					w := dst.Index(j).String()
 					if v == w {
-						return fmt.Errorf("duplicate value '" + v + "' in field : " + field.Name)
+						return fmt.Errorf("duplicate value '%s' in field %s", v, field.Name)
 					}
 				}
 			}


### PR DESCRIPTION
`tinygo targets` was failing and has been corrected.
Improv error messages to determine the error location.
Add run `tinygo targets` to CI.