### PR TITLE
rp2040: remove mem allocation in GPIO ISR

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -288,8 +288,8 @@ func gpioHandleInterrupt(intr interrupt.Interrupt) {
 			base = &ioBank0.proc1IRQctrl
 		}
 
-		statreg := base.intS[gpio>>3]
-		change := getIntChange(gpio, statreg.Get())
+		statreg := base.intS[gpio>>3].Get()
+		change := getIntChange(gpio, statreg)
 		if change != 0 {
 			gpio.acknowledgeInterrupt(change)
 			callback := pinCallbacks[core][gpio]


### PR DESCRIPTION
Fixes #3217

It's unclear why this fixes the issue (since code is logically equivalent), but avoiding the assignment of register to a variable appears to enable some additional optimization logic to apply that prevents an 'escape'.

Have confirmed the fix by output of `tinygo flash -target feather-rp2040 -print-allocs . -serial uart .`, which no longer shows an allocation inside `machine_rp2040_gpio.go` - also confirmed on scope that test app from #3217 no longer experiences GC pauses.

I think this is a good example of why it would be good to have the allocation path explicitly fail inside ISRs so that subtle issues like this become obvious.