### PR TITLE
machine: hide internal pin modes

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -17,20 +17,20 @@ import (
 const deviceName = sam.Device
 
 const (
-	PinAnalog    PinMode = 1
-	PinSERCOM    PinMode = 2
-	PinSERCOMAlt PinMode = 3
-	PinTimer     PinMode = 4
-	PinTimerAlt  PinMode = 5
-	PinCom       PinMode = 6
-	//PinAC_CLK        PinMode = 7
-	PinDigital       PinMode = 8
 	PinInput         PinMode = 9
 	PinInputPullup   PinMode = 10
 	PinOutput        PinMode = 11
-	PinTCC           PinMode = PinTimer
-	PinTCCAlt        PinMode = PinTimerAlt
 	PinInputPulldown PinMode = 12
+
+	// internal pin modes
+	pinAnalog    PinMode = 1
+	pinSERCOM    PinMode = 2
+	pinSERCOMAlt PinMode = 3
+	pinTCC       PinMode = 4
+	pinTCCAlt    PinMode = 5
+	pinCom       PinMode = 6
+	//PinAC_CLK        PinMode = 7
+	pinDigital PinMode = 8
 )
 
 type PinChange uint8
@@ -149,7 +149,7 @@ func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok b
 	if upper != 0 {
 		// SERCOM
 		if (upper>>1)-1 == sercom {
-			pinMode = PinSERCOM
+			pinMode = pinSERCOM
 			pad |= uint32((upper & 1) << 1)
 			ok = true
 		}
@@ -157,7 +157,7 @@ func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok b
 	if lower != 0 {
 		// SERCOM-ALT
 		if (lower>>1)-1 == sercom {
-			pinMode = PinSERCOMAlt
+			pinMode = pinSERCOMAlt
 			pad |= uint32((lower & 1) << 1)
 			ok = true
 		}
@@ -381,7 +381,7 @@ func (a ADC) Configure(config ADCConfig) {
 	// 1/2 VDDANA = 0.5 * 3V3 = 1.65V
 	sam.ADC.REFCTRL.SetBits(sam.ADC_REFCTRL_REFSEL_INTVCC1 << sam.ADC_REFCTRL_REFSEL_Pos)
 
-	a.Pin.Configure(PinConfig{Mode: PinAnalog})
+	a.Pin.Configure(PinConfig{Mode: pinAnalog})
 	return
 }
 
@@ -1000,11 +1000,11 @@ func (i2s I2S) Configure(config I2SConfig) {
 	}
 
 	// configure pin for clock
-	config.SCK.Configure(PinConfig{Mode: PinCom})
+	config.SCK.Configure(PinConfig{Mode: pinCom})
 
 	// configure pin for WS, if needed
 	if config.WS != NoPin {
-		config.WS.Configure(PinConfig{Mode: PinCom})
+		config.WS.Configure(PinConfig{Mode: pinCom})
 	}
 
 	// now set serializer data size.
@@ -1043,7 +1043,7 @@ func (i2s I2S) Configure(config I2SConfig) {
 	}
 
 	// configure data pin
-	config.SD.Configure(PinConfig{Mode: PinCom})
+	config.SD.Configure(PinConfig{Mode: pinCom})
 
 	// re-enable
 	i2s.Bus.CTRLA.SetBits(sam.I2S_CTRLA_ENABLE)
@@ -1636,12 +1636,12 @@ func findPinTimerMapping(timer uint8, pin Pin) (PinMode, uint8) {
 	if mapping&0x07 == timer+1 {
 		// PWM output is on peripheral function E.
 		evenChannel := ((mapping >> 3) & 1) * 2
-		return PinTCC, evenChannel + uint8(pin&1)
+		return pinTCC, evenChannel + uint8(pin&1)
 	}
 	if (mapping&0x70)>>4 == timer+1 {
 		// PWM output is on peripheral function F.
 		evenChannel := ((mapping >> 7) & 1) * 2
-		return PinTCCAlt, evenChannel + uint8(pin&1)
+		return pinTCCAlt, evenChannel + uint8(pin&1)
 	}
 	return 0, 0
 }

--- a/src/machine/machine_atsamd21_usb.go
+++ b/src/machine/machine_atsamd21_usb.go
@@ -37,8 +37,8 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	sam.USB_DEVICE.DESCADD.Set(uint32(uintptr(unsafe.Pointer(&usbEndpointDescriptors))))
 
 	// configure pins
-	USBCDC_DM_PIN.Configure(PinConfig{Mode: PinCom})
-	USBCDC_DP_PIN.Configure(PinConfig{Mode: PinCom})
+	USBCDC_DM_PIN.Configure(PinConfig{Mode: pinCom})
+	USBCDC_DP_PIN.Configure(PinConfig{Mode: pinCom})
 
 	// performs pad calibration from store fuses
 	handlePadCalibration()

--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -86,53 +86,53 @@ func (p Pin) Configure(config PinConfig) {
 		sam.PORT.OUTSET0.Set(1 << uint8(p))
 		p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 
-	case PinSERCOM:
+	case pinSERCOM:
 		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR | sam.PORT_PINCFG0_INEN)
 
-	case PinSERCOMAlt:
+	case pinSERCOMAlt:
 		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
 
-	case PinCom:
+	case pinCom:
 		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN)
-	case PinAnalog:
+	case pinAnalog:
 		if uint8(p)&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -137,53 +137,53 @@ func (p Pin) Configure(config PinConfig) {
 			p.setPinCfg(sam.PORT_PINCFG0_INEN | sam.PORT_PINCFG0_PULLEN)
 		}
 
-	case PinSERCOM:
+	case pinSERCOM:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR | sam.PORT_PINCFG0_INEN)
 
-	case PinSERCOMAlt:
+	case pinSERCOMAlt:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)
 
