### PR TITLE
cgo: support anonymous enums included in multiple Go files

### DIFF
--- a/testdata/cgo/extra.go
+++ b/testdata/cgo/extra.go
@@ -2,6 +2,7 @@ package main
 
 // Make sure CGo supports multiple files.
 
+// #include "test.h"
 // int fortytwo(void);
 // static float headerfunc_static(float a) { return a - 1; }
 // static void headerfunc_void(int a, int *ptr) { *ptr = a; }
@@ -17,4 +18,8 @@ func headerfunc_2() {
 	var n C.int
 	C.headerfunc_void(3, &n)
 	println("static headerfunc void:", n)
+
+	// anonymous structs and enums in multiple Go files
+	var _ C.teststruct
+	var _ C.testenum
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -4,6 +4,7 @@ package main
 #include <stdio.h>
 int fortytwo(void);
 #include "main.h"
+#include "test.h"
 int mul(int, int);
 #include <string.h>
 #cgo CFLAGS: -DSOME_CONSTANT=17
@@ -127,6 +128,10 @@ func main() {
 	var _ C.option3_t = C.option3A
 	println("option 2A:", C.option2A)
 	println("option 3A:", C.option3A)
+
+	// anonymous structs and enums in multiple Go files
+	var _ C.teststruct
+	var _ C.testenum
 
 	// Check that enums are considered the same width in C and CGo.
 	println("enum width matches:", unsafe.Sizeof(C.option2_t(0)) == uintptr(C.smallEnumWidth))

--- a/testdata/cgo/test.h
+++ b/testdata/cgo/test.h
@@ -1,0 +1,11 @@
+#pragma once
+
+typedef struct {
+    int a;
+    int b;
+} teststruct;
+
+typedef enum {
+    v0,
+    v1
+} testenum;


### PR DESCRIPTION
Anonymous enums (often used in typedefs) triggered a problem that was already solved for structs but wasn't yet solved for enums. So this patch generalizes the code to work for both structs and enums, and adds testing for both.