### PR TITLE
machine/stm32: fix when reading multiple ADC pins

### DIFF
--- a/src/machine/machine_stm32_adc_f1.go
+++ b/src/machine/machine_stm32_adc_f1.go
@@ -75,7 +75,7 @@ func (a ADC) Get() uint16 {
 	stm32.ADC1.SR.ClearBits(stm32.ADC_SR_EOC)
 
 	// clear rank
-	stm32.ADC1.SMPR1.ClearBits(ch)
+	stm32.ADC1.SQR3.ClearBits(ch)
 
 	return result
 }

--- a/src/machine/machine_stm32_adc_f4.go
+++ b/src/machine/machine_stm32_adc_f4.go
@@ -70,7 +70,7 @@ func (a ADC) Get() uint16 {
 	stm32.ADC1.SR.ClearBits(stm32.ADC_SR_EOC)
 
 	// clear rank
-	stm32.ADC1.SMPR1.ClearBits(ch)
+	stm32.ADC1.SQR3.ClearBits(ch)
 
 	return result
 }

--- a/src/machine/machine_stm32_moder_gpio.go
+++ b/src/machine/machine_stm32_moder_gpio.go
@@ -148,6 +148,7 @@ func (p Pin) ConfigureAltFunc(config PinConfig, altFunc uint8) {
 	// ADC
 	case PinInputAnalog:
 		port.MODER.ReplaceBits(gpioModeAnalog, gpioModeMask, pos)
+		port.PUPDR.ReplaceBits(gpioPullFloating, gpioPullMask, pos)
 	}
 }
 


### PR DESCRIPTION
This PR changes the STM32 ADC pin configuration to always set the pullup resistor on that pin to floating, otherwise I do not think it can actually read a correct value on that pin, if already set to pullup or pulldown.

UPDATE: it also includes a fix when reading multiple analog pins. The existing code was not correctly clearing the register used to determine the rank of which pins to read, which would result in multiple readings overwriting the value of the desired single pin.