### PR TITLE
machine: do not expose RESET_MAGIC_VALUE

### DIFF
--- a/src/machine/board_arduino_mkr1000.go
+++ b/src/machine/board_arduino_mkr1000.go
@@ -7,7 +7,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0x07738135
+const resetMagicValue = 0x07738135
 
 // GPIO Pins
 const (

--- a/src/machine/board_arduino_mkrwifi1010.go
+++ b/src/machine/board_arduino_mkrwifi1010.go
@@ -7,7 +7,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0x07738135
+const resetMagicValue = 0x07738135
 
 // GPIO Pins
 const (

--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -7,7 +7,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0x07738135
+const resetMagicValue = 0x07738135
 
 // GPIO Pins
 const (

--- a/src/machine/board_arduino_zero.go
+++ b/src/machine/board_arduino_zero.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0x07738135
+const resetMagicValue = 0x07738135
 
 // GPIO Pins - Digital Low
 const (

--- a/src/machine/board_atsame54-xpro.go
+++ b/src/machine/board_atsame54-xpro.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Definition for compatibility, but not used
-const RESET_MAGIC_VALUE = 0x00000000
+const resetMagicValue = 0x00000000
 
 const (
 	LED    = PC18

--- a/src/machine/board_circuitplay_express.go
+++ b/src/machine/board_circuitplay_express.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_feather-m4-can.go
+++ b/src/machine/board_feather-m4-can.go
@@ -8,7 +8,7 @@ import (
 )
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_feather-m4.go
+++ b/src/machine/board_feather-m4.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_grandcentral-m4.go
+++ b/src/machine/board_grandcentral-m4.go
@@ -245,7 +245,7 @@ const (
 
 // Other peripheral constants
 const (
-	RESET_MAGIC_VALUE = 0xF01669EF // Used to reset into bootloader
+	resetMagicValue = 0xF01669EF // Used to reset into bootloader
 )
 
 // USB CDC pins

--- a/src/machine/board_itsybitsy-m0.go
+++ b/src/machine/board_itsybitsy-m0.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_itsybitsy-m4.go
+++ b/src/machine/board_itsybitsy-m4.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_matrixportal-m4.go
+++ b/src/machine/board_matrixportal-m4.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xF01669EF
+const resetMagicValue = 0xF01669EF
 
 // Digital pins
 const (

--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_p1am-100.go
+++ b/src/machine/board_p1am-100.go
@@ -7,7 +7,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0x07738135
+const resetMagicValue = 0x07738135
 
 // Note: On the P1AM-100, pins D8, D9, D10, A3, and A4 are used for
 // communication with the base controller.

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_pygamer.go
+++ b/src/machine/board_pygamer.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_trinket.go
+++ b/src/machine/board_trinket.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 const (
 	ADC0 = A0

--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -4,7 +4,7 @@
 package machine
 
 // used to reset into bootloader
-const RESET_MAGIC_VALUE = 0xf01669ef
+const resetMagicValue = 0xf01669ef
 
 // GPIO Pins
 const (

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1740,7 +1740,7 @@ func EnterBootloader() {
 
 	// Perform magic reset into bootloader, as mentioned in
 	// https://github.com/arduino/ArduinoCore-samd/issues/197
-	*(*uint32)(unsafe.Pointer(uintptr(0x20007FFC))) = RESET_MAGIC_VALUE
+	*(*uint32)(unsafe.Pointer(uintptr(0x20007FFC))) = resetMagicValue
 
 	arm.SystemReset()
 }

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1980,7 +1980,7 @@ func EnterBootloader() {
 
 	// Perform magic reset into bootloader, as mentioned in
 	// https://github.com/arduino/ArduinoCore-samd/issues/197
-	*(*uint32)(unsafe.Pointer(uintptr(0x20000000 + HSRAM_SIZE - 4))) = RESET_MAGIC_VALUE
+	*(*uint32)(unsafe.Pointer(uintptr(0x20000000 + HSRAM_SIZE - 4))) = resetMagicValue
 
 	arm.SystemReset()
 }


### PR DESCRIPTION
This is a constant for internal use only, but was (unintentionally?) exported. In addition, it doesn't follow the Go naming convention. This change simply renames the constant so that it is unexported.

Part of #3170.