### PR TITLE
xiao-rp2040: add pin definitions

### DIFF
--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -38,7 +38,10 @@ const (
 
 // Onboard LEDs
 const (
-	NEOPIXEL = GPIO12
+	NEOPIXEL       = GPIO12
+	WS2812         = GPIO12
+	NEO_PWR        = GPIO11
+	NEOPIXEL_POWER = GPIO11
 
 	LED       = GPIO17
 	LED_RED   = GPIO17
@@ -58,8 +61,8 @@ const (
 // SPI pins
 const (
 	SPI0_SCK_PIN Pin = D8
-	SPI0_SDO_PIN Pin = D9
-	SPI0_SDI_PIN Pin = D10
+	SPI0_SDO_PIN Pin = D10
+	SPI0_SDI_PIN Pin = D9
 
 	SPI1_SCK_PIN Pin = NoPin
 	SPI1_SDO_PIN Pin = NoPin


### PR DESCRIPTION
This PR updates the definition of xiao-rp2040.


One is the addition of pin names related to NEOPIXEL.
To use WS2812 on xiao-rp2040, NEOPIXEL_POWER must be set to High.
The pin names were taken from board_qtpy.go and arduino definitions.

The other is to correct an error in the SPI pin definition.

arduino definitions
https://github.com/earlephilhower/arduino-pico/blob/a7cf5cd1caf1afc8aebc8723776847227fed8966/variants/seeed_xiao_rp2040/pins_arduino.h

pinout
![image](https://user-images.githubusercontent.com/9251039/203473550-85db5779-fab3-4f73-9ead-d1c69560c423.png)

schema
https://wiki.seeedstudio.com/XIAO-RP2040/