### PR TITLE
Revert "Bump CMSIS to 5.9.0"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/NordicSemiconductor/nrfx.git
 [submodule "lib/CMSIS"]
 	path = lib/CMSIS
-	url = https://github.com/ARM-software/CMSIS_5.git
+	url = https://github.com/ARM-software/CMSIS.git
 [submodule "lib/avr"]
 	path = lib/avr
 	url = https://github.com/avr-rust/avr-mcu.git

--- a/Makefile
+++ b/Makefile
@@ -748,7 +748,7 @@ wasmtest:
 build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
 	@mkdir -p build/release/tinygo/bin
 	@mkdir -p build/release/tinygo/lib/clang/include
-	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS/Core
+	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
 	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-headers/defaults
@@ -768,7 +768,7 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
 	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
 endif
 	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
-	@cp -rp lib/CMSIS/CMSIS/Core/Include build/release/tinygo/lib/CMSIS/CMSIS/Core
+	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
 	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
 	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
 	@cp -rp lib/musl/arch/aarch64        build/release/tinygo/lib/musl/arch

--- a/targets/nrf51.json
+++ b/targets/nrf51.json
@@ -3,7 +3,7 @@
 	"build-tags": ["nrf51822", "nrf51", "nrf"],
 	"cflags": [
 		"-DNRF51",
-		"-I{root}/lib/CMSIS/CMSIS/Core/Include",
+		"-I{root}/lib/CMSIS/CMSIS/Include",
 		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf51.ld",

--- a/targets/nrf52.json
+++ b/targets/nrf52.json
@@ -3,7 +3,7 @@
 	"build-tags": ["nrf52", "nrf"],
 	"cflags": [
 		"-DNRF52832_XXAA",
-		"-I{root}/lib/CMSIS/CMSIS/Core/Include",
+		"-I{root}/lib/CMSIS/CMSIS/Include",
 		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf52.ld",

--- a/targets/nrf52833.json
+++ b/targets/nrf52833.json
@@ -3,7 +3,7 @@
 	"build-tags": ["nrf52833", "nrf"],
 	"cflags": [
 		"-DNRF52833_XXAA",
-		"-I{root}/lib/CMSIS/CMSIS/Core/Include",
+		"-I{root}/lib/CMSIS/CMSIS/Include",
 		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf52833.ld",

--- a/targets/nrf52840.json
+++ b/targets/nrf52840.json
@@ -3,7 +3,7 @@
 	"build-tags": ["nrf52840", "nrf"],
 	"cflags": [
 		"-DNRF52840_XXAA",
-		"-I{root}/lib/CMSIS/CMSIS/Core/Include",
+		"-I{root}/lib/CMSIS/CMSIS/Include",
 		"-I{root}/lib/nrfx/mdk"
 	],
 	"linkerscript": "targets/nrf52840.ld",


### PR DESCRIPTION
Reverts tinygo-org/tinygo#3339 due to failure in TinyGo Bluetooth package. See https://github.com/tinygo-org/bluetooth/actions/runs/3714845327/jobs/6299516750#step:6:15