### PR TITLE
ci: use the Go Alpine image for building the release binary

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,14 +18,13 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: alpine:3.16
+      image: golang:1.18-alpine
     steps:
       - name: Install apk dependencies
         # tar: needed for actions/cache@v3
         # git+openssh: needed for checkout (I think?)
-        # gcompat: needed for go binary
         # ruby: needed to install fpm
-        run: apk add tar git openssh gcompat make g++ ruby
+        run: apk add tar git openssh make g++ ruby
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -33,11 +32,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Install Go
-        # TODO: v2 until https://github.com/tinygo-org/tinygo/issues/3146
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18.1'
       - name: Cache Go
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/tinygo/issues/3146 by using a prebuilt Docker image. I don't remember why I used `setup-go` but probably to make it faster (setup-go usually uses cached binaries).