### PR TITLE
runtime/pprof, runtime/trace: stub some additional functions

### DIFF
--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -10,8 +10,7 @@ import (
 
 var ErrUnimplemented = errors.New("runtime/pprof: unimplemented")
 
-type Profile struct {
-}
+type Profile struct{}
 
 func StartCPUProfile(w io.Writer) error {
 	return nil
@@ -28,6 +27,18 @@ func Lookup(name string) *Profile {
 	return nil
 }
 
+func (p *Profile) Name() string {
+	return ""
+}
+
+func (p *Profile) Count() int {
+	return 0
+}
+
 func (p *Profile) WriteTo(w io.Writer, debug int) error {
 	return ErrUnimplemented
+}
+
+func Profiles() []*Profile {
+	return nil
 }

--- a/src/runtime/trace/trace.go
+++ b/src/runtime/trace/trace.go
@@ -1,0 +1,13 @@
+// Stubs for the runtime/trace package
+package trace
+
+import (
+	"errors"
+	"io"
+)
+
+func Start(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+func Stop() {}


### PR DESCRIPTION
These are necessary to import some parts of the net/http package.

Fixes #1997 