### PR TITLE
testdata: increase timings used for timers test to try to avoid race condition errors on macOS CI

### DIFF
--- a/testdata/timers.go
+++ b/testdata/timers.go
@@ -4,51 +4,51 @@ import "time"
 
 func main() {
 	// Test ticker.
-	ticker := time.NewTicker(time.Millisecond * 250)
+	ticker := time.NewTicker(time.Millisecond * 500)
 	println("waiting on ticker")
 	go func() {
-		time.Sleep(time.Millisecond * 125)
-		println(" - after 125ms")
-		time.Sleep(time.Millisecond * 250)
-		println(" - after 375ms")
-		time.Sleep(time.Millisecond * 250)
-		println(" - after 625ms")
+		time.Sleep(time.Millisecond * 150)
+		println(" - after 150ms")
+		time.Sleep(time.Millisecond * 200)
+		println(" - after 200ms")
+		time.Sleep(time.Millisecond * 300)
+		println(" - after 300ms")
 	}()
 	<-ticker.C
-	println("waited on ticker at 250ms")
-	<-ticker.C
 	println("waited on ticker at 500ms")
+	<-ticker.C
+	println("waited on ticker at 1000ms")
 	ticker.Stop()
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Millisecond * 750)
 	select {
 	case <-ticker.C:
 		println("fail: ticker should have stopped!")
 	default:
-		println("ticker was stopped (didn't send anything after 500ms)")
+		println("ticker was stopped (didn't send anything after 750ms)")
 	}
 
-	timer := time.NewTimer(time.Millisecond * 250)
+	timer := time.NewTimer(time.Millisecond * 500)
 	println("waiting on timer")
 	go func() {
-		time.Sleep(time.Millisecond * 125)
-		println(" - after 125ms")
-		time.Sleep(time.Millisecond * 250)
-		println(" - after 250ms")
+		time.Sleep(time.Millisecond * 200)
+		println(" - after 200ms")
+		time.Sleep(time.Millisecond * 400)
+		println(" - after 400ms")
 	}()
 	<-timer.C
-	println("waited on timer at 250ms")
-	time.Sleep(time.Millisecond * 250)
+	println("waited on timer at 500ms")
+	time.Sleep(time.Millisecond * 500)
 
-	reset := timer.Reset(time.Millisecond * 250)
+	reset := timer.Reset(time.Millisecond * 500)
 	println("timer reset:", reset)
 	println("waiting on timer")
 	go func() {
-		time.Sleep(time.Millisecond * 125)
-		println(" - after 125ms")
-		time.Sleep(time.Millisecond * 250)
-		println(" - after 250ms")
+		time.Sleep(time.Millisecond * 200)
+		println(" - after 200ms")
+		time.Sleep(time.Millisecond * 400)
+		println(" - after 400ms")
 	}()
 	<-timer.C
-	println("waited on timer at 250ms")
-	time.Sleep(time.Millisecond * 250)
+	println("waited on timer at 500ms")
+	time.Sleep(time.Millisecond * 500)
 }

--- a/testdata/timers.txt
+++ b/testdata/timers.txt
@@ -1,16 +1,16 @@
 waiting on ticker
- - after 125ms
-waited on ticker at 250ms
- - after 375ms
+ - after 150ms
+ - after 200ms
 waited on ticker at 500ms
- - after 625ms
-ticker was stopped (didn't send anything after 500ms)
+ - after 300ms
+waited on ticker at 1000ms
+ticker was stopped (didn't send anything after 750ms)
 waiting on timer
- - after 125ms
-waited on timer at 250ms
- - after 250ms
+ - after 200ms
+waited on timer at 500ms
+ - after 400ms
 timer reset: false
 waiting on timer
- - after 125ms
-waited on timer at 250ms
- - after 250ms
+ - after 200ms
+waited on timer at 500ms
+ - after 400ms


### PR DESCRIPTION
This PR increases the timings used for the `timers.go` test to try to avoid spurious race condition errors on macOS CI