### PR TITLE
src/runtime: add xorshift-based fastrand64

### DIFF
--- a/src/runtime/algorithm.go
+++ b/src/runtime/algorithm.go
@@ -26,6 +26,22 @@ func xorshift32(x uint32) uint32 {
 }
 
 // This function is used by hash/maphash.
+func fastrand64() uint64 {
+	xorshift64State = xorshiftMult64(xorshift64State)
+	return xorshift64State
+}
+
+var xorshift64State uint64 = 1
+
+// 64-bit xorshift multiply rng from http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
+func xorshiftMult64(x uint64) uint64 {
+	x ^= x >> 12 // a
+	x ^= x << 25 // b
+	x ^= x >> 27 // c
+	return x * 2685821657736338717
+}
+
+// This function is used by hash/maphash.
 func memhash(p unsafe.Pointer, seed, s uintptr) uintptr {
 	if unsafe.Sizeof(uintptr(0)) > 4 {
 		return uintptr(hash64(p, s, seed))


### PR DESCRIPTION
`hash/maphash` uses `runtime_fastrand64` now.

https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/hash/maphash/maphash.go;l=257