### PR TITLE
darwin: fix error with `tinygo lldb`

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -195,6 +195,7 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 		default:
 			llvmarch = options.GOARCH
 		}
+		llvmvendor := "unknown"
 		llvmos := options.GOOS
 		if llvmos == "darwin" {
 			// Use macosx* instead of darwin, otherwise darwin/arm64 will refer
@@ -204,12 +205,14 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 				// Looks like Apple prefers to call this architecture ARM64
 				// instead of AArch64.
 				llvmarch = "arm64"
+				llvmos = "macosx11.0.0"
 			}
+			llvmvendor = "apple"
 		}
 		// Target triples (which actually have four components, but are called
 		// triples for historical reasons) have the form:
 		//   arch-vendor-os-environment
-		target := llvmarch + "-unknown-" + llvmos
+		target := llvmarch + "-" + llvmvendor + "-" + llvmos
 		if options.GOOS == "windows" {
 			target += "-gnu"
 		} else if options.GOARCH == "arm" {


### PR DESCRIPTION
Before this patch, `tinygo lldb path/to/package` would result in an error:

    (lldb) target create --arch=arm64-unknown-macosx10.12.0 "/var/folders/17/btmpymwj0wv6n50cmslwyr900000gn/T/tinygo2731663853/main"
    error: the specified architecture 'arm64-unknown-macosx10.12.0' is not compatible with 'arm64-apple-macosx10.12.0' in '/var/folders/17/btmpymwj0wv6n50cmslwyr900000gn/T/tinygo2731663853/main'

This patch fixes this error.

Unfortunately, it doesn't get debug information to work yet. I still haven't figured out what's going wrong here. But it's progress, I guess.