### PR TITLE
avr: add channel test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -194,10 +194,6 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 				// Breaks interp.
 				continue
 
-			case "channel.go":
-				// Freezes after recv from closed channel.
-				continue
-
 			case "math.go":
 				// Stuck somewhere, not sure what's happening.
 				continue

--- a/main_test.go
+++ b/main_test.go
@@ -134,10 +134,7 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("AVR", func(t *testing.T) {
-		// LLVM backend crash:
-		// LIBCLANG FATAL ERROR: Cannot select: t3: i16 = JumpTable<0>
-		// This bug is non-deterministic.
-		t.Skip("skipped due to non-deterministic backend bugs")
+		t.Parallel()
 		runPlatTests(optionsFromTarget("simavr", sema), tests, t)
 	})
 


### PR DESCRIPTION
It is working now, so add it as a test. Not sure why, maybe the ThinLTO change fixed something here?

I've also gotten testdata/math.go to work, but it requires a fix in either picolibc or Clang (and I've sent a patch to both).

Also re-enable the AVR CI tests. I hope they'll work now, but if not we can simply disable them again.