### PR TITLE
rp2040: rtc deep sleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,6 +465,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/pininterrupt
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nano-rp2040         examples/rtcinterrupt
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/systick

--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nano-rp2040         examples/rtcinterrupt
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nano-rp2040         examples/rtcsleep
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/serial
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040            examples/systick

--- a/src/examples/rtcinterrupt/rtcinterrupt.go
+++ b/src/examples/rtcinterrupt/rtcinterrupt.go
@@ -1,0 +1,35 @@
+//go:build rp2040
+
+package main
+
+// This example demonstrates scheduling a delayed interrupt by real time clock.
+//
+// An interrupt may execute user callback function or used for its side effects
+// like waking up from sleep or dormant states.
+//
+// The interrupt can be configured to repeat.
+//
+// There is no separate method to disable interrupt, use 0 delay for that.
+//
+// Unfortunately, it is not possible to use time.Duration to work with RTC directly,
+// that would introduce a circular dependency between "machine" and "time" packages.
+
+import (
+	"fmt"
+	"machine"
+	"time"
+)
+
+func main() {
+
+	// Schedule and enable recurring interrupt.
+	// The callback function is executed in the context of an interrupt handler,
+	// so regular restructions for this sort of code apply: no blocking, no memory allocation, etc.
+	delay := time.Minute + 12*time.Second
+	machine.RTC.SetInterrupt(uint32(delay.Seconds()), true, func() { println("Peekaboo!") })
+
+	for {
+		fmt.Printf("%v\r\n", time.Now().Format(time.RFC3339))
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/src/examples/rtcsleep/rtcsleep.go
+++ b/src/examples/rtcsleep/rtcsleep.go
@@ -1,0 +1,75 @@
+//go:build rp2040
+
+package main
+
+// This example shows how to send a board to a low power mode (deep sleep) and wake it up on timer.
+//
+// There are 3 states the board can be in this example:
+// - Base power: on-board LED is off, does not consume power (5 seconds);
+// - High power: on-board LED shines, consumes power (5 seconds);
+// -  Low power: almost everything is off but crystal oscilator, rtc, sys and ref clocks (5 seconds).
+//
+// Measured power consumption for Arduino Nano RP2040 Connect board powered from 2S battery (~8.2v)
+// - Base power: 13.55 mA (0.11W)  bare minimum on fully powered up RP2040 chip
+// - High power: 15.55 mA (0.13W)  on-board LED consumes 2 mA (same for power LED, see below)
+// - Deep sleep:  4.00 mA (0.03W)  power LED consumes 2 mA
+//                2.00 mA (0.015W) power LED removed => ~month life time, see below
+//
+// Life expectancy on 2S 2200 Li-Ion battery.
+// 4.2v->3.2v, avg 3.7v per cell (7.4v total).
+// Remaining charge ~1000mAh not to ruin the battery => 1.2Ah consumable.
+//
+// Expected number of hours = 3.7*2*1.2 / w, there "w" is power consumption, in Watts.
+//
+// High power:  68h (~3 days)
+// Base power:  81h (~3.5 days)
+// Deep sleep: 296h (~12 days)
+//             592h (~24 days)
+
+import (
+	"machine"
+	"time"
+)
+
+const led = machine.LED
+
+func main() {
+
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+
+	// Pause and let user connect to serial console
+	time.Sleep(5 * time.Second)
+
+	// Fire RTC interrupt every 15 seconds: ~10 seconds we spend in high+base power and sleep the rest
+	machine.RTC.SetInterrupt(10+5, true, nil)
+
+	for {
+
+		// Base power
+		// Nano RP2040 Connect: 0.11W
+		log("Base power, 5 sec, 0.11W")
+		led.Low()
+		time.Sleep(5 * time.Second) // light sleep
+
+		// High power
+		// Nano RP2040 Connect: 0.13W
+		log("High power, 5 sec, 0.13W")
+		led.High()
+		time.Sleep(5 * time.Second) // light sleep
+
+		// Low power
+		// Nano RP2040 Connect: 0.03W
+		log(" Low power, 5 sec, 0.03W")
+		led.Low()
+		// machine.RTC.SetInterrupt(10, false, nil) // alternatively non-recurring RTC interrupt can be scheduled every time
+		machine.Sleep() // deep sleep
+
+	}
+
+}
+
+func log(message string) {
+	time.Sleep(10 * time.Millisecond) // ensure output subsystem fully initialised
+	println(time.Now().Format(time.RFC3339) + " " + message)
+	time.Sleep(10 * time.Millisecond) // ensure output subsystem doe not go sleep before message printed out
+}

--- a/src/machine/machine_rp2040_pll.go
+++ b/src/machine/machine_rp2040_pll.go
@@ -98,3 +98,9 @@ func (pll *pll) init(refdiv, vcoFreq, postDiv1, postDiv2 uint32) {
 	pll.pwr.ClearBits(rp.PLL_SYS_PWR_POSTDIVPD)
 
 }
+
+func (pll *pll) stop() {
+	// Turn off PLL
+	pwr := uint32(rp.PLL_SYS_PWR_PD | rp.PLL_SYS_PWR_VCOPD | rp.PLL_SYS_PWR_POSTDIVPD)
+	pll.pwr.SetBits(pwr)
+}

--- a/src/machine/machine_rp2040_rtc.go
+++ b/src/machine/machine_rp2040_rtc.go
@@ -1,0 +1,240 @@
+//go:build rp2040
+
+// Implementation based on code located here:
+// https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_rtc/rtc.c
+
+package machine
+
+import (
+	"device/rp"
+	"errors"
+	"runtime/interrupt"
+	"unsafe"
+)
+
+type rtcType rp.RTC_Type
+
+type rtcTime struct {
+	Year  int16
+	Month int8
+	Day   int8
+	Dotw  int8
+	Hour  int8
+	Min   int8
+	Sec   int8
+}
+
+var RTC = (*rtcType)(unsafe.Pointer(rp.RTC))
+
+const (
+	second = 1
+	minute = 60 * second
+	hour   = 60 * minute
+	day    = 24 * hour
+)
+
+var (
+	rtcAlarmRepeats bool
+	rtcCallback     func()
+	rtcEpoch        = rtcTime{
+		Year: 1970, Month: 1, Day: 1, Dotw: 4, Hour: 0, Min: 0, Sec: 0,
+	}
+)
+
+var (
+	ErrRtcDelayTooSmall = errors.New("RTC interrupt deplay is too small, shall be at least 1 second")
+	ErrRtcDelayTooLarge = errors.New("RTC interrupt deplay is too large, shall be no more than 1 day")
+)
+
+// SetInterrupt configures delayed and optionally recurring interrupt by real time clock.
+//
+// Delay is specified in whole seconds, allowed range depends on platform.
+// Zero delay disables previously configured interrupt, if any.
+//
+// RP2040 implementation allows delay to be up to 1 day, otherwise a respective error is emitted.
+func (rtc *rtcType) SetInterrupt(delay uint32, repeat bool, callback func()) error {
+
+	// Verify delay range
+	if delay > day {
+		return ErrRtcDelayTooLarge
+	}
+
+	// De-configure delayed interrupt if delay is zero
+	if delay == 0 {
+		rtc.disableInterruptMatch()
+		return nil
+	}
+
+	// Configure delayed interrupt
+	rtc.setDivider()
+
+	rtcAlarmRepeats = repeat
+	rtcCallback = callback
+
+	err := rtc.setTime(rtcEpoch)
+	if err != nil {
+		return err
+	}
+	rtc.setAlarm(toAlarmTime(delay), callback)
+
+	return nil
+}
+
+func toAlarmTime(delay uint32) rtcTime {
+	result := rtcEpoch
+	remainder := delay + 1 // needed "+1", otherwise alarm fires one second too early
+	if remainder >= hour {
+		result.Hour = int8(remainder / hour)
+		remainder %= hour
+	}
+	if remainder >= minute {
+		result.Min = int8(remainder / minute)
+		remainder %= minute
+	}
+	result.Sec = int8(remainder)
+	return result
+}
+
+func (rtc *rtcType) setDivider() {
+	// Get clk_rtc freq and make sure it is running
+	rtcFreq := configuredFreq[clkRTC]
+	if rtcFreq == 0 {
+		panic("can not set RTC divider, clock is not running")
+	}
+
+	// Take rtc out of reset now that we know clk_rtc is running
+	resetBlock(rp.RESETS_RESET_RTC)
+	unresetBlockWait(rp.RESETS_RESET_RTC)
+
+	// Set up the 1 second divider.
+	// If rtc_freq is 400 then clkdiv_m1 should be 399
+	rtcFreq -= 1
+
+	// Check the freq is not too big to divide
+	if rtcFreq > rp.RTC_CLKDIV_M1_CLKDIV_M1_Msk {
+		panic("can not set RTC divider, clock frequency is too big to divide")
+	}
+
+	// Write divide value
+	rtc.CLKDIV_M1.Set(rtcFreq)
+}
+
+// setTime configures RTC with supplied time, initialises and activates it.
+func (rtc *rtcType) setTime(t rtcTime) error {
+
+	// Disable RTC and wait while it is still running
+	rtc.CTRL.Set(0)
+	for rtc.isActive() {
+	}
+
+	rtc.SETUP_0.Set((uint32(t.Year) << rp.RTC_SETUP_0_YEAR_Pos) |
+		(uint32(t.Month) << rp.RTC_SETUP_0_MONTH_Pos) |
+		(uint32(t.Day) << rp.RTC_SETUP_0_DAY_Pos))
+
+	rtc.SETUP_1.Set((uint32(t.Dotw) << rp.RTC_SETUP_1_DOTW_Pos) |
+		(uint32(t.Hour) << rp.RTC_SETUP_1_HOUR_Pos) |
+		(uint32(t.Min) << rp.RTC_SETUP_1_MIN_Pos) |
+		(uint32(t.Sec) << rp.RTC_SETUP_1_SEC_Pos))
+
+	// Load setup values into RTC clock domain
+	rtc.CTRL.SetBits(rp.RTC_CTRL_LOAD)
+
+	// Enable RTC and wait for it to be running
+	rtc.CTRL.SetBits(rp.RTC_CTRL_RTC_ENABLE)
+	for !rtc.isActive() {
+	}
+
+	return nil
+}
+
+func (rtc *rtcType) isActive() bool {
+	return rtc.CTRL.HasBits(rp.RTC_CTRL_RTC_ACTIVE)
+}
+
+// setAlarm configures alarm in RTC and arms it.
+// The callback is executed in the context of an interrupt handler,
+// so regular restructions for this sort of code apply: no blocking, no memory allocation, etc.
+func (rtc *rtcType) setAlarm(t rtcTime, callback func()) {
+
+	rtc.disableInterruptMatch()
+
+	// Clear all match enable bits
+	rtc.IRQ_SETUP_0.ClearBits(rp.RTC_IRQ_SETUP_0_YEAR_ENA | rp.RTC_IRQ_SETUP_0_MONTH_ENA | rp.RTC_IRQ_SETUP_0_DAY_ENA)
+	rtc.IRQ_SETUP_1.ClearBits(rp.RTC_IRQ_SETUP_1_DOTW_ENA | rp.RTC_IRQ_SETUP_1_HOUR_ENA | rp.RTC_IRQ_SETUP_1_MIN_ENA | rp.RTC_IRQ_SETUP_1_SEC_ENA)
+
+	// Only add to setup if it isn't -1 and set the match enable bits for things we care about
+	if t.Year >= 0 {
+		rtc.IRQ_SETUP_0.SetBits(uint32(t.Year) << rp.RTC_SETUP_0_YEAR_Pos)
+		rtc.IRQ_SETUP_0.SetBits(rp.RTC_IRQ_SETUP_0_YEAR_ENA)
+	}
+
+	if t.Month >= 0 {
+		rtc.IRQ_SETUP_0.SetBits(uint32(t.Month) << rp.RTC_SETUP_0_MONTH_Pos)
+		rtc.IRQ_SETUP_0.SetBits(rp.RTC_IRQ_SETUP_0_MONTH_ENA)
+	}
+
+	if t.Day >= 0 {
+		rtc.IRQ_SETUP_0.SetBits(uint32(t.Day) << rp.RTC_SETUP_0_DAY_Pos)
+		rtc.IRQ_SETUP_0.SetBits(rp.RTC_IRQ_SETUP_0_DAY_ENA)
+	}
+
+	if t.Dotw >= 0 {
+		rtc.IRQ_SETUP_1.SetBits(uint32(t.Dotw) << rp.RTC_SETUP_1_DOTW_Pos)
+		rtc.IRQ_SETUP_1.SetBits(rp.RTC_IRQ_SETUP_1_DOTW_ENA)
+	}
+
+	if t.Hour >= 0 {
+		rtc.IRQ_SETUP_1.SetBits(uint32(t.Hour) << rp.RTC_SETUP_1_HOUR_Pos)
+		rtc.IRQ_SETUP_1.SetBits(rp.RTC_IRQ_SETUP_1_HOUR_ENA)
+	}
+
+	if t.Min >= 0 {
+		rtc.IRQ_SETUP_1.SetBits(uint32(t.Min) << rp.RTC_SETUP_1_MIN_Pos)
+		rtc.IRQ_SETUP_1.SetBits(rp.RTC_IRQ_SETUP_1_MIN_ENA)
+	}
+
+	if t.Sec >= 0 {
+		rtc.IRQ_SETUP_1.SetBits(uint32(t.Sec) << rp.RTC_SETUP_1_SEC_Pos)
+		rtc.IRQ_SETUP_1.SetBits(rp.RTC_IRQ_SETUP_1_SEC_ENA)
+	}
+
+	// Enable the IRQ at the proc
+	interrupt.New(rp.IRQ_RTC_IRQ, rtcHandleInterrupt).Enable()
+
+	// Enable the IRQ at the peri
+	rtc.INTE.Set(rp.RTC_INTE_RTC)
+
+	rtc.enableInterruptMatch()
+}
+
+func (rtc *rtcType) enableInterruptMatch() {
+	// Set matching and wait for it to be enabled
+	rtc.IRQ_SETUP_0.SetBits(rp.RTC_IRQ_SETUP_0_MATCH_ENA)
+	for !rtc.IRQ_SETUP_0.HasBits(rp.RTC_IRQ_SETUP_0_MATCH_ACTIVE) {
+	}
+}
+
+func (rtc *rtcType) disableInterruptMatch() {
+	// Disable matching and wait for it to stop being active
+	rtc.IRQ_SETUP_0.ClearBits(rp.RTC_IRQ_SETUP_0_MATCH_ENA)
+	for rtc.IRQ_SETUP_0.HasBits(rp.RTC_IRQ_SETUP_0_MATCH_ACTIVE) {
+	}
+}
+
+func rtcHandleInterrupt(itr interrupt.Interrupt) {
+	// Always disable the alarm to clear the current IRQ.
+	// Even if it is a repeatable alarm, we don't want it to keep firing.
+	// If it matches on a second it can keep firing for that second.
+	RTC.disableInterruptMatch()
+
+	// Call user callback function
+	if rtcCallback != nil {
+		rtcCallback()
+	}
+
+	if rtcAlarmRepeats {
+		// If it is a repeatable alarm, reset time and re-enable the alarm.
+		RTC.setTime(rtcEpoch)
+		RTC.enableInterruptMatch()
+	}
+}

--- a/src/machine/machine_rp2040_sleep.go
+++ b/src/machine/machine_rp2040_sleep.go
@@ -1,0 +1,37 @@
+//go:build rp2040
+
+package machine
+
+import (
+	"device/arm"
+	"device/rp"
+)
+
+// Sleep until RTC interrupt
+func Sleep() {
+
+	scb_orig := arm.SCB.SCR.Get()
+	clock0_orig := clocks.sleepEN0.Get()
+	clock1_orig := clocks.sleepEN1.Get()
+
+	// Stop all clocks but RTC
+	clocks.sleep()
+
+	// Turn off all clocks when in sleep mode except for RTC
+	clocks.sleepEN0.Set(rp.CLOCKS_SLEEP_EN0_CLK_RTC_RTC)
+	clocks.sleepEN1.Set(0x0)
+
+	// Enable deep sleep at the proc
+	arm.SCB.SCR.SetBits(arm.SCB_SCR_SLEEPDEEP)
+
+	// Go to sleep
+	arm.Asm("wfi")
+
+	// Restore state
+	arm.SCB.SCR.Set(scb_orig)
+	clocks.sleepEN0.Set(clock0_orig)
+	clocks.sleepEN1.Set(clock1_orig)
+
+	// Enable clocks
+	clocks.init()
+}


### PR DESCRIPTION
_Builds on top of #3403 (hence includes a commit from there)_

This PR implements deep sleep (not dormant state!) on RP2040.
Example added that shows how to use the feature with some power consumption stats for Nano RP2040 Connect board.

Example output
```
1970-01-01T00:00:05Z Base power, 5 sec, 0.11W
1970-01-01T00:00:10Z High power, 5 sec, 0.13W
1970-01-01T00:00:15Z  Low power, 5 sec, 0.03W
1970-01-01T00:00:15Z Base power, 5 sec, 0.11W
1970-01-01T00:00:20Z High power, 5 sec, 0.13W
1970-01-01T00:00:25Z  Low power, 5 sec, 0.03W
1970-01-01T00:00:25Z Base power, 5 sec, 0.11W
1970-01-01T00:00:30Z High power, 5 sec, 0.13W
1970-01-01T00:00:35Z  Low power, 5 sec, 0.03W
```
Observe how internal time (accessed by `time.Now()`) stops while system is in deep sleep.

Draft, because I still observe Serial console problems after wake up.
The application does work, judging by on-board led going on and off and measured power consumption, but output in Serial stops. No disconnects though, just nothing prints.