### PR TITLE
builder: do not ignore debug info on baremetal targets

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -703,13 +703,6 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 	// Determine whether the compilation configuration would result in debug
 	// (DWARF) information in the object files.
 	var hasDebug = true
-	for _, tag := range config.BuildTags() {
-		if tag == "baremetal" {
-			// Don't use -no-debug on baremetal targets. It makes no sense:
-			// the debug information isn't flashed to the device anyway.
-			hasDebug = false
-		}
-	}
 	if config.GOOS() == "darwin" {
 		// Debug information isn't stored in the binary itself on MacOS but
 		// is left in the object files by default. The binary does store the


### PR DESCRIPTION
Since https://github.com/tinygo-org/tinygo/pull/3200, `-no-debug` would ignore debug info for some linkers. Example:

    $ tinygo build -o test.elf -target=arduino -no-debug examples/blinky1
    $ objdump -h test.elf

    test.elf:       file format elf32-avr

    Sections:
    Idx Name            Size     VMA      LMA      Type
      0                 00000000 00000000 00000000
      1 .text           000004e0 00000000 00000000 TEXT
      2 .trampolines    00000000 000004e0 000004e0 TEXT
      3 .stack          00000200 00800100 00800100 BSS
      4 .data           0000004c 00800300 000004e0 DATA
      5 .bss            000000a9 0080034c 0000052c BSS
      6 .debug_loc      00001bf0 00000000 00000000 DEBUG
      7 .debug_abbrev   000004ed 00000000 00000000 DEBUG
      8 .debug_info     00004176 00000000 00000000 DEBUG
      9 .debug_ranges   00000150 00000000 00000000 DEBUG
     10 .debug_str      0000206e 00000000 00000000 DEBUG
     11 .debug_pubnames 000024bf 00000000 00000000 DEBUG
     12 .debug_pubtypes 000004ca 00000000 00000000 DEBUG
     13 .debug_line     0000193c 00000000 00000000 DEBUG
     14 .debug_aranges  0000002c 00000000 00000000 DEBUG
     15 .debug_rnglists 00000015 00000000 00000000 DEBUG
     16 .debug_line_str 00000082 00000000 00000000 DEBUG
     17 .shstrtab       000000d9 00000000 00000000
     18 .symtab         000006d0 00000000 00000000
     19 .strtab         00000607 00000000 00000000

This shows that even though `-no-debug` is supplied, debug information is emitted in the ELF file. This is clearly a bug.

With this PR, debug information is not stripped when TinyGo doesn't know how to do it:

    $ tinygo build -o test.elf -target=arduino -no-debug examples/blinky1
    error: cannot remove debug information: unknown linker: avr-gcc

(This issue will eventually be fixed by moving to `ld.lld`).

---

Some context: I originally added the `stripping debug information is unnecessary for baremetal targets` error to avoid misguided attempts to strip debug information when compiling microcontroller firmware. It doesn't really harm, but it is probably not what the user wants or needs. And `unknown linker: avr-gcc` doesn't guide the user in the right direction: that is, telling them that this is probably not what they need.

Some more context: I also didn't allow `-no-debug` on darwin because at the time I didn't understand how DWARF works on darwin. Now I know it's not typically stored in the binary (as it is on Linux) but instead kept in the object files, which is actually a quite reasonable choice. Therefore, `-no-debug` is kind of the default.