### PR TITLE
esp32c3: remove unused UARTStopBits constants

### DIFF
--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -264,15 +264,6 @@ type UART struct {
 	DataOverflowDetected bool // set when data overflow detected in UART FIFO buffer or RingBuffer
 }
 
-type UARTStopBits int
-
-const (
-	UARTStopBits_Default UARTStopBits = iota
-	UARTStopBits_1
-	UARTStopBits_1_5
-	UARTStopBits_2
-)
-
 const (
 	defaultDataBits = 8
 	defaultStopBit  = 1


### PR DESCRIPTION
Found while working on #3170. These constants aren't used, instead the method `SetFormat` accepts the number of stop bits as `int` type. We may want to revisit the `SetFormat` signature, but for now let's just remove these unused constants.