### PR TITLE
esp: use ThinLTO for Xtensa

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -200,7 +200,7 @@ func (c *Config) UseThinLTO() bool {
 		// wasm-ld doesn't seem to support ThinLTO yet.
 		return false
 	}
-	if parts[0] == "avr" || parts[0] == "xtensa" {
+	if parts[0] == "avr" {
 		// These use external (GNU) linkers which might perhaps support ThinLTO
 		// through a plugin, but it's too much hassle to set up.
 		return false


### PR DESCRIPTION
This is now possible because we're using the LLVM linker. It results in some very minor code size reductions. The main benefit however is consistency: eventually, all targets will support ThinLTO at which point we can remove support for GNU linkers and simplify the compiler.

Also see #2870.