### PR TITLE
add a new target: zkvm

### DIFF
--- a/src/runtime/runtime_zkvm.go
+++ b/src/runtime/runtime_zkvm.go
@@ -1,0 +1,67 @@
+//go:build tinygo.zkvm
+// +build tinygo.zkvm
+
+package runtime
+
+import (
+	"device/riscv"
+)
+
+type timeUnit int64
+
+var timestamp timeUnit
+
+const GOARCH = "zkvm"
+const TargetBits = 32
+
+//export main
+func main() {
+	run()
+	exit(0)
+}
+
+// Align on word boundary.
+func align(ptr uintptr) uintptr {
+	return (ptr + 3) &^ 3
+}
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	return int64(ticks)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	return timeUnit(ns)
+}
+
+func sleepTicks(d timeUnit) {
+	// TODO
+	timestamp += d
+}
+
+func ticks() timeUnit {
+	return timestamp
+}
+
+func putchar(c byte) {
+	// TODO
+	return
+}
+
+func getchar() byte {
+	// TODO
+	return 0
+}
+
+func buffered() int {
+	// TODO
+	return 0
+}
+
+func abort() {
+	exit(1)
+}
+
+func exit(code int) {
+	riscv.Asm("li t0, 0")
+	riscv.Asm("ecall")
+}

--- a/targets/riscv32im-risc0-zkvm-elf.ld
+++ b/targets/riscv32im-risc0-zkvm-elf.ld
@@ -1,0 +1,82 @@
+/*
+  Copyright 2022 Risc0, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+EXTERN(__start)
+
+/* Must match risc0/zkvm/platform/src/memory.rs */
+MEMORY {
+  stack        : ORIGIN = 0x00000000, LENGTH =  16M
+  data    (RW) : ORIGIN = 0x01000000, LENGTH =  16M
+  heap         : ORIGIN = 0x02000000, LENGTH =  32M
+  input        : ORIGIN = 0x04000000, LENGTH =  32M
+  prog    (X)  : ORIGIN = 0x06000000, LENGTH =  32M
+}
+
+SECTIONS {
+  .text : {
+    *(.text._start)
+    *(.text.__start)
+    *(.text*)
+    *(.rodata*)
+    *(.srodata*)
+  } >prog
+
+  .data : {
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    __global_pointer$ = . + 0x800;
+    *(.sdata .sdata.* .sdata2.*)
+    *(.gnu.linkonce.s.*)
+  } >data
+
+  . = ALIGN(4);
+
+  .bss (NOLOAD) :  {
+    __bss_begin = .;
+    *(.sbss*)
+    *(.gnu.linkonce.sb.*)
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __result = .;
+    /* Result is 9 words * 4 = 36 bytes, 8 words for output, and 1 word for output size*/
+    __bss_end = . + 36;
+  } >data
+
+  __bss_size = __bss_end - __bss_begin;
+
+  __heap_start = ORIGIN(heap);
+  __heap_end = __heap_start + LENGTH(heap);
+  __heap_size = LENGTH(heap);
+
+  __stack_init$ = ORIGIN(stack) + LENGTH(stack) - 4;
+
+  /* for tinygo's mm */
+  _heap_start = __heap_start;
+  _heap_end = __heap_end;
+  _stack_top = __stack_init$;
+
+  /DISCARD/ : {
+    *(.rel*)
+    *(.comment)
+    *(.eh_frame)
+    *(.riscv.attributes)
+  }
+}

--- a/targets/zkvm.json
+++ b/targets/zkvm.json
@@ -1,0 +1,17 @@
+{
+    "inherits": ["riscv"],
+	"llvm-target": "riscv32",
+    "scheduler": "none",
+	"build-tags": ["tinygo.zkvm"],
+    "cflags": [
+        "-march=rv32im",
+        "-mabi=ilp32"
+    ],
+    "ldflags": [
+        "-melf32lriscv"
+    ],
+    "gc": "leaking",
+    "features": "+m",
+    "linkerscript": "targets/riscv32im-risc0-zkvm-elf.ld",
+	"gdb": ["gdb-multiarch"]
+}


### PR DESCRIPTION
This is a first attempt to add the zkvm as a new target. At this point, all files in testdata compile except for those involving goroutines and channels. Some tests can run on r0vm but most fail. The failures require further investigation and it's possible that this code being added contains mistakes...