### PR TITLE
machine/nrf52840: implement RNG peripheral operation

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build stm32 || (sam && atsamd51) || (sam && atsame5x) || rp2040
-// +build stm32 sam,atsamd51 sam,atsame5x rp2040
+//go:build nrf52840 || stm32 || (sam && atsamd51) || (sam && atsame5x) || rp2040
+// +build nrf52840 stm32 sam,atsamd51 sam,atsame5x rp2040
 
 package rand
 

--- a/src/machine/machine_nrf52840_rng.go
+++ b/src/machine/machine_nrf52840_rng.go
@@ -1,0 +1,60 @@
+//go:build nrf52840
+// +build nrf52840
+
+package machine
+
+import (
+	"device/nrf"
+)
+
+// Implementation based on Nordic Semiconductor's nRF52840 documentation version 1.7 found here:
+// https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.7.pdf
+
+// SetRNGBiasCorrection configures the RNG peripheral's bias correction mechanism. Note that when
+// bias correction is enabled, the peripheral is slower to produce random values.
+func SetRNGBiasCorrection(enabled bool) {
+	var val uint32
+	if enabled {
+		val = nrf.RNG_CONFIG_DERCEN_Enabled
+	}
+	nrf.RNG.SetCONFIG_DERCEN(val)
+}
+
+// RNGBiasCorrectionEnabled determines whether the RNG peripheral's bias correction mechanism is
+// enabled or not.
+func RNGBiasCorrectionEnabled() bool {
+	return nrf.RNG.GetCONFIG_DERCEN() == nrf.RNG_CONFIG_DERCEN_Enabled
+}
+
+// StartRNG starts the RNG peripheral core. This is automatically called by GetRNG, but can be
+// manually called for interacting with the RNG peripheral directly.
+func StartRNG() {
+	nrf.RNG.SetTASKS_START(nrf.RNG_TASKS_START_TASKS_START_Trigger)
+}
+
+// StopRNG stops the RNG peripheral core. This is not called automatically. It may make sense to
+// manually disable RNG peripheral for power conservation.
+func StopRNG() {
+	nrf.RNG.SetTASKS_STOP(nrf.RNG_TASKS_STOP_TASKS_STOP_Trigger)
+}
+
+// GetRNG returns 32 bits of non-deterministic random data based on internal thermal noise.
+// According to Nordic's documentation, the random output is suitable for cryptographic purposes.
+func GetRNG() (ret uint32, err error) {
+	// There's no apparent way to check the status of the RNG peripheral's task, so simply start it
+	// to avoid deadlocking while waiting for output.
+	StartRNG()
+
+	// The RNG returns one byte at a time, so stack up four bytes into a single uint32 for return.
+	for i := 0; i < 4; i++ {
+		// Wait for data to be ready.
+		for nrf.RNG.GetEVENTS_VALRDY() == nrf.RNG_EVENTS_VALRDY_EVENTS_VALRDY_NotGenerated {
+		}
+		// Append random byte to output.
+		ret = (ret << 8) ^ nrf.RNG.GetVALUE()
+		// Unset the EVENTS_VALRDY register to avoid reading the same random output twice.
+		nrf.RNG.SetEVENTS_VALRDY(nrf.RNG_EVENTS_VALRDY_EVENTS_VALRDY_NotGenerated)
+	}
+
+	return ret, nil
+}


### PR DESCRIPTION
Howdy y'all. This adds RNG support for Nordic's nRF52840. Alongside the `GetRNG` function used by `crypto/rand/rand_baremetal.go` I've added some functions to control and configure the RNG peripheral. There's also an ARM CryptoCell 310 subsystem on the machine that contains another TRNG, but interaction with it isn't via an easy register interface like this.

Snippet of sample output from `src/examples/rand` flashed to a `xiao-ble`:
```
e73ba017e959eef43a0307379d595245b114418ba0243e82ba6cf3860830254d
e6825f781dd1a401d9a75afadccce9133e30a27d82193f45cc6353d505e85ed7
51e9e198c65dbbae7a1b37861a409d7d78301467c348197e595d765e71b1fe4c
a066ed186aa7cc4798f68b0cc3fee04d08d4046fe6faa33b9a6ea0db51f87e0e
40447c2d0bcde76a47424b2710baa7e5b1339f7c6c3a322ff275cf5f6f653047
```