### PR TITLE
avr: use precise GC by default

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -210,10 +210,6 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 				// limited amount of memory.
 				continue
 
-			case "gc.go":
-				// Does not pass due to high mark false positive rate.
-				continue
-
 			case "json.go", "stdlib.go", "testing.go":
 				// Too big for AVR. Doesn't fit in flash/RAM.
 				continue

--- a/targets/avr.json
+++ b/targets/avr.json
@@ -3,7 +3,7 @@
 	"build-tags": ["avr", "baremetal", "linux", "arm"],
 	"goos": "linux",
 	"goarch": "arm",
-	"gc": "conservative",
+	"gc": "precise",
 	"linker": "ld.lld",
 	"scheduler": "none",
 	"rtlib": "compiler-rt",


### PR DESCRIPTION
AVR is especially sensitive to false positives in the GC for a few reasons:

  * Pointer values are only two bytes, instead of four on most other microcontrollers.
  * Pointers are not aligned, so any two-byte value in an object coud be a pointer.
  * Memory typically starts at a low address, which makes it much more likely to clash with a regular integer value (which tend to be small values).

Therefore, use the precise GC (instead of the conservative GC) by default. This increases binary size by around 350 bytes, but I think it's a good tradeoff in most cases: it avoids some runtime errors and generally RAM tends to be a lot more scarce than flash on AVR chips. If this is too much, `-gc=conservative` or `-gc=leaking` can be used instead.

@niaow