### PR TITLE
all: remove remaining +build lines

### DIFF
--- a/builder/cc1as.cpp
+++ b/builder/cc1as.cpp
@@ -1,4 +1,4 @@
-// +build byollvm
+//go:build byollvm
 
 //===-- cc1as.cpp - Clang Assembler  --------------------------------------===//
 //

--- a/builder/clang.cpp
+++ b/builder/clang.cpp
@@ -1,4 +1,4 @@
-// +build byollvm
+//go:build byollvm
 
 #include <clang/Basic/DiagnosticOptions.h>
 #include <clang/CodeGen/CodeGenAction.h>

--- a/builder/lld.cpp
+++ b/builder/lld.cpp
@@ -1,4 +1,4 @@
-// +build byollvm
+//go:build byollvm
 
 // This file provides C wrappers for liblld.
 

--- a/src/machine/machine_esp32c3_spi.go
+++ b/src/machine/machine_esp32c3_spi.go
@@ -1,5 +1,4 @@
 //go:build esp32c3
-// +build esp32c3
 
 package machine
 


### PR DESCRIPTION
The C++ files weren't updated automatically using `go fmt`, and I guess the one in machine_esp32c3_spi.go was merged after all the others were updated.