### PR TITLE
Return unique pointer when size 0 passed to malloc

### DIFF
--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -13,7 +13,7 @@ var allocs = make(map[uintptr][]byte)
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
 	if size == 0 {
-		return nil
+		size = 1 // Match dlmalloc's behavior to allocate a "minimum-sized chunk"
 	}
 	buf := make([]byte, size)
 	ptr := unsafe.Pointer(&buf[0])
@@ -42,8 +42,7 @@ func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 //export realloc
 func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
 	if size == 0 {
-		libc_free(oldPtr)
-		return nil
+		size = 1 // Match dlmalloc's behavior to allocate a "minimum-sized chunk"
 	}
 
 	// It's hard to optimize this to expand the current buffer with our GC, but

--- a/tests/runtime_wasi/malloc_test.go
+++ b/tests/runtime_wasi/malloc_test.go
@@ -127,19 +127,19 @@ func TestMallocFree(t *testing.T) {
 
 func TestMallocEmpty(t *testing.T) {
 	ptr := libc_malloc(0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
+	if ptr == nil {
+		t.Error("expected pointer but was nil")
 	}
 }
 
 func TestCallocEmpty(t *testing.T) {
 	ptr := libc_calloc(0, 1)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
+	if ptr == nil {
+		t.Error("expected pointer but was nil")
 	}
 	ptr = libc_calloc(1, 0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
+	if ptr == nil {
+		t.Error("expected pointer but was nil")
 	}
 }
 
@@ -149,7 +149,7 @@ func TestReallocEmpty(t *testing.T) {
 		t.Error("expected pointer but was nil")
 	}
 	ptr = libc_realloc(ptr, 0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
+	if ptr == nil {
+		t.Error("expected pointer but was nil")
 	}
 }


### PR DESCRIPTION
PR #3303 addressed panics when malloc'ing with size 0 by returning nil. While this is permitted by the C standard, some Wasm environments expect the behavior to match that of glibc/dlmalloc, which is to always return a unique pointer.