### PR TITLE
wasm: implement the //go:wasmimport directive

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -288,6 +288,15 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 					continue
 				}
 				info.module = parts[1]
+			case "//go:wasmimport":
+				// Import a WebAssembly function, for example a WASI function.
+				// For details, see: https://github.com/golang/go/issues/38248
+				if len(parts) != 3 {
+					continue
+				}
+				info.exported = true
+				info.module = parts[1]
+				info.importName = parts[2]
 			case "//go:inline":
 				info.inline = inlineHint
 			case "//go:noinline":

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -12,15 +12,13 @@ type __wasi_iovec_t struct {
 	bufLen uint
 }
 
-//go:wasm-module wasi_snapshot_preview1
-//export fd_write
+//go:wasmimport wasi_snapshot_preview1 fd_write
 func fd_write(id uint32, iovs *__wasi_iovec_t, iovs_len uint, nwritten *uint) (errno uint)
 
 // See:
 // https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-proc_exitrval-exitcode
 //
-//go:wasm-module wasi_snapshot_preview1
-//export proc_exit
+//go:wasmimport wasi_snapshot_preview1 proc_exit
 func proc_exit(exitcode uint32)
 
 const (

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -101,20 +101,16 @@ func ticks() timeUnit {
 
 // Implementations of WASI APIs
 
-//go:wasm-module wasi_snapshot_preview1
-//export args_get
+//go:wasmimport wasi_snapshot_preview1 args_get
 func args_get(argv *unsafe.Pointer, argv_buf unsafe.Pointer) (errno uint16)
 
-//go:wasm-module wasi_snapshot_preview1
-//export args_sizes_get
+//go:wasmimport wasi_snapshot_preview1 args_sizes_get
 func args_sizes_get(argc *uint32, argv_buf_size *uint32) (errno uint16)
 
-//go:wasm-module wasi_snapshot_preview1
-//export clock_time_get
+//go:wasmimport wasi_snapshot_preview1 clock_time_get
 func clock_time_get(clockid uint32, precision uint64, time *uint64) (errno uint16)
 
-//go:wasm-module wasi_snapshot_preview1
-//export poll_oneoff
+//go:wasmimport wasi_snapshot_preview1 poll_oneoff
 func poll_oneoff(in *__wasi_subscription_t, out *__wasi_event_t, nsubscriptions uint32, nevents *uint32) (errno uint16)
 
 type __wasi_eventtype_t = uint8


### PR DESCRIPTION
It is ~implemented upstream~ almost implemented upstream and looks pretty stable.

@neelance I'd like to get your opinion on this.
This would mean that TinyGo implements the `//go:wasmimport` directive for all packages (not just runtime and syscall/js). This seems mostly safe to me, and certainly better than the current `//go:wasm-module` directive that we're using. What do you think, am I missing something?
The ABI will be mostly the same as the one used in the Go toolchain, with minor differences here and there. It roughly matches the C ABI.