### PR TITLE
rp2040: do not use GetRNG in crypto/rand

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,5 +1,5 @@
-//go:build nrf52840 || stm32 || (sam && atsamd51) || (sam && atsame5x) || rp2040
-// +build nrf52840 stm32 sam,atsamd51 sam,atsame5x rp2040
+//go:build nrf52840 || stm32 || (sam && atsamd51) || (sam && atsame5x)
+// +build nrf52840 stm32 sam,atsamd51 sam,atsame5x
 
 package rand
 

--- a/src/machine/machine_rp2040_rng.go
+++ b/src/machine/machine_rp2040_rng.go
@@ -13,6 +13,10 @@ import (
 const numberOfCycles = 32
 
 // GetRNG returns 32 bits of semi-random data based on ring oscillator.
+//
+// Unlike some other implementations of GetRNG, these random numbers are not
+// cryptographically secure and must not be used for cryptographic operations
+// (nonces, etc).
 func GetRNG() (uint32, error) {
 	var val uint32
 	for i := 0; i < 4; i++ {


### PR DESCRIPTION
The crypto/rand package is used for sensitive cryptographic operations. Do not use the rp2040 RNG for this purpose, because it's not strong enough for cryptography.

I think it is _possible_ to make use of the RP2040 RNG to create cryptographically secure pseudo-random numbers, but it needs some entropy calculation and secure hashing (blake2s or so) to make them truly unpredictable.

See the discussion in #3144 