### PR TITLE
compileopts: silently succeed when there's no debug info to strip

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -700,25 +700,20 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// Add embedded files.
 	linkerDependencies = append(linkerDependencies, embedFileObjects...)
 
-	// Determine whether the compilation configuration would result in debug
-	// (DWARF) information in the object files.
-	var hasDebug = true
-	for _, tag := range config.BuildTags() {
-		if tag == "baremetal" {
-			// Don't use -no-debug on baremetal targets. It makes no sense:
-			// the debug information isn't flashed to the device anyway.
-			hasDebug = false
-		}
-	}
-	if config.GOOS() == "darwin" {
-		// Debug information isn't stored in the binary itself on MacOS but
-		// is left in the object files by default. The binary does store the
-		// path to these object files though.
-		hasDebug = false
-	}
+	// Debug information isn't stored in the binary itself on MacOS but
+	// is left in the object files by default. The binary does store the
+	// path to these object files though.
+	var hasDebug = config.GOOS() != "darwin"
 
 	// Strip debug information with -no-debug.
 	if hasDebug && !config.Debug() {
+		for _, tag := range config.BuildTags() {
+			if tag == "baremetal" {
+				// Don't use -no-debug on baremetal targets. It makes no sense:
+				// the debug information isn't flashed to the device anyway.
+				return fmt.Errorf("stripping debug information is unnecessary for baremetal targets")
+			}
+		}
 		if config.Target.Linker == "wasm-ld" {
 			// Don't just strip debug information, also compress relocations
 			// while we're at it. Relocations can only be compressed when debug

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -377,8 +377,8 @@ func (c *Config) VerifyIR() bool {
 }
 
 // Debug returns whether debug (DWARF) information should be retained by the
-// linker. By default, debug information is retained but it can be removed with
-// the -no-debug flag.
+// linker. By default, debug information is retained, but it can be removed
+// with the -no-debug flag.
 func (c *Config) Debug() bool {
 	return c.Options.Debug
 }


### PR DESCRIPTION
Before, on MacOS, we erred if the user provided configuration to strip debug info.

Ex.
```bash
$ tinygo build -o main.go  -scheduler=none --no-debug  main.go
error: cannot remove debug information: MacOS doesn't store debug info in the executable by default
```

This is a poor experience which results in having OS-specific CLI behavior. Silently succeeding is good keeping with the Linux philosophy and less distracting than logging the same without failing.