### PR TITLE
Print PASS on pass when running standalone test binaries

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,6 +290,7 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 
 		// Run the test.
 		start := time.Now()
+		cmd.Args = append(cmd.Args, "--test.batch")
 		err = cmd.Run()
 		duration := time.Since(start)
 

--- a/main.go
+++ b/main.go
@@ -224,8 +224,9 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 		flags = append(flags, "-test.benchmem")
 	}
 
+	buf := bytes.Buffer{}
 	passed := false
-	err = buildAndRun(pkgName, config, os.Stdout, flags, nil, 0, func(cmd *exec.Cmd, result builder.BuildResult) error {
+	err = buildAndRun(pkgName, config, &buf, flags, nil, 0, func(cmd *exec.Cmd, result builder.BuildResult) error {
 		if testCompileOnly || outpath != "" {
 			// Write test binary to the specified file name.
 			if outpath == "" {
@@ -286,9 +287,6 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 			// directory is added last.
 			args = append(args, cmd.Args[1:]...)
 			cmd.Args = append(cmd.Args[:1:1], args...)
-		} else if config.EmulatorName() == "" {
-			// Make sure the test knows its running as part of a batch
-			cmd.Args = append(cmd.Args, "-test.batch")
 		}
 
 		// Run the test.
@@ -300,8 +298,12 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 		importPath := strings.TrimSuffix(result.ImportPath, ".test")
 		passed = err == nil
 		if passed {
+			if testVerbose {
+				buf.WriteTo(stdout)
+			}
 			fmt.Fprintf(stdout, "ok  \t%s\t%.3fs\n", importPath, duration.Seconds())
 		} else {
+			buf.WriteTo(stdout)
 			fmt.Fprintf(stdout, "FAIL\t%s\t%.3fs\n", importPath, duration.Seconds())
 		}
 		if _, ok := err.(*exec.ExitError); ok {
@@ -1619,7 +1621,7 @@ func main() {
 		wg.Wait()
 		close(fail)
 		if _, fail := <-fail; fail {
-			fmt.Println("FAIL")
+			//fmt.Println("FAIL")
 			os.Exit(1)
 		}
 	case "monitor":

--- a/main.go
+++ b/main.go
@@ -1621,7 +1621,6 @@ func main() {
 		wg.Wait()
 		close(fail)
 		if _, fail := <-fail; fail {
-			//fmt.Println("FAIL")
 			os.Exit(1)
 		}
 	case "monitor":

--- a/main.go
+++ b/main.go
@@ -286,12 +286,15 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 			// directory is added last.
 			args = append(args, cmd.Args[1:]...)
 			cmd.Args = append(cmd.Args[:1:1], args...)
+			// Allow
+			cmd.Args = append(cmd.Args, "--")
+		} else {
+			// Make sure the test knows its running as part of a batch
+			cmd.Args = append(cmd.Args, "-test.batch")
 		}
 
 		// Run the test.
 		start := time.Now()
-		// Make sure the test knows its running as part of a batch
-		cmd.Args = append(cmd.Args, "-test.batch")
 		err = cmd.Run()
 		duration := time.Since(start)
 

--- a/main.go
+++ b/main.go
@@ -290,7 +290,8 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 
 		// Run the test.
 		start := time.Now()
-		cmd.Args = append(cmd.Args, "--test.batch")
+		// Make sure the test knows its running as part of a batch
+		cmd.Args = append(cmd.Args, "-test.batch")
 		err = cmd.Run()
 		duration := time.Since(start)
 

--- a/main.go
+++ b/main.go
@@ -286,9 +286,7 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 			// directory is added last.
 			args = append(args, cmd.Args[1:]...)
 			cmd.Args = append(cmd.Args[:1:1], args...)
-			// Allow
-			cmd.Args = append(cmd.Args, "--")
-		} else {
+		} else if config.EmulatorName() == "" {
 			// Make sure the test knows its running as part of a batch
 			cmd.Args = append(cmd.Args, "-test.batch")
 		}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -26,7 +26,6 @@ var (
 	flagVerbose   bool
 	flagShort     bool
 	flagRunRegexp string
-	flagBatch     bool
 )
 
 var initRan bool
@@ -41,7 +40,6 @@ func Init() {
 	flag.BoolVar(&flagVerbose, "test.v", false, "verbose: print additional output")
 	flag.BoolVar(&flagShort, "test.short", false, "short: run smaller test suite to save time")
 	flag.StringVar(&flagRunRegexp, "test.run", "", "run: regexp of tests to run")
-	flag.BoolVar(&flagBatch, "test.batch", false, "batch: run test as part of a batch")
 
 	initBenchmarkFlags()
 }
@@ -451,9 +449,7 @@ func (m *M) Run() (code int) {
 		fmt.Println("FAIL")
 		m.exitCode = 1
 	} else {
-		if !flagBatch || flagVerbose {
-			fmt.Println("PASS")
-		}
+		fmt.Println("PASS")
 		m.exitCode = 0
 	}
 	return

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -26,6 +26,7 @@ var (
 	flagVerbose   bool
 	flagShort     bool
 	flagRunRegexp string
+	flagBatch     bool
 )
 
 var initRan bool
@@ -40,6 +41,7 @@ func Init() {
 	flag.BoolVar(&flagVerbose, "test.v", false, "verbose: print additional output")
 	flag.BoolVar(&flagShort, "test.short", false, "short: run smaller test suite to save time")
 	flag.StringVar(&flagRunRegexp, "test.run", "", "run: regexp of tests to run")
+	flag.BoolVar(&flagBatch, "test.batch", false, "batch: run test as part of a batch")
 
 	initBenchmarkFlags()
 }
@@ -449,7 +451,7 @@ func (m *M) Run() (code int) {
 		fmt.Println("FAIL")
 		m.exitCode = 1
 	} else {
-		if flagVerbose {
+		if !flagBatch || flagVerbose {
 			fmt.Println("PASS")
 		}
 		m.exitCode = 0


### PR DESCRIPTION
This commit allows tests run as standalone binaries to print 'PASS' on a test pass, to address https://github.com/tinygo-org/tinygo/issues/2415

It does this by adding a new test flag, test.batch, which is automatically passed to the test binaries when they are run as part of a batch (via `tinygo test`).

If the "test.batch" flag is *present*, current behavior is maintained; if it is *absent*, then a test suite pass will print out "PASS".

Maybe slightly inelegant, but I couldn't find any other way to suppress the PASS message when running as part of a batch of tests. Also, I'm not sure calling it a "batch" is strictly accurate when you can run just one suite with `tinygo test`, but it was the best name I could come up with.