### PR TITLE
interp: fix reading from external global

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -369,6 +369,11 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				nBytes := uint32(operands[3].Uint())
 				dstObj := mem.getWritable(dst.index())
 				dstBuf := dstObj.buffer.asRawValue(r)
+				if mem.get(src.index()).buffer == nil {
+					// Looks like the source buffer is not defined.
+					// This can happen with //extern or //go:embed.
+					return nil, mem, r.errorAt(inst, errUnsupportedRuntimeInst)
+				}
 				srcBuf := mem.get(src.index()).buffer.asRawValue(r)
 				copy(dstBuf.buf[dst.offset():dst.offset()+nBytes], srcBuf.buf[src.offset():])
 				dstObj.buffer = dstBuf

--- a/testdata/embed/embed.go
+++ b/testdata/embed/embed.go
@@ -20,9 +20,12 @@ var (
 //go:embed a/b/.hidden
 var hidden string
 
+var helloStringBytes = []byte(helloString)
+
 func main() {
 	println("string:", strings.TrimSpace(helloString))
 	println("bytes:", strings.TrimSpace(string(helloBytes)))
+	println("[]byte(string):", strings.TrimSpace(string(helloStringBytes)))
 	println("files:")
 	readFiles(".")
 }

--- a/testdata/embed/out.txt
+++ b/testdata/embed/out.txt
@@ -1,5 +1,6 @@
 string: hello world!
 bytes: hello world!
+[]byte(string): hello world!
 files:
 - a
 - a/b


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/tinygo/issues/3020.