### PR TITLE
add github.com/soypat/mu8 to corpus.yaml

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -282,3 +282,4 @@
   version: master
 - repo: github.com/russross/blackfriday
   version: v2
+- repo: github.com/soypat/mu8


### PR DESCRIPTION
Messed up other PR, found it easier to just create new PR.

> Tests on this repo aren't very in-depth, but I thought it'd be nice to bring in a generics repository.