### PR TITLE
rp2040: fix interrupt issue

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -101,6 +101,7 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 		}
 
 		s2 := rp.USBCTRL_REGS.BUFF_STATUS.Get()
+		rp.USBCTRL_REGS.BUFF_STATUS.Set(s2)
 
 		// OUT (PC -> rp2040)
 		for i := 0; i < 16; i++ {
@@ -121,8 +122,6 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 				}
 			}
 		}
-
-		rp.USBCTRL_REGS.BUFF_STATUS.Set(0xFFFFFFFF)
 	}
 
 	// Bus is reset


### PR DESCRIPTION
This PR fixes the problem of interruptions.

Prior to the correction, the following problems existed.

* BUFF_STATUS was being cleared with 0xFFFFFFFFFF, which could clear unprocessed bits
* The bit was cleared illegally in the case where the bit rises again immediately after IN and OUT processing.

The code before modification will not be able to send/receive USB immediately when executed in the following environment.

* Flash the following source code
    * https://gist.github.com/sago35/0cb7aa5d08fca4aaab385962d04b1cf5
* Open the following site in chrome
    * Many MIDI events are sent from the rp2040
    * https://webmidi-examples.glitch.me/
* Receive USB-CDC on tinygo monitor, etc.
    * Lots of USB CDC events occur
