### PR TITLE
Stub out reflect.Type FieldByIndex

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -295,7 +295,7 @@ type Type interface {
 	// to the index sequence. It is equivalent to calling Field
 	// successively for each index i.
 	// It panics if the type's Kind is not Struct.
-	//FieldByIndex(index []int) StructField
+	FieldByIndex(index []int) StructField
 
 	// FieldByName returns the struct field with the given name
 	// and a boolean indicating if the field was found.
@@ -759,6 +759,10 @@ func (t rawType) PkgPath() string {
 
 func (t rawType) FieldByName(name string) (StructField, bool) {
 	panic("unimplemented: (reflect.Type).FieldByName()")
+}
+
+func (t rawType) FieldByIndex(index []int) StructField {
+	panic("unimplemented: (reflect.Type).FieldByIndex()")
 }
 
 // A StructField describes a single field in a struct.


### PR DESCRIPTION
The same named function on `reflect.Value` is stubbed similarly so there seems to be precedent. This is high impact because currently the `encoding/xml` package can't be compiled at all - with this change, manual use of `xml.Decoder` without reflection-based marshaling works fine with TinyGo so some sort of XML usage becomes possible.

Related #3085 which would be solved by actually implementing this for reflection-based XML usage, but unblocking non-reflection would be good