### PR TITLE
machine: add KHz, MHz, GHz constants, deprecate TWI_FREQ_* constants

### DIFF
--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -8,6 +8,8 @@ import (
 )
 
 // TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
+//
+// Deprecated: use 100 * machine.KHz or 400 * machine.KHz instead.
 const (
 	TWI_FREQ_100KHZ = 100000
 	TWI_FREQ_400KHZ = 400000

--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -18,6 +18,13 @@ var (
 // particular chip but instead runs in WebAssembly for example.
 const Device = deviceName
 
+// Generic constants.
+const (
+	KHz = 1000
+	MHz = 1000_000
+	GHz = 1000_000_000
+)
+
 // PinMode sets the direction and pull mode of the pin. For example, PinOutput
 // sets the pin as an output and PinInputPullup sets the pin as an input with a
 // pull-up.

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -26,7 +26,7 @@ type I2CConfig struct {
 func (i2c *I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 
 	// Activate internal pullups for twi.

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -677,7 +677,7 @@ const i2cTimeout = 1000
 func (i2c *I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 	if config.SDA == 0 && config.SCL == 0 {
 		config.SDA = SDA_PIN

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1151,7 +1151,7 @@ const i2cTimeout = 1000
 func (i2c *I2C) Configure(config I2CConfig) error {
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 
 	// Use default I2C pins if not set.

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -231,7 +231,7 @@ type I2CConfig struct {
 func (i2c *I2C) Configure(config I2CConfig) error {
 	var i2cClockFrequency uint32 = 32000000
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 
 	if config.SDA == 0 && config.SCL == 0 {

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -517,7 +517,7 @@ type I2CConfig struct {
 func (i2c *I2C) Configure(config I2CConfig) error {
 
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 
 	if config.SDA == 0 && config.SCL == 0 {

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -230,7 +230,7 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 
 	// Default I2C bus speed is 100 kHz.
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 	// Default I2C pins if not set.
 	if config.SDA == 0 && config.SCL == 0 {
@@ -253,7 +253,7 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 		(nrf.GPIO_PIN_CNF_DRIVE_S0D1 << nrf.GPIO_PIN_CNF_DRIVE_Pos) |
 		(nrf.GPIO_PIN_CNF_SENSE_Disabled << nrf.GPIO_PIN_CNF_SENSE_Pos))
 
-	if config.Frequency == TWI_FREQ_400KHZ {
+	if config.Frequency >= 400*KHz {
 		i2c.Bus.FREQUENCY.Set(nrf.TWI_FREQUENCY_FREQUENCY_K400)
 	} else {
 		i2c.Bus.FREQUENCY.Set(nrf.TWI_FREQUENCY_FREQUENCY_K100)

--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -10,11 +10,6 @@ import (
 	"unsafe"
 )
 
-const (
-	KHz = 1000
-	MHz = 1000000
-)
-
 func CPUFrequency() uint32 {
 	return 125 * MHz
 }

--- a/src/machine/machine_stm32_i2c_reva.go
+++ b/src/machine/machine_stm32_i2c_reva.go
@@ -137,7 +137,7 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 
 	// default to 100 kHz (Sm, standard mode) if no frequency is set
 	if config.Frequency == 0 {
-		config.Frequency = TWI_FREQ_100KHZ
+		config.Frequency = 100 * KHz
 	}
 
 	// configure I2C input clock


### PR DESCRIPTION
There are two main issues with these constants:

  * They don't follow the Go naming convention.
  * They call themselves "TWI", while it makes a lot more sense to refer to the actual name which is I2C (or I²C).

I have not removed them but just deprecated them. Perhaps we can remove them when we move towards version 1.0.

---

This may be a somewhat radical change. A less radical change would be to also define new I2C specific constants, like:

```go
const (
    I2CFrequency100KHz = 100 * KHz
    I2CFrequency400KHz = 400 * KHz
)
```

A bit longer but IMHO a lot better than `TWI_FREQ_100KHZ` etc.

Part of #3170.