### PR TITLE
windows: update mingw-w64 version

### DIFF
--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -52,7 +52,7 @@ func makeMinGWExtraLibs(tmpdir string) []*compileJob {
 	for _, name := range []string{
 		"kernel32.def.in",
 		"api-ms-win-crt-conio-l1-1-0.def",
-		"api-ms-win-crt-convert-l1-1-0.def",
+		"api-ms-win-crt-convert-l1-1-0.def.in",
 		"api-ms-win-crt-environment-l1-1-0.def",
 		"api-ms-win-crt-filesystem-l1-1-0.def",
 		"api-ms-win-crt-heap-l1-1-0.def",


### PR DESCRIPTION
This gets rid of the following messages when compiling for Windows:

    ld.lld: warning: duplicate /export option: hypot
    ld.lld: warning: duplicate /export option: nextafter

I've wanted to wait for the next release but that may take a long while, so I've simply set the submodule to the commit that fixes this message.