### PR TITLE
machine: rename PinInputPullUp/PinInputPullDown

### DIFF
--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -23,9 +23,15 @@ type PinChange uint8
 // Pin modes.
 const (
 	PinInput PinMode = iota
-	PinInputPullUp
-	PinInputPullDown
+	PinInputPullup
+	PinInputPulldown
 	PinOutput
+)
+
+// Deprecated: use PinInputPullup and PinInputPulldown instead.
+const (
+	PinInputPullUp   = PinInputPullup
+	PinInputPullDown = PinInputPulldown
 )
 
 // FPIOA internal pull resistors.
@@ -89,10 +95,10 @@ func (p Pin) Configure(config PinConfig) {
 	case PinInput:
 		p.setFPIOAIOPull(fpioaPullNone)
 		input = true
-	case PinInputPullUp:
+	case PinInputPullup:
 		p.setFPIOAIOPull(fpioaPullUp)
 		input = true
-	case PinInputPullDown:
+	case PinInputPulldown:
 		p.setFPIOAIOPull(fpioaPullDown)
 		input = true
 	case PinOutput:

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -21,8 +21,8 @@ func CPUFrequency() uint32 {
 const (
 	// GPIO
 	PinInput PinMode = iota
-	PinInputPullUp
-	PinInputPullDown
+	PinInputPullup
+	PinInputPulldown
 	PinOutput
 	PinOutputOpenDrain
 	PinDisable
@@ -43,6 +43,12 @@ const (
 	// I2C
 	PinModeI2CSDA
 	PinModeI2CSCL
+)
+
+// Deprecated: use PinInputPullup and PinInputPulldown instead.
+const (
+	PinInputPullUp   = PinInputPullup
+	PinInputPullDown = PinInputPulldown
 )
 
 type PinChange uint8
@@ -259,11 +265,11 @@ func (p Pin) Configure(config PinConfig) {
 		gpio.GDIR.ClearBits(p.getMask())
 		pad.Set(dse(7))
 
-	case PinInputPullUp:
+	case PinInputPullup:
 		gpio.GDIR.ClearBits(p.getMask())
 		pad.Set(dse(7) | pke | pue | pup(3) | hys)
 
-	case PinInputPullDown:
+	case PinInputPulldown:
 		gpio.GDIR.ClearBits(p.getMask())
 		pad.Set(dse(7) | pke | pue | hys)
 
@@ -746,7 +752,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 	switch config.Mode {
 
 	// GPIO
-	case PinInput, PinInputPullUp, PinInputPullDown,
+	case PinInput, PinInputPullup, PinInputPulldown,
 		PinOutput, PinOutputOpenDrain, PinDisable:
 		mode := uint32(0x5) // GPIO is always alternate function 5
 		if forcePath {

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -159,8 +159,8 @@ func (uart *UART) Disable() {
 		uart.Bus.CTRL.ClearBits(nxp.LPUART_CTRL_TE | nxp.LPUART_CTRL_RE)
 
 		// put pins back into GPIO mode
-		uart.rx.Configure(PinConfig{Mode: PinInputPullUp})
-		uart.tx.Configure(PinConfig{Mode: PinInputPullUp})
+		uart.rx.Configure(PinConfig{Mode: PinInputPullup})
+		uart.tx.Configure(PinConfig{Mode: PinInputPullup})
 	}
 	uart.configured = false
 }

--- a/src/machine/machine_nxpmk66f18.go
+++ b/src/machine/machine_nxpmk66f18.go
@@ -42,11 +42,17 @@ const deviceName = nxp.Device
 
 const (
 	PinInput PinMode = iota
-	PinInputPullUp
-	PinInputPullDown
+	PinInputPullup
+	PinInputPulldown
 	PinOutput
 	PinOutputOpenDrain
 	PinDisable
+)
+
+// Deprecated: use PinInputPullup and PinInputPulldown instead.
+const (
+	PinInputPullUp   = PinInputPullup
+	PinInputPullDown = PinInputPulldown
 )
 
 const (
@@ -223,11 +229,11 @@ func (p Pin) Configure(config PinConfig) {
 		gpio.PDDR.ClearBits(1 << pos)
 		pcr.Set((1 << nxp.PORT_PCR0_MUX_Pos))
 
-	case PinInputPullUp:
+	case PinInputPullup:
 		gpio.PDDR.ClearBits(1 << pos)
 		pcr.Set((1 << nxp.PORT_PCR0_MUX_Pos) | nxp.PORT_PCR0_PE | nxp.PORT_PCR0_PS)
 
-	case PinInputPullDown:
+	case PinInputPulldown:
 		gpio.PDDR.ClearBits(1 << pos)
 		pcr.Set((1 << nxp.PORT_PCR0_MUX_Pos) | nxp.PORT_PCR0_PE)
 

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -203,8 +203,8 @@ func (u *UART) Disable() {
 	u.C2.Set(0)
 
 	// reconfigure pin
-	u.DefaultRX.Configure(PinConfig{Mode: PinInputPullUp})
-	u.DefaultTX.Configure(PinConfig{Mode: PinInputPullUp})
+	u.DefaultRX.Configure(PinConfig{Mode: PinInputPullup})
+	u.DefaultTX.Configure(PinConfig{Mode: PinInputPullup})
 
 	// clear flags
 	u.S1.Get()


### PR DESCRIPTION
Some targets used capital PullUp/PullDown, while the documented standard is Pullup/Pulldown. This commit fixes this mismatch.

Perhaps PullUp/PullDown were better names, I don't know. But right now we use Pullup/Pulldown so I'd say we should use that for all chips.

Found while working on #3170. Also, another reason why we need automatic checking (like in #3170) for the machine package.