### PR TITLE
os: add a stub for os.Chtimes

### DIFF
--- a/src/os/file_posix.go
+++ b/src/os/file_posix.go
@@ -1,0 +1,10 @@
+package os
+
+import (
+	"time"
+)
+
+// Chtimes is a stub, not yet implemented
+func Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return ErrNotImplemented
+}


### PR DESCRIPTION
`Chtimes not declared by package os` Chtimes is not yet implemented 