### PR TITLE
Add PDM support for circuitplay-bluefruit

### DIFF
--- a/src/examples/pdm/pdm.go
+++ b/src/examples/pdm/pdm.go
@@ -20,7 +20,7 @@ func main() {
 	for {
 		if machine.BUTTONA.Get() {
 			println("Recording new audio clip into memory")
-			pdm.Read(&audio[0], uint32(len(audio)))
+			pdm.Read(audio)
 			println(fmt.Sprintf("Recorded new audio clip into memory: %v", audio))
 		}
 	}

--- a/src/examples/pdm/pdm.go
+++ b/src/examples/pdm/pdm.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+)
+
+var (
+	audio = make([]int16, 16)
+	pdm   = machine.PDM{}
+)
+
+func main() {
+	machine.BUTTONA.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
+	err := pdm.Configure(machine.PDMConfig{})
+	if err != nil {
+		panic(fmt.Sprintf("Failed to configure PDM:%v", err))
+	}
+
+	for {
+		if machine.BUTTONA.Get() {
+			println("Recording new audio clip into memory")
+			pdm.Read(&audio[0], uint32(len(audio)))
+			println(fmt.Sprintf("Recorded new audio clip into memory: %v", audio))
+		}
+	}
+}

--- a/src/examples/pdm/pdm.go
+++ b/src/examples/pdm/pdm.go
@@ -12,7 +12,7 @@ var (
 
 func main() {
 	machine.BUTTONA.Configure(machine.PinConfig{Mode: machine.PinInputPulldown})
-	err := pdm.Configure(machine.PDMConfig{})
+	err := pdm.Configure(machine.PDMConfig{CLK: machine.PDM_CLK_PIN, DIN: machine.PDM_DIN_PIN})
 	if err != nil {
 		panic(fmt.Sprintf("Failed to configure PDM:%v", err))
 	}

--- a/src/machine/board_circuitplay_bluefruit.go
+++ b/src/machine/board_circuitplay_bluefruit.go
@@ -74,6 +74,12 @@ const (
 	SPI0_SDI_PIN = P0_23 // SDI
 )
 
+// PDM pins
+const (
+	PDM_CLK_PIN = P0_17 // CLK
+	PDM_DIN_PIN = P0_16 // DIN
+)
+
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Adafruit Circuit Playground Bluefruit"

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -346,67 +346,6 @@ func (i2c *I2C) readByte() (byte, error) {
 	return byte(i2c.Bus.RXD.Get()), nil
 }
 
-// PDM represents a PDM device
-type PDM struct {
-	device        *nrf.PDM_Type
-	defaultBuffer int16
-}
-
-// Configure is intended to set up the PDM interface prior to use.
-func (pdm *PDM) Configure(config PDMConfig) error {
-	PDM_DIN_PIN.Configure(PinConfig{Mode: PinInput})
-	PDM_CLK_PIN.Configure(PinConfig{Mode: PinOutput})
-	pdm.device = nrf.PDM
-	pdm.device.PSEL.DIN.Set(uint32(PDM_DIN_PIN))
-	pdm.device.PSEL.CLK.Set(uint32(PDM_CLK_PIN))
-	pdm.device.PDMCLKCTRL.Set(nrf.PDM_PDMCLKCTRL_FREQ_Default)
-	pdm.device.RATIO.Set(nrf.PDM_RATIO_RATIO_Ratio64)
-	pdm.device.GAINL.Set(nrf.PDM_GAINL_GAINL_DefaultGain)
-	pdm.device.GAINR.Set(nrf.PDM_GAINR_GAINR_DefaultGain)
-	pdm.device.ENABLE.Set(nrf.PDM_ENABLE_ENABLE_Enabled)
-
-	if config.Stereo {
-		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Stereo | nrf.PDM_MODE_EDGE_LeftRising)
-	} else {
-		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Mono | nrf.PDM_MODE_EDGE_LeftRising)
-	}
-
-	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
-	pdm.device.SAMPLE.SetMAXCNT_BUFFSIZE(1)
-	pdm.device.SetTASKS_START(1)
-	return nil
-}
-
-// Read stores a set of samples in the given target buffer. Pointer should
-// represent first element of buffer slice, not the pointer to the slice itself.
-func (pdm *PDM) Read(bufptr *int16, bufsz uint32) (uint32, error) {
-	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(bufptr))))
-	pdm.device.SAMPLE.MAXCNT.Set(bufsz)
-	pdm.device.EVENTS_STARTED.Set(0)
-
-	// Step 1: wait for new sampling to start for target buffer
-	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
-	}
-	pdm.device.EVENTS_END.Set(0)
-
-	// Step 2: swap out buffers for next recording so we don't continue to
-	// write to the target buffer
-	pdm.device.EVENTS_STARTED.Set(0)
-	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
-	pdm.device.SAMPLE.MAXCNT.Set(1)
-
-	// Step 3: wait for original event to end
-	for pdm.device.EVENTS_END.HasBits(nrf.PDM_EVENTS_STOPPED_EVENTS_STOPPED) {
-	}
-
-	// Step 4: wait for default buffer to start recording before proceeding
-	// otherwise we see the contents of target buffer change later
-	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
-	}
-
-	return bufsz, nil
-}
-
 var rngStarted = false
 
 // GetRNG returns 32 bits of non-deterministic random data based on internal thermal noise.

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -346,6 +346,67 @@ func (i2c *I2C) readByte() (byte, error) {
 	return byte(i2c.Bus.RXD.Get()), nil
 }
 
