### PR TITLE
wasm: fix scanning of the stack

### DIFF
--- a/src/runtime/gc_stack_portable.go
+++ b/src/runtime/gc_stack_portable.go
@@ -6,6 +6,7 @@ package runtime
 
 import (
 	"internal/task"
+	"runtime/volatile"
 	"unsafe"
 )
 
@@ -39,6 +40,13 @@ type stackChainObject struct {
 // stackChainStart. Luckily we don't need to scan these, as these globals are
 // stored on the goroutine stack and are therefore already getting scanned.
 func markStack() {
+	// Hack to force LLVM to consider stackChainStart to be live.
+	// Without this hack, loads and stores may be considered dead and objects on
+	// the stack might not be correctly tracked. With this volatile load, LLVM
+	// is forced to consider stackChainStart (and everything it points to) as
+	// live.
+	volatile.LoadUint32((*uint32)(unsafe.Pointer(&stackChainStart)))
+
 	if task.OnSystemStack() {
 		markRoots(getCurrentStackPointer(), stackTop)
 	}


### PR DESCRIPTION
LLVM wasn't aware that runtime.stackChainStart must be kept live and can't be optimized away. With this hack, it is forced to consider stackChainStart live at the time of the stack scan.

This fixes the corruption in https://github.com/tinygo-org/tinygo/issues/3277

EDIT: I should point out that @dgryski did investigate the bug so much of the credit goes to him.