### PR TITLE
main: print ldflags including ThinLTO flags with -x

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -738,9 +738,6 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 				}
 				ldflags = append(ldflags, dependency.result)
 			}
-			if config.Options.PrintCommands != nil {
-				config.Options.PrintCommands(config.Target.Linker, ldflags...)
-			}
 			if config.UseThinLTO() {
 				ldflags = append(ldflags, "-mllvm", "-mcpu="+config.CPU())
 				if config.GOOS() == "windows" {
@@ -771,6 +768,9 @@ func Build(pkgName, outpath string, config *compileopts.Config, action func(Buil
 					ldflags = append(ldflags,
 						"-mllvm", "--rotation-max-header-size=0")
 				}
+			}
+			if config.Options.PrintCommands != nil {
+				config.Options.PrintCommands(config.Target.Linker, ldflags...)
 			}
 			err = link(config.Target.Linker, ldflags...)
 			if err != nil {


### PR DESCRIPTION
The -x flag prints commands as they are executed. Unfortunately, for the link command, they were printed too early: before the ThinLTO flags were added. This is somewhat confusing while debugging.