-	case PinCom:
+	case pinCom:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN)
-	case PinAnalog:
+	case pinAnalog:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXE_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_PMUX0_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_PMUX0_PMUXO_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_PMUX0_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_PINCFG0_PMUXEN | sam.PORT_PINCFG0_DRVSTR)

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -21,30 +21,29 @@ func CPUFrequency() uint32 {
 }
 
 const (
-	PinAnalog        PinMode = 1
-	PinSERCOM        PinMode = 2
-	PinSERCOMAlt     PinMode = 3
-	PinTimer         PinMode = 4
-	PinTimerAlt      PinMode = 5
-	PinTCCPDEC       PinMode = 6
-	PinCom           PinMode = 7
-	PinSDHC          PinMode = 8
-	PinI2S           PinMode = 9
-	PinPCC           PinMode = 10
-	PinGMAC          PinMode = 11
-	PinACCLK         PinMode = 12
-	PinCCL           PinMode = 13
-	PinDigital       PinMode = 14
 	PinInput         PinMode = 15
 	PinInputPullup   PinMode = 16
 	PinOutput        PinMode = 17
-	PinTCCE          PinMode = PinTimer
-	PinTCCF          PinMode = PinTimerAlt
-	PinTCCG          PinMode = PinTCCPDEC
 	PinInputPulldown PinMode = 18
-	PinCAN           PinMode = 19
-	PinCAN0          PinMode = PinSDHC
-	PinCAN1          PinMode = PinCom
+
+	// internal pin modes
+	pinAnalog    PinMode = 1
+	pinSERCOM    PinMode = 2
+	pinSERCOMAlt PinMode = 3
+	pinTCCE      PinMode = 4
+	pinTCCF      PinMode = 5
+	pinTCCG      PinMode = 6
+	pinCom       PinMode = 7
+	pinSDHC      PinMode = 8
+	pinI2S       PinMode = 9
+	pinPCC       PinMode = 10
+	pinGMAC      PinMode = 11
+	pinACCLK     PinMode = 12
+	pinCCL       PinMode = 13
+	pinDigital   PinMode = 14
+	pinCAN       PinMode = 19
+	pinCAN0      PinMode = pinSDHC
+	pinCAN1      PinMode = pinCom
 )
 
 type PinChange uint8
@@ -338,7 +337,7 @@ func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok b
 	if upper != 0 {
 		// SERCOM
 		if (upper>>4)-1 == sercom {
-			pinMode = PinSERCOM
+			pinMode = pinSERCOM
 			pad |= uint32(upper % 4)
 			ok = true
 		}
@@ -346,7 +345,7 @@ func findPinPadMapping(sercom uint8, pin Pin) (pinMode PinMode, pad uint32, ok b
 	if lower != 0 {
 		// SERCOM-ALT
 		if (lower>>4)-1 == sercom {
-			pinMode = PinSERCOMAlt
+			pinMode = pinSERCOMAlt
 			pad |= uint32(lower % 4)
 			ok = true
 		}
@@ -580,65 +579,65 @@ func (p Pin) Configure(config PinConfig) {
 		sam.PORT.GROUP[group].OUTSET.Set(1 << pin_in_group)
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_INEN | sam.PORT_GROUP_PINCFG_PULLEN)
 
-	case PinSERCOM:
+	case pinSERCOM:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOM) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOM) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_PMUXEN | sam.PORT_GROUP_PINCFG_DRVSTR | sam.PORT_GROUP_PINCFG_INEN)
 
-	case PinSERCOMAlt:
+	case pinSERCOMAlt:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSERCOMAlt) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSERCOMAlt) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_PMUXEN | sam.PORT_GROUP_PINCFG_DRVSTR)
 
