### PR TITLE
targets: do not set stack size per board

### DIFF
--- a/targets/atsame54-xpro.json
+++ b/targets/atsame54-xpro.json
@@ -3,6 +3,5 @@
     "build-tags": ["atsame54_xpro"],
     "serial": "usb",
     "flash-method": "openocd",
-    "openocd-interface": "cmsis-dap",
-    "default-stack-size": 4096
+    "openocd-interface": "cmsis-dap"
 }

--- a/targets/feather-m4-can.json
+++ b/targets/feather-m4-can.json
@@ -6,6 +6,5 @@
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHRCANBOOT",
-    "msd-firmware-name": "firmware.uf2",
-    "default-stack-size": 4096
+    "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/qtpy-rp2040.json
+++ b/targets/qtpy-rp2040.json
@@ -7,6 +7,5 @@
     "linkerscript": "targets/qtpy-rp2040.ld",
     "extra-files": [
         "targets/qtpy-rp2040-boot-stage2.S"
-    ],
-    "default-stack-size": 4096
+    ]
 }

--- a/targets/teensy40.json
+++ b/targets/teensy40.json
@@ -3,7 +3,6 @@
   "build-tags": ["teensy40", "teensy", "mimxrt1062", "nxp"],
   "serial": "uart",
   "automatic-stack-size": false,
-  "default-stack-size": 4096,
   "linkerscript": "targets/mimxrt1062-teensy40.ld",
   "extra-files": [
     "src/device/nxp/mimxrt1062.s",

--- a/targets/teensy41.json
+++ b/targets/teensy41.json
@@ -3,7 +3,6 @@
   "build-tags": ["teensy41", "teensy", "mimxrt1062", "nxp"],
   "serial": "uart",
   "automatic-stack-size": false,
-  "default-stack-size": 4096,
   "linkerscript": "targets/mimxrt1062-teensy40.ld",
   "extra-files": [
     "src/device/nxp/mimxrt1062.s",


### PR DESCRIPTION
The needed stack size for a goroutine is hard to determine by the compiler. It will try, but will fail in many common cases. Therefore, the compiler will pick a fixed stack size at compile time.

There is a tradeoff between avoiding stack overflows and wasting RAM. This tradeoff depends on the application: some don't need large stack sizes but do need a lot of memory, while others need deep stacks but aren't so memory constrained. That's why I've added a flag to do this on the command line: https://github.com/tinygo-org/tinygo/pull/3159

It may be reasonable to use a different stack size per chip, for example chips with lots of RAM could default to a larger stack size. But I don't think it's a good idea to do this per board.

@eyz @sago35 @ardnew @bgould what do you think?