### PR TITLE
main: more attempts to find MSD volume when flashing

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	PrintJSON       bool
 	Monitor         bool
 	BaudRate        int
+	Retries         int
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/main.go
+++ b/main.go
@@ -928,8 +928,6 @@ func touchSerialPortAt1200bps(port string) (err error) {
 	return fmt.Errorf("opening port: %s", err)
 }
 
-const maxMSDRetries = 10
-
 func flashUF2UsingMSD(volume, tmppath string, options *compileopts.Options) error {
 	// find standard UF2 info path
 	var infoPath string
@@ -951,7 +949,7 @@ func flashUF2UsingMSD(volume, tmppath string, options *compileopts.Options) erro
 		infoPath = path + "/INFO_UF2.TXT"
 	}
 
-	d, err := locateDevice(volume, infoPath)
+	d, err := locateDevice(volume, infoPath, options.Retries)
 	if err != nil {
 		return err
 	}
@@ -980,7 +978,7 @@ func flashHexUsingMSD(volume, tmppath string, options *compileopts.Options) erro
 		destPath = path + "/"
 	}
 
-	d, err := locateDevice(volume, destPath)
+	d, err := locateDevice(volume, destPath, options.Retries)
 	if err != nil {
 		return err
 	}
@@ -988,10 +986,10 @@ func flashHexUsingMSD(volume, tmppath string, options *compileopts.Options) erro
 	return moveFile(tmppath, d+"/flash.hex")
 }
 
-func locateDevice(volume, path string) (string, error) {
+func locateDevice(volume, path string, maxRetries int) (string, error) {
 	var d []string
 	var err error
-	for i := 0; i < maxMSDRetries; i++ {
+	for i := 0; i < maxRetries; i++ {
 		d, err = filepath.Glob(path)
 		if err != nil {
 			return "", err
@@ -1398,6 +1396,7 @@ func main() {
 	ocdCommandsString := flag.String("ocd-commands", "", "OpenOCD commands, overriding target spec (can specify multiple separated by commas)")
 	ocdOutput := flag.Bool("ocd-output", false, "print OCD daemon output during debug")
 	port := flag.String("port", "", "flash port (can specify multiple candidates separated by commas)")
+	maxRetries := flag.Int("retries", 10, "the maximum number of times to retry locating the MSD volume to be used for flashing")
 	programmer := flag.String("programmer", "", "which hardware programmer to use")
 	ldflags := flag.String("ldflags", "", "Go link tool compatible ldflags")
 	llvmFeatures := flag.String("llvm-features", "", "comma separated LLVM features to enable")
@@ -1494,6 +1493,7 @@ func main() {
 		PrintJSON:       flagJSON,
 		Monitor:         *monitor,
 		BaudRate:        *baudrate,
+		Retries:         *maxRetries,
 	}
 	if *printCommands {
 		options.PrintCommands = printCommand


### PR DESCRIPTION
This PR adds a `retries` flag to set the number of times to retry locating the MSD volume to be used for flashing UF2 devices. The reason we might need to increase this value is to try to let slower systems handle after a reset when the `flash` command needs to locate the correct MSD volume.