### PR TITLE
machine/usb: change to not send before endpoint initialization

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -10,7 +10,8 @@ import (
 )
 
 type USBDevice struct {
-	initcomplete bool
+	initcomplete         bool
+	InitEndpointComplete bool
 }
 
 var (
@@ -215,6 +216,7 @@ func handleStandardSetup(setup usb.Setup) bool {
 			}
 
 			usbConfiguration = setup.WValueL
+			USBDev.InitEndpointComplete = true
 
 			SendZlp()
 			return true

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -2,6 +2,7 @@ package keyboard
 
 import (
 	"errors"
+	"machine"
 	"machine/usb/hid"
 )
 
@@ -91,11 +92,13 @@ func (kb *keyboard) Handler() bool {
 }
 
 func (kb *keyboard) tx(b []byte) {
-	if kb.waitTxc {
-		kb.buf.Put(b)
-	} else {
-		kb.waitTxc = true
-		hid.SendUSBPacket(b)
+	if machine.USBDev.InitEndpointComplete {
+		if kb.waitTxc {
+			kb.buf.Put(b)
+		} else {
+			kb.waitTxc = true
+			hid.SendUSBPacket(b)
+		}
 	}
 }
 

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -1,6 +1,7 @@
 package mouse
 
 import (
+	"machine"
 	"machine/usb/hid"
 )
 
@@ -55,11 +56,13 @@ func (m *mouse) Handler() bool {
 }
 
 func (m *mouse) tx(b []byte) {
-	if m.waitTxc {
-		m.buf.Put(b)
-	} else {
-		m.waitTxc = true
-		hid.SendUSBPacket(b)
+	if machine.USBDev.InitEndpointComplete {
+		if m.waitTxc {
+			m.buf.Put(b)
+		} else {
+			m.waitTxc = true
+			hid.SendUSBPacket(b)
+		}
 	}
 }
 

--- a/src/machine/usb/joystick/joystick.go
+++ b/src/machine/usb/joystick/joystick.go
@@ -76,11 +76,13 @@ func (m *Joystick) rxHandler(b []byte) {
 }
 
 func (m *Joystick) tx(b []byte) {
-	if m.waitTxc {
-		m.buf.Put(b)
-	} else {
-		m.waitTxc = true
-		m.sendUSBPacket(b)
+	if machine.USBDev.InitEndpointComplete {
+		if m.waitTxc {
+			m.buf.Put(b)
+		} else {
+			m.waitTxc = true
+			m.sendUSBPacket(b)
+		}
 	}
 }
 

--- a/src/machine/usb/midi/midi.go
+++ b/src/machine/usb/midi/midi.go
@@ -71,11 +71,13 @@ func (m *midi) Handler() {
 }
 
 func (m *midi) tx(b []byte) {
-	if m.waitTxc {
-		m.buf.Put(b)
-	} else {
-		m.waitTxc = true
-		m.sendUSBPacket(b)
+	if machine.USBDev.InitEndpointComplete {
+		if m.waitTxc {
+			m.buf.Put(b)
+		} else {
+			m.waitTxc = true
+			m.sendUSBPacket(b)
+		}
 	}
 }
 


### PR DESCRIPTION
Until now, the problem was caused by trying to send before the endpoint was initialized.
This PR will add code to check if endpoint initialization is complete and resolve the issue.

* issues
  * https://github.com/tinygo-org/tinygo/pull/3367#issuecomment-1374365943
  * https://twitter.com/sago35tk/status/1611911029059117057?s=20&t=EbY5u85_AdCGRyooF5CHiQ

USBCDC monitored linestate and had no problems.

https://github.com/tinygo-org/tinygo/blob/b5ad81c884981f42c1ac491cc1d195aea886ddbe/src/machine/usb/cdc/usbcdc.go#L100-L108