### PR TITLE
wasm,wasi: make sure buffers returned by malloc are not freed until f…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,9 +395,9 @@ tinygo-bench-fast:
 
 # Same thing, except for wasi rather than the current platform.
 tinygo-test-wasi:
-	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW)
+	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW) ./tests/runtime_wasi
 tinygo-test-wasi-fast:
-	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST)
+	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-bench-wasi:
 	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW)
 tinygo-bench-wasi-fast:

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -83,7 +83,7 @@ func libc_free(ptr unsafe.Pointer) {
 	if _, ok := allocs[uintptr(ptr)]; ok {
 		delete(allocs, uintptr(ptr))
 	} else {
-		panic("invalid pointer")
+		panic("free: invalid pointer")
 	}
 }
 
@@ -101,10 +101,10 @@ func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
 
 	if oldPtr != nil {
 		if oldBuf, ok := allocs[uintptr(oldPtr)]; ok {
-			delete(allocs, uintptr(oldPtr))
 			copy(buf, oldBuf)
+			delete(allocs, uintptr(oldPtr))
 		} else {
-			panic("invalid pointer")
+			panic("realloc: invalid pointer")
 		}
 	}
 

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -77,7 +77,14 @@ func libc_malloc(size uintptr) unsafe.Pointer {
 
 //export free
 func libc_free(ptr unsafe.Pointer) {
-	delete(allocs, uintptr(ptr))
+	if ptr == nil {
+		return
+	}
+	if _, ok := allocs[uintptr(ptr)]; ok {
+		delete(allocs, uintptr(ptr))
+	} else {
+		panic("invalid pointer")
+	}
 }
 
 //export calloc
@@ -93,9 +100,12 @@ func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
 	buf := make([]byte, size)
 
 	if oldPtr != nil {
-		oldBuf := allocs[uintptr(oldPtr)]
-		delete(allocs, uintptr(oldPtr))
-		copy(buf, oldBuf)
+		if oldBuf, ok := allocs[uintptr(oldPtr)]; ok {
+			delete(allocs, uintptr(oldPtr))
+			copy(buf, oldBuf)
+		} else {
+			panic("invalid pointer")
+		}
 	}
 
 	ptr := unsafe.Pointer(&buf[0])

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -61,31 +61,44 @@ func growHeap() bool {
 	return true
 }
 
-// The below functions override the default allocator of wasi-libc.
-// Most functions are defined but unimplemented to make sure that if there is
-// any code using them, they will get an error instead of (incorrectly) using
-// the wasi-libc dlmalloc heap implementation instead. If they are needed by any
-// program, they can certainly be implemented.
+// The below functions override the default allocator of wasi-libc. This ensures
+// code linked from other languages can allocate memory without colliding with
+// our GC allocations.
+
+var allocs = make(map[uintptr][]byte)
 
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
-	return alloc(size, nil)
+	buf := make([]byte, size)
+	ptr := unsafe.Pointer(&buf[0])
+	allocs[uintptr(ptr)] = buf
+	return ptr
 }
 
 //export free
 func libc_free(ptr unsafe.Pointer) {
-	free(ptr)
+	delete(allocs, uintptr(ptr))
 }
 
 //export calloc
 func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
-	// Note: we could be even more correct here and check that nmemb * size
-	// doesn't overflow. However the current implementation should normally work
-	// fine.
-	return alloc(nmemb*size, nil)
+	// No difference between calloc and malloc.
+	return libc_malloc(nmemb * size)
 }
 
 //export realloc
-func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
-	return realloc(ptr, size)
+func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
+	// It's hard to optimize this to expand the current buffer with our GC, but
+	// it is theoretically possible. For now, just always allocate fresh.
+	buf := make([]byte, size)
+
+	if oldPtr != nil {
+		oldBuf := allocs[uintptr(oldPtr)]
+		delete(allocs, uintptr(oldPtr))
+		copy(buf, oldBuf)
+	}
+
+	ptr := unsafe.Pointer(&buf[0])
+	allocs[uintptr(ptr)] = buf
+	return ptr
 }

