### PR TITLE
add constant for xiao esp32c3 boot button

### DIFF
--- a/src/machine/board_xiao-esp32c3.go
+++ b/src/machine/board_xiao-esp32c3.go
@@ -34,6 +34,12 @@ const (
 	A3 = GPIO5
 )
 
+// Button
+const (
+	BUTTON      = BUTTON_BOOT
+	BUTTON_BOOT = GPIO9
+)
+
 // UART pins
 const (
 	UART_RX_PIN = GPIO20


### PR DESCRIPTION
the xiao esp32c3 has a "boot" button on d9/gpio9
https://files.seeedstudio.com/wiki/XIAO_WiFi/Resources/Seeed_Studio_XIAO_ESP32C3_v1.0_SCH.pdf
