### PR TITLE
all: use DWARF version 4

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -142,7 +142,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 	// Note: -fdebug-prefix-map is necessary to make the output archive
 	// reproducible. Otherwise the temporary directory is stored in the archive
 	// itself, which varies each run.
-	args := append(l.cflags(target, headerPath), "-c", "-Oz", "-g", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
+	args := append(l.cflags(target, headerPath), "-c", "-Oz", "-gdwarf-4", "-ffunction-sections", "-fdata-sections", "-Wno-macro-redefined", "--target="+target, "-fdebug-prefix-map="+dir+"="+remapDir)
 	cpu := config.CPU()
 	if cpu != "" {
 		// X86 has deprecated the -mcpu flag, so we need to use -march instead.

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -329,7 +329,7 @@ func (c *Config) CFlags() []string {
 		panic("unknown libc: " + c.Target.Libc)
 	}
 	// Always emit debug information. It is optionally stripped at link time.
-	cflags = append(cflags, "-g")
+	cflags = append(cflags, "-gdwarf-4")
 	// Use the same optimization level as TinyGo.
 	cflags = append(cflags, "-O"+c.Options.Opt)
 	// Set the LLVM target triple.


### PR DESCRIPTION
This should hopefully fix the following issue when running `tinygo gdb`:

    DW_FORM_rnglistx index pointing outside of .debug_rnglists offset array [in module /tmp/tinygo4013272868/main]

I didn't actually test this branch. I hope to do so eventually. But I think I tested this particular change before and it worked at the time. I did test that the resulting binaries are indeed DWARF v4, and not the newer DWARF v5 which appears to have bugs.