### PR TITLE
Revert "Enable wasm pointer tracking for gc=none."

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -105,8 +105,6 @@ func (c *Config) GC() string {
 // that can be traced by the garbage collector.
 func (c *Config) NeedsStackObjects() bool {
 	switch c.GC() {
-	case "none":
-		fallthrough
 	case "conservative":
 		for _, tag := range c.BuildTags() {
 			if tag == "tinygo.wasm" {

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -4,8 +4,8 @@
 package runtime
 
 // This GC strategy provides no memory allocation at all. It can be useful to
-// detect where in a program memory is allocated, or to combine this runtime
-// with a separate (external) garbage collector.
+// detect where in a program memory is allocated (via linker errors) or for
+// targets that have far too little RAM even for the leaking memory allocator.
 
 import (
 	"unsafe"

--- a/src/runtime/gc_stack_portable.go
+++ b/src/runtime/gc_stack_portable.go
@@ -1,6 +1,5 @@
-//go:build (gc.conservative || gc.none) && tinygo.wasm
-// +build gc.conservative gc.none
-// +build tinygo.wasm
+//go:build gc.conservative && tinygo.wasm
+// +build gc.conservative,tinygo.wasm
 
 package runtime
 


### PR DESCRIPTION
This reverts commit 0b3a7280fa7fd9cf479a6ebcf608c40280d86b9f and updates the documentation a little bit to explain the purpose of -gc=none. (I'm thinking about the attiny10 by the way where defaulting to -gc=none makes sense).

If we're going to do something like this, IMHO it should be in a separate `-gc=custom`.