### PR TITLE
targets: remove usbpid of bootloader

### DIFF
--- a/targets/circuitplay-bluefruit.json
+++ b/targets/circuitplay-bluefruit.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["circuitplay_bluefruit"],
-    "serial-port": ["acm:239a:8045", "acm:239a:45"],
+    "serial-port": ["acm:239a:8045"],
     "msd-volume-name": "CPLAYBTBOOT"
 }

--- a/targets/circuitplay-express.json
+++ b/targets/circuitplay-express.json
@@ -3,7 +3,7 @@
     "build-tags": ["circuitplay_express"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8018", "acm:239a:18"],
+    "serial-port": ["acm:239a:8018"],
     "msd-volume-name": "CPLAYBOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/clue-alpha.json
+++ b/targets/clue-alpha.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["clue_alpha"],
-    "serial-port": ["acm:239a:8072", "acm:239a:0072", "acm:239a:0071", "acm:239a:8071"],
+    "serial-port": ["acm:239a:8072", "acm:239a:8071"],
     "msd-volume-name": "CLUEBOOT"
 }

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["feather_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:801b", "acm:239a:001b", "acm:239a:800b", "acm:239a:000b", "acm:239a:0015"],
+    "serial-port": ["acm:239a:801b", "acm:239a:800b"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-m4-can.json
+++ b/targets/feather-m4-can.json
@@ -2,7 +2,7 @@
     "inherits": ["atsame51j19a"],
     "build-tags": ["feather_m4_can"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80cd", "acm:239a:00cd"],
+    "serial-port": ["acm:239a:80cd"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHRCANBOOT",

--- a/targets/feather-m4.json
+++ b/targets/feather-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["feather_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:8022", "acm:239a:0022"],
+    "serial-port": ["acm:239a:8022"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-nrf52840-sense.json
+++ b/targets/feather-nrf52840-sense.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["feather_nrf52840_sense"],
-    "serial-port": ["acm:239a:8087", "acm:239a:0087", "acm:239a:0088", "acm:239a:8088"],
+    "serial-port": ["acm:239a:8087", "acm:239a:8088"],
     "msd-volume-name": "FTHRSNSBOOT"
 }

--- a/targets/feather-nrf52840.json
+++ b/targets/feather-nrf52840.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["feather_nrf52840"],
-    "serial-port": ["acm:239a:8029", "acm:239a:0029", "acm:239a:002a", "acm:239a:802a"],
+    "serial-port": ["acm:239a:8029", "acm:239a:802a"],
     "msd-volume-name": "FTHR840BOOT"
 }

--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51p20a"],
     "build-tags": ["grandcentral_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:8031", "acm:239a:0031", "acm:239a:0032"],
+    "serial-port": ["acm:239a:8031"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["itsybitsy_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:800f", "acm:239a:000f", "acm:239a:8012"],
+    "serial-port": ["acm:239a:800f", "acm:239a:8012"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSYBOOT",

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:802b", "acm:239a:002b"],
+    "serial-port": ["acm:239a:802b"],
     "msd-volume-name": "ITSYM4BOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/itsybitsy-nrf52840.json
+++ b/targets/itsybitsy-nrf52840.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["itsybitsy_nrf52840"],
-    "serial-port": ["acm:239A:8052", "acm:239A:0052", "acm:239A:0051", "acm:239A:8051"],
+    "serial-port": ["acm:239A:8052", "acm:239A:8051"],
     "msd-volume-name": "ITSY840BOOT"
 }

--- a/targets/matrixportal-m4.json
+++ b/targets/matrixportal-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["matrixportal_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80c9", "acm:239a:00c9", "acm:239a:80ca"],
+    "serial-port": ["acm:239a:80c9", "acm:239a:80ca"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "MATRIXBOOT",

--- a/targets/mdbt50qrx-uf2.json
+++ b/targets/mdbt50qrx-uf2.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["mdbt50qrx"],
-    "serial-port": ["acm:239a:810b", "acm:239a:010b", "acm:239a:810c"],
+    "serial-port": ["acm:239a:810b", "acm:239a:810c"],
     "msd-volume-name": "MDBT50QBOOT"
 }

--- a/targets/metro-m4-airlift.json
+++ b/targets/metro-m4-airlift.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["metro_m4_airlift"],
     "serial": "usb",
-    "serial-port": ["acm:239A:8037", "acm:239A:0037"],
+    "serial-port": ["acm:239A:8037"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "METROM4BOOT",

--- a/targets/pybadge.json
+++ b/targets/pybadge.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8033", "acm:239a:33"],
+    "serial-port": ["acm:239a:8033"],
     "msd-volume-name": "PYBADGEBOOT",
     "msd-firmware-name": "arcade.uf2"
 }

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["pygamer"],
     "serial": "usb",
-    "serial-port": ["acm:239a:803d", "acm:239a:003d", "acm:239a:803e"],
+    "serial-port": ["acm:239a:803d", "acm:239a:803e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8035", "acm:239a:35", "acm:239a:8036"],
+    "serial-port": ["acm:239a:8035", "acm:239a:8036"],
     "msd-volume-name": "PORTALBOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/qtpy.json
+++ b/targets/qtpy.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21e18a"],
     "build-tags": ["qtpy"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80cb", "acm:239a:00cb", "acm:239a:00cc"],
+    "serial-port": ["acm:239a:80cb"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "QTPY_BOOT",

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21e18a"],
     "build-tags": ["trinket_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:801e", "acm:239a:001e"],
+    "serial-port": ["acm:239a:801e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "TRINKETBOOT",

--- a/targets/xiao-ble.json
+++ b/targets/xiao-ble.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["nrf52840", "nrf52840-s140v7-uf2"],
 	"build-tags": ["xiao_ble"],
-	"serial-port": ["acm:2886:8045", "acm:2886:0045"],
+	"serial-port": ["acm:2886:8045"],
 	"msd-volume-name": "XIAO-SENSE"
 }

--- a/targets/xiao.json
+++ b/targets/xiao.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["xiao"],
     "serial": "usb",
-    "serial-port": ["acm:2886:802f", "acm:2886:002f"],
+    "serial-port": ["acm:2886:802f"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",


### PR DESCRIPTION
Removing the USBPID in the bootloader allows `tinygo flash -monitor` to work well.
Since #2992, touchSerialPortAt1200bps to bootloader is no longer needed, 

The relevant URLs are
* #3168
* #3172
* #2992 
* #3156
