### PR TITLE
compileopts: replace 'retries' flag with more correct 'timeout' flag

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -51,7 +51,7 @@ type Options struct {
 	PrintJSON       bool
 	Monitor         bool
 	BaudRate        int
-	Retries         int
+	Timeout         time.Duration
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.


### PR DESCRIPTION
This PR replaces this poorly named `tinygo flash -retries` flag with the better named `tinygo flash -timeout` flag, which also uses the more understandable values related to time, e.g. `tinygo flash -timeout=30s`.