### PR TITLE
wasi: makes wasmtime "run" explicit

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,9 +285,9 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 			// relative directory up to the module root, even if the test never
 			// reads any files.
 			//
-			// Ex. --dir=.. --dir=../.. --dir=../../..
+			// Ex. run --dir=.. --dir=../.. --dir=../../..
 			dirs := dirsToModuleRoot(result.MainDir, result.ModuleRoot)
-			var args []string
+			args := []string{"run"}
 			for _, d := range dirs[1:] {
 				args = append(args, "--dir="+d)
 			}

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -24,7 +24,7 @@ func _start() {
 // Read the command line arguments from WASI.
 // For example, they can be passed to a program with wasmtime like this:
 //
-//	wasmtime ./program.wasm arg1 arg2
+//	wasmtime run ./program.wasm arg1 arg2
 func init() {
 	__wasm_call_ctors()
 }


### PR DESCRIPTION
wasmtime by default will assume the subcommand is "run" vs one of its others, but being explicit helps clarify the actual command invoked.

For example, we pass similar looking args to wasmtime in different places due to how filesystem lookup works at the moment.

Specifically, `build/tinygo test -target wasi os` ends up compiling `main` to wasm and invoking it like so. I found the "run" here was helpful as it is surely the marker of where things start.

```bash
dir=/Users/adrian/Library/Caches/tinygo/goroot-663b9f64fa32ef34422ae1c56b5d12237701f7e39c3efcc1087329a71121caff/src/os
args=[wasmtime run --dir=.. --dir=../.. --dir=/var/folders/vd/1cf8zdb1721f4z5rjggy8bp40000gn/T/tinygotmp2965559219 --env=TMPDIR=/var/folders/vd/1cf8zdb1721f4z5rjggy8bp40000gn/T/tinygotmp2965559219 /var/folders/vd/1cf8zdb1721f4z5rjggy8bp40000gn/T/tinygo2707001624/main --dir=.]
ok  	os	0.094s
```