### PR TITLE
runtime/stm32wlx: change init order so clock speeds are correct

### DIFF
--- a/src/runtime/runtime_stm32wlx.go
+++ b/src/runtime/runtime_stm32wlx.go
@@ -21,12 +21,11 @@ func init() {
 	// Configure 48Mhz clock
 	initCLK()
 
-	// UART init
-	machine.InitSerial()
-
 	// Timers init
 	initTickTimer(&machine.TIM1)
 
+	// UART init
+	machine.InitSerial()
 }
 
 func initCLK() {


### PR DESCRIPTION
This PR modifies the runtime init order for the `stm32wlx` so the clock speeds are set before peripherals started.