### PR TITLE
runtime/debug: stubs PrintStack

### DIFF
--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -9,6 +9,11 @@ func SetMaxStack(n int) int {
 	return n
 }
 
+// PrintStack prints to standard error the stack trace returned by runtime.Stack.
+//
+// Not implemented.
+func PrintStack() {}
+
 // Stack returns a formatted stack trace of the goroutine that calls it.
 //
 // Not implemented.


### PR DESCRIPTION
Some applications reference this symbol (guarded by a constant bool flag though),
but this makes it possible to compile at least.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>