### PR TITLE
corpus: remove 'noasm' from some tests

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -205,7 +205,6 @@
 - repo: github.com/cespare/xxhash
   tags: appengine
 - repo: gonum.org/v1/gonum
-  tags: noasm
 - repo: gonum.org/v1/gonum
   tags: noasm appengine
   subdirs:
@@ -278,7 +277,6 @@
 #  subdirs:
 #  - pkg: go
 - repo: github.com/chewxy/math32
-  tags: noasm
   version: master
 - repo: github.com/russross/blackfriday
   version: v2


### PR DESCRIPTION
Unfortunately I couldn't fully test these changes (because I'm on linux/arm64), but they don't seem to be needed on linux/amd64.