### PR TITLE
fix resource leak in os.(*File).Close

### DIFF
--- a/src/os/dir_darwin.go
+++ b/src/os/dir_darwin.go
@@ -147,7 +147,7 @@ func darwinOpenDir(fd syscallFd) (uintptr, string, error) {
 	return dir, "", nil
 }
 
-// Implemented in syscall/syscall_darwin.go.
+// Implemented in syscall/syscall_libc_darwin_*.go.
 
 //go:linkname closedir syscall.closedir
 func closedir(dir uintptr) (err error)

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -13,6 +13,9 @@ import (
 type dirInfo struct {
 }
 
+func (*dirInfo) close() {
+}
+
 func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
 	return nil, nil, nil, &PathError{Op: "readdir unimplemented", Err: syscall.ENOTDIR}
 }

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -8,43 +8,29 @@ package os
 
 import (
 	"io"
-	"sync"
 	"syscall"
 	"unsafe"
 )
 
 // Auxiliary information if the File describes a directory
 type dirInfo struct {
-	buf  *[]byte // buffer for directory I/O
-	nbuf int     // length of buf; return value from Getdirentries
-	bufp int     // location of next record in buf.
+	nbuf int             // length of buf; return value from Getdirentries
+	bufp int             // location of next record in buf.
+	buf  [blockSize]byte // buffer for directory I/O
 }
 
 const (
 	// More than 5760 to work around https://golang.org/issue/24015.
-	blockSize = 8192
+	blockSize = 8192 - 2*unsafe.Sizeof(int(0))
 )
 
