### PR TITLE
avr: support ThinLTO

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -200,11 +200,6 @@ func (c *Config) UseThinLTO() bool {
 		// wasm-ld doesn't seem to support ThinLTO yet.
 		return false
 	}
-	if parts[0] == "avr" {
-		// These use external (GNU) linkers which might perhaps support ThinLTO
-		// through a plugin, but it's too much hassle to set up.
-		return false
-	}
 	// Other architectures support ThinLTO.
 	return true
 }

--- a/src/runtime/arch_avr.go
+++ b/src/runtime/arch_avr.go
@@ -40,6 +40,8 @@ func procUnpin() {
 
 // The following functions are workarounds for things missing in compiler-rt.
 // They will likely need special assembly implementations.
+// They are treated specially: they're added to @llvm.compiler.used so that the
+// linker won't eliminate them.
 
 //export __mulsi3
 func __mulsi3(a, b uint32) uint32 {

--- a/targets/avr.ld
+++ b/targets/avr.ld
@@ -5,7 +5,7 @@ MEMORY
     RAM (xrw)       : ORIGIN = 0x800000 + __ram_start, LENGTH = __ram_size
 }
 
-ENTRY(__vector_RESET)
+ENTRY(main)
 
 SECTIONS
 {

--- a/transform/stacksize.go
+++ b/transform/stacksize.go
@@ -53,7 +53,7 @@ func CreateStackSizeLoads(mod llvm.Module, config *compileopts.Config) []string 
 	stackSizesGlobal.SetInitializer(llvm.ConstArray(functions[0].Type(), defaultStackSizes))
 
 	// Add all relevant values to llvm.used (for LTO).
-	llvmutil.AppendToUsedGlobals(mod, append([]llvm.Value{stackSizesGlobal}, functionValues...)...)
+	llvmutil.AppendToGlobal(mod, "llvm.used", append([]llvm.Value{stackSizesGlobal}, functionValues...)...)
 
 	// Replace the calls with loads from the new global with stack sizes.
 	irbuilder := ctx.NewBuilder()

--- a/transform/stacksize.go
+++ b/transform/stacksize.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/compiler/llvmutil"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -52,7 +53,7 @@ func CreateStackSizeLoads(mod llvm.Module, config *compileopts.Config) []string 
 	stackSizesGlobal.SetInitializer(llvm.ConstArray(functions[0].Type(), defaultStackSizes))
 
 	// Add all relevant values to llvm.used (for LTO).
-	appendToUsedGlobals(mod, append([]llvm.Value{stackSizesGlobal}, functionValues...)...)
+	llvmutil.AppendToUsedGlobals(mod, append([]llvm.Value{stackSizesGlobal}, functionValues...)...)
 
 	// Replace the calls with loads from the new global with stack sizes.
 	irbuilder := ctx.NewBuilder()
@@ -71,23 +72,4 @@ func CreateStackSizeLoads(mod llvm.Module, config *compileopts.Config) []string 
 	}
 
 	return functionNames
-}
-
-// Append the given values to the llvm.used array. The values can be any pointer
-// type, they will be bitcast to i8*.
-func appendToUsedGlobals(mod llvm.Module, values ...llvm.Value) {
-	if !mod.NamedGlobal("llvm.used").IsNil() {
-		// Sanity check. TODO: we don't emit such a global at the moment, but
-		// when we do we should append to it instead.
-		panic("todo: append to existing llvm.used")
-	}
-	i8ptrType := llvm.PointerType(mod.Context().Int8Type(), 0)
-	var castValues []llvm.Value
-	for _, value := range values {
-		castValues = append(castValues, llvm.ConstBitCast(value, i8ptrType))
-	}
-	usedInitializer := llvm.ConstArray(i8ptrType, castValues)
-	used := llvm.AddGlobal(mod, usedInitializer.Type(), "llvm.used")
-	used.SetInitializer(usedInitializer)
-	used.SetLinkage(llvm.AppendingLinkage)
 }


### PR DESCRIPTION
ThinLTO results in a small code size reduction, which is nice (especially on these very small chips). It also brings us one step closer to using ThinLTO everywhere.

See: #2870