### PR TITLE
machine: use NoPin constant where appropriate

### DIFF
--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -52,8 +52,8 @@ const (
 	I2C0_SDA_PIN = GPIO20
 	I2C0_SCL_PIN = GPIO21
 
-	I2C1_SDA_PIN = 31 // not pinned out
-	I2C1_SCL_PIN = 31 // not pinned out
+	I2C1_SDA_PIN = NoPin // not pinned out
+	I2C1_SCL_PIN = NoPin // not pinned out
 )
 
 // SPI default pins
@@ -65,9 +65,9 @@ const (
 	// Default Serial In Bus 1 for SPI communications
 	SPI1_SDI_PIN = GPIO28 // Rx
 
-	SPI0_SCK_PIN = 31 // not pinned out
-	SPI0_SDO_PIN = 31 // not pinned out
-	SPI0_SDI_PIN = 31 // not pinned out
+	SPI0_SCK_PIN = NoPin // not pinned out
+	SPI0_SDO_PIN = NoPin // not pinned out
+	SPI0_SDI_PIN = NoPin // not pinned out
 )
 
 // UART pins

--- a/src/machine/board_mdbt50qrx.go
+++ b/src/machine/board_mdbt50qrx.go
@@ -18,15 +18,15 @@ const (
 
 // MDBT50Q-RX dongle does not have pins broken out for the peripherals below,
 // however the machine_nrf*.go implementations of I2C/SPI/etc expect the pin
-// constants to be defined, so we are defining them all as 0
+// constants to be defined, so we are defining them all as NoPin
 const (
-	UART_TX_PIN  = 0
-	UART_RX_PIN  = 0
-	SDA_PIN      = 0
-	SCL_PIN      = 0
-	SPI0_SCK_PIN = 0
-	SPI0_SDO_PIN = 0
-	SPI0_SDI_PIN = 0
+	UART_TX_PIN  = NoPin
+	UART_RX_PIN  = NoPin
+	SDA_PIN      = NoPin
+	SCL_PIN      = NoPin
+	SPI0_SCK_PIN = NoPin
+	SPI0_SDO_PIN = NoPin
+	SPI0_SDI_PIN = NoPin
 )
 
 // USB CDC identifiers


### PR DESCRIPTION
In some cases, regular integers were used. But we have a constant to explicitly say these pins are undefined: `NoPin`. So use this.

A better solution would be to not require these constants, like with the proposal in https://github.com/tinygo-org/tinygo/issues/3152. This change is just a slight improvement over the current state.

---

Found using #3170.