### PR TITLE
esp: use LLVM Xtensa linker instead of Espressif toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,6 @@ commands:
       - run:
           name: "Pull submodules"
           command: git submodule update --init
-  install-xtensa-toolchain:
-    parameters:
-      variant:
-        type: string
-    steps:
-      - run:
-          name: "Install Xtensa toolchain"
-          command: |
-            curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-2020r2/xtensa-esp32-elf-gcc8_2_0-esp-2020r2-<<parameters.variant>>.tar.gz -o xtensa-esp32-elf-gcc8_2_0-esp-2020r2-<<parameters.variant>>.tar.gz
-            sudo tar -C /usr/local -xf xtensa-esp32-elf-gcc8_2_0-esp-2020r2-<<parameters.variant>>.tar.gz
-            sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
-            rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-<<parameters.variant>>.tar.gz
   llvm-source-linux:
     steps:
       - restore_cache:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -20,13 +20,6 @@ jobs:
         shell: bash
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu binaryen
-      - name: Install Xtensa toolchain
-        shell: bash
-        run: |
-          curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-2020r2/xtensa-esp32-elf-gcc8_2_0-esp-2020r2-macos.tar.gz -o xtensa-esp32-elf-gcc8_2_0-esp-2020r2-macos.tar.gz
-          sudo tar -C /usr/local -xf xtensa-esp32-elf-gcc8_2_0-esp-2020r2-macos.tar.gz
-          sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
-          rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-macos.tar.gz
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -40,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-macos-v1
+          key: llvm-source-15-macos-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -54,7 +47,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-macos-v1
+          key: llvm-build-15-macos-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-alpine-v1
+          key: llvm-source-15-linux-alpine-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-alpine-v1
+          key: llvm-build-15-linux-alpine-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -138,12 +138,6 @@ jobs:
           sudo apt-get install --no-install-recommends \
               gcc-avr \
               avr-libc
-      - name: "Install Xtensa toolchain"
-        run: |
-          curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-2020r2/xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz -o xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
-          sudo tar -C /usr/local -xf xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
-          sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
-          rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
       - run: make tinygo-test-wasi-fast
       - run: make smoketest
   assert-test-linux:
@@ -185,7 +179,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-asserts-v1
+          key: llvm-source-15-linux-asserts-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -199,7 +193,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-asserts-v1
+          key: llvm-build-15-linux-asserts-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -238,12 +232,6 @@ jobs:
           echo "$(pwd)/build" >> $GITHUB_PATH
       - name: Test stdlib packages
         run: make tinygo-test
-      - name: Install Xtensa toolchain
-        run: |
-          curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-2020r2/xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz -o xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
-          sudo tar -C /usr/local -xf xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
-          sudo ln -s /usr/local/xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/xtensa-esp32-elf-ld
-          rm xtensa-esp32-elf-gcc8_2_0-esp-2020r2-linux-amd64.tar.gz
       - run: make smoketest
       - run: make wasmtest
       - run: make tinygo-baremetal
@@ -277,7 +265,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v1
+          key: llvm-source-15-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -291,7 +279,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm-v1
+          key: llvm-build-15-linux-arm-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -377,7 +365,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v1
+          key: llvm-source-15-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -391,7 +379,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm64-v1
+          key: llvm-build-15-linux-arm64-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-windows-v1
+          key: llvm-source-15-windows-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-windows-v1
+          key: llvm-build-15-windows-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -125,7 +125,7 @@ jobs:
         run: 7z x release.zip -r
       - name: Smoke tests
         shell: bash
-        run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo AVR=0 XTENSA=0
+        run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo AVR=0
 
   stdlib-test-windows:
     runs-on: windows-2022

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,8 @@ FROM tinygo-llvm AS tinygo-llvm-build
 RUN cd /tinygo/ && \
     make llvm-build
 
-# tinygo-xtensa stage installs tools needed for ESP32
-FROM tinygo-llvm-build AS tinygo-xtensa
-
-ARG xtensa_version="1.22.0-80-g6c4433a-5.2.0"
-RUN cd /tmp/ && \
-    wget -q https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-${xtensa_version}.tar.gz && \
-    tar xzf xtensa-esp32-elf-linux64-${xtensa_version}.tar.gz && \
-    cp ./xtensa-esp32-elf/bin/xtensa-esp32-elf-ld /usr/local/bin/ && \
-    rm -rf /tmp/xtensa*
-
 # tinygo-compiler stage builds the compiler itself
-FROM tinygo-xtensa AS tinygo-compiler
+FROM tinygo-llvm-build AS tinygo-compiler
 
 COPY . /tinygo
 

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -5,7 +5,7 @@
 	"build-tags": ["esp32", "esp"],
 	"scheduler": "tasks",
 	"serial": "uart",
-	"linker": "xtensa-esp32-elf-ld",
+	"linker": "ld.lld",
 	"default-stack-size": 2048,
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",

--- a/targets/esp8266.json
+++ b/targets/esp8266.json
@@ -4,7 +4,7 @@
 	"features": "+debug,+density,+exception,+extendedl32r,+highpriinterrupts,+interrupt,+mul32,+nsa,+prid,+regprotect,+rvector,+timerint",
 	"build-tags": ["esp8266", "esp"],
 	"scheduler": "tasks",
-	"linker": "xtensa-esp32-elf-ld",
+	"linker": "ld.lld",
 	"default-stack-size": 2048,
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",


### PR DESCRIPTION
The Espressif fork of LLVM now has Xtensa support in the linker LLD. (This support was written mosly by me). This means we don't have to use the Espressif GNU toolchain anymore and makes installing TinyGo simpler.

In the future, this also paves the way for ThinLTO support for Espressif chips. Right now it is mostly just a way to simplify TinyGo installation and speed up CI slightly.

---

(Note: this PR probably won't pass CI, I will update it later).