### PR TITLE
compileopts: silently succeed when there's no debug info to strip

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -377,8 +377,8 @@ func (c *Config) VerifyIR() bool {
 }
 
 // Debug returns whether debug (DWARF) information should be retained by the
-// linker. By default, debug information is retained but it can be removed with
-// the -no-debug flag.
+// linker. By default, debug information is retained, but it can be removed
+// with the -no-debug flag.
 func (c *Config) Debug() bool {
 	return c.Options.Debug
 }


### PR DESCRIPTION
This PR is to use only the first commit from #3188 courtesy of @codefromthecrypt 

Before, on the baremetal target or MacOS, we errored if the user provided configuration to strip debug info.

Ex.
```bash
$ $ tinygo build -o main.go  -scheduler=none --no-debug  main.go
error: cannot remove debug information: MacOS doesn't store debug info in the executable by default
```

This is a poor experience which results in having OS-specific CLI behavior. Silently succeeding is good keeping with the Linux philosophy and less distracting than logging the same without failing.

Signed-off-by: Adrian Cole <adrian@tetrate.io>