### PR TITLE
build: set circleci resource class to large for CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
     steps:
       - test-linux:
           llvm: "14"
+    resource_class: large
 
 workflows:
   test-all:


### PR DESCRIPTION
This PR sets the CircleCI resource class to large for CI build` to speed them up. (approx 43%)