### PR TITLE
xiao-ble: fix usbpid

### DIFF
--- a/src/machine/board_xiao-ble.go
+++ b/src/machine/board_xiao-ble.go
@@ -104,7 +104,7 @@ const (
 
 var (
 	usb_VID uint16 = 0x2886
-	usb_PID uint16 = 0x0045
+	usb_PID uint16 = 0x8045
 )
 
 var (


### PR DESCRIPTION
0x0045 is the PID for bootloader.

* The problem comes when running tinygo flash -monitor
* Flash from Arduino IDE to 0x8045