+// PDM represents a PDM device
+type PDM struct {
+	device        *nrf.PDM_Type
+	defaultBuffer int16
+}
+
+// Configure is intended to set up the PDM interface prior to use.
+func (pdm *PDM) Configure(config PDMConfig) error {
+	PDM_DIN_PIN.Configure(PinConfig{Mode: PinInput})
+	PDM_CLK_PIN.Configure(PinConfig{Mode: PinOutput})
+	pdm.device = nrf.PDM
+	pdm.device.PSEL.DIN.Set(uint32(PDM_DIN_PIN))
+	pdm.device.PSEL.CLK.Set(uint32(PDM_CLK_PIN))
+	pdm.device.PDMCLKCTRL.Set(nrf.PDM_PDMCLKCTRL_FREQ_Default)
+	pdm.device.RATIO.Set(nrf.PDM_RATIO_RATIO_Ratio64)
+	pdm.device.GAINL.Set(nrf.PDM_GAINL_GAINL_DefaultGain)
+	pdm.device.GAINR.Set(nrf.PDM_GAINR_GAINR_DefaultGain)
+	pdm.device.ENABLE.Set(nrf.PDM_ENABLE_ENABLE_Enabled)
+
+	if config.Stereo {
+		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Stereo | nrf.PDM_MODE_EDGE_LeftRising)
+	} else {
+		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Mono | nrf.PDM_MODE_EDGE_LeftRising)
+	}
+
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
+	pdm.device.SAMPLE.SetMAXCNT_BUFFSIZE(1)
+	pdm.device.SetTASKS_START(1)
+	return nil
+}
+
+// Read stores a set of samples in the given target buffer. Pointer should
+// represent first element of buffer slice, not the pointer to the slice itself.
+func (pdm *PDM) Read(bufptr *int16, bufsz uint32) (uint32, error) {
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(bufptr))))
+	pdm.device.SAMPLE.MAXCNT.Set(bufsz)
+	pdm.device.EVENTS_STARTED.Set(0)
+
+	// Step 1: wait for new sampling to start for target buffer
+	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
+	}
+	pdm.device.EVENTS_END.Set(0)
+
+	// Step 2: swap out buffers for next recording so we don't continue to
+	// write to the target buffer
+	pdm.device.EVENTS_STARTED.Set(0)
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
+	pdm.device.SAMPLE.MAXCNT.Set(1)
+
+	// Step 3: wait for original event to end
+	for pdm.device.EVENTS_END.HasBits(nrf.PDM_EVENTS_STOPPED_EVENTS_STOPPED) {
+	}
+
+	// Step 4: wait for default buffer to start recording before proceeding
+	// otherwise we see the contents of target buffer change later
+	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
+	}
+
+	return bufsz, nil
+}
+
 var rngStarted = false
 
 // GetRNG returns 32 bits of non-deterministic random data based on internal thermal noise.

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -77,9 +77,9 @@ func (pdm *PDM) Configure(config PDMConfig) error {
 
 // Read stores a set of samples in the given target buffer. Pointer should
 // represent first element of buffer slice, not the pointer to the slice itself.
-func (pdm *PDM) Read(bufptr *int16, bufsz uint32) (uint32, error) {
-	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(bufptr))))
-	pdm.device.SAMPLE.MAXCNT.Set(bufsz)
+func (pdm *PDM) Read(buf []int16) (uint32, error) {
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&buf[0]))))
+	pdm.device.SAMPLE.MAXCNT.Set(uint32(len(buf)))
 	pdm.device.EVENTS_STARTED.Set(0)
 
 	// Step 1: wait for new sampling to start for target buffer
@@ -102,5 +102,5 @@ func (pdm *PDM) Read(bufptr *int16, bufsz uint32) (uint32, error) {
 	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
 	}
 
-	return bufsz, nil
+	return uint32(len(buf)), nil
 }

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -75,8 +75,7 @@ func (pdm *PDM) Configure(config PDMConfig) error {
 	return nil
 }
 
-// Read stores a set of samples in the given target buffer. Pointer should
-// represent first element of buffer slice, not the pointer to the slice itself.
+// Read stores a set of samples in the given target buffer.
 func (pdm *PDM) Read(buf []int16) (uint32, error) {
 	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&buf[0]))))
 	pdm.device.SAMPLE.MAXCNT.Set(uint32(len(buf)))

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -5,6 +5,8 @@ package machine
 
 import (
 	"device/nrf"
+	"errors"
+	"unsafe"
 )
 
 // Get peripheral and pin number for this GPIO pin.
