### PR TITLE
cgo: add support for bitwise operators

### DIFF
--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -37,6 +37,10 @@ func TestParseConst(t *testing.T) {
 		{`5*5`, `5 * 5`},
 		{`5/5`, `5 / 5`},
 		{`5%5`, `5 % 5`},
+		{`5&5`, `5 & 5`},
+		{`5|5`, `5 | 5`},
+		{`5^5`, `5 ^ 5`},
+		{`5||5`, `error: 1:2: unexpected token ||, expected end of expression`}, // logical binops aren't supported yet
 		{`(5/5)`, `(5 / 5)`},
 		{`1 - 2`, `1 - 2`},
 		{`1 - 2 + 3`, `1 - 2 + 3`},


### PR DESCRIPTION
This is a partial fix for https://github.com/tinygo-org/tinygo/issues/3369.