### PR TITLE
wasm: remove -wasm-abi= flag

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -1077,7 +1077,6 @@ func optimizeProgram(mod llvm.Module, config *compileopts.Config) error {
 	// cannot be represented exactly in JavaScript (JS only has doubles). To
 	// keep functions interoperable, pass int64 types as pointers to
 	// stack-allocated values.
-	// Use -wasm-abi=generic to disable this behaviour.
 	if config.WasmAbi() == "js" {
 		err := transform.ExternalInt64AsPtr(mod, config)
 		if err != nil {

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -511,12 +511,8 @@ func (c *Config) RelocationModel() string {
 	return "static"
 }
 
-// WasmAbi returns the WASM ABI which is specified in the target JSON file, and
-// the value is overridden by `-wasm-abi` flag if it is provided
+// WasmAbi returns the WASM ABI which is specified in the target JSON file.
 func (c *Config) WasmAbi() string {
-	if c.Options.WasmAbi != "" {
-		return c.Options.WasmAbi
-	}
 	return c.Target.WasmAbi
 }
 

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -42,7 +42,6 @@ type Options struct {
 	PrintAllocs     *regexp.Regexp // regexp string
 	PrintStacks     bool
 	Tags            []string
-	WasmAbi         string
 	GlobalValues    map[string]map[string]string // map[pkgpath]map[varname]value
 	TestConfig      TestConfig
 	Programmer      string

--- a/main.go
+++ b/main.go
@@ -1392,7 +1392,6 @@ func main() {
 	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	ldflags := flag.String("ldflags", "", "Go link tool compatible ldflags")
-	wasmAbi := flag.String("wasm-abi", "", "WebAssembly ABI conventions: js (no i64 params) or generic")
 	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
@@ -1481,7 +1480,6 @@ func main() {
 		PrintAllocs:     printAllocs,
 		Tags:            []string(tags),
 		GlobalValues:    globalVarValues,
-		WasmAbi:         *wasmAbi,
 		Programmer:      *programmer,
 		OpenOCDCommands: ocdCommands,
 		LLVMFeatures:    *llvmFeatures,

--- a/transform/wasm-abi.go
+++ b/transform/wasm-abi.go
@@ -14,8 +14,7 @@ import (
 // resolved, this pass may be avoided. For more details:
 // https://github.com/WebAssembly/design/issues/1172
 //
-// This pass can be enabled/disabled with the -wasm-abi flag, and is enabled by
-// default as of december 2019.
+// This pass is enabled via the wasm-abi JSON target key.
 func ExternalInt64AsPtr(mod llvm.Module, config *compileopts.Config) error {
 	ctx := mod.Context()
 	builder := ctx.NewBuilder()
@@ -145,7 +144,7 @@ func ExternalInt64AsPtr(mod llvm.Module, config *compileopts.Config) error {
 			builder.SetInsertPointAtEnd(entryBlock)
 			var callParams []llvm.Value
 			if fnType.ReturnType() == int64Type {
-				return errors.New("not yet implemented: exported function returns i64 with -wasm-abi=js; " +
+				return errors.New("not yet implemented: exported function returns i64 with the JS wasm-abi; " +
 					"see https://tinygo.org/compiler-internals/calling-convention/")
 			}
 			for i, origParam := range fn.Params() {


### PR DESCRIPTION
This flag controls whether to convert external i64 parameters for use in a browser-like environment.

This flag was needed in the past because back then we only supported wasm on browsers but no WASI. Now, I can't think of a reason why anybody would want to change the default. For `-target=wasm` (used for browser-like environments), the wasm_exec.js file expects this i64-via-stack ABI, which is the default. For WASI, there is no limitation on i64 values and `-wasm-abi=generic` is the default.

So far, all the times I've seen this flag in the wild it wasn't necessary and could just as well be left out. So the main purpose of this PR is to avoid confusion and unnecessary complexity.