-	case PinCom:
+	case pinCom:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXE_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXO_Msk
-			p.setPMux(val | (uint8(PinCom) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinCom) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_PMUXEN)
-	case PinAnalog:
+	case pinAnalog:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXE_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXO_Msk
-			p.setPMux(val | (uint8(PinAnalog) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinAnalog) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_PMUXEN | sam.PORT_GROUP_PINCFG_DRVSTR)
-	case PinSDHC:
+	case pinSDHC:
 		if p&1 > 0 {
 			// odd pin, so save the even pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXE_Msk
-			p.setPMux(val | (uint8(PinSDHC) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
+			p.setPMux(val | (uint8(pinSDHC) << sam.PORT_GROUP_PMUX_PMUXO_Pos))
 		} else {
 			// even pin, so save the odd pins
 			val := p.getPMux() & sam.PORT_GROUP_PMUX_PMUXO_Msk
-			p.setPMux(val | (uint8(PinSDHC) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
+			p.setPMux(val | (uint8(pinSDHC) << sam.PORT_GROUP_PMUX_PMUXE_Pos))
 		}
 		// enable port config
 		p.setPinCfg(sam.PORT_GROUP_PINCFG_PMUXEN)
@@ -814,7 +813,7 @@ func (a ADC) Configure(config ADCConfig) {
 		adc.REFCTRL.SetBits(sam.ADC_REFCTRL_REFSEL_INTVCC1)
 	}
 
-	a.Pin.Configure(PinConfig{Mode: PinAnalog})
+	a.Pin.Configure(PinConfig{Mode: pinAnalog})
 }
 
 // Get returns the current value of a ADC pin, in the range 0..0xffff.
@@ -1867,7 +1866,7 @@ var pinTimerMapping = [...]struct{ F, G uint8 }{
 	PB02 / 2: {pinTCC2_2, 0},
 }
 
-// findPinPadMapping returns the pin mode (PinTCCF or PinTCCG) and the channel
+// findPinPadMapping returns the pin mode (pinTCCF or pinTCCG) and the channel
 // number for a given timer and pin. A zero PinMode is returned if no mapping
 // could be found.
 func findPinTimerMapping(timer uint8, pin Pin) (PinMode, uint8) {
@@ -1879,12 +1878,12 @@ func findPinTimerMapping(timer uint8, pin Pin) (PinMode, uint8) {
 
 	// Check for column F in the datasheet.
 	if mapping.F>>4-1 == timer {
-		return PinTCCF, mapping.F&0x0f + uint8(pin)&1
+		return pinTCCF, mapping.F&0x0f + uint8(pin)&1
 	}
 
 	// Check for column G in the datasheet.
 	if mapping.G>>4-1 == timer {
-		return PinTCCG, mapping.G&0x0f + uint8(pin)&1
+		return pinTCCG, mapping.G&0x0f + uint8(pin)&1
 	}
 
 	// Nothing found.

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -37,8 +37,8 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	sam.USB_DEVICE.DESCADD.Set(uint32(uintptr(unsafe.Pointer(&usbEndpointDescriptors))))
 
 	// configure pins
-	USBCDC_DM_PIN.Configure(PinConfig{Mode: PinCom})
-	USBCDC_DP_PIN.Configure(PinConfig{Mode: PinCom})
+	USBCDC_DM_PIN.Configure(PinConfig{Mode: pinCom})
+	USBCDC_DP_PIN.Configure(PinConfig{Mode: pinCom})
 
 	// performs pad calibration from store fuses
 	handlePadCalibration()

--- a/src/machine/machine_atsame5x_can.go
+++ b/src/machine/machine_atsame5x_can.go
@@ -68,9 +68,9 @@ func (can *CAN) Configure(config CANConfig) error {
 		config.Standby.Low()
 	}
 
-	mode := PinCAN0
+	mode := pinCAN0
 	if can.instance() == 1 {
-		mode = PinCAN1
+		mode = pinCAN1
 	}
 
 	config.Rx.Configure(PinConfig{Mode: mode})

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -18,9 +18,11 @@ func CPUFrequency() uint32 {
 const (
 	PinInput PinMode = iota
 	PinOutput
-	PinPWM
-	PinSPI
-	PinI2C = PinSPI
+
+	// internal pin modes
+	pinPWM
+	pinSPI
+	pinI2C = pinSPI
 )
 
 // Configure this pin with the given configuration.
@@ -29,10 +31,10 @@ func (p Pin) Configure(config PinConfig) {
 	switch config.Mode {
 	case PinOutput:
 		sifive.GPIO0.OUTPUT_EN.SetBits(1 << uint8(p))
-	case PinPWM:
+	case pinPWM:
 		sifive.GPIO0.IOF_EN.SetBits(1 << uint8(p))
 		sifive.GPIO0.IOF_SEL.SetBits(1 << uint8(p))
-	case PinSPI:
+	case pinSPI:
 		sifive.GPIO0.IOF_EN.SetBits(1 << uint8(p))
 		sifive.GPIO0.IOF_SEL.ClearBits(1 << uint8(p))
 	}
@@ -145,9 +147,9 @@ func (spi SPI) Configure(config SPIConfig) error {
 	}
 
 	// enable pins for SPI
-	config.SCK.Configure(PinConfig{Mode: PinSPI})
-	config.SDO.Configure(PinConfig{Mode: PinSPI})
-	config.SDI.Configure(PinConfig{Mode: PinSPI})
+	config.SCK.Configure(PinConfig{Mode: pinSPI})
+	config.SDO.Configure(PinConfig{Mode: pinSPI})
+	config.SDI.Configure(PinConfig{Mode: pinSPI})
 
 	// set default frequency
 	if config.Frequency == 0 {
@@ -251,8 +253,8 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 	// enable controller
 	i2c.Bus.CTR.SetBits(sifive.I2C_CTR_EN)
 
-	config.SDA.Configure(PinConfig{Mode: PinI2C})
-	config.SCL.Configure(PinConfig{Mode: PinI2C})
+	config.SDA.Configure(PinConfig{Mode: pinI2C})
+	config.SCL.Configure(PinConfig{Mode: pinI2C})
 
 	return nil
 }

--- a/src/machine/machine_mimxrt1062.go
+++ b/src/machine/machine_mimxrt1062.go
@@ -28,21 +28,21 @@ const (
 	PinDisable
 
 	// ADC
-	PinInputAnalog
+	pinInputAnalog
 
 	// UART
-	PinModeUARTTX
-	PinModeUARTRX
+	pinModeUARTTX
+	pinModeUARTRX
 
 	// SPI
-	PinModeSPISDI
-	PinModeSPISDO
-	PinModeSPICLK
-	PinModeSPICS
+	pinModeSPISDI
+	pinModeSPISDO
+	pinModeSPICLK
+	pinModeSPICS
 
 	// I2C
-	PinModeI2CSDA
-	PinModeI2CSCL
+	pinModeI2CSDA
+	pinModeI2CSCL
 )
 
 // Deprecated: use PinInputPullup and PinInputPulldown instead.
@@ -283,29 +283,29 @@ func (p Pin) Configure(config PinConfig) {
 		gpio.GDIR.ClearBits(p.getMask())
 		pad.Set(dse(7) | hys)
 
-	case PinInputAnalog:
+	case pinInputAnalog:
 		gpio.GDIR.ClearBits(p.getMask())
 		pad.Set(dse(7))
 
-	case PinModeUARTTX:
+	case pinModeUARTTX:
 		pad.Set(sre | dse(3) | spd(3))
 
-	case PinModeUARTRX:
+	case pinModeUARTRX:
 		pad.Set(dse(7) | pke | pue | pup(3) | hys)
 
-	case PinModeSPISDI:
+	case pinModeSPISDI:
 		pad.Set(dse(7) | spd(2))
 
-	case PinModeSPISDO:
+	case pinModeSPISDO:
 		pad.Set(dse(7) | spd(2))
 
-	case PinModeSPICLK:
+	case pinModeSPICLK:
 		pad.Set(dse(7) | spd(2))
 
-	case PinModeSPICS:
+	case pinModeSPICS:
 		pad.Set(dse(7))
 
-	case PinModeI2CSDA, PinModeI2CSCL:
+	case pinModeI2CSDA, pinModeI2CSCL:
 		pad.Set(ode | sre | dse(4) | spd(1) | pke | pue | pup(3))
 	}
 
@@ -759,7 +759,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// ADC
-	case PinInputAnalog:
+	case pinInputAnalog:
 		mode := uint32(0x5) // use alternate function 5 (GPIO)
 		if forcePath {
 			mode |= 0x10 // SION bit
@@ -767,7 +767,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// UART RX/TX
-	case PinModeUARTRX, PinModeUARTTX:
+	case pinModeUARTRX, pinModeUARTTX:
 		mode := uint32(0x2) // UART is usually alternate function 2 on Teensy 4.x
 		// Teensy 4.1 has a UART (LPUART5) with alternate function 1
 		if p == PB28 || p == PB29 {
@@ -776,7 +776,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// SPI SDI
-	case PinModeSPISDI:
+	case pinModeSPISDI:
 		var mode uint32
 		switch p {
 		case PC15: // LPSPI1 SDI on PC15 alternate function 4
@@ -794,7 +794,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// SPI SDO
-	case PinModeSPISDO:
+	case pinModeSPISDO:
 		var mode uint32
 		switch p {
 		case PC14: // LPSPI1 SDO on PC14 alternate function 4
@@ -812,7 +812,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// SPI SCK
-	case PinModeSPICLK:
+	case pinModeSPICLK:
 		var mode uint32
 		switch p {
 		case PC12: // LPSPI1 SCK on PC12 alternate function 4
@@ -830,7 +830,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// SPI CS
-	case PinModeSPICS:
+	case pinModeSPICS:
 		var mode uint32
 		switch p {
 		case PC13: // LPSPI1 CS on PC13 alternate function 4
@@ -848,7 +848,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// I2C SDA
-	case PinModeI2CSDA:
+	case pinModeI2CSDA:
 		var mode uint32
 		switch p {
 		case PA13: // LPI2C4 SDA on PA13 alternate function 0
@@ -866,7 +866,7 @@ func (p Pin) getMuxMode(config PinConfig) uint32 {
 		return mode
 
 	// I2C SCL
-	case PinModeI2CSCL:
+	case pinModeI2CSCL:
 		var mode uint32
 		switch p {
 		case PA12: // LPI2C4 SCL on PA12 alternate function 0
@@ -902,7 +902,7 @@ func (a ADC) Configure(config ADCConfig) {
 		defaultSamples    = uint32(4)
 	)
 
-	a.Pin.Configure(PinConfig{Mode: PinInputAnalog})
+	a.Pin.Configure(PinConfig{Mode: pinInputAnalog})
 
 	resolution, samples := config.Resolution, config.Samples
 	if 0 == resolution {

--- a/src/machine/machine_mimxrt1062_i2c.go
+++ b/src/machine/machine_mimxrt1062_i2c.go
@@ -156,8 +156,8 @@ func (i2c *I2C) Configure(config I2CConfig) {
 	sda, scl := i2c.setPins(config)
 
 	// configure the mux and pad control registers
-	sda.Configure(PinConfig{Mode: PinModeI2CSDA})
-	scl.Configure(PinConfig{Mode: PinModeI2CSCL})
+	sda.Configure(PinConfig{Mode: pinModeI2CSDA})
+	scl.Configure(PinConfig{Mode: pinModeI2CSCL})
 
 	// configure the mux input selector
 	i2c.muxSDA.connect()

--- a/src/machine/machine_mimxrt1062_spi.go
+++ b/src/machine/machine_mimxrt1062_spi.go
@@ -77,10 +77,10 @@ func (spi *SPI) Configure(config SPIConfig) {
 	spi.sdi, spi.sdo, spi.sck, spi.cs = config.getPins()
 
 	// configure the mux and pad control registers
-	spi.sdi.Configure(PinConfig{Mode: PinModeSPISDI})
-	spi.sdo.Configure(PinConfig{Mode: PinModeSPISDO})
-	spi.sck.Configure(PinConfig{Mode: PinModeSPICLK})
-	spi.cs.Configure(PinConfig{Mode: PinModeSPICS})
+	spi.sdi.Configure(PinConfig{Mode: pinModeSPISDI})
+	spi.sdo.Configure(PinConfig{Mode: pinModeSPISDO})
+	spi.sck.Configure(PinConfig{Mode: pinModeSPICLK})
+	spi.cs.Configure(PinConfig{Mode: pinModeSPICS})
 
 	// configure the mux input selector
 	spi.muxSDI.connect()

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -68,8 +68,8 @@ func (uart *UART) Configure(config UARTConfig) {
 	uart.tx = config.TX
 
 	// configure the mux and pad control registers
-	uart.rx.Configure(PinConfig{Mode: PinModeUARTRX})
-	uart.tx.Configure(PinConfig{Mode: PinModeUARTTX})
+	uart.rx.Configure(PinConfig{Mode: pinModeUARTRX})
+	uart.tx.Configure(PinConfig{Mode: pinModeUARTTX})
 
 	// configure the mux input selector
 	uart.muxRX.connect()

--- a/src/machine/machine_rp2040_adc.go
+++ b/src/machine/machine_rp2040_adc.go
@@ -85,7 +85,7 @@ func (c ADCChannel) Configure(config ADCConfig) error {
 	if err != nil {
 		return err
 	}
-	p.Configure(PinConfig{Mode: PinAnalog})
+	p.Configure(PinConfig{Mode: pinAnalog})
 	return nil
 }
 

--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -81,11 +81,13 @@ const (
 	PinInput
 	PinInputPulldown
 	PinInputPullup
-	PinAnalog
-	PinUART
-	PinPWM
-	PinI2C
-	PinSPI
+
+	// internal pin modes
+	pinAnalog
+	pinUART
+	pinPWM
+	pinI2C
+	pinSPI
 )
 
 func (p Pin) PortMaskSet() (*uint32, uint32) {
@@ -188,20 +190,20 @@ func (p Pin) Configure(config PinConfig) {
 	case PinInputPullup:
 		p.setFunc(fnSIO)
 		p.pullup()
-	case PinAnalog:
+	case pinAnalog:
 		p.setFunc(fnNULL)
 		p.pulloff()
-	case PinUART:
+	case pinUART:
 		p.setFunc(fnUART)
-	case PinPWM:
+	case pinPWM:
 		p.setFunc(fnPWM)
-	case PinI2C:
+	case pinI2C:
 		// IO config according to 4.3.1.3 of rp2040 datasheet.
 		p.setFunc(fnI2C)
 		p.pullup()
 		p.setSchmitt(true)
 		p.setSlew(false)
-	case PinSPI:
+	case pinSPI:
 		p.setFunc(fnSPI)
 	}
 }

--- a/src/machine/machine_rp2040_i2c.go
+++ b/src/machine/machine_rp2040_i2c.go
@@ -105,8 +105,8 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 	if config.Frequency == 0 {
 		config.Frequency = defaultBaud
 	}
-	config.SDA.Configure(PinConfig{PinI2C})
-	config.SCL.Configure(PinConfig{PinI2C})
+	config.SDA.Configure(PinConfig{pinI2C})
+	config.SCL.Configure(PinConfig{pinI2C})
 	return i2c.init(config)
 }
 

--- a/src/machine/machine_rp2040_pwm.go
+++ b/src/machine/machine_rp2040_pwm.go
@@ -92,7 +92,7 @@ func (pwm *pwmGroup) Channel(pin Pin) (channel uint8, err error) {
 	if pin > maxPWMPins || pwmGPIOToSlice(pin) != pwm.peripheral() {
 		return 3, ErrInvalidOutputPin
 	}
-	pin.Configure(PinConfig{PinPWM})
+	pin.Configure(PinConfig{pinPWM})
 	return pwmGPIOToChannel(pin), nil
 }
 

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -42,8 +42,8 @@ func (uart *UART) Configure(config UARTConfig) error {
 		rp.UART0_UARTCR_TXE)
 
 	// set GPIO mux to UART for the pins
-	config.TX.Configure(PinConfig{Mode: PinUART})
-	config.RX.Configure(PinConfig{Mode: PinUART})
+	config.TX.Configure(PinConfig{Mode: pinUART})
+	config.RX.Configure(PinConfig{Mode: pinUART})
 
 	// Enable RX IRQ.
 	uart.Interrupt.SetPriority(0x80)

--- a/src/machine/machine_stm32_adc_f1.go
+++ b/src/machine/machine_stm32_adc_f1.go
@@ -41,7 +41,7 @@ func InitADC() {
 
 // Configure configures an ADC pin to be able to read analog data.
 func (a ADC) Configure(ADCConfig) {
-	a.Pin.Configure(PinConfig{Mode: PinInputModeAnalog})
+	a.Pin.Configure(PinConfig{Mode: pinInputModeAnalog})
 
 	// set sample time
 	ch := a.getChannel()

--- a/src/machine/machine_stm32_adc_f4.go
+++ b/src/machine/machine_stm32_adc_f4.go
@@ -36,7 +36,7 @@ func InitADC() {
 
 // Configure configures an ADC pin to be able to read analog data.
 func (a ADC) Configure(ADCConfig) {
-	a.Pin.ConfigureAltFunc(PinConfig{Mode: PinInputAnalog}, 0)
+	a.Pin.ConfigureAltFunc(PinConfig{Mode: pinInputAnalog}, 0)
 
 	// set sample time
 	ch := a.getChannel()

--- a/src/machine/machine_stm32_i2c_revb.go
+++ b/src/machine/machine_stm32_i2c_revb.go
@@ -102,8 +102,8 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) error {
 }
 
 func (i2c *I2C) configurePins(config I2CConfig) {
-	config.SCL.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSCL}, i2c.AltFuncSelector)
-	config.SDA.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSDA}, i2c.AltFuncSelector)
+	config.SCL.ConfigureAltFunc(PinConfig{Mode: pinModeI2CSCL}, i2c.AltFuncSelector)
+	config.SDA.ConfigureAltFunc(PinConfig{Mode: pinModeI2CSDA}, i2c.AltFuncSelector)
 }
 
 func (i2c *I2C) controllerTransmit(addr uint16, w []byte) error {

--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -14,29 +14,28 @@ import (
 const (
 	// Mode Flag
 	PinOutput        PinMode = 0
-	PinInput         PinMode = PinInputFloating
-	PinInputFloating PinMode = 1
+	PinInput         PinMode = 1
 	PinInputPulldown PinMode = 2
 	PinInputPullup   PinMode = 3
 
 	// for UART
-	PinModeUARTTX PinMode = 4
-	PinModeUARTRX PinMode = 5
+	pinModeUARTTX PinMode = 4
+	pinModeUARTRX PinMode = 5
 
 	// for I2C
-	PinModeI2CSCL PinMode = 6
-	PinModeI2CSDA PinMode = 7
+	pinModeI2CSCL PinMode = 6
+	pinModeI2CSDA PinMode = 7
 
 	// for SPI
-	PinModeSPICLK PinMode = 8
-	PinModeSPISDO PinMode = 9
-	PinModeSPISDI PinMode = 10
+	pinModeSPICLK PinMode = 8
+	pinModeSPISDO PinMode = 9
+	pinModeSPISDI PinMode = 10
 
 	// for analog/ADC
-	PinInputAnalog PinMode = 11
+	pinInputAnalog PinMode = 11
 
 	// for PWM
-	PinModePWMOutput PinMode = 12
+	pinModePWMOutput PinMode = 12
 )
 
 // Define several bitfields that have different names across chip families but
@@ -83,7 +82,7 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 	switch config.Mode {
 
 	// GPIO
-	case PinInputFloating:
+	case PinInput:
 		port.MODER.ReplaceBits(gpioModeInput, gpioModeMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 	case PinInputPulldown:
@@ -97,24 +96,24 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedHigh, gpioOutputSpeedMask, pos)
 
 	// UART
-	case PinModeUARTTX:
+	case pinModeUARTTX:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedHigh, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullUp, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
-	case PinModeUARTRX:
+	case pinModeUARTRX:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 
 	// I2C
-	case PinModeI2CSCL:
+	case pinModeI2CSCL:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OTYPER.ReplaceBits(stm32.GPIO_OTYPER_OT0_OpenDrain, stm32.GPIO_OTYPER_OT0_Msk, pos/2)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullUp, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
-	case PinModeI2CSDA:
+	case pinModeI2CSDA:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OTYPER.ReplaceBits(stm32.GPIO_OTYPER_OT0_OpenDrain, stm32.GPIO_OTYPER_OT0_Msk, pos/2)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
@@ -122,31 +121,31 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 		p.SetAltFunc(altFunc)
 
 	// SPI
-	case PinModeSPICLK:
+	case pinModeSPICLK:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedHigh, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
-	case PinModeSPISDO:
+	case pinModeSPISDO:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
-	case PinModeSPISDI:
+	case pinModeSPISDI:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedLow, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 
 	// PWM
-	case PinModePWMOutput:
+	case pinModePWMOutput:
 		port.MODER.ReplaceBits(gpioModeAlternate, gpioModeMask, pos)
 		port.OSPEEDR.ReplaceBits(gpioOutputSpeedHigh, gpioOutputSpeedMask, pos)
 		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 		p.SetAltFunc(altFunc)
 
 	// ADC
-	case PinInputAnalog:
+	case pinInputAnalog:
 		port.MODER.ReplaceBits(gpioModeAnalog, gpioModeMask, pos)
 	}
 }

--- a/src/machine/machine_stm32_tim.go
+++ b/src/machine/machine_stm32_tim.go
@@ -183,7 +183,7 @@ func (t *TIM) Channel(pin Pin) (uint8, error) {
 		for _, p := range ch.Pins {
 			if p.Pin == pin {
 				t.configurePin(uint8(chi), p)
-				//p.Pin.ConfigureAltFunc(PinConfig{Mode: PinModePWMOutput}, p.AltFunc)
+				//p.Pin.ConfigureAltFunc(PinConfig{Mode: pinModePWMOutput}, p.AltFunc)
 				return uint8(chi), nil
 			}
 		}

--- a/src/machine/machine_stm32_tim_moder.go
+++ b/src/machine/machine_stm32_tim_moder.go
@@ -7,5 +7,5 @@ package machine
 // register (most MCUs except STM32F1 series).
 
 func (t *TIM) configurePin(channel uint8, pf PinFunction) {
-	pf.Pin.ConfigureAltFunc(PinConfig{Mode: PinModePWMOutput}, pf.AltFunc)
+	pf.Pin.ConfigureAltFunc(PinConfig{Mode: pinModePWMOutput}, pf.AltFunc)
 }

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -29,20 +29,20 @@ const (
 	PinOutput50MHz PinMode = 3 // Output mode, max speed 50MHz
 	PinOutput      PinMode = PinOutput2MHz
 
-	PinInputModeAnalog     PinMode = 0  // Input analog mode
-	PinInputModeFloating   PinMode = 4  // Input floating mode
-	PinInputModePullUpDown PinMode = 8  // Input pull up/down mode
-	PinInputModeReserved   PinMode = 12 // Input mode (reserved)
+	pinInputModeAnalog     PinMode = 0  // Input analog mode
+	pinInputModeFloating   PinMode = 4  // Input floating mode
+	pinInputModePullUpDown PinMode = 8  // Input pull up/down mode
+	pinInputModeReserved   PinMode = 12 // Input mode (reserved)
 
-	PinOutputModeGPPushPull   PinMode = 0  // Output mode general purpose push/pull
-	PinOutputModeGPOpenDrain  PinMode = 4  // Output mode general purpose open drain
-	PinOutputModeAltPushPull  PinMode = 8  // Output mode alt. purpose push/pull
-	PinOutputModeAltOpenDrain PinMode = 12 // Output mode alt. purpose open drain
+	pinOutputModeGPPushPull   PinMode = 0  // Output mode general purpose push/pull
+	pinOutputModeGPOpenDrain  PinMode = 4  // Output mode general purpose open drain
+	pinOutputModeAltPushPull  PinMode = 8  // Output mode alt. purpose push/pull
+	pinOutputModeAltOpenDrain PinMode = 12 // Output mode alt. purpose open drain
 
 	// Pull-up vs Pull down is not part of the CNF0 / CNF1 bits, but is
 	// controlled by PxODR.  Encoded using the 'spare' bit 5.
-	PinInputPulldown PinMode = PinInputModePullUpDown
-	PinInputPullup   PinMode = PinInputModePullUpDown | 0x10
+	PinInputPulldown PinMode = pinInputModePullUpDown
+	PinInputPullup   PinMode = pinInputModePullUpDown | 0x10
 )
 
 // Pin constants for all stm32f103 package sizes
@@ -166,7 +166,7 @@ func (p Pin) Configure(config PinConfig) {
 
 	// If configured for input pull-up or pull-down, set ODR
 	// for desired pull-up or pull-down.
-	if (config.Mode & 0xf) == PinInputModePullUpDown {
+	if (config.Mode & 0xf) == pinInputModePullUpDown {
 		var pullup uint32
 		if config.Mode == PinInputPullup {
 			pullup = 1
@@ -290,8 +290,8 @@ func (uart *UART) configurePins(config UARTConfig) {
 	default:
 		// use standard TX/RX pins PA9 and PA10
 	}
-	config.TX.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
-	config.RX.Configure(PinConfig{Mode: PinInputModeFloating})
+	config.TX.Configure(PinConfig{Mode: PinOutput50MHz + pinOutputModeAltPushPull})
+	config.RX.Configure(PinConfig{Mode: pinInputModeFloating})
 }
 
 // Determine the divisor for USARTs to get the given baudrate
@@ -363,9 +363,9 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 
 // Configure SPI pins for input output and clock
 func (spi SPI) configurePins(config SPIConfig) {
-	config.SCK.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
-	config.SDO.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
-	config.SDI.Configure(PinConfig{Mode: PinInputModeFloating})
+	config.SCK.Configure(PinConfig{Mode: PinOutput50MHz + pinOutputModeAltPushPull})
+	config.SDO.Configure(PinConfig{Mode: PinOutput50MHz + pinOutputModeAltPushPull})
+	config.SDI.Configure(PinConfig{Mode: pinInputModeFloating})
 }
 
 //---------- I2C related types and code
@@ -390,8 +390,8 @@ func (i2c *I2C) configurePins(config I2CConfig) {
 		stm32.AFIO.MAPR.SetBits(stm32.AFIO_MAPR_I2C1_REMAP)
 	}
 
-	config.SDA.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltOpenDrain})
-	config.SCL.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltOpenDrain})
+	config.SDA.Configure(PinConfig{Mode: PinOutput50MHz + pinOutputModeAltOpenDrain})
+	config.SCL.Configure(PinConfig{Mode: PinOutput50MHz + pinOutputModeAltOpenDrain})
 }
 
 func (i2c *I2C) getFreqRange(config I2CConfig) uint32 {
@@ -717,7 +717,7 @@ func (t *TIM) configurePin(channel uint8, pf PinFunction) {
 		stm32.AFIO.MAPR.ReplaceBits(remap<<stm32.AFIO_MAPR2_TIM14_REMAP_Pos, stm32.AFIO_MAPR2_TIM14_REMAP_Msk, 0)
 	}
 
-	pf.Pin.Configure(PinConfig{Mode: PinOutput + PinOutputModeAltPushPull})
+	pf.Pin.Configure(PinConfig{Mode: PinOutput + pinOutputModeAltPushPull})
 }
 
 func (t *TIM) enableMainOutput() {

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -640,8 +640,8 @@ const (
 
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 func (uart *UART) getBaudRateDivisor(baudRate uint32) uint32 {
@@ -674,9 +674,9 @@ func (spi SPI) config8Bits() {
 }
 
 func (spi SPI) configurePins(config SPIConfig) {
-	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
-	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
-	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
+	config.SCK.ConfigureAltFunc(PinConfig{Mode: pinModeSPICLK}, spi.AltFuncSelector)
+	config.SDO.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDO}, spi.AltFuncSelector)
+	config.SDI.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDI}, spi.AltFuncSelector)
 }
 
 func (spi SPI) getBaudRate(config SPIConfig) uint32 {
@@ -723,8 +723,8 @@ type I2C struct {
 }
 
 func (i2c *I2C) configurePins(config I2CConfig) {
-	config.SCL.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSCL}, i2c.AltFuncSelector)
-	config.SDA.ConfigureAltFunc(PinConfig{Mode: PinModeI2CSDA}, i2c.AltFuncSelector)
+	config.SCL.ConfigureAltFunc(PinConfig{Mode: pinModeI2CSCL}, i2c.AltFuncSelector)
+	config.SDA.ConfigureAltFunc(PinConfig{Mode: pinModeI2CSDA}, i2c.AltFuncSelector)
 }
 
 func (i2c *I2C) getFreqRange(config I2CConfig) uint32 {

--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -24,8 +24,8 @@ const APB2_TIM_FREQ = 216e6 // 216MHz
 // Configure the UART.
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -195,8 +195,8 @@ func (p Pin) registerInterrupt() interrupt.Interrupt {
 // Configure the UART.
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed
@@ -289,9 +289,9 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 
 // Configure SPI pins for input output and clock
 func (spi SPI) configurePins(config SPIConfig) {
-	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
-	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
-	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
+	config.SCK.ConfigureAltFunc(PinConfig{Mode: pinModeSPICLK}, spi.AltFuncSelector)
+	config.SDO.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDO}, spi.AltFuncSelector)
+	config.SDI.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDI}, spi.AltFuncSelector)
 }
 
 //---------- I2C related types and code

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -280,8 +280,8 @@ func (p Pin) registerInterrupt() interrupt.Interrupt {
 // Configure the UART.
 func (uart *UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed
@@ -357,9 +357,9 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 
 // Configure SPI pins for input output and clock
 func (spi SPI) configurePins(config SPIConfig) {
-	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
-	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
-	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
+	config.SCK.ConfigureAltFunc(PinConfig{Mode: pinModeSPICLK}, spi.AltFuncSelector)
+	config.SDO.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDO}, spi.AltFuncSelector)
+	config.SDI.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDI}, spi.AltFuncSelector)
 }
 
 //---------- Timer related code

--- a/src/machine/machine_stm32l5x2.go
+++ b/src/machine/machine_stm32l5x2.go
@@ -29,8 +29,8 @@ func (uart *UART) configurePins(config UARTConfig) {
 	}
 
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -239,9 +239,9 @@ func (spi SPI) config8Bits() {
 }
 
 func (spi SPI) configurePins(config SPIConfig) {
-	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
-	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
-	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
+	config.SCK.ConfigureAltFunc(PinConfig{Mode: pinModeSPICLK}, spi.AltFuncSelector)
+	config.SDO.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDO}, spi.AltFuncSelector)
+	config.SDI.ConfigureAltFunc(PinConfig{Mode: pinModeSPISDI}, spi.AltFuncSelector)
 }
 
 func (spi SPI) getBaudRate(config SPIConfig) uint32 {
@@ -298,8 +298,8 @@ func (i2c *I2C) getFreqRange() uint32 {
 // Configure the UART.
 func (uart UART) configurePins(config UARTConfig) {
 	// enable the alternate functions on the TX and RX pins
-	config.TX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTTX}, uart.TxAltFuncSelector)
-	config.RX.ConfigureAltFunc(PinConfig{Mode: PinModeUARTRX}, uart.RxAltFuncSelector)
+	config.TX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTTX}, uart.TxAltFuncSelector)
+	config.RX.ConfigureAltFunc(PinConfig{Mode: pinModeUARTRX}, uart.RxAltFuncSelector)
 }
 
 // UART baudrate calc based on the bus and clockspeed


### PR DESCRIPTION
Many pin modes are only for peripherals like SPI and PWM. Do not make these part of the public API: the public API is the `Configure` method on the peripheral, not the `PinMode` constant.

This may be a somewhat controversial change because it hides things that were previously exported, but I think the API will be in a better shape with these constants hidden.

Part of #3170.