### PR TITLE
target/lgt92: fix openocd target and interface

### DIFF
--- a/targets/lgt92.json
+++ b/targets/lgt92.json
@@ -8,6 +8,6 @@
 	"serial": "uart",
 	"linkerscript": "targets/stm32l072czt6.ld",
 	"flash-method": "openocd",
-	"openocd-interface": "stlink-v2",
-	"openocd-target": "stm32f0x"
+	"openocd-interface": "stlink",
+	"openocd-target": "stm32l0"
 }


### PR DESCRIPTION
Some fixes for Dragino LGT92 target board: 

- Target MCU was not properly defined for LGT92 target (should be stm32l0)
- Change openocd interface from stlink-v2 to stlink (interface/stlink-v2.cfg is deprecated)

Specifications : https://www.dragino.com/products/lora-lorawan-end-node/item/142-lgt-92.html
Changes were tested on LGT92 device.