### PR TITLE
machine/usb: improve buffer size definition

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -66,10 +66,10 @@ var (
 var udd_ep_control_cache_buffer [256]uint8
 
 //go:align 4
-var udd_ep_in_cache_buffer [7][64]uint8
+var udd_ep_in_cache_buffer [usb.NumberOfEndpoints][64]uint8
 
 //go:align 4
-var udd_ep_out_cache_buffer [7][64]uint8
+var udd_ep_out_cache_buffer [usb.NumberOfEndpoints][64]uint8
 
 // usb_trans_buffer max size is 255 since that is max size
 // for a descriptor (bLength is 1 byte), and the biggest use


### PR DESCRIPTION
This PR fixes the following problems

> #3366
> Also, I couldn't get the usb-midi branch to work with samd51 on this branch.

I have confirmed that it works on the nobonobo/add-support-joystick branch to which I have added this change.

* examples/usb-midi
    * samd51 : wioterminal
    * rp2040 : pico
    * nrf52840 : feather-nrf52840-sense

However, I could not confirm that it works with samd21.
It appears that usb-midi is not working on samd21 as of the current dev branch.
This is a separate issue.