### PR TITLE
avoid allocating clock on heap [rp2040]

### DIFF
--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -83,8 +83,8 @@ type clock struct {
 }
 
 // clock returns the clock identified by cix.
-func (clks *clocksType) clock(cix clockIndex) *clock {
-	return &clock{
+func (clks *clocksType) clock(cix clockIndex) clock {
+	return clock{
 		&clks.clk[cix],
 		cix,
 	}


### PR DESCRIPTION
One less heap allocation since the type already has a pointer to struct. This function and its result is used exclusively in `func (clks *clocksType) init()` as far as my IDE can tell. `time.Sleep` is still working after this change.