### PR TITLE
main: allow setting the baud rate for serial monitors

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	Directory       string
 	PrintJSON       bool
 	Monitor         bool
+	BaudRate        int
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/main.go
+++ b/main.go
@@ -1337,6 +1337,7 @@ func main() {
 	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
+	baudrate := flag.Int("baudrate", 0, "baudrate of serial monitor")
 
 	var flagJSON, flagDeps, flagTest bool
 	if command == "help" || command == "list" || command == "info" || command == "build" {
@@ -1427,6 +1428,7 @@ func main() {
 		LLVMFeatures:    *llvmFeatures,
 		PrintJSON:       flagJSON,
 		Monitor:         *monitor,
+		BaudRate:        *baudrate,
 	}
 	if *printCommands {
 		options.PrintCommands = printCommand

--- a/main.go
+++ b/main.go
@@ -1337,7 +1337,7 @@ func main() {
 	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
-	baudrate := flag.Int("baudrate", 0, "baudrate of serial monitor")
+	baudrate := flag.Int("baudrate", 115200, "baudrate of serial monitor")
 
 	var flagJSON, flagDeps, flagTest bool
 	if command == "help" || command == "list" || command == "info" || command == "build" {

--- a/monitor.go
+++ b/monitor.go
@@ -32,10 +32,15 @@ func Monitor(port string, options *compileopts.Options) error {
 		break
 	}
 
+	br := options.BaudRate
+	if br <= 0 {
+		br = 115200
+	}
+
 	wait = 300
 	var p serial.Port
 	for i := 0; i <= wait; i++ {
-		p, err = serial.Open(port, &serial.Mode{})
+		p, err = serial.Open(port, &serial.Mode{BaudRate: br})
 		if err != nil {
 			if i < wait {
 				time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
The m5stamp-c3 is connected via UART-USB conversion.
And the baud rate was 115200 bps.

The following changes were made in this PR

* Default setting changed to 115200 bps (from 9600 bps) to match the standard baud rate of TinyGo's UART
* Can now be changed from the command line with `--baudrate 115200`

With this change, it can now be used as a simple serial monitor tool.


```
# example
$ tinygo monitor --port COM1 --baudrate 9600 
```