### PR TITLE
wasm: do not export malloc, calloc, realloc, free

### DIFF
--- a/cgo/security.go
+++ b/cgo/security.go
@@ -142,6 +142,7 @@ var validLinkerFlags = []*regexp.Regexp{
 	re(`-L([^@\-].*)`),
 	re(`-O`),
 	re(`-O([^@\-].*)`),
+	re(`--export=(.+)`), // for wasm-ld
 	re(`-f(no-)?(pic|PIC|pie|PIE)`),
 	re(`-f(no-)?openmp(-simd)?`),
 	re(`-fsanitize=([^@\-].*)`),

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1059,11 +1059,12 @@ func (b *builder) createFunctionStart(intrinsic bool) {
 	if b.info.section != "" {
 		b.llvmFn.SetSection(b.info.section)
 	}
-	if b.info.exported && strings.HasPrefix(b.Triple, "wasm") {
+	if b.info.exported && b.info.module != "" && strings.HasPrefix(b.Triple, "wasm") {
 		// Set the exported name. This is necessary for WebAssembly because
 		// otherwise the function is not exported.
-		functionAttr := b.ctx.CreateStringAttribute("wasm-export-name", b.info.linkName)
-		b.llvmFn.AddFunctionAttr(functionAttr)
+		b.llvmFn.AddFunctionAttr(b.ctx.CreateStringAttribute("wasm-export-name", b.info.linkName))
+		// Set the export module.
+		b.llvmFn.AddFunctionAttr(b.ctx.CreateStringAttribute("wasm-export-module", b.info.module))
 	}
 
 	// Some functions have a pragma controlling the inlining level.

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -62,7 +62,7 @@ declare void @main.undefinedFunctionNotInSection(i8*) #0
 
 attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-module"="env" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
 attributes #3 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #4 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-module"="env" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -68,6 +68,7 @@ func growHeap() bool {
 var allocs = make(map[uintptr][]byte)
 
 //export malloc
+//go:wasm-module
 func libc_malloc(size uintptr) unsafe.Pointer {
 	buf := make([]byte, size)
 	ptr := unsafe.Pointer(&buf[0])
@@ -76,6 +77,7 @@ func libc_malloc(size uintptr) unsafe.Pointer {
 }
 
 //export free
+//go:wasm-module
 func libc_free(ptr unsafe.Pointer) {
 	if ptr == nil {
 		return
@@ -88,12 +90,14 @@ func libc_free(ptr unsafe.Pointer) {
 }
 
 //export calloc
+//go:wasm-module
 func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 	// No difference between calloc and malloc.
 	return libc_malloc(nmemb * size)
 }
 
 //export realloc
+//go:wasm-module
 func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
 	// It's hard to optimize this to expand the current buffer with our GC, but
 	// it is theoretically possible. For now, just always allocate fresh.


### PR DESCRIPTION
These functions were exported by accident, because the compiler had no way of saying these functions shouldn't be exported. Unfortunately, they can easily be misused and bloat WebAssembly programs.

Not exporting them can be a big code size reduction for small programs. Before:

    $ tinygo build -o test.wasm -target=wasi -no-debug -scheduler=none ./testdata/alias.go && ls -l test.wasm
    -rwxrwxr-x 1 ayke ayke 2947  8 sep 13:47 test.wasm

After:

    $ tinygo build -o test.wasm -target=wasi -no-debug -scheduler=none ./testdata/alias.go && ls -l test.wasm
    -rwxrwxr-x 1 ayke ayke 968  8 sep 13:47 test.wasm

That's a 2kB reduction in binary size, because the GC isn't needed anymore.

This change also adds support for using `//go:wasm-module` to set the module name of an exported function (the default remains env).

---

I expect this can be a controversial change, because some people have been relying on the exported `malloc` function. While this function does work, it is not intended to be used like that (it's only to be used for C linked using CGo). Instead, memory should be allocated by exporting a specific function for it. For example:

```go
var allocatedBytes *byte

//export allocateBytes
func allocateBytes(n int) *byte {
    buf := make([]byte, n)
    allocatedBytes = &buf[0]
    return &buf[0]
}
```

This is a safe way to export memory.