### PR TITLE
ci: build TinyGo using Go 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,13 +118,6 @@ jobs:
     steps:
       - test-linux:
           llvm: "14"
-  test-llvm14-go119:
-    docker:
-      - image: golang:1.19beta1-buster
-    steps:
-      - test-linux:
-          llvm: "14"
-          fmt-check: false
 
 workflows:
   test-all:
@@ -132,6 +125,3 @@ workflows:
       # This tests our lowest supported versions of Go and LLVM, to make sure at
       # least the smoke tests still pass.
       - test-llvm14-go118
-      # This tests a beta version of Go. It should be removed once regular
-      # release builds are built using this version.
-      - test-llvm14-go119

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
@@ -114,7 +114,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Build TinyGo
         run: go install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.18-alpine
+      image: golang:1.19-alpine
     steps:
       - name: Install apk dependencies
         # tar: needed for actions/cache@v3
@@ -118,7 +118,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Install wasmtime
         run: |
@@ -171,7 +171,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v2
@@ -271,7 +271,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3
@@ -371,7 +371,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           cache: true
       - name: Cache LLVM source
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.18 AS tinygo-llvm
+FROM golang:1.19 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-11 binutils-avr gcc-avr avr-libc ninja-build


### PR DESCRIPTION
We've supported Go 1.19 for a while now, let's actually use it in CI.