### PR TITLE
document the origin of src/os/file.go and reason why the os.lstat variable exists

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -2,6 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This file was originally copied from Go, see:
+// https://github.com/golang/go/blob/master/src/os/file.go
+//
+// Some of the code inherited from Go is not used anymore in Tinygo, but we keep
+// changes to a minimum to help simplify bringing changes (e.g. the lstat global
+// is not used here anymore, but we might need it if we add tests from Go in
+// this package).
+
 // Package os implements a subset of the Go "os" package. See
 // https://godoc.org/os for details.
 //


### PR DESCRIPTION
Hello!

While working on https://github.com/tinygo-org/tinygo/pull/3370, I noticed that there was an unused global variable in the `os` package. This PR removes it.

The comment claimed that the variable was used in test, but I could not find any reference to it in tests. I believe we can safely remove it and replace references to this variable with direct calls to `Lstat` instead.
