### PR TITLE
Fix bug introduced in #3207

### DIFF
--- a/main.go
+++ b/main.go
@@ -1028,11 +1028,11 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 			if len(parts) != 2 {
 				return "", fmt.Errorf("could not parse USB VID/PID pair %q", s)
 			}
-			vid, err := strconv.ParseUint(parts[1], 16, 16)
+			vid, err := strconv.ParseUint(parts[0], 16, 16)
 			if err != nil {
 				return "", fmt.Errorf("could not parse USB vendor ID %q: %w", parts[1], err)
 			}
-			pid, err := strconv.ParseUint(parts[2], 16, 16)
+			pid, err := strconv.ParseUint(parts[1], 16, 16)
 			if err != nil {
 				return "", fmt.Errorf("could not parse USB product ID %q: %w", parts[1], err)
 			}

--- a/main.go
+++ b/main.go
@@ -401,7 +401,7 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 		if err == nil {
 			err = touchSerialPortAt1200bps(port)
 			if err != nil {
-				return &commandError{"failed to reset port", result.Binary, err}
+				return &commandError{"failed to reset port", port, err}
 			}
 			// give the target MCU a chance to restart into bootloader
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
I introduced a bug in https://github.com/tinygo-org/tinygo/pull/3207: looking up a VID/PID pair would result in a slice out of bounds panic. This is a trivial fix for that bug.

I also fixed a cosmetic issue in an error message to be more readable.