### PR TITLE
compiler: fix stack overflow when creating recursive pointer types

### DIFF
--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -43,7 +43,7 @@ func (b *builder) createChanSend(instr *ssa.Send) {
 	}
 
 	// Allocate blockedlist buffer.
-	channelBlockedList := b.mod.GetTypeByName("runtime.channelBlockedList")
+	channelBlockedList := b.getLLVMRuntimeType("channelBlockedList")
 	channelBlockedListAlloca, channelBlockedListAllocaCast, channelBlockedListAllocaSize := b.createTemporaryAlloca(channelBlockedList, "chan.blockedList")
 
 	// Do the send.
@@ -75,7 +75,7 @@ func (b *builder) createChanRecv(unop *ssa.UnOp) llvm.Value {
 	}
 
 	// Allocate blockedlist buffer.
-	channelBlockedList := b.mod.GetTypeByName("runtime.channelBlockedList")
+	channelBlockedList := b.getLLVMRuntimeType("channelBlockedList")
 	channelBlockedListAlloca, channelBlockedListAllocaCast, channelBlockedListAllocaSize := b.createTemporaryAlloca(channelBlockedList, "chan.blockedList")
 
 	// Do the receive.

--- a/compiler/testdata/basic.go
+++ b/compiler/testdata/basic.go
@@ -90,3 +90,9 @@ func foo() {
 	// Use this type.
 	func(b kv) {}(kv{})
 }
+
+type T1 []T1
+type T2 [2]*T2
+
+var a T1
+var b T2

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -7,6 +7,8 @@ target triple = "wasm32-unknown-wasi"
 %main.kv.0 = type { i8, i32, i32, i32 }
 
 @main.kvGlobal = hidden global %main.kv zeroinitializer, align 4
+@main.a = hidden global { ptr, i32, i32 } zeroinitializer, align 4
+@main.b = hidden global [2 x ptr] zeroinitializer, align 4
 
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 


### PR DESCRIPTION
There were two types that could result in a compiler stack overflow. This is difficult to fix in LLVM 14, so I won't even bother. However, this is trivial to fix with opaque pointers in LLVM 15. Therefore, this fix is for LLVM 15 only.

Fixes: https://github.com/tinygo-org/tinygo/issues/3341