### PR TITLE
build: use wasmtime 1.0.0 since 1.0.1 did not release correctly for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,7 +122,7 @@ jobs:
           cache: true
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version 1.0.0
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v2
@@ -179,7 +179,7 @@ jobs:
           node-version: '14'
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version 1.0.0
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Cache LLVM source
         uses: actions/cache@v3


### PR DESCRIPTION
This PR is to use wasmtime 1.0.0 for CI since 1.0.1 did not release correctly the Linux 64-bit version.

See https://github.com/bytecodealliance/wasmtime/issues/4968