### PR TITLE
Fix XIAO RP2040 pin variable assignment

### DIFF
--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -24,8 +24,8 @@ const (
 	D6  Pin = GPIO0
 	D7  Pin = GPIO1
 	D8  Pin = GPIO2
-	D9  Pin = GPIO3
-	D10 Pin = GPIO4
+	D9  Pin = GPIO4
+	D10 Pin = GPIO3
 )
 
 // Analog pins


### PR DESCRIPTION
According to XIAO RP2040 wiki, D9 and D10 correspond to GPIO4 and GPIO3, respectively.

![](https://files.seeedstudio.com/wiki/XIAO-RP2040/img/xinpin.jpg)