### PR TITLE
cgo: fixes panic when FuncType.Results is nil

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -948,6 +948,9 @@ func (p *cgoPackage) isEquivalentAST(a, b ast.Node) bool {
 		if !ok {
 			return false
 		}
+		if node == nil || b == nil {
+			return node == b
+		}
 		if len(node.List) != len(b.List) {
 			return false
 		}

--- a/cgo/cgo_test.go
+++ b/cgo/cgo_test.go
@@ -184,7 +184,6 @@ func Test_cgoPackage_isEquivalentAST(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // avoid a race condition
 		t.Run(tc.name, func(t *testing.T) {
 			p := &cgoPackage{}
 			if got := p.isEquivalentAST(tc.a, tc.b); tc.expected != got {


### PR DESCRIPTION
FuncType.Results can be nil. This fixes the comparison and backfills relevant tests.

Fixes #3096