### PR TITLE
wioterminal: remove serial-port setting of bootloader

### DIFF
--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51p19a"],
     "build-tags": ["wioterminal"],
     "serial": "usb",
-    "serial-port": ["acm:2886:002d", "acm:2886:802d"],
+    "serial-port": ["acm:2886:802d"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",


### PR DESCRIPTION
 #3156 adds `tinygo flash -monitor`.

With wioterminal, it is possible to connect to a serialport after flashing but before it is reset.
This occurs when the following conditions are present

* bootloader has VID/PID for USBCDC
* VID/PID of the bootloader is listed in `targets/*.json`.
* Reset after flash takes time

before: COM4==bootloader, COM131==application
```
$ tinygo flash --target wioterminal --monitor examples/serial
Connected to COM4. Press Ctrl-C to exit.
error: read error: Port has been closed: The I/O operation has been aborted because of either a thread exit or an application request.
```


after:  COM4==bootloader, COM131==application
```
$ tinygo flash --target wioterminal --monitor examples/serial
Connected to COM131. Press Ctrl-C to exit.
hello world!
hello world!
```

----

Although it probably occurs at other boards than the Wio Terminal, it is necessary to determine which one is the bootloader.
If `tinygo flash -monitor` fails, most likely you are experiencing the same problem as this PR.
If you are using a board that causes problems, you can report and create a PR.