### PR TITLE
Allows the emulator to expand {tmpDir}

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -544,6 +544,8 @@ func (c *Config) Emulator(format, binary string) ([]string, error) {
 	var emulator []string
 	for _, s := range parts {
 		s = strings.ReplaceAll(s, "{root}", goenv.Get("TINYGOROOT"))
+		// Allow replacement of what's usually /tmp except notably Windows.
+		s = strings.ReplaceAll(s, "{tmpDir}", os.TempDir())
 		s = strings.ReplaceAll(s, "{"+format+"}", binary)
 		emulator = append(emulator, s)
 	}

--- a/main.go
+++ b/main.go
@@ -293,17 +293,6 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 				args = append(args, "--dir="+d)
 			}
 
-			// Some tests create temp directories using os.MkdirTemp or via
-			// t.TempDir(). Create a writeable directory and map it to the
-			// default tempDir environment variable: TMPDIR.
-			tmpdir, err := os.MkdirTemp("", "tinygotmp")
-			if err != nil {
-				return fmt.Errorf("failed to create temporary directory: %w", err)
-			}
-			args = append(args, "--dir="+tmpdir, "--env=TMPDIR="+tmpdir)
-			// TODO: add option to not delete temp dir for debugging?
-			defer os.RemoveAll(tmpdir)
-
 			// The below re-organizes the arguments so that the current
 			// directory is added last.
 			args = append(args, cmd.Args[1:]...)

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -21,6 +21,6 @@
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator":      "wasmtime {}",
+	"emulator":      "wasmtime --mapdir=/tmp::{tmpDir} {}",
 	"wasm-abi":      "generic"
 }


### PR DESCRIPTION
This allows you to expand {tmpDir} in the json "emulator" field, and uses it in wasmtime instead of custom TMPDIR mapping logic.

Before, we had custom logic for wasmtime to create a separate tmpDir when running go tests. This overwrite the TMPDIR variable when running, after making a mount point. A simpler way to accomplish the end goal of writing temp files is to use wasmtime's map-dir instead. When code is compiled to wasm with the wasi target, tempDir is always /tmp, so we don't need to add variables (since we know what it is). Further, the test code is the same between normal go and run through wasmtime. So, we don't need to make a separate temp dir first, and avoiding that reduces logic, as well makes it easier to swap out the emulator (for wazero which has no depedencies). To map the correct directory, this introduces a {tmpDir} token whose value is the host-specific value taken from `os.TempDir()`.

The motivation I have for this isn't so much to clean up the wasmtime code, but allow wazero to execute the same tests. After this change, the only thing needed to pass tests is to change the emulator, due to differences in how wazero deals with relative lookups (they aren't restricted by default, so there's not a huge amount of custom logic needed).

In other words, installing wazero from main, `make tinygo-test-wasi` works with no other changes except this PR and patching `targets/wasi.json`.
```json
	"emulator":      "wazero run -mount=.:/ -mount={tmpDir}:/tmp {}",
```

On that note, if there's a way to override the emulator via arg or env, this would be even better, but in any case patching json is fine.