### PR TITLE
main: add serial port monitoring functionality

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	LLVMFeatures    string
 	Directory       string
 	PrintJSON       bool
+	Monitor         bool
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892
 	github.com/mattn/go-colorable v0.1.8
+	github.com/mattn/go-tty v0.0.4
 	go.bug.st/serial v1.3.5
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261
 	golang.org/x/tools v0.1.11
@@ -28,5 +29,4 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,16 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892 h1:6J+qramlHVLmiBOgRiBOnQkno8uprqG6YFFQTt6uYIw=
 github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892/go.mod h1:Pb6XcsXyropB9LNHhnqaknG/vEwYztLkQzVCHv8sQ3M=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-tty v0.0.4 h1:NVikla9X8MN0SQAqCYzpGyXv0jY7MNl3HOWD2dkle7E=
+github.com/mattn/go-tty v0.0.4/go.mod h1:u5GGXBtZU6RQoKV8gY5W6UhMudbR5vXnUe7j3pxse28=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -41,7 +47,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 go.bug.st/serial v1.3.5 h1:k50SqGZCnHZ2MiBQgzccXWG+kd/XpOs1jUljpDDKzaE=
 go.bug.st/serial v1.3.5/go.mod h1:z8CesKorE90Qr/oRSJiEuvzYRKol9r/anJZEb5kt304=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/mattn/go-tty"
+	"github.com/tinygo-org/tinygo/builder"
+	"github.com/tinygo-org/tinygo/compileopts"
+	"go.bug.st/serial"
+)
+
+// Monitor connects to the given port and reads/writes the serial port.
+func Monitor(port string, options *compileopts.Options) error {
+	config, err := builder.NewConfig(options)
+	if err != nil {
+		return err
+	}
+
+	wait := 300
+	for i := 0; i <= wait; i++ {
+		port, err = getDefaultPort(port, config.Target.SerialPort)
+		if err != nil {
+			if i < wait {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		break
+	}
+
+	wait = 300
+	var p serial.Port
+	for i := 0; i <= wait; i++ {
+		p, err = serial.Open(port, &serial.Mode{})
+		if err != nil {
+			if i < wait {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		break
+	}
+	defer p.Close()
+
+	tty, err := tty.Open()
+	if err != nil {
+		return err
+	}
+	defer tty.Close()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	defer signal.Stop(sig)
+
+	go func() {
+		<-sig
+		tty.Close()
+		os.Exit(0)
+	}()
+
+	fmt.Printf("Connected to %s. Press Ctrl-C to exit.\n", port)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 100*1024)
+		for {
+			n, err := p.Read(buf)
+			if err != nil {
+				errCh <- fmt.Errorf("read error: %w", err)
+				return
+			}
+
+			if n == 0 {
+				continue
+			}
+			fmt.Printf("%v", string(buf[:n]))
+		}
+	}()
+
+	go func() {
+		for {
+			r, err := tty.ReadRune()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if r == 0 {
+				continue
+			}
+			p.Write([]byte(string(r)))
+		}
+	}()
+
+	return <-errCh
+}


### PR DESCRIPTION
This PR adds the following features

* `tinygo flash -monitor`
    * After flashing, connect to the serial port
    * Serial port is automatically selected
* `tinygo monitor`
    * Subcommand to connect to serial port
    * `-target` or `-port` can be specified


It can be used as follows.

```
$ tinygo flash --target xiao-ble --size short -monitor examples/echo
   code    data     bss |   flash     ram
   8268     112    7840 |    8380    7952
Connected to COM134. Press Ctrl-C to exit.
hello there
You typed: hello there
こんにちは
You typed: こんにちは
```

```
$ tinygo flash --target xiao-ble --size short examples/serial
   code    data     bss |   flash     ram
   8000     112    7840 |    8112    7952

$ tinygo monitor -target xiao-ble
Connected to COM134. Press Ctrl-C to exit.
hello world!
hello world!
...

$ tinygo monitor -port COM134
Connected to COM134. Press Ctrl-C to exit.
hello world!
hello world!
...
```


I just made this as a trial, but it is very comfortable and I want you to try it.


----

Unfortunately, the Wio Terminal gives an error.
This is because the Bootloader is connected via USB-CDC and then reset.
Since #2992, touchSerialPortAt1200bps to bootloader is no longer needed, wioterminal.json should be changed.
I will create another PR that will make the json changes.

```
$ tinygo flash --target wioterminal --size short -monitor examples/echo
   code    data     bss |   flash     ram
   7688     108    6280 |    7796    6388
Connected to COM4. Press Ctrl-C to exit.
error: read error
```