### PR TITLE
Enable wasm pointer tracking for gc=none.

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -105,6 +105,8 @@ func (c *Config) GC() string {
 // that can be traced by the garbage collector.
 func (c *Config) NeedsStackObjects() bool {
 	switch c.GC() {
+	case "none":
+		fallthrough
 	case "conservative":
 		for _, tag := range c.BuildTags() {
 			if tag == "tinygo.wasm" {

--- a/src/runtime/gc_stack_portable.go
+++ b/src/runtime/gc_stack_portable.go
@@ -1,5 +1,6 @@
-//go:build gc.conservative && tinygo.wasm
-// +build gc.conservative,tinygo.wasm
+//go:build (gc.conservative || gc.none) && tinygo.wasm
+// +build gc.conservative gc.none
+// +build tinygo.wasm
 
 package runtime
 


### PR DESCRIPTION
Fixes #3278 

This takes the simpler approach of allowing wasm pointer tracking on the stack to be enabled even with `gc=none`. none is [documented](https://github.com/tinygo-org/tinygo/blob/release/src/runtime/gc_none.go#L8) as being useful for combining with a separate garbage collector. However in practice, it is basically impossible to do this with wasm because tracking pointers on the stack is required for any GC to be able to see them to mark them.

It seems reasonable to enable the stack tracking code even when not using the TinyGo GC. Either a) an external GC is being used and the tracking is required or b) an external GC is not being used meaning there are no allocations, and therefore no tracking will actually happen.

Having the ability to swap in a custom GC allows TinyGo compiled wasm to perform quite well with low pause times, so this is very enabling for projects like [coraza-proxy-wasm](https://github.com/corazawaf/coraza-proxy-wasm)