### PR TITLE
build: uses setup-go@v3 to simplify cache config

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,10 +16,6 @@ jobs:
     name: build-macos
     runs-on: macos-11
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18.1'
       - name: Install Dependencies
         shell: bash
         run: |
@@ -35,6 +31,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.1'
+          cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source
@@ -104,23 +105,17 @@ jobs:
     name: homebrew-install
     runs-on: macos-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - name: Install LLVM
         shell: bash
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm@14
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache Go
-        uses: actions/cache@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
         with:
-          key: go-cache-macos-homebrew-v1-${{ hashFiles('go.mod') }}
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
+          go-version: '1.18'
+          cache: true
       - name: Build TinyGo
         run: go install
       - name: Check binary

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           submodules: true
       - name: Install Go
+        # TODO: v2 until https://github.com/tinygo-org/tinygo/issues/3146
         uses: actions/setup-go@v2
         with:
           go-version: '1.18.1'
@@ -121,9 +122,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18.1'
+          cache: true
       - name: Install wasmtime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
@@ -173,9 +175,10 @@ jobs:
               simavr \
               ninja-build
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18.1'
+          cache: true
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
@@ -184,13 +187,6 @@ jobs:
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        uses: actions/cache@v3
-        with:
-          key: go-cache-linux-asserts-v1-${{ hashFiles('go.mod') }}
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source
@@ -279,16 +275,10 @@ jobs:
               g++-arm-linux-gnueabihf \
               libc6-dev-armhf-cross
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18.1'
-      - name: Cache Go
-        uses: actions/cache@v3
-        with:
-          key: go-cache-linux-arm-v2-${{ hashFiles('go.mod') }}
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
+          cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source
@@ -385,16 +375,10 @@ jobs:
               libc6-dev-arm64-cross \
               ninja-build
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '1.18.1'
-      - name: Cache Go
-        uses: actions/cache@v3
-        with:
-          key: go-cache-linux-arm64-v2-${{ hashFiles('go.mod') }}
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
+          cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,10 +15,6 @@ jobs:
   build-windows:
     runs-on: windows-2022
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18.1'
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'
@@ -30,13 +26,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Cache Go
-        uses: actions/cache@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
         with:
-          key: go-cache-windows-v1-${{ hashFiles('go.mod') }}
-          path: |
-            ~/AppData/Local/go-build
-            ~/go/pkg/mod
+          go-version: '1.18.1'
+          cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source


### PR DESCRIPTION
This updates to setup-go@v3 which is the only updated version (v2 last
updated in feb), and employs its cache to simplify workflow
configuration.

Notably, we can't do this for Alpine until https://github.com/tinygo-org/tinygo/issues/3146