@@ -33,3 +35,72 @@ var (
 	PWM2 = &PWM{PWM: nrf.PWM2}
 	PWM3 = &PWM{PWM: nrf.PWM3}
 )
+
+// PDM represents a PDM device
+type PDM struct {
+	device        *nrf.PDM_Type
+	defaultBuffer int16
+}
+
+// Configure is intended to set up the PDM interface prior to use.
+func (pdm *PDM) Configure(config PDMConfig) error {
+	if config.DIN == 0 {
+		return errors.New("No DIN pin provided in configuration")
+	}
+
+	if config.CLK == 0 {
+		return errors.New("No CLK pin provided in configuration")
+	}
+
+	config.DIN.Configure(PinConfig{Mode: PinInput})
+	config.CLK.Configure(PinConfig{Mode: PinOutput})
+	pdm.device = nrf.PDM
+	pdm.device.PSEL.DIN.Set(uint32(config.DIN))
+	pdm.device.PSEL.CLK.Set(uint32(config.CLK))
+	pdm.device.PDMCLKCTRL.Set(nrf.PDM_PDMCLKCTRL_FREQ_Default)
+	pdm.device.RATIO.Set(nrf.PDM_RATIO_RATIO_Ratio64)
+	pdm.device.GAINL.Set(nrf.PDM_GAINL_GAINL_DefaultGain)
+	pdm.device.GAINR.Set(nrf.PDM_GAINR_GAINR_DefaultGain)
+	pdm.device.ENABLE.Set(nrf.PDM_ENABLE_ENABLE_Enabled)
+
+	if config.Stereo {
+		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Stereo | nrf.PDM_MODE_EDGE_LeftRising)
+	} else {
+		pdm.device.MODE.Set(nrf.PDM_MODE_OPERATION_Mono | nrf.PDM_MODE_EDGE_LeftRising)
+	}
+
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
+	pdm.device.SAMPLE.SetMAXCNT_BUFFSIZE(1)
+	pdm.device.SetTASKS_START(1)
+	return nil
+}
+
+// Read stores a set of samples in the given target buffer. Pointer should
+// represent first element of buffer slice, not the pointer to the slice itself.
+func (pdm *PDM) Read(bufptr *int16, bufsz uint32) (uint32, error) {
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(bufptr))))
+	pdm.device.SAMPLE.MAXCNT.Set(bufsz)
+	pdm.device.EVENTS_STARTED.Set(0)
+
+	// Step 1: wait for new sampling to start for target buffer
+	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
+	}
+	pdm.device.EVENTS_END.Set(0)
+
+	// Step 2: swap out buffers for next recording so we don't continue to
+	// write to the target buffer
+	pdm.device.EVENTS_STARTED.Set(0)
+	pdm.device.SAMPLE.SetPTR(uint32(uintptr(unsafe.Pointer(&pdm.defaultBuffer))))
+	pdm.device.SAMPLE.MAXCNT.Set(1)
+
+	// Step 3: wait for original event to end
+	for pdm.device.EVENTS_END.HasBits(nrf.PDM_EVENTS_STOPPED_EVENTS_STOPPED) {
+	}
+
+	// Step 4: wait for default buffer to start recording before proceeding
+	// otherwise we see the contents of target buffer change later
+	for !pdm.device.EVENTS_STARTED.HasBits(nrf.PDM_EVENTS_STARTED_EVENTS_STARTED) {
+	}
+
+	return bufsz, nil
+}

--- a/src/machine/pdm.go
+++ b/src/machine/pdm.go
@@ -2,4 +2,6 @@ package machine
 
 type PDMConfig struct {
 	Stereo bool
+	DIN    Pin
+	CLK    Pin
 }

--- a/src/machine/pdm.go
+++ b/src/machine/pdm.go
@@ -1,0 +1,5 @@
+package machine
+
+type PDMConfig struct {
+	Stereo bool
+}


### PR DESCRIPTION
This PR attempts to add some basic support for PDM and implements it for the Nordic 52840 based SoCs and the CircuitPlayground-Bluefruit board.  

I could imagine maybe the configuration and API can be filled out a bit more to do things like configure and fetch sample rate.  I'm completely new to tinygo and have only played with microcontrollers here and there as a hobby, so hopefully I haven't done anything too boneheaded.

With the change in this PR, I was able to complete a tinygo version of the [Adafruit VU meter](https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/playground-sound-meter) with my son on the Bluefruit.  I couldn't easily figure out how to write to the "CPLAYBTBOOT" onboard flash filesystem to try storing a WAV file, but I did go so far as to echo out a 1 second integer buffer (per the PR's example code) and save that as a WAV on my laptop and play it back. So I think in general it works.

As a side note, I noticed that there is a "microphone" PDM driver that can run I2S in PDM mode. I think maybe this is a quirk of a specific board, to be able to run I2S in PDM mode?  I wonder if it would make sense later to refactor this as a PDM device and just make the controller-specific implementation leverage its I2S.  It was a bit confusing to me to see this microphone driver documented as a PDM but then need an I2S in order to use it.

Thanks!