### PR TITLE
Rp2040 fix usb allocations inside isr

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -305,23 +305,26 @@ type USBBuffer struct {
 }
 
 var (
-	usbDPSRAM = (*USBDPSRAM)(unsafe.Pointer(uintptr(0x50100000)))
-	epXdata0  [16]bool
+	usbDPSRAM  = (*USBDPSRAM)(unsafe.Pointer(uintptr(0x50100000)))
+	epXdata0   [16]bool
+	setupBytes [8]byte
 )
 
 func (d *USBDPSRAM) setupBytes() []byte {
-	var buf [8]byte
 
-	buf[0] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].In.Get())
-	buf[1] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].In.Get() >> 8)
-	buf[2] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].In.Get() >> 16)
-	buf[3] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].In.Get() >> 24)
-	buf[4] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].Out.Get())
-	buf[5] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].Out.Get() >> 8)
-	buf[6] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].Out.Get() >> 16)
-	buf[7] = byte(d.EPxControl[usb.CONTROL_ENDPOINT].Out.Get() >> 24)
+	data := d.EPxControl[usb.CONTROL_ENDPOINT].In.Get()
+	setupBytes[0] = byte(data)
+	setupBytes[1] = byte(data >> 8)
+	setupBytes[2] = byte(data >> 16)
+	setupBytes[3] = byte(data >> 24)
 
-	return buf[:]
+	data = d.EPxControl[usb.CONTROL_ENDPOINT].Out.Get()
+	setupBytes[4] = byte(data)
+	setupBytes[5] = byte(data >> 8)
+	setupBytes[6] = byte(data >> 16)
+	setupBytes[7] = byte(data >> 24)
+
+	return setupBytes[:]
 }
 
 func (d *USBDPSRAM) clear() {

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -129,19 +129,20 @@ func cdcCallbackRx(b []byte) {
 	}
 }
 
+var cdcSetupBuff [cdcLineInfoSize]byte
+
 func cdcSetup(setup usb.Setup) bool {
 	if setup.BmRequestType == usb_REQUEST_DEVICETOHOST_CLASS_INTERFACE {
 		if setup.BRequest == usb_CDC_GET_LINE_CODING {
-			var b [cdcLineInfoSize]byte
-			b[0] = byte(usbLineInfo.dwDTERate)
-			b[1] = byte(usbLineInfo.dwDTERate >> 8)
-			b[2] = byte(usbLineInfo.dwDTERate >> 16)
-			b[3] = byte(usbLineInfo.dwDTERate >> 24)
-			b[4] = byte(usbLineInfo.bCharFormat)
-			b[5] = byte(usbLineInfo.bParityType)
-			b[6] = byte(usbLineInfo.bDataBits)
+			cdcSetupBuff[0] = byte(usbLineInfo.dwDTERate)
+			cdcSetupBuff[1] = byte(usbLineInfo.dwDTERate >> 8)
+			cdcSetupBuff[2] = byte(usbLineInfo.dwDTERate >> 16)
+			cdcSetupBuff[3] = byte(usbLineInfo.dwDTERate >> 24)
+			cdcSetupBuff[4] = byte(usbLineInfo.bCharFormat)
+			cdcSetupBuff[5] = byte(usbLineInfo.bParityType)
+			cdcSetupBuff[6] = byte(usbLineInfo.bDataBits)
 
-			machine.SendUSBInPacket(0, b[:])
+			machine.SendUSBInPacket(0, cdcSetupBuff[:])
 			return true
 		}
 	}


### PR DESCRIPTION
See #3217 and #1460

This is a quick-and-dirty fix for USB (particularly on RP2040) which runs inside ISRs and was doing some allocation.  Replace buffer allocation with pre-allocated buffers.

