### PR TITLE
machine/usb: rename 'New()' to 'Port()' to have the API better match what it does

### DIFF
--- a/src/examples/hid-keyboard/main.go
+++ b/src/examples/hid-keyboard/main.go
@@ -10,7 +10,7 @@ func main() {
 	button := machine.BUTTON
 	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	kb := keyboard.New()
+	kb := keyboard.Port()
 
 	for {
 		if !button.Get() {

--- a/src/examples/hid-mouse/main.go
+++ b/src/examples/hid-mouse/main.go
@@ -10,7 +10,7 @@ func main() {
 	button := machine.BUTTON
 	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	mouse := mouse.New()
+	mouse := mouse.Port()
 
 	for {
 		if !button.Get() {

--- a/src/examples/usb-midi/main.go
+++ b/src/examples/usb-midi/main.go
@@ -17,7 +17,7 @@ func main() {
 	button := machine.BUTTON
 	button.Configure(machine.PinConfig{Mode: machine.PinInputPullup})
 
-	m := midi.New()
+	m := midi.Port()
 	m.SetHandler(func(b []byte) {
 		led.Set(!led.Get())
 		fmt.Printf("% X\r\n", b)

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -63,8 +63,8 @@ func init() {
 	}
 }
 
-// New returns hid-keybord.
-func New() *keyboard {
+// Port returns the USB hid-keyboard port.
+func Port() *keyboard {
 	return Keyboard
 }
 

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -63,6 +63,12 @@ func init() {
 	}
 }
 
+// New returns the USB hid-keyboard port.
+// Deprecated, better to just use Port()
+func New() *keyboard {
+	return Port()
+}
+
 // Port returns the USB hid-keyboard port.
 func Port() *keyboard {
 	return Keyboard

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -27,6 +27,12 @@ func init() {
 	}
 }
 
+// New returns the USB hid-mouse port.
+// Deprecated, better to just use Port()
+func New() *mouse {
+	return Port()
+}
+
 // Port returns the USB hid-mouse port.
 func Port() *mouse {
 	return Mouse

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -27,8 +27,8 @@ func init() {
 	}
 }
 
-// New returns hid-mouse.
-func New() *mouse {
+// Port returns the USB hid-mouse port.
+func Port() *mouse {
 	return Mouse
 }
 

--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -24,6 +24,12 @@ func init() {
 	}
 }
 
+// New returns the USB MIDI port.
+// Deprecated, better to just use Port()
+func New() *midi {
+	return Port()
+}
+
 // Port returns the USB midi port.
 func Port() *midi {
 	return Midi

--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -24,8 +24,8 @@ func init() {
 	}
 }
 
-// New returns hid-mouse.
-func New() *midi {
+// Port returns the USB midi port.
+func Port() *midi {
 	return Midi
 }
 


### PR DESCRIPTION
This PR modifies the `machine/usb` HID and MIDI package to rename 'New()' to 'Port()'. 

This is intended to have the API better match the singleton that is actually being returned, in part based on feedback during recent workshops.

It does unfortunately break the existing API slightly, but at a very minor cost vs. the readability.