### PR TITLE
Upgrade GitHub actions packages from v2 to v3

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -28,7 +28,7 @@ jobs:
           sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
           rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-macos.tar.gz
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install Go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up Docker Buildx

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Cache Go
@@ -102,7 +102,7 @@ jobs:
           cp -p build/release.tar.gz /tmp/tinygo.linux-amd64.tar.gz
           cp -p build/release.deb    /tmp/tinygo_amd64.deb
       - name: Publish release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-amd64-double-zipped
           path: |
@@ -114,7 +114,7 @@ jobs:
     needs: build-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Go
         uses: actions/setup-go@v3
         with:
@@ -125,7 +125,7 @@ jobs:
           curl https://wasmtime.dev/install.sh -sSf | bash
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-amd64-double-zipped
       - name: Extract release tarball
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install apt dependencies
@@ -174,7 +174,7 @@ jobs:
           go-version: '1.19'
           cache: true
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Install wasmtime
@@ -260,7 +260,7 @@ jobs:
     needs: build-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install apt dependencies
         run: |
           sudo apt-get update
@@ -326,7 +326,7 @@ jobs:
         run: |
           make CROSS=arm-linux-gnueabihf
       - name: Download amd64 release
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-amd64-double-zipped
       - name: Extract amd64 release
@@ -343,7 +343,7 @@ jobs:
           cp -p build/release.tar.gz /tmp/tinygo.linux-arm.tar.gz
           cp -p build/release.deb    /tmp/tinygo_armhf.deb
       - name: Publish release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-arm-double-zipped
           path: |
@@ -359,7 +359,7 @@ jobs:
     needs: build-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install apt dependencies
         run: |
           sudo apt-get update
@@ -423,7 +423,7 @@ jobs:
         run: |
           make CROSS=aarch64-linux-gnu
       - name: Download amd64 release
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-amd64-double-zipped
       - name: Extract amd64 release
@@ -440,7 +440,7 @@ jobs:
           cp -p build/release.tar.gz /tmp/tinygo.linux-arm64.tar.gz
           cp -p build/release.deb    /tmp/tinygo_arm64.deb
       - name: Publish release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-arm64-double-zipped
           path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           scoop install ninja binaryen
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Install Go
@@ -91,7 +91,7 @@ jobs:
         # - have a dobule-zipped artifact when downloaded from the UI
         # - have a very slow artifact upload
         # We're doing the former here, to keep artifact uploads fast.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-double-zipped
           path: build/release/release.zip


### PR DESCRIPTION
Update actions/checkout, actions/upload-artifact, actions/download-artifact, and actions/setup-node packages from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Austin Vazquez <macedonv@amazon.com>