### PR TITLE
build/windows: use GH actions parallel execution to speed up build time

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,10 +95,87 @@ jobs:
         with:
           name: release-double-zipped
           path: build/release/release.zip
+
+  smoke-test-windows:
+    runs-on: windows-2022
+    needs: build-windows
+    steps:
+      - uses: brechtm/setup-scoop@v2
+        with:
+          scoop_update: 'false'
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          scoop install binaryen
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v2
+        with:
+          name: release-double-zipped
+          path: build/
+      - name: Unzip TinyGo build
+        shell: bash
+        working-directory: build
+        run: 7z x release.zip -r
       - name: Smoke tests
         shell: bash
-        run: make smoketest TINYGO=$(PWD)/build/tinygo AVR=0 XTENSA=0
+        run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo AVR=0 XTENSA=0
+
+  stdlib-test-windows:
+    runs-on: windows-2022
+    needs: build-windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v2
+        with:
+          name: release-double-zipped
+          path: build/
+      - name: Unzip TinyGo build
+        shell: bash
+        working-directory: build
+        run: 7z x release.zip -r
       - name: Test stdlib packages
-        run: make tinygo-test
+        run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
+
+  stdlib-wasi-test-windows:
+    runs-on: windows-2022
+    needs: build-windows
+    steps:
+      - uses: brechtm/setup-scoop@v2
+        with:
+          scoop_update: 'false'
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          scoop install binaryen wasmtime
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v2
+        with:
+          name: release-double-zipped
+          path: build/
+      - name: Unzip TinyGo build
+        shell: bash
+        working-directory: build
+        run: 7z x release.zip -r
       - name: Test stdlib packages on wasi
-        run: make tinygo-test-wasi-fast
+        run: make tinygo-test-wasi-fast TINYGO=$(PWD)/build/tinygo/bin/tinygo


### PR DESCRIPTION
This PR cuts build time in half by using parallel execution in Github Actions when performing the Windows build.

It splits the build into 4 different jobs, the first job does the building, and the other 3 each run their respective tests in parallel.

Before this change, total build time for Windows: `1h 0m 29s`

https://github.com/tinygo-org/tinygo/actions/runs/3249645395

With this PR , total build time for Windows: `35m 5s`

https://github.com/tinygo-org/tinygo/actions/runs/3251822513
