### PR TITLE
Add qtpy-rp2040

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -585,6 +585,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-rp2040 		examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=qtpy-rp2040         examples/echo
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=macropad-rp2040 	examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=badger2040          examples/blinky1

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following 91 microcontroller boards are currently supported:
 * [Adafruit PyGamer](https://www.adafruit.com/product/4242)
 * [Adafruit PyPortal](https://www.adafruit.com/product/4116)
 * [Adafruit QT Py](https://www.adafruit.com/product/4600)
+* [Adafruit QT Py RP2040](https://www.adafruit.com/product/4900)
 * [Adafruit Trinket M0](https://www.adafruit.com/product/3500)
 * [Adafruit Trinkey QT2040](https://adafruit.com/product/5056)
 * [Arduino Mega 1280](https://www.arduino.cc/en/Main/arduinoBoardMega/)

--- a/src/machine/board_qtpy_rp2040.go
+++ b/src/machine/board_qtpy_rp2040.go
@@ -1,0 +1,120 @@
+//go:build qtpy_rp2040
+// +build qtpy_rp2040
+
+package machine
+
+import (
+	"device/rp"
+	"runtime/interrupt"
+)
+
+// Onboard crystal oscillator frequency, in MHz.
+const xoscFreq = 12 // MHz
+
+// GPIO Pins
+const (
+	SDA  = GPIO24
+	SCL  = GPIO25
+	TX   = GPIO20
+	MO   = GPIO3
+	MOSI = GPIO3
+	MI   = GPIO4
+	MISO = GPIO4
+	SCK  = GPIO6
+	RX   = GPIO5
+
+	QT_SCL1 = GPIO23
+	QT_SDA1 = GPIO22
+)
+
+// Analog pins
+const (
+	A0 = GPIO29
+	A1 = GPIO28
+	A2 = GPIO27
+	A3 = GPIO26
+)
+
+const (
+	NEOPIXELS       = GPIO12
+	WS2812          = GPIO12
+	NEOPIXELS_POWER = GPIO11
+	LED             = GPIO20
+)
+
+// I2C Pins.
+const (
+	I2C0_SDA_PIN = GPIO24
+	I2C0_SCL_PIN = GPIO25
+
+	I2C1_SDA_PIN = GPIO26
+	I2C1_SCL_PIN = GPIO27
+
+	I2C1_QT_SDA_PIN = GPIO22
+	I2C1_QT_SCL_PIN = GPIO23
+
+	SDA_PIN = GPIO24
+	SCL_PIN = GPIO25
+)
+
+// SPI default pins
+const (
+	// Default Serial Clock Bus 0 for SPI communications
+	SPI0_SCK_PIN = GPIO6
+	// Default Serial Out Bus 0 for SPI communications
+	SPI0_SDO_PIN = GPIO3 // Tx
+	// Default Serial In Bus 0 for SPI communications
+	SPI0_SDI_PIN = GPIO4 // Rx
+	SPI0_CS      = GPIO5
+
+	// Default Serial Clock Bus 1 for SPI communications
+	SPI1_SCK_PIN = GPIO26
+	// Default Serial Out Bus 1 for SPI communications
+	SPI1_SDO_PIN = GPIO27 // Tx
+	// Default Serial In Bus 1 for SPI communications
+	SPI1_SDI_PIN = GPIO24 // Rx
+	SPI1_CS      = GPIO25
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO28
+	UART0_RX_PIN = GPIO29
+	UART1_TX_PIN = GPIO20
+	UART1_RX_PIN = GPIO5
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+// UART on the RP2040
+var (
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART0,
+	}
+
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
+)
+
+var DefaultUART = UART0
+
+func init() {
+	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
+}
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "QT Py RP2040"
+	usb_STRING_MANUFACTURER = "Adafruit"
+)
+
+var (
+	usb_VID uint16 = 0x239A
+	usb_PID uint16 = 0x80F7
+)

--- a/targets/qtpy-rp2040-boot-stage2.S
+++ b/targets/qtpy-rp2040-boot-stage2.S
@@ -1,0 +1,17 @@
+// Adafruit QT Py RP2040 Stage 2 Bootloader
+
+//
+// This file defines the parameters specific to the flash-chip found
+// on the Adafruit QT Py RP2040.  The generic implementation is in
+// rp2040-boot-stage2.S
+//
+
+#define BOARD_PICO_FLASH_SPI_CLKDIV   2
+#define BOARD_CMD_READ                0xe7
+#define BOARD_QUAD_OK                 1
+#define BOARD_QUAD_ENABLE_STATUS_BYTE 2
+#define BOARD_QUAD_ENABLE_BIT_MASK    2
+#define BOARD_SPLIT_STATUS_WRITE      1
+#define BOARD_WAIT_CYCLES             2
+
+#include "rp2040-boot-stage2.S"

--- a/targets/qtpy-rp2040.json
+++ b/targets/qtpy-rp2040.json
@@ -1,0 +1,11 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial-port": ["acm:239a:80f7"],
+    "build-tags": ["qtpy_rp2040"],
+    "linkerscript": "targets/qtpy-rp2040.ld",
+    "extra-files": [
+        "targets/qtpy-rp2040-boot-stage2.S"
+    ]
+}

--- a/targets/qtpy-rp2040.ld
+++ b/targets/qtpy-rp2040.ld
@@ -1,0 +1,10 @@
+
+MEMORY
+{
+    /* Reserve exactly 256 bytes at start of flash for second stage bootloader */
+    BOOT2_TEXT (rx) : ORIGIN = 0x10000000, LENGTH = 256
+    FLASH_TEXT (rx) : ORIGIN = 0x10000000 + 256, LENGTH = 8192K - 256
+    RAM (rwx)       : ORIGIN = 0x20000000, LENGTH = 256k
+}
+
+INCLUDE "targets/rp2040.ld"


### PR DESCRIPTION
- Primary Guide: Adafruit QT Py RP2040
  * https://learn.adafruit.com/adafruit-qt-py-2040
  * schema : https://learn.adafruit.com/adafruit-qt-py-2040/downloads
  * pinout : https://learn.adafruit.com/adafruit-qt-py-2040/pinouts

Although not directly related to TinyGo, here is the Arduino-core pinout for reference.
https://github.com/earlephilhower/arduino-pico/blob/master/variants/adafruit_qtpy/pins_arduino.h

@sago35 