### PR TITLE
wasm: do not allow undefined symbols

### DIFF
--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -62,7 +62,7 @@ declare void @main.undefinedFunctionNotInSection(i8*) #0
 
 attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
 attributes #3 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #4 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }

--- a/src/internal/task/task_asyncify_wasm.S
+++ b/src/internal/task/task_asyncify_wasm.S
@@ -2,12 +2,16 @@
 
 .functype start_unwind (i32) -> ()
 .import_module start_unwind, asyncify
+.import_name start_unwind, start_unwind
 .functype stop_unwind () -> ()
 .import_module stop_unwind, asyncify
+.import_name stop_unwind, stop_unwind
 .functype start_rewind (i32) -> ()
 .import_module start_rewind, asyncify
+.import_name start_rewind, start_rewind
 .functype stop_rewind () -> ()
 .import_module stop_rewind, asyncify
+.import_name stop_rewind, stop_rewind
 
 .global  tinygo_unwind
 .hidden  tinygo_unwind

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -15,7 +15,6 @@
 		"-msign-ext"
 	],
 	"ldflags": [
-		"--allow-undefined",
 		"--stack-first",
 		"--no-demangle"
 	],

--- a/targets/wasm-undefined.txt
+++ b/targets/wasm-undefined.txt
@@ -1,0 +1,16 @@
+syscall/js.copyBytesToGo
+syscall/js.copyBytesToJS
+syscall/js.finalizeRef
+syscall/js.stringVal
+syscall/js.valueCall
+syscall/js.valueDelete
+syscall/js.valueGet
+syscall/js.valueIndex
+syscall/js.valueInstanceOf
+syscall/js.valueInvoke
+syscall/js.valueLength
+syscall/js.valueLoadString
+syscall/js.valueNew
+syscall/js.valuePrepareString
+syscall/js.valueSet
+syscall/js.valueSetIndex

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -15,7 +15,7 @@
 		"-msign-ext"
 	],
 	"ldflags": [
-		"--allow-undefined",
+		"--allow-undefined-file={root}/targets/wasm-undefined.txt",
 		"--stack-first",
 		"--no-demangle"
 	],


### PR DESCRIPTION
`--allow-undefined` can be a problem: it allows compiling code that will fail when loaded. This change makes sure that if some symbols are undefined, they are reported as an error by the linker.

Previously, people could get away with importing a function that was not defined, like this:

```go
func add(int a, int b) int

func test() {
    println(add(3, 5))
}
```

This was technically unsupported but mostly worked. With this change, it isn't possible anymore. Now every function needs to be marked with `//export` explicitly:

```go
//export add
func add(int a, int b) int

func test() {
    println(add(3, 5))
}
```

As before, functions will be placed in the `env` module with the name set from the `//export` tag. This can be overridden with `//go:import-module`:

```go
//go:import-module math
//export add
func add(int a, int b) int

func test() {
    println(add(3, 5))
}
```

For the syscall/js package, I needed to give a list of symbols that are undefined in any case because the package doesn't mark these functions as imported in any way.