### PR TITLE
rp2040: fix interrupt issue (2)

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -101,7 +101,6 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 		}
 
 		s2 := rp.USBCTRL_REGS.BUFF_STATUS.Get()
-		rp.USBCTRL_REGS.BUFF_STATUS.Set(s2)
 
 		// OUT (PC -> rp2040)
 		for i := 0; i < 16; i++ {
@@ -122,6 +121,8 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 				}
 			}
 		}
+
+		rp.USBCTRL_REGS.BUFF_STATUS.Set(s2)
 	}
 
 	// Bus is reset


### PR DESCRIPTION
The method I fixed in #3343 was a bit wrong.
If BUFF_STATUS must updated after IN/OUT processing is performed, the data in usbDPSRAM.EPxBufferControl may be corrupted.

Please review again. @deadprogram 