### PR TITLE
runtime: move KeepAlive/SetFinalizer to common code

### DIFF
--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -640,11 +640,3 @@ func dumpHeap() {
 		}
 	}
 }
-
-func KeepAlive(x interface{}) {
-	// Unimplemented. Only required with SetFinalizer().
-}
-
-func SetFinalizer(obj interface{}, finalizer interface{}) {
-	// Unimplemented.
-}

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -69,14 +69,6 @@ func GC() {
 	// No-op.
 }
 
-func KeepAlive(x interface{}) {
-	// Unimplemented. Only required with SetFinalizer().
-}
-
-func SetFinalizer(obj interface{}, finalizer interface{}) {
-	// Unimplemented.
-}
-
 func initHeap() {
 	// preinit() may have moved heapStart; reset heapptr
 	heapptr = heapStart

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -27,14 +27,6 @@ func GC() {
 	// Unimplemented.
 }
 
-func KeepAlive(x interface{}) {
-	// Unimplemented. Only required with SetFinalizer().
-}
-
-func SetFinalizer(obj interface{}, finalizer interface{}) {
-	// Unimplemented.
-}
-
 func initHeap() {
 	// Nothing to initialize.
 }

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -87,3 +87,11 @@ func LockOSThread() {
 // Stub for now
 func UnlockOSThread() {
 }
+
+func KeepAlive(x interface{}) {
+	// Unimplemented. Only required with SetFinalizer().
+}
+
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// Unimplemented.
+}


### PR DESCRIPTION
We don't support these yet so let's just put them in a central location. Once these functions are supported we can think about how to structure the code again.

Motivated by #3302.