### PR TITLE
Update musl

### DIFF
--- a/builder/musl.go
+++ b/builder/musl.go
@@ -90,6 +90,7 @@ var Musl = Library{
 			"-Wno-ignored-attributes",
 			"-Wno-string-plus-int",
 			"-Wno-ignored-pragmas",
+			"-Wno-tautological-constant-out-of-range-compare",
 			"-Qunused-arguments",
 			// Select include dirs. Don't include standard library includes
 			// (that would introduce host dependencies and other complications),
@@ -117,6 +118,7 @@ var Musl = Library{
 			"internal/vdso.c",
 			"legacy/*.c",
 			"malloc/*.c",
+			"malloc/mallocng/*.c",
 			"mman/*.c",
 			"math/*.c",
 			"signal/*.c",


### PR DESCRIPTION
Update from v1.2.0 to v1.2.3.

We were 3 versions behind, including one security issue (that is very unlikely to ever occur in practice). A number of improvements have been made to musl since the last release, see https://musl.libc.org/releases.html for details.

There is no direct reason to update, but it seems like a good thing to stay up to date with musl releases.