### PR TITLE
Makefile: add `ASAN=1` flag to build with AddressSanitizer enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ else
     LLVM_OPTION += '-DLLVM_ENABLE_ASSERTIONS=OFF'
 endif
 
+# Enable AddressSanitizer
+ifeq (1, $(ASAN))
+    LLVM_OPTION += -DLLVM_USE_SANITIZER=Address
+    CGO_LDFLAGS += -fsanitize=address
+endif
+
 ifeq (1, $(STATIC))
     # Build TinyGo as a fully statically linked binary (no dynamically loaded
     # libraries such as a libc). This is not supported with glibc which is used


### PR DESCRIPTION
This sanitizer is useful to detect use-after-free, double free, buffer overflows, and more such errors.

I've found it useful lately to detect some bugs in TinyGo, and having a single flag to enable it makes it much easier to use AddressSanitizer.