### PR TITLE
Add github.com/soypat/mu8 to corpus.yaml

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -280,3 +280,4 @@
 - repo: github.com/chewxy/math32
   tags: noasm
   version: master
+- repo: github.com/soypat/mu8


### PR DESCRIPTION
Tests on this repo aren't very in-depth, but I thought it'd be nice to bring in a generics repository.