-var dirBufPool = sync.Pool{
-	New: func() interface{} {
-		// The buffer must be at least a block long.
-		buf := make([]byte, blockSize)
-		return &buf
-	},
-}
-
 func (d *dirInfo) close() {
-	if d.buf != nil {
-		dirBufPool.Put(d.buf)
-		d.buf = nil
-	}
 }
 
 func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEntry, infos []FileInfo, err error) {
 	// If this file has no dirinfo, create one.
 	if f.dirinfo == nil {
 		f.dirinfo = new(dirInfo)
-		f.dirinfo.buf = dirBufPool.Get().(*[]byte)
 	}
 	d := f.dirinfo
 
@@ -66,7 +52,7 @@ func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEn
 		if d.bufp >= d.nbuf {
 			d.bufp = 0
 			var errno error
-			d.nbuf, errno = syscall.ReadDirent(syscallFd(f.handle.(unixFileHandle)), *d.buf)
+			d.nbuf, errno = syscall.ReadDirent(syscallFd(f.handle.(unixFileHandle)), d.buf[:])
 			if d.nbuf < 0 {
 				errno = handleSyscallError(errno)
 			}
@@ -79,7 +65,7 @@ func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEn
 		}
 
 		// Drain the buffer
-		buf := (*d.buf)[d.bufp:d.nbuf]
+		buf := d.buf[d.bufp:d.nbuf]
 		reclen, ok := direntReclen(buf)
 		if !ok || reclen > uint64(len(buf)) {
 			break

--- a/src/os/file.go
+++ b/src/os/file.go
@@ -42,11 +42,11 @@ var lstat = Lstat
 func Mkdir(path string, perm FileMode) error {
 	fs, suffix := findMount(path)
 	if fs == nil {
-		return &PathError{"mkdir", path, ErrNotExist}
+		return &PathError{Op: "mkdir", Path: path, Err: ErrNotExist}
 	}
 	err := fs.Mkdir(suffix, perm)
 	if err != nil {
-		return &PathError{"mkdir", path, err}
+		return &PathError{Op: "mkdir", Path: path, Err: err}
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func fixCount(n int, err error) (int, error) {
 func Remove(path string) error {
 	fs, suffix := findMount(path)
 	if fs == nil {
-		return &PathError{"remove", path, ErrNotExist}
+		return &PathError{Op: "remove", Path: path, Err: ErrNotExist}
 	}
 	err := fs.Remove(suffix)
 	if err != nil {
@@ -84,11 +84,11 @@ func (f *File) Name() string {
 func OpenFile(name string, flag int, perm FileMode) (*File, error) {
 	fs, suffix := findMount(name)
 	if fs == nil {
-		return nil, &PathError{"open", name, ErrNotExist}
+		return nil, &PathError{Op: "open", Path: name, Err: ErrNotExist}
 	}
 	handle, err := fs.OpenFile(suffix, flag, perm)
 	if err != nil {
-		return nil, &PathError{"open", name, err}
+		return nil, &PathError{Op: "open", Path: name, Err: err}
 	}
 	return NewFile(handle, name), nil
 }
@@ -106,10 +106,14 @@ func Create(name string) (*File, error) {
 // Read reads up to len(b) bytes from the File. It returns the number of bytes
 // read and any error encountered. At end of file, Read returns 0, io.EOF.
 func (f *File) Read(b []byte) (n int, err error) {
-	n, err = f.handle.Read(b)
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		n, err = f.handle.Read(b)
+	}
 	// TODO: want to always wrap, like upstream, but ReadFile() compares against exactly io.EOF?
 	if err != nil && err != io.EOF {
-		err = &PathError{"read", f.name, err}
+		err = &PathError{Op: "read", Path: f.name, Err: err}
 	}
 	return
 }
@@ -123,13 +127,16 @@ func (f *File) ReadAt(b []byte, offset int64) (n int, err error) {
 	if offset < 0 {
 		return 0, &PathError{Op: "readat", Path: f.name, Err: errNegativeOffset}
 	}
+	if f.handle == nil {
+		return 0, &PathError{Op: "readat", Path: f.name, Err: ErrClosed}
+	}
 
 	for len(b) > 0 {
 		m, e := f.handle.ReadAt(b, offset)
 		if e != nil {
 			// TODO: want to always wrap, like upstream, but TestReadAtEOF compares against exactly io.EOF?
 			if e != io.EOF {
-				err = &PathError{"readat", f.name, e}
+				err = &PathError{Op: "readat", Path: f.name, Err: e}
 			} else {
 				err = e
 			}
@@ -146,9 +153,13 @@ func (f *File) ReadAt(b []byte, offset int64) (n int, err error) {
 // Write writes len(b) bytes to the File. It returns the number of bytes written
 // and an error, if any. Write returns a non-nil error when n != len(b).
 func (f *File) Write(b []byte) (n int, err error) {
-	n, err = f.handle.Write(b)
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		n, err = f.handle.Write(b)
+	}
 	if err != nil {
-		err = &PathError{"write", f.name, err}
+		err = &PathError{Op: "write", Path: f.name, Err: err}
 	}
 	return
 }
@@ -160,14 +171,33 @@ func (f *File) WriteString(s string) (n int, err error) {
 }
 
 func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
-	return 0, ErrNotImplemented
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		err = ErrNotImplemented
+	}
+	err = &PathError{Op: "writeat", Path: f.name, Err: err}
+	return
 }
 
 // Close closes the File, rendering it unusable for I/O.
 func (f *File) Close() (err error) {
-	err = f.handle.Close()
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		// Some platforms manage extra state other than the system handle which
+		// needs to be released when the file is closed. For example, darwin
+		// files have a DIR object holding a dup of the file descriptor.
+		//
+		// These platform-specific logic is provided by the (*file).close method
+		// which is why we do not call the handle's Close method directly.
+		err = f.file.close()
+		if err == nil {
+			f.handle = nil
+		}
+	}
 	if err != nil {
-		err = &PathError{"close", f.name, err}
+		err = &PathError{Op: "close", Path: f.name, Err: err}
 	}
 	return
 }
@@ -182,11 +212,24 @@ func (f *File) Close() (err error) {
 // system; you can seek to the beginning of the directory on Unix-like
 // operating systems, but not on Windows.
 func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
-	return f.handle.Seek(offset, whence)
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		ret, err = f.handle.Seek(offset, whence)
+	}
+	if err != nil {
+		err = &PathError{Op: "seek", Path: f.name, Err: err}
+	}
+	return
 }
 
-func (f *File) SyscallConn() (syscall.RawConn, error) {
-	return nil, ErrNotImplemented
+func (f *File) SyscallConn() (conn syscall.RawConn, err error) {
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		err = ErrNotImplemented
+	}
+	return
 }
 
 // fd is an internal interface that is used to try a type assertion in order to
@@ -201,12 +244,17 @@ func (f *File) Fd() uintptr {
 	if ok {
 		return handle.Fd()
 	}
-	return 0
+	return ^uintptr(0)
 }
 
 // Truncate is a stub, not yet implemented
-func (f *File) Truncate(size int64) error {
-	return &PathError{"truncate", f.name, ErrNotImplemented}
+func (f *File) Truncate(size int64) (err error) {
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		err = ErrNotImplemented
+	}
+	return &PathError{Op: "truncate", Path: f.name, Err: err}
 }
 
 // LinkError records an error during a link or symlink or rename system call and

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -33,6 +33,10 @@ type file struct {
 	name   string
 }
 
+func (f *file) close() error {
+	return f.handle.Close()
+}
+
 func NewFile(fd uintptr, name string) *File {
 	return &File{&file{stdioFileHandle(fd), name}}
 }

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -42,6 +42,14 @@ type file struct {
 	dirinfo *dirInfo // nil unless directory being read
 }
 
+func (f *file) close() (err error) {
+	if f.dirinfo != nil {
+		f.dirinfo.close()
+		f.dirinfo = nil
+	}
+	return f.handle.Close()
+}
+
 func NewFile(fd uintptr, name string) *File {
 	return &File{&file{unixFileHandle(fd), name, nil}}
 }

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -39,6 +39,10 @@ type file struct {
 	name   string
 }
 
+func (f *file) close() error {
+	return f.handle.Close()
+}
+
 func NewFile(fd uintptr, name string) *File {
 	return &File{&file{unixFileHandle(fd), name}}
 }

--- a/src/syscall/syscall_libc_darwin.go
+++ b/src/syscall/syscall_libc_darwin.go
@@ -263,6 +263,14 @@ func Pipe2(fds []int, flags int) (err error) {
 	return
 }
 
+func closedir(dir uintptr) (err error) {
+	e := libc_closedir(unsafe.Pointer(dir))
+	if e != 0 {
+		err = getErrno()
+	}
+	return
+}
+
 func readdir_r(dir uintptr, entry *Dirent, result **Dirent) (err error) {
 	e1 := libc_readdir_r(unsafe.Pointer(dir), unsafe.Pointer(entry), unsafe.Pointer(result))
 	if e1 != 0 {

--- a/src/syscall/syscall_libc_darwin_amd64.go
+++ b/src/syscall/syscall_libc_darwin_amd64.go
@@ -17,6 +17,11 @@ import (
 //export fdopendir$INODE64
 func libc_fdopendir(fd int32) unsafe.Pointer
 
+// int closedir(struct DIR * buf);
+//
+//export closedir
+func libc_closedir(unsafe.Pointer) int32
+
 // int readdir_r(struct DIR * buf, struct dirent *entry, struct dirent **result);
 //
 //export readdir_r$INODE64

--- a/src/syscall/syscall_libc_darwin_arm64.go
+++ b/src/syscall/syscall_libc_darwin_arm64.go
@@ -11,6 +11,11 @@ import (
 //export fdopendir
 func libc_fdopendir(fd int32) unsafe.Pointer
 
+// int closedir(struct DIR * buf);
+//
+//export closedir
+func libc_closedir(unsafe.Pointer) int32
+
 // int readdir_r(struct DIR * buf, struct dirent *entry, struct dirent **result);
 //
 //export readdir_r


### PR DESCRIPTION
Hello!

I am opening this PR to modify the `os.File` implementation to do two things:
- handle platform-specific logic on `Close`, allowing the release of resources that may be held by the file
- set the internal file handle to `nil` on `Close` and return `ErrClosed` afterwards if a file keeps being used

I am making this change to address the following issues:
- on Darwin, the `dirInfo` type references memory allocated by the C library, as well as a copy of the file descriptor created by `dup`. Because the object wasn't close, both the memory and file descriptor were being leaked.

- on Linux, the `dirInfo` type holds a buffer claimed from an internal pool. While I don't have evidence that this pooling is effective, the buffers were never released, resulting in no buffer pooling at all.
- Because the file handle was not released on close, multiple calls to `os.(*File).Close` could result in closing file descriptors that are reused, likely leading to bugs that would be really difficult to track down.

I am tempted to suggest that we should remove the buffer pooling entirely on Linux, since it was never effective, it seems like unnecessary complexity that has never provided any benefits, and the fix here could introduce new behaviors that may not be desirable (e.g. sync.Pool seems to never release memory in tinygo). Let me know what you think and I can make the change.

I also made a change to have `os.(*File).Fd` return `^uintptr(0)` after close, which matches the behavior of Go and seems better than the historical behavior of returning 0, which could be mistaken for stdin.

I have yet to test the code because I am running into what looks like linking issues against libc (see https://github.com/tinygo-org/tinygo/issues/3057#issuecomment-1374497605).

I do not have a great sense of how to validate that the underlying `dirInfo` value is closed on unix platforms, the compiler does ensure that the `close` method exists because it is called, but that doesn't protect against regressions. Happy to get guidance on this front.

Let me know if you'd like to see anything changed!