### PR TITLE
testing: run cleanups after exiting a benchmark run

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -159,6 +159,7 @@ func (b *B) ReportAllocs() {
 
 // runN runs a single benchmark for the specified number of iterations.
 func (b *B) runN(n int) {
+	b.runCleanup() // start fresh in the next iteration
 	b.N = n
 	runtime.GC()
 	b.ResetTimer()
@@ -457,6 +458,7 @@ func (b *B) Run(name string, f func(b *B)) bool {
 		// Only process sub-benchmarks, if any.
 		sub.hasSub = true
 	}
+	defer sub.runCleanup() // make sure all cleanups are run, even when panicking
 	if sub.run1() {
 		sub.run()
 	}


### PR DESCRIPTION
This is important, otherwise temporary directories don't get removed and `tinygo test testing` fails with a "ran out of space" error (which actually just means all the inodes are used up).

Issue found while working on Go 1.20 support. I don't know why this wasn't an issue before, but with Go 1.20 it is so let's fix it. It could also be that my system has an unusually low inode count in /tmp for some reason.