### PR TITLE
Use renamed EXTRA_CFLAGS when building wasi-libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ endif
 wasi-libc: lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a
 lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
 	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
-	cd lib/wasi-libc && make -j4 WASM_CFLAGS="-O2 -g -DNDEBUG -mnontrapping-fptoint -msign-ext" MALLOC_IMPL=none CC=$(CLANG) AR=$(LLVM_AR) NM=$(LLVM_NM)
+	cd lib/wasi-libc && make -j4 EXTRA_CFLAGS="-O2 -g -DNDEBUG -mnontrapping-fptoint -msign-ext" MALLOC_IMPL=none CC=$(CLANG) AR=$(LLVM_AR) NM=$(LLVM_NM)
 
 
 # Build the Go compiler.


### PR DESCRIPTION
When looking at logs during `make wasi-libc`, I randomly noticed these flags aren't set because of https://github.com/WebAssembly/wasi-libc/commit/8852e15a343c260d6a7bd4f4cca314cfb38308fd