### PR TITLE
Implement PkgPath on reflect.Type

### DIFF
--- a/src/reflect/sidetables.go
+++ b/src/reflect/sidetables.go
@@ -20,6 +20,15 @@ var structNamesSidetable byte
 //go:extern reflect.arrayTypesSidetable
 var arrayTypesSidetable byte
 
+//go:extern reflect.namedBasicTypesPkgPathsSidetable
+var namedBasicTypesPkgPathsSidetable uintptr
+
+//go:extern reflect.namedNonBasicTypesPkgPathsSidetable
+var namedNonBasicTypesPkgPathsSidetable uintptr
+
+//go:extern reflect.pkgPathsSidetable
+var pkgPathsSidetable byte
+
 // readStringSidetable reads a string from the given table (like
 // structNamesSidetable) and returns this string. No heap allocation is
 // necessary because it makes the string point directly to the raw bytes of the

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -754,7 +754,23 @@ func (t rawType) MethodByName(name string) (Method, bool) {
 }
 
 func (t rawType) PkgPath() string {
-	panic("unimplemented: (reflect.Type).PkgPath()")
+	if t%2 == 0 {
+		// basic type
+		id := t >> 6
+		if id == 0 {
+			// not a named type
+			return ""
+		}
+		n, _ := readVarint(unsafe.Pointer(uintptr(unsafe.Pointer(&namedBasicTypesPkgPathsSidetable)) + uintptr(id)*unsafe.Sizeof(uintptr(0))))
+		return readStringSidetable(unsafe.Pointer(&pkgPathsSidetable), n)
+	} else if (t>>4)%2 == 0 {
+		// not a named type
+		return ""
+	}
+	// named complex type
+	id := t >> 5
+	n, _ := readVarint(unsafe.Pointer(uintptr(unsafe.Pointer(&namedNonBasicTypesPkgPathsSidetable)) + uintptr(id)*unsafe.Sizeof(uintptr(0))))
+	return readStringSidetable(unsafe.Pointer(&pkgPathsSidetable), n)
 }
 
 func (t rawType) FieldByName(name string) (StructField, bool) {


### PR DESCRIPTION
This fixes #2668, implementing PkgPath on reflect.Type using sidetables.

The general idea:
- Store a sidetable of unique package paths
- Store a sidetable of named basic types that indexes into the package paths sidetable
- Store a sidetable of named non-basic types that indexes into the package paths sidetable

I've tested this by actually using it, but I would be happy to add some unit tests.