--- a/tests/runtime_wasi/malloc_test.go
+++ b/tests/runtime_wasi/malloc_test.go
@@ -1,0 +1,127 @@
+//go:build tinygo.wasm
+// +build tinygo.wasm
+
+package runtime_wasi
+
+import (
+	"reflect"
+	"runtime"
+	"strconv"
+	"testing"
+	"unsafe"
+)
+
+//export malloc
+func libc_malloc(size uintptr) unsafe.Pointer
+
+//export free
+func libc_free(ptr unsafe.Pointer)
+
+//export calloc
+func libc_calloc(nmemb, size uintptr) unsafe.Pointer
+
+//export realloc
+func libc_realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer
+
+func getFilledBuffer_malloc() uintptr {
+	ptr := libc_malloc(5)
+	fillPanda(ptr)
+	return uintptr(ptr)
+}
+
+func getFilledBuffer_calloc() uintptr {
+	ptr := libc_calloc(2, 5)
+	fillPanda(ptr)
+	*(*byte)(unsafe.Add(ptr, 5)) = 'b'
+	*(*byte)(unsafe.Add(ptr, 6)) = 'e'
+	*(*byte)(unsafe.Add(ptr, 7)) = 'a'
+	*(*byte)(unsafe.Add(ptr, 8)) = 'r'
+	*(*byte)(unsafe.Add(ptr, 9)) = 's'
+	return uintptr(ptr)
+}
+
+func getFilledBuffer_realloc() uintptr {
+	origPtr := getFilledBuffer_malloc()
+	ptr := libc_realloc(unsafe.Pointer(origPtr), 9)
+	*(*byte)(unsafe.Add(ptr, 5)) = 'b'
+	*(*byte)(unsafe.Add(ptr, 6)) = 'e'
+	*(*byte)(unsafe.Add(ptr, 7)) = 'a'
+	*(*byte)(unsafe.Add(ptr, 8)) = 'r'
+	return uintptr(ptr)
+}
+
+func getFilledBuffer_reallocNil() uintptr {
+	ptr := libc_realloc(nil, 5)
+	fillPanda(ptr)
+	return uintptr(ptr)
+}
+
+func fillPanda(ptr unsafe.Pointer) {
+	*(*byte)(unsafe.Add(ptr, 0)) = 'p'
+	*(*byte)(unsafe.Add(ptr, 1)) = 'a'
+	*(*byte)(unsafe.Add(ptr, 2)) = 'n'
+	*(*byte)(unsafe.Add(ptr, 3)) = 'd'
+	*(*byte)(unsafe.Add(ptr, 4)) = 'a'
+}
+
+func checkFilledBuffer(t *testing.T, ptr uintptr, content string) {
+	t.Helper()
+	buf := *(*string)(unsafe.Pointer(&reflect.StringHeader{
+		Data: ptr,
+		Len:  uintptr(len(content)),
+	}))
+	if buf != content {
+		t.Errorf("expected %q, got %q", content, buf)
+	}
+}
+
+func TestMallocFree(t *testing.T) {
+	tests := []struct {
+		name      string
+		getBuffer func() uintptr
+		content   string
+	}{
+		{
+			name:      "malloc",
+			getBuffer: getFilledBuffer_malloc,
+			content:   "panda",
+		},
+		{
+			name:      "calloc",
+			getBuffer: getFilledBuffer_calloc,
+			content:   "pandabears",
+		},
+		{
+			name:      "realloc",
+			getBuffer: getFilledBuffer_realloc,
+			content:   "pandabear",
+		},
+		{
+			name:      "realloc nil",
+			getBuffer: getFilledBuffer_reallocNil,
+			content:   "panda",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.name, func(t *testing.T) {
+			bufPtr := tt.getBuffer()
+			// Don't use defer to free the buffer as it seems to cause the GC to track it.
+
+			// Churn GC, the pointer should still be valid until free is called.
+			for i := 0; i < 1000; i++ {
+				a := "hello" + strconv.Itoa(i)
+				// Some conditional logic to ensure optimization doesn't remove the loop completely.
+				if len(a) < 0 {
+					break
+				}
+				runtime.GC()
+			}
+
+			checkFilledBuffer(t, bufPtr, tt.content)
+
+			libc_free(unsafe.Pointer(bufPtr))
+		})
+	}
+}


### PR DESCRIPTION
…ree is called

I am trying to create a wasm app that links two wasm binaries, one compiled from C++ with clang and one compiled from TinyGo. This is to reuse C++ libraries in a TinyGo app.

I found when doing this, that malloc/free that TinyGo implements to make sure they collaborate with the GC are not actually functional (this is probably what the comment meant by `unimplemented`) - `free` being a noop is the obvious hint, but basically the buffer returned by malloc is not referenced by Go so is ready to be GC'd right away, even though it needs to be able to survive until `free` is called. Hoping the note that if they're needed they can be implemented is true :) I believe these do need to be implemented properly to support polyglot wasm apps built from different compilers.

This PR changes to keep track of allocations within Go to make sure buffers are referenced until `free` is called. Then, they won't be referenced anymore and will be cleaned up when GC runs.

I couldn't find any similar wasi test in the repo, so would appreciate any pointer on how to write a test for this. I have this repository with a test, maybe it is OK to add as a subdirectory, with the wasm compilation wired to Makefile instead of checked in?

https://github.com/anuraaga/tinygo-wasialloctest

This test shows a malloc'd buffer becoming invalidated with current TinyGo, but not after this change.