### PR TITLE
stm32wl: Fix for incomplete RNG initialisation

### DIFF
--- a/src/machine/machine.go
+++ b/src/machine/machine.go
@@ -4,6 +4,8 @@ import "errors"
 
 var (
 	ErrTimeoutRNG         = errors.New("machine: RNG Timeout")
+	ErrClockRNG           = errors.New("machine: RNG Clock Error")
+	ErrSeedRNG            = errors.New("machine: RNG Seed Error")
 	ErrInvalidInputPin    = errors.New("machine: invalid input pin")
 	ErrInvalidOutputPin   = errors.New("machine: invalid output pin")
 	ErrInvalidClockPin    = errors.New("machine: invalid clock pin")

--- a/src/machine/machine_stm32_rng.go
+++ b/src/machine/machine_stm32_rng.go
@@ -15,6 +15,13 @@ func GetRNG() (uint32, error) {
 		rngInitDone = true
 	}
 
+	if stm32.RNG.SR.HasBits(stm32.RNG_SR_CECS) {
+		return 0, ErrClockRNG
+	}
+	if stm32.RNG.SR.HasBits(stm32.RNG_SR_SECS) {
+		return 0, ErrSeedRNG
+	}
+
 	cnt := RNG_MAX_READ_RETRIES
 	for !stm32.RNG.SR.HasBits(stm32.RNG_SR_DRDY) {
 		cnt--

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -407,7 +407,12 @@ func (t *TIM) enableMainOutput() {
 
 func initRNG() {
 	stm32.RCC.AHB3ENR.SetBits(stm32.RCC_AHB3ENR_RNGEN)
-	stm32.RNG.CR.SetBits(stm32.RNG_CR_RNGEN)
+
+	// Enable RNG with config.A  (See RM0453 22.6.2)
+	stm32.RNG.CR.Set(0x40F00D40)   // RNG Config. A
+	stm32.RNG.HTCR.Set(0x17590ABC) // MAGIC NUMBER
+	stm32.RNG.HTCR.Set(0x0000AA74) // HTCR VALUE
+	stm32.RNG.CR.Set(0x00F00D4C)   // CONFIG A  + RNG_EN=1 + IE=1
 }
 
 //----------


### PR DESCRIPTION
STM32WL's RNG was not properly initialized.
RNG Timeout errors were appearing after 1-2 successful requests to rand.Read() function.

This PR completes initialization of RNG registers and add checks for CECS (Clock) and SECS(Seed) status registers

Steps to reproduce the problem from dev branch (on LoraE5 dev board)

```
package main

import (
	"time"
	"crypto/rand"
)

func main() {
	println("*** stm32wl RNG test")

	var randomBytes [2]byte
	for {
		_, err := rand.Read(randomBytes[:])
		if err !=nil{
			println("error:",err)
		}
		println("randomBytes:", randomBytes[0], randomBytes[1])
		time.Sleep(time.Millisecond * 25)
	}
}


$ tinygo flash  -target=lorae5
$  picocom -b 115200 /dev/ttyUSB0

*** stm32wl RNG test
randomBytes: 147 36
randomBytes: 100 21
error: machine: RNG Timeout
randomBytes: 100 21
error: machine: RNG Timeout
randomBytes: 100 21
error: machine: RNG Timeout
randomBytes: 100 21
```

With the fix, I could call rand.Read() hundreds of time without errors.
