### PR TITLE
Add LoadAndDelete for sync.Map

### DIFF
--- a/src/sync/map.go
+++ b/src/sync/map.go
@@ -34,6 +34,17 @@ func (m *Map) LoadOrStore(key, value interface{}) (actual interface{}, loaded bo
 	return value, false
 }
 
+func (m *Map) LoadAndDelete(key interface{}) (value interface{}, loaded bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	value, ok := m.m[key]
+	if !ok {
+		return nil, false
+	}
+	delete(m.m, key)
+	return value, true
+}
+
 func (m *Map) Store(key, value interface{}) {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/src/sync/map_test.go
+++ b/src/sync/map_test.go
@@ -1,0 +1,19 @@
+package sync_test
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMapLoadAndDelete(t *testing.T) {
+	var sm sync.Map
+	sm.Store("present", "value")
+
+	if v, ok := sm.LoadAndDelete("present"); !ok || v != "value" {
+		t.Errorf("LoadAndDelete returned %v, %v, want value, true", v, ok)
+	}
+
+	if v, ok := sm.LoadAndDelete("absent"); ok || v != nil {
+		t.Errorf("LoadAndDelete returned %v, %v, want nil, false", v, ok)
+	}
+}


### PR DESCRIPTION
This adds `LoadAndDelete` support for `sync.Map`.

See also https://github.com/golang/go/commit/2e8dbae85ce88d02f651e53338984288057f14cb.
