### PR TITLE
darwin: fix syscall.Open on darwin/arm64

### DIFF
--- a/src/runtime/os_darwin.c
+++ b/src/runtime/os_darwin.c
@@ -1,0 +1,7 @@
+// Wrapper function because 'open' is a variadic function and variadic functions
+// use a different (incompatible) calling convention on darwin/arm64.
+
+#include <fcntl.h>
+int syscall_libc_open(const char *pathname, int flags, mode_t mode) {
+    return open(pathname, flags, mode);
+}

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -5,6 +5,8 @@ package runtime
 
 import "unsafe"
 
+import "C" // dummy import so that os_darwin.c works
+
 const GOOS = "darwin"
 
 const (

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -351,11 +351,6 @@ func libc_pread(fd int32, buf *byte, count uint, offset int64) int
 //export lseek
 func libc_lseek(fd int32, offset int64, whence int) int64
 
-// int open(const char *pathname, int flags, mode_t mode);
-//
-//export open
-func libc_open(pathname *byte, flags int32, mode uint32) int32
-
 // int close(int fd)
 //
 //export close

--- a/src/syscall/syscall_libc_darwin.go
+++ b/src/syscall/syscall_libc_darwin.go
@@ -281,3 +281,8 @@ func libc_pipe(fds *int32) int32
 //
 //export getpagesize
 func libc_getpagesize() int32
+
+// int open(const char *pathname, int flags, mode_t mode);
+//
+//export syscall_libc_open
+func libc_open(pathname *byte, flags int32, mode uint32) int32

--- a/src/syscall/syscall_libc_nintendoswitch.go
+++ b/src/syscall/syscall_libc_nintendoswitch.go
@@ -71,3 +71,8 @@ func Pipe2(p []int, flags int) (err error) {
 func Getpagesize() int {
 	return 4096 // TODO
 }
+
+// int open(const char *pathname, int flags, mode_t mode);
+//
+//export open
+func libc_open(pathname *byte, flags int32, mode uint32) int32

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -323,3 +323,8 @@ func libc_fstat(fd int32, ptr unsafe.Pointer) int32
 //
 //export lstat
 func libc_lstat(pathname *byte, ptr unsafe.Pointer) int32
+
+// int open(const char *pathname, int flags, mode_t mode);
+//
+//export open
+func libc_open(pathname *byte, flags int32, mode uint32) int32


### PR DESCRIPTION
Unfortunately the calling convention for variadic functions is different from the calling convention of regular functions on darwin/arm64, and `open` happens to be such a variadic function. The syscall package treated it like a regular function, which resulted in buggy behavior.

This fix introduces a wrapper function. This is the cleanest change I could come up with.

This fixes `tinygo test archive/zip` on darwin/arm64, and hopefully also fixes #2997.