### PR TITLE
atsame5x: reduce heap allocation

### DIFF
--- a/src/examples/can/main.go
+++ b/src/examples/can/main.go
@@ -37,7 +37,11 @@ func main() {
 			fmt.Printf("CAN0 %d\r\n", sz0)
 			for i := 0; i < sz0; i++ {
 				can0.RxRaw(&rxMsg)
-				fmt.Printf("-> %08X %X %#v\r\n", rxMsg.ID, rxMsg.DLC, rxMsg.Data())
+				fmt.Printf("-> %08X %X", rxMsg.ID, rxMsg.DLC)
+				for j := byte(0); j < rxMsg.Length(); j++ {
+					fmt.Printf(" %02X", rxMsg.DB[j])
+				}
+				fmt.Printf("\r\n")
 			}
 		}
 
@@ -46,7 +50,11 @@ func main() {
 			fmt.Printf("CAN1 %d\r\n", sz1)
 			for i := 0; i < sz1; i++ {
 				can1.RxRaw(&rxMsg)
-				fmt.Printf("-> %08X %X %#v\r\n", rxMsg.ID, rxMsg.DLC, rxMsg.Data())
+				fmt.Printf("-> %08X %X", rxMsg.ID, rxMsg.DLC)
+				for j := byte(0); j < rxMsg.Length(); j++ {
+					fmt.Printf(" %02X", rxMsg.DB[j])
+				}
+				fmt.Printf("\r\n")
 			}
 		}
 	}

--- a/src/machine/machine_atsame5x_can.go
+++ b/src/machine/machine_atsame5x_can.go
@@ -424,6 +424,11 @@ func (e CANRxBufferElement) Data() []byte {
 	return e.DB[:CANDlcToLength(e.DLC, e.FDF)]
 }
 
+// Length returns its actual length.
+func (e CANRxBufferElement) Length() byte {
+	return CANDlcToLength(e.DLC, e.FDF)
+}
+
 // CANDlcToLength() converts a DLC value to its actual length.
 func CANDlcToLength(dlc byte, isFD bool) byte {
 	length := dlc


### PR DESCRIPTION
This PR reduces atsame5x-can's heap allocation.
Data() is easy to use but causes heap allocation, so rxMsg.Length() was added.

