### PR TITLE
wasm: add legacy target

### DIFF
--- a/targets/wasm-legacy.json
+++ b/targets/wasm-legacy.json
@@ -1,0 +1,18 @@
+{
+	"llvm-target":   "wasm32-unknown-wasi",
+	"cpu":           "generic",
+	"build-tags":    ["tinygo.wasm"],
+	"goos":          "js",
+	"goarch":        "wasm",
+	"linker":        "wasm-ld",
+	"libc":          "wasi-libc",
+	"scheduler":     "asyncify",
+	"default-stack-size": 16384,
+	"ldflags": [
+		"--allow-undefined-file={root}/targets/wasm-undefined.txt",
+		"--stack-first",
+		"--no-demangle"
+	],
+	"emulator":      "node {root}/targets/wasm_exec.js {}",
+	"wasm-abi":      "js"
+}

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,24 +1,9 @@
 {
-	"llvm-target":   "wasm32-unknown-wasi",
-	"cpu":           "generic",
-	"features":      "+bulk-memory,+nontrapping-fptoint,+sign-ext",
-	"build-tags":    ["tinygo.wasm"],
-	"goos":          "js",
-	"goarch":        "wasm",
-	"linker":        "wasm-ld",
-	"libc":          "wasi-libc",
-	"scheduler":     "asyncify",
-	"default-stack-size": 16384,
+	"inherits": ["wasm-legacy"],
+	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
 	"cflags": [
 		"-mbulk-memory",
 		"-mnontrapping-fptoint",
 		"-msign-ext"
-	],
-	"ldflags": [
-		"--allow-undefined-file={root}/targets/wasm-undefined.txt",
-		"--stack-first",
-		"--no-demangle"
-	],
-	"emulator":      "node {root}/targets/wasm_exec.js {}",
-	"wasm-abi":      "js"
+	]
 }


### PR DESCRIPTION
This should keep at least some compatibility with older browsers. It isn't complete though: wasi-libc is still built with the bulk-memory feature enabled. But it may be good enough for some uses.

If needed, I guess we could ship a separate wasi-libc build with the bulk-memory feature disabled.