### PR TITLE
machine: move SPI Tx function into separate file

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -10,7 +10,6 @@ package machine
 import (
 	"device/arm"
 	"device/sam"
-	"errors"
 	"runtime/interrupt"
 	"unsafe"
 )
@@ -1273,10 +1272,6 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 	// return data
 	return byte(spi.Bus.DATA.Get()), nil
 }
-
-var (
-	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
-)
 
 // Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
 // interface, there must always be the same number of bytes written as bytes read.

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -10,7 +10,6 @@ package machine
 import (
 	"device/arm"
 	"device/sam"
-	"errors"
 	"runtime/interrupt"
 	"unsafe"
 )
@@ -1526,10 +1525,6 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 	// return data
 	return byte(spi.Bus.DATA.Get()), nil
 }
-
-var (
-	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
-)
 
 // Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
 // interface, there must always be the same number of bytes written as bytes read.

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -5,13 +5,8 @@ package machine
 
 import (
 	"device/nrf"
-	"errors"
 	"runtime/interrupt"
 	"unsafe"
-)
-
-var (
-	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
 )
 
 const deviceName = nrf.Device

--- a/src/machine/machine_rp2040_spi.go
+++ b/src/machine/machine_rp2040_spi.go
@@ -38,10 +38,9 @@ type SPIConfig struct {
 }
 
 var (
-	ErrLSBNotSupported    = errors.New("SPI LSB unsupported on PL022")
-	ErrTxInvalidSliceSize = errors.New("SPI write and read slices must be same size")
-	ErrSPITimeout         = errors.New("SPI timeout")
-	ErrSPIBaud            = errors.New("SPI baud too low or above 66.5Mhz")
+	ErrLSBNotSupported = errors.New("SPI LSB unsupported on PL022")
+	ErrSPITimeout      = errors.New("SPI timeout")
+	ErrSPIBaud         = errors.New("SPI baud too low or above 66.5Mhz")
 )
 
 type SPI struct {

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,5 +1,5 @@
-//go:build !baremetal || (stm32 && !stm32f7x2 && !stm32l5x2) || fe310 || k210 || (nxp && !mk66f18) || atmega
-// +build !baremetal stm32,!stm32f7x2,!stm32l5x2 fe310 k210 nxp,!mk66f18 atmega
+//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+// +build !baremetal atmega esp32 fe310 k210 nrf nxp,!mk66f18 rp2040 sam stm32,!stm32f7x2,!stm32l5x2
 
 package machine
 
@@ -17,58 +17,3 @@ var (
 	ErrTxInvalidSliceSize      = errors.New("SPI write and read slices must be same size")
 	errSPIInvalidMachineConfig = errors.New("SPI port was not configured properly by the machine")
 )
-
-// Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
-// interface, there must always be the same number of bytes written as bytes read.
-// The Tx method knows about this, and offers a few different ways of calling it.
-//
-// This form sends the bytes in tx buffer, putting the resulting bytes read into the rx buffer.
-// Note that the tx and rx buffers must be the same size:
-//
-//	spi.Tx(tx, rx)
-//
-// This form sends the tx buffer, ignoring the result. Useful for sending "commands" that return zeros
-// until all the bytes in the command packet have been received:
-//
-//	spi.Tx(tx, nil)
-//
-// This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
-//
-//	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
-	var err error
-
-	switch {
-	case w == nil:
-		// read only, so write zero and read a result.
-		for i := range r {
-			r[i], err = spi.Transfer(0)
-			if err != nil {
-				return err
-			}
-		}
-	case r == nil:
-		// write only
-		for _, b := range w {
-			_, err = spi.Transfer(b)
-			if err != nil {
-				return err
-			}
-		}
-
-	default:
-		// write/read
-		if len(w) != len(r) {
-			return ErrTxInvalidSliceSize
-		}
-
-		for i, b := range w {
-			r[i], err = spi.Transfer(b)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}

--- a/src/machine/spi_tx.go
+++ b/src/machine/spi_tx.go
@@ -1,0 +1,62 @@
+//go:build !baremetal || atmega || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
+// +build !baremetal atmega fe310 k210 nxp,!mk66f18 stm32,!stm32f7x2,!stm32l5x2
+
+// This file implements the SPI Tx function for targets that don't have a custom
+// (faster) implementation for it.
+
+package machine
+
+// Tx handles read/write operation for SPI interface. Since SPI is a syncronous write/read
+// interface, there must always be the same number of bytes written as bytes read.
+// The Tx method knows about this, and offers a few different ways of calling it.
+//
+// This form sends the bytes in tx buffer, putting the resulting bytes read into the rx buffer.
+// Note that the tx and rx buffers must be the same size:
+//
+//	spi.Tx(tx, rx)
+//
+// This form sends the tx buffer, ignoring the result. Useful for sending "commands" that return zeros
+// until all the bytes in the command packet have been received:
+//
+//	spi.Tx(tx, nil)
+//
+// This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
+//
+//	spi.Tx(nil, rx)
+func (spi SPI) Tx(w, r []byte) error {
+	var err error
+
+	switch {
+	case w == nil:
+		// read only, so write zero and read a result.
+		for i := range r {
+			r[i], err = spi.Transfer(0)
+			if err != nil {
+				return err
+			}
+		}
+	case r == nil:
+		// write only
+		for _, b := range w {
+			_, err = spi.Transfer(b)
+			if err != nil {
+				return err
+			}
+		}
+
+	default:
+		// write/read
+		if len(w) != len(r) {
+			return ErrTxInvalidSliceSize
+		}
+
+		for i, b := range w {
+			r[i], err = spi.Transfer(b)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This makes the code a bit cleaner because ErrTxInvalidSliceSize isn't redefined in every file that uses SPI and Mode0/Mode1/Mode2/Mode3 is defined for every target that uses SPI.

Found while working on #3170.