### PR TITLE
wasm: support ThinLTO

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -190,17 +190,11 @@ func (c *Config) StackSize() uint64 {
 	return c.Target.DefaultStackSize
 }
 
-// UseThinLTO returns whether ThinLTO should be used for the given target. Some
-// targets (such as wasm) are not yet supported.
-// We should try and remove as many exceptions as possible in the future, so
-// that this optimization can be applied in more places.
+// UseThinLTO returns whether ThinLTO should be used for the given target.
 func (c *Config) UseThinLTO() bool {
-	parts := strings.Split(c.Triple(), "-")
-	if parts[0] == "wasm32" {
-		// wasm-ld doesn't seem to support ThinLTO yet.
-		return false
-	}
-	// Other architectures support ThinLTO.
+	// All architectures support ThinLTO now. However, this code is kept for the
+	// time being in case there are regressions. The non-ThinLTO code support
+	// should be removed when it is proven to work reliably.
 	return true
 }
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1099,6 +1099,11 @@ func (b *builder) createFunctionStart(intrinsic bool) {
 		// otherwise the function is not exported.
 		functionAttr := b.ctx.CreateStringAttribute("wasm-export-name", b.info.linkName)
 		b.llvmFn.AddFunctionAttr(functionAttr)
+		// Unlike most targets, exported functions are actually visible in
+		// WebAssembly (even if it's not called from within the WebAssembly
+		// module). But LTO generally optimizes such functions away. Therefore,
+		// exported functions must be explicitly marked as used.
+		llvmutil.AppendToGlobal(b.mod, "llvm.used", b.llvmFn)
 	}
 
 	// Some functions have a pragma controlling the inlining level.

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -6,6 +6,7 @@ target triple = "wasm32-unknown-wasi"
 @extern_global = external global [0 x i8], align 1
 @main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32
 @main.alignedGlobal16 = hidden global [4 x i32] zeroinitializer, align 16
+@llvm.used = appending global [2 x ptr] [ptr @extern_func, ptr @exportedFunctionInSection]
 @main.globalInSection = hidden global i32 0, section ".special_global_section", align 4
 @undefinedGlobalNotInSection = external global i32, align 4
 @main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024


### PR DESCRIPTION
Using ThinLTO manages to optimize binaries significantly. The exact amount varies a lot by program but it's easily a 25-30% reduction.

Don't remove non-ThinLTO support yet. It would not surprise me if this triggered some unintended side effect (especially considering the very large reduction in code size). Eventually, it should be removed though.