### PR TITLE
Initial Go 1.20 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,13 @@ jobs:
       - test-linux:
           llvm: "14"
     resource_class: large
+  test-llvm15-go120:
+    docker:
+      - image: golang:1.20-rc-buster
+    steps:
+      - test-linux:
+          llvm: "15"
+    resource_class: large
 
 workflows:
   test-all:
@@ -112,3 +119,4 @@ workflows:
       # This tests our lowest supported versions of Go and LLVM, to make sure at
       # least the smoke tests still pass.
       - test-llvm14-go118
+      - test-llvm15-go120

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,6 @@ TEST_PACKAGES_FAST = \
 	container/list \
 	container/ring \
 	crypto/des \
-	crypto/internal/subtle \
 	crypto/md5 \
 	crypto/rc4 \
 	crypto/sha1 \

--- a/builder/config.go
+++ b/builder/config.go
@@ -33,8 +33,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
-	if major != 1 || minor < 18 || minor > 19 {
-		return nil, fmt.Errorf("requires go version 1.18 through 1.19, got go%d.%d", major, minor)
+	if major != 1 || minor < 18 || minor > 20 {
+		return nil, fmt.Errorf("requires go version 1.18 through 1.20, got go%d.%d", major, minor)
 	}
 
 	clangHeaderPath := getClangHeaderPath(goenv.Get("TINYGOROOT"))

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -8,9 +8,9 @@
 // Type checking errors after CGo processing:
 //     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as C.char value in variable declaration (overflows)
 //     testdata/errors.go:105: unknown field z in struct literal
-//     testdata/errors.go:108: undeclared name: C.SOME_CONST_1
+//     testdata/errors.go:108: undefined: C.SOME_CONST_1
 //     testdata/errors.go:110: cannot use C.SOME_CONST_3 (untyped int constant 1234) as byte value in variable declaration (overflows)
-//     testdata/errors.go:112: undeclared name: C.SOME_CONST_4
+//     testdata/errors.go:112: undefined: C.SOME_CONST_4
 
 package main
 

--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -89,10 +89,11 @@ func (b *builder) createSliceToArrayPointerCheck(sliceLen llvm.Value, arrayLen i
 	b.createRuntimeAssert(isLess, "slicetoarray", "sliceToArrayPointerPanic")
 }
 
-// createUnsafeSliceCheck inserts a runtime check used for unsafe.Slice. This
-// function must panic if the ptr/len parameters are invalid.
-func (b *builder) createUnsafeSliceCheck(ptr, len llvm.Value, elementType llvm.Type, lenType *types.Basic) {
-	// From the documentation of unsafe.Slice:
+// createUnsafeSliceStringCheck inserts a runtime check used for unsafe.Slice
+// and unsafe.String. This function must panic if the ptr/len parameters are
+// invalid.
+func (b *builder) createUnsafeSliceStringCheck(name string, ptr, len llvm.Value, elementType llvm.Type, lenType *types.Basic) {
+	// From the documentation of unsafe.Slice and unsafe.String:
 	//   > At run time, if len is negative, or if ptr is nil and len is not
 	//   > zero, a run-time panic occurs.
 	// However, in practice, it is also necessary to check that the length is
@@ -117,7 +118,7 @@ func (b *builder) createUnsafeSliceCheck(ptr, len llvm.Value, elementType llvm.T
 	lenIsNotZero := b.CreateICmp(llvm.IntNE, len, zero, "")
 	assert := b.CreateAnd(ptrIsNil, lenIsNotZero, "")
 	assert = b.CreateOr(assert, lenOutOfBounds, "")
-	b.createRuntimeAssert(assert, "unsafe.Slice", "unsafeSlicePanic")
+	b.createRuntimeAssert(assert, name, "unsafeSlicePanic")
 }
 
 // createChanBoundsCheck creates a bounds check before creating a new channel to

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/goenv"
 	"github.com/tinygo-org/tinygo/loader"
 	"tinygo.org/x/go-llvm"
 )
@@ -27,6 +28,12 @@ type testCase struct {
 func TestCompiler(t *testing.T) {
 	t.Parallel()
 
+	// Determine Go minor version (e.g. 16 in go1.16.3).
+	_, goMinor, err := goenv.GetGorootVersion(goenv.Get("GOROOT"))
+	if err != nil {
+		t.Fatal("could not read Go version:", err)
+	}
+
 	// Determine which tests to run, depending on the Go and LLVM versions.
 	tests := []testCase{
 		{"basic.go", "", ""},
@@ -42,6 +49,9 @@ func TestCompiler(t *testing.T) {
 		{"goroutine.go", "cortex-m-qemu", "tasks"},
 		{"channel.go", "", ""},
 		{"gc.go", "", ""},
+	}
+	if goMinor >= 20 {
+		tests = append(tests, testCase{"go1.20.go", "", ""})
 	}
 
 	for _, tc := range tests {

--- a/compiler/testdata/go1.20.go
+++ b/compiler/testdata/go1.20.go
@@ -1,0 +1,15 @@
+package main
+
+import "unsafe"
+
+func unsafeSliceData(s []int) *int {
+	return unsafe.SliceData(s)
+}
+
+func unsafeString(ptr *byte, len int16) string {
+	return unsafe.String(ptr, len)
+}
+
+func unsafeStringData(s string) *byte {
+	return unsafe.StringData(s)
+}

--- a/compiler/testdata/go1.20.ll
+++ b/compiler/testdata/go1.20.ll
@@ -1,0 +1,58 @@
+; ModuleID = 'go1.20.go'
+source_filename = "go1.20.go"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-wasi"
+
+%runtime._string = type { ptr, i32 }
+
+declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
+
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr) #0
+
+; Function Attrs: nounwind
+define hidden void @main.init(ptr %context) unnamed_addr #1 {
+entry:
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden ptr @main.unsafeSliceData(ptr %s.data, i32 %s.len, i32 %s.cap, ptr %context) unnamed_addr #1 {
+entry:
+  call void @runtime.trackPointer(ptr %s.data, ptr undef) #2
+  ret ptr %s.data
+}
+
+; Function Attrs: nounwind
+define hidden %runtime._string @main.unsafeString(ptr dereferenceable_or_null(1) %ptr, i16 %len, ptr %context) unnamed_addr #1 {
+entry:
+  %0 = icmp slt i16 %len, 0
+  %1 = icmp eq ptr %ptr, null
+  %2 = icmp ne i16 %len, 0
+  %3 = and i1 %1, %2
+  %4 = or i1 %3, %0
+  br i1 %4, label %unsafe.String.throw, label %unsafe.String.next
+
+unsafe.String.next:                               ; preds = %entry
+  %5 = zext i16 %len to i32
+  %6 = insertvalue %runtime._string undef, ptr %ptr, 0
+  %7 = insertvalue %runtime._string %6, i32 %5, 1
+  call void @runtime.trackPointer(ptr %ptr, ptr undef) #2
+  ret %runtime._string %7
+
+unsafe.String.throw:                              ; preds = %entry
+  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  unreachable
+}
+
+declare void @runtime.unsafeSlicePanic(ptr) #0
+
+; Function Attrs: nounwind
+define hidden ptr @main.unsafeStringData(ptr %s.data, i32 %s.len, ptr %context) unnamed_addr #1 {
+entry:
+  call void @runtime.trackPointer(ptr %s.data, ptr undef) #2
+  ret ptr %s.data
+}
+
+attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind }

--- a/src/runtime/algorithm.go
+++ b/src/runtime/algorithm.go
@@ -7,6 +7,14 @@ import (
 	"unsafe"
 )
 
+// This function is needed by math/rand since Go 1.20.
+// See: https://github.com/golang/go/issues/54880
+//
+//go:linkname rand_fastrand64 math/rand.fastrand64
+func rand_fastrand64() uint64 {
+	return fastrand64()
+}
+
 // This function is used by hash/maphash.
 func fastrand() uint32 {
 	xorshift32State = xorshift32(xorshift32State)

--- a/src/runtime/env_unix.go
+++ b/src/runtime/env_unix.go
@@ -1,28 +1,40 @@
-//go:build linux
+//go:build linux || darwin
 
 package runtime
 
 // Update the C environment if cgo is loaded.
-// Called from syscall.Setenv.
+// Called from Go 1.20 and above.
 //
-//go:linkname syscall_setenv_c syscall.setenv_c
-func syscall_setenv_c(key string, val string) {
+//go:linkname syscallSetenv syscall.runtimeSetenv
+func syscallSetenv(key, value string) {
 	keydata := cstring(key)
-	valdata := cstring(val)
+	valdata := cstring(value)
 	// ignore any errors
 	libc_setenv(&keydata[0], &valdata[0], 1)
-	return
 }
 
 // Update the C environment if cgo is loaded.
-// Called from syscall.Unsetenv.
+// Called from Go 1.20 and above.
 //
-//go:linkname syscall_unsetenv_c syscall.unsetenv_c
-func syscall_unsetenv_c(key string) {
+//go:linkname syscallUnsetenv syscall.runtimeUnsetenv
+func syscallUnsetenv(key string) {
 	keydata := cstring(key)
 	// ignore any errors
 	libc_unsetenv(&keydata[0])
-	return
+}
+
+// Compatibility with Go 1.19 and below.
+//
+//go:linkname syscall_setenv_c syscall.setenv_c
+func syscall_setenv_c(key string, val string) {
+	syscallSetenv(key, val)
+}
+
+// Compatibility with Go 1.19 and below.
+//
+//go:linkname syscall_unsetenv_c syscall.unsetenv_c
+func syscall_unsetenv_c(key string) {
+	syscallUnsetenv(key)
 }
 
 // cstring converts a Go string to a C string.

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -143,10 +143,11 @@ func sliceToArrayPointerPanic() {
 	runtimePanic("slice smaller than array")
 }
 
-// Panic when calling unsafe.Slice() (Go 1.17+) with a len that's too large
-// (which includes if the ptr is nil and len is nonzero).
+// Panic when calling unsafe.Slice() (Go 1.17+) or unsafe.String() (Go 1.20+)
+// with a len that's too large (which includes if the ptr is nil and len is
+// nonzero).
 func unsafeSlicePanic() {
-	runtimePanic("unsafe.Slice: len out of range")
+	runtimePanic("unsafe.Slice/String: len out of range")
 }
 
 // Panic when trying to create a new channel that is too big.

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -95,3 +95,9 @@ func KeepAlive(x interface{}) {
 func SetFinalizer(obj interface{}, finalizer interface{}) {
 	// Unimplemented.
 }
+
+//go:linkname godebug_setUpdate internal/godebug.setUpdate
+func godebug_setUpdate(update func(string, string)) {
+	// Unimplemented. The 'update' function needs to be called whenever the
+	// GODEBUG environment variable changes (for example, via os.Setenv).
+}

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -197,21 +197,12 @@ func Setenv(key, val string) (err error) {
 			return EINVAL
 		}
 	}
-	keydata := cstring(key)
-	valdata := cstring(val)
-	errCode := libc_setenv(&keydata[0], &valdata[0], 1)
-	if errCode != 0 {
-		err = getErrno()
-	}
+	runtimeSetenv(key, val)
 	return
 }
 
 func Unsetenv(key string) (err error) {
-	keydata := cstring(key)
-	errCode := libc_unsetenv(&keydata[0])
-	if errCode != 0 {
-		err = getErrno()
-	}
+	runtimeUnsetenv(key)
 	return
 }
 
@@ -312,6 +303,10 @@ func splitSlice(p []byte) (buf *byte, len uintptr) {
 	return slice.buf, slice.len
 }
 
+// These two functions are provided by the runtime.
+func runtimeSetenv(key, value string)
+func runtimeUnsetenv(key string)
+
 //export strlen
 func libc_strlen(ptr unsafe.Pointer) uintptr
 
@@ -324,16 +319,6 @@ func libc_write(fd int32, buf *byte, count uint) int
 //
 //export getenv
 func libc_getenv(name *byte) *byte
-
-// int setenv(const char *name, const char *val, int replace);
-//
-//export setenv
-func libc_setenv(name *byte, val *byte, replace int32) int32
-
-// int unsetenv(const char *name);
-//
-//export unsetenv
-func libc_unsetenv(name *byte) int32
 
 // ssize_t read(int fd, void *buf, size_t count);
 //

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -24,7 +24,7 @@ func main() {
 	syscall.Getppid()
 
 	// package math/rand
-	fmt.Println("pseudorandom number:", rand.Int31())
+	fmt.Println("pseudorandom number:", rand.New(rand.NewSource(1)).Int31())
 
 	// package strings
 	fmt.Println("strings.IndexByte:", strings.IndexByte("asdf", 'd'))


### PR DESCRIPTION
Not all features are supported yet and some tests still fail, but most code should compile with these patches.
We can work on full support with this merged, to get it in shape for Go 1.20 when it is released.