### PR TITLE
corpus: remove golang.org/x/crypto/internal/subtle

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -113,7 +113,6 @@
   - pkg: curve25519
   - pkg: ed25519
   - pkg: hkdf
-  - pkg: internal/subtle
   - pkg: md4
   - pkg: nacl/auth
   - pkg: nacl/box


### PR DESCRIPTION
This subdirectory appears to be gone now.

Perhaps a more future-proof way to fix this would be to test particular versions or hashes, instead of simply the latest version? That way we're always testing the same code.