### PR TITLE
Add basic GPIO support for rp2040 PIO

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -86,6 +86,8 @@ const (
 	PinPWM
 	PinI2C
 	PinSPI
+	PinPIO0
+	PinPIO1
 )
 
 func (p Pin) PortMaskSet() (*uint32, uint32) {
@@ -203,6 +205,10 @@ func (p Pin) Configure(config PinConfig) {
 		p.setSlew(false)
 	case PinSPI:
 		p.setFunc(fnSPI)
+	case PinPIO0:
+		p.setFunc(fnPIO0)
+	case PinPIO1:
+		p.setFunc(fnPIO1)
 	}
 }
 


### PR DESCRIPTION
Code stolen from #1983
Also see discussion #1953 and #2589  

Adding the constants for Pin types to support PIO means that any implementation can be done in user code, until a final API is implemented in core for PIO compilation and instruction loading (which would be a more complicated and debatable PR)