### PR TITLE
example: adjust time offset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/test
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/time-offset
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=wioterminal         examples/hid-mouse
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=wioterminal         examples/hid-keyboard

--- a/src/examples/time-offset/time-offset.go
+++ b/src/examples/time-offset/time-offset.go
@@ -1,0 +1,32 @@
+package main
+
+// This example demonstrates how to set the system time.
+//
+// Usually, boards don't keep time on power cycles and restarts, it resets to Unix epoch.
+// The system time can be set by calling runtime.AdjustTimeOffset().
+//
+// Possible time sources: an external RTC clock or network (WiFi access point or NTP server)
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+const myTime = "2006-01-02T15:04:05Z" // this is an example time you source somewhere
+
+func main() {
+
+	// measure how many nanoseconds the internal clock is behind
+	timeOfMeasurement := time.Now()
+	actualTime, _ := time.Parse(time.RFC3339, myTime)
+	offset := actualTime.Sub(timeOfMeasurement)
+
+	// adjust internal clock by adding the offset to the internal clock
+	runtime.AdjustTimeOffset(int64(offset))
+
+	for {
+		fmt.Printf("%v\r\n", time.Now().Format(time.RFC3339))
+		time.Sleep(5 * time.Second)
+	}
+}


### PR DESCRIPTION
As discussed in #3398 we don't really have an example on how to use `runtime.AdjustTimeOffset()` functionality.
So here it is.