### PR TITLE
targets: remove "acm:"` prefix for USB vid/pid pair

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -47,7 +47,7 @@ type TargetSpec struct {
 	FlashCommand     string   `json:"flash-command"`
 	GDB              []string `json:"gdb"`
 	PortReset        string   `json:"flash-1200-bps-reset"`
-	SerialPort       []string `json:"serial-port"` // serial port IDs in the form "acm:vid:pid" or "usb:vid:pid"
+	SerialPort       []string `json:"serial-port"` // serial port IDs in the form "vid:pid"
 	FlashMethod      string   `json:"flash-method"`
 	FlashVolume      string   `json:"msd-volume-name"`
 	FlashFilename    string   `json:"msd-firmware-name"`

--- a/main.go
+++ b/main.go
@@ -980,12 +980,8 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 		var preferredPortIDs [][2]uint16
 		for _, s := range usbInterfaces {
 			parts := strings.Split(s, ":")
-			if len(parts) != 3 || (parts[0] != "acm" && parts[0] == "usb") {
-				// acm and usb are the two types of serial ports recognized
-				// under Linux (ttyACM*, ttyUSB*). Other operating systems don't
-				// generally make this distinction. If this is not one of the
-				// given USB devices, don't try to parse the USB IDs.
-				continue
+			if len(parts) != 2 {
+				return "", fmt.Errorf("could not parse USB VID/PID pair %q", s)
 			}
 			vid, err := strconv.ParseUint(parts[1], 16, 16)
 			if err != nil {

--- a/targets/arduino-mkrwifi1010.json
+++ b/targets/arduino-mkrwifi1010.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_mkrwifi1010"],
     "serial": "usb",
-    "serial-port": ["acm:2341:8054", "acm:2341:0054"],
+    "serial-port": ["2341:8054", "2341:0054"],
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -2,6 +2,6 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_nano33"],
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
-    "serial-port": ["acm:2341:8057", "acm:2341:0057"],
+    "serial-port": ["2341:8057", "2341:0057"],
     "flash-1200-bps-reset": "true"
 }

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -6,6 +6,6 @@
 		"-Wl,--defsym=_stack_size=512"
 	],
 	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
-	"serial-port": ["acm:2341:0043", "acm:2341:0001", "acm:2a03:0043", "acm:2341:0243"],
+	"serial-port": ["2341:0043", "2341:0001", "2a03:0043", "2341:0243"],
 	"emulator": "simavr -m atmega328p -f 16000000 {}"
 }

--- a/targets/badger2040.json
+++ b/targets/badger2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:2e8a:0003"],
+    "serial-port": ["2e8a:0003"],
     "build-tags": ["badger2040"],
     "linkerscript": "targets/badger2040.ld",
     "extra-files": [

--- a/targets/challenger-rp2040.json
+++ b/targets/challenger-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:2e8a:1023"],
+    "serial-port": ["2e8a:1023"],
     "build-tags": ["challenger_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",
     "extra-files": [

--- a/targets/circuitplay-bluefruit.json
+++ b/targets/circuitplay-bluefruit.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["circuitplay_bluefruit"],
-    "serial-port": ["acm:239a:8045"],
+    "serial-port": ["239a:8045"],
     "msd-volume-name": "CPLAYBTBOOT"
 }

--- a/targets/circuitplay-express.json
+++ b/targets/circuitplay-express.json
@@ -3,7 +3,7 @@
     "build-tags": ["circuitplay_express"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8018"],
+    "serial-port": ["239a:8018"],
     "msd-volume-name": "CPLAYBOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/clue-alpha.json
+++ b/targets/clue-alpha.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["clue_alpha"],
-    "serial-port": ["acm:239a:8072", "acm:239a:8071"],
+    "serial-port": ["239a:8072", "239a:8071"],
     "msd-volume-name": "CLUEBOOT"
 }

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -14,7 +14,7 @@
 	],
 	"binary-format": "esp32c3",
 	"flash-command": "esptool.py --chip=esp32c3 --port {port} write_flash 0x0 {bin}",
-	"serial-port": ["acm:303a:1001"],
+	"serial-port": ["303a:1001"],
 	"openocd-interface": "esp_usb_jtag",
 	"openocd-target": "esp32c3",
  	"openocd-commands": ["gdb_memory_map disable"],

--- a/targets/feather-m0.json
+++ b/targets/feather-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["feather_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:801b", "acm:239a:800b"],
+    "serial-port": ["239a:801b", "239a:800b"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-m4-can.json
+++ b/targets/feather-m4-can.json
@@ -2,7 +2,7 @@
     "inherits": ["atsame51j19a"],
     "build-tags": ["feather_m4_can"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80cd"],
+    "serial-port": ["239a:80cd"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FTHRCANBOOT",

--- a/targets/feather-m4.json
+++ b/targets/feather-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["feather_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:8022"],
+    "serial-port": ["239a:8022"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "FEATHERBOOT",

--- a/targets/feather-nrf52840-sense.json
+++ b/targets/feather-nrf52840-sense.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["feather_nrf52840_sense"],
-    "serial-port": ["acm:239a:8087", "acm:239a:8088"],
+    "serial-port": ["239a:8087", "239a:8088"],
     "msd-volume-name": "FTHRSNSBOOT"
 }

--- a/targets/feather-nrf52840.json
+++ b/targets/feather-nrf52840.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["feather_nrf52840"],
-    "serial-port": ["acm:239a:8029", "acm:239a:802a"],
+    "serial-port": ["239a:8029", "239a:802a"],
     "msd-volume-name": "FTHR840BOOT"
 }

--- a/targets/feather-rp2040.json
+++ b/targets/feather-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:239a:80f1"],
+    "serial-port": ["239a:80f1"],
     "build-tags": ["feather_rp2040"],
     "linkerscript": "targets/feather-rp2040.ld",
     "extra-files": [

--- a/targets/grandcentral-m4.json
+++ b/targets/grandcentral-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51p20a"],
     "build-tags": ["grandcentral_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:8031"],
+    "serial-port": ["239a:8031"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "GCM4BOOT",

--- a/targets/itsybitsy-m0.json
+++ b/targets/itsybitsy-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["itsybitsy_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:800f", "acm:239a:8012"],
+    "serial-port": ["239a:800f", "239a:8012"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "ITSYBOOT",

--- a/targets/itsybitsy-m4.json
+++ b/targets/itsybitsy-m4.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:802b"],
+    "serial-port": ["239a:802b"],
     "msd-volume-name": "ITSYM4BOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/itsybitsy-nrf52840.json
+++ b/targets/itsybitsy-nrf52840.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["itsybitsy_nrf52840"],
-    "serial-port": ["acm:239A:8052", "acm:239A:8051"],
+    "serial-port": ["239A:8052", "239A:8051"],
     "msd-volume-name": "ITSY840BOOT"
 }

--- a/targets/m5stack-core2.json
+++ b/targets/m5stack-core2.json
@@ -1,5 +1,5 @@
 {
 	"inherits": ["esp32"],
 	"build-tags": ["m5stack_core2"],
-	"serial-port": ["acm:10c4:ea60"]
+	"serial-port": ["10c4:ea60"]
 }

--- a/targets/m5stack.json
+++ b/targets/m5stack.json
@@ -1,5 +1,5 @@
 {
 	"inherits": ["esp32"],
 	"build-tags": ["m5stack"],
-	"serial-port": ["acm:10c4:ea60"]
+	"serial-port": ["10c4:ea60"]
 }

--- a/targets/m5stamp-c3.json
+++ b/targets/m5stamp-c3.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["esp32c3"],
 	"build-tags": ["m5stamp_c3"],
-	"serial-port": ["acm:1a86:55d4"]
+	"serial-port": ["1a86:55d4"]
 }
 

--- a/targets/macropad-rp2040.json
+++ b/targets/macropad-rp2040.json
@@ -3,7 +3,7 @@
         "rp2040"
     ],
     "build-tags": ["macropad_rp2040"],
-    "serial-port": ["acm:239a:8107"],
+    "serial-port": ["239a:8107"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [
         "targets/macropad-rp2040-boot-stage2.S"

--- a/targets/matrixportal-m4.json
+++ b/targets/matrixportal-m4.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["matrixportal_m4"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80c9", "acm:239a:80ca"],
+    "serial-port": ["239a:80c9", "239a:80ca"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "MATRIXBOOT",

--- a/targets/mdbt50qrx-uf2.json
+++ b/targets/mdbt50qrx-uf2.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["mdbt50qrx"],
-    "serial-port": ["acm:239a:810b", "acm:239a:810c"],
+    "serial-port": ["239a:810b", "239a:810c"],
     "msd-volume-name": "MDBT50QBOOT"
 }

--- a/targets/metro-m4-airlift.json
+++ b/targets/metro-m4-airlift.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["metro_m4_airlift"],
     "serial": "usb",
-    "serial-port": ["acm:239A:8037"],
+    "serial-port": ["239A:8037"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "METROM4BOOT",

--- a/targets/nano-33-ble-s140v6-uf2.json
+++ b/targets/nano-33-ble-s140v6-uf2.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
 	"build-tags": ["nano_33_ble"],
-	"serial-port": ["acm:239a:8063", "acm:239a:0063"],
+	"serial-port": ["239a:8063", "239a:0063"],
 	"msd-volume-name": "NANO33BOOT"
 }

--- a/targets/nano-33-ble-s140v7-uf2.json
+++ b/targets/nano-33-ble-s140v7-uf2.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["nrf52840", "nrf52840-s140v7-uf2"],
 	"build-tags": ["nano_33_ble"],
-	"serial-port": ["acm:239a:8063", "acm:239a:0063"],
+	"serial-port": ["239a:8063", "239a:0063"],
 	"msd-volume-name": "NANO33BOOT"
 }

--- a/targets/nano-33-ble.json
+++ b/targets/nano-33-ble.json
@@ -2,7 +2,7 @@
 	"inherits": ["nrf52840"],
 	"build-tags": ["nano_33_ble", "nrf52840_reset_bossa"],
 	"flash-command": "bossac_arduino2 -d -i -e -w -v -R --port={port} {bin}",
-	"serial-port": ["acm:2341:805a", "acm:2341:005a"],
+	"serial-port": ["2341:805a", "2341:005a"],
 	"serial": "usb",
 	"flash-1200-bps-reset": "true",
 	"linkerscript": "targets/nano-33-ble.ld"

--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:2341:005e"],
+    "serial-port": ["2341:005e"],
     "build-tags": ["nano_rp2040"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [

--- a/targets/pico.json
+++ b/targets/pico.json
@@ -3,7 +3,7 @@
         "rp2040"
     ],
     "build-tags": ["pico"],
-    "serial-port": ["acm:2e8a:000A"],
+    "serial-port": ["2e8a:000A"],
     "linkerscript": "targets/pico.ld",
     "extra-files": [
         "targets/pico-boot-stage2.S"

--- a/targets/pybadge.json
+++ b/targets/pybadge.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8033"],
+    "serial-port": ["239a:8033"],
     "msd-volume-name": "PYBADGEBOOT",
     "msd-firmware-name": "arcade.uf2"
 }

--- a/targets/pygamer.json
+++ b/targets/pygamer.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51j19a"],
     "build-tags": ["pygamer"],
     "serial": "usb",
-    "serial-port": ["acm:239a:803d", "acm:239a:803e"],
+    "serial-port": ["239a:803d", "239a:803e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "PYGAMERBOOT",

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -4,7 +4,7 @@
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
-    "serial-port": ["acm:239a:8035", "acm:239a:8036"],
+    "serial-port": ["239a:8035", "239a:8036"],
     "msd-volume-name": "PORTALBOOT",
     "msd-firmware-name": "firmware.uf2"
 }

--- a/targets/qtpy-rp2040.json
+++ b/targets/qtpy-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:239a:80f7"],
+    "serial-port": ["239a:80f7"],
     "build-tags": ["qtpy_rp2040"],
     "linkerscript": "targets/qtpy-rp2040.ld",
     "extra-files": [

--- a/targets/qtpy.json
+++ b/targets/qtpy.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21e18a"],
     "build-tags": ["qtpy"],
     "serial": "usb",
-    "serial-port": ["acm:239a:80cb"],
+    "serial-port": ["239a:80cb"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "QTPY_BOOT",

--- a/targets/thingplus-rp2040.json
+++ b/targets/thingplus-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:1b4f:0026"],
+    "serial-port": ["1b4f:0026"],
     "build-tags": ["thingplus_rp2040"],
     "linkerscript": "targets/thingplus-rp2040.ld",
     "extra-files": [

--- a/targets/trinket-m0.json
+++ b/targets/trinket-m0.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21e18a"],
     "build-tags": ["trinket_m0"],
     "serial": "usb",
-    "serial-port": ["acm:239a:801e"],
+    "serial-port": ["239a:801e"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "TRINKETBOOT",

--- a/targets/trinkey-qt2040.json
+++ b/targets/trinkey-qt2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:239a:8109"],
+    "serial-port": ["239a:8109"],
     "build-tags": ["trinkey_qt2040"],
     "linkerscript": "targets/trinkey-qt2040.ld",
     "extra-files": [

--- a/targets/tufty2040.json
+++ b/targets/tufty2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:2e8a:0003"],
+    "serial-port": ["2e8a:0003"],
     "build-tags": ["tufty2040"],
     "linkerscript": "targets/tufty2040.ld",
     "extra-files": [

--- a/targets/wioterminal.json
+++ b/targets/wioterminal.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd51p19a"],
     "build-tags": ["wioterminal"],
     "serial": "usb",
-    "serial-port": ["acm:2886:802d"],
+    "serial-port": ["2886:802d"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",

--- a/targets/xiao-ble.json
+++ b/targets/xiao-ble.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["nrf52840", "nrf52840-s140v7-uf2"],
 	"build-tags": ["xiao_ble"],
-	"serial-port": ["acm:2886:8045"],
+	"serial-port": ["2886:8045"],
 	"msd-volume-name": "XIAO-SENSE"
 }

--- a/targets/xiao-rp2040.json
+++ b/targets/xiao-rp2040.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "serial-port": ["acm:2e8a:000a"],
+    "serial-port": ["2e8a:000a"],
     "build-tags": ["xiao_rp2040"],
     "linkerscript": "targets/xiao-rp2040.ld",
     "extra-files": [

--- a/targets/xiao.json
+++ b/targets/xiao.json
@@ -2,7 +2,7 @@
     "inherits": ["atsamd21g18a"],
     "build-tags": ["xiao"],
     "serial": "usb",
-    "serial-port": ["acm:2886:802f"],
+    "serial-port": ["2886:802f"],
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "msd-volume-name": "Arduino",


### PR DESCRIPTION
This prefix isn't actually used and only adds noise, so remove it.

It may have been useful on Linux that makes a distinction between /dev/ttyACM* and /dev/ttyUSB* but it isn't now. Also, it's unlikely that the same vid/pid pair will be shared between an acm and usb driver anyway.

---

I made this distinction originally because it seemed like a good idea at the time. But it really isn't.