### PR TITLE
Allow custom-gc SetFinalizer and clarify KeepAlive

### DIFF
--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -687,3 +687,7 @@ func ReadMemStats(m *MemStats) {
 	m.Frees = gcFrees
 	m.Sys = uint64(heapEnd - heapStart)
 }
+
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// Unimplemented.
+}

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -20,6 +20,7 @@ package runtime
 // - func free(ptr unsafe.Pointer)
 // - func markRoots(start, end uintptr)
 // - func GC()
+// - func SetFinalizer(obj interface{}, finalizer interface{})
 //
 //
 // In addition, if targeting wasi, the following functions should be exported for interoperability
@@ -49,6 +50,9 @@ func markRoots(start, end uintptr)
 
 // GC is called to explicitly run garbage collection.
 func GC()
+
+// SetFinalizer registers a finalizer.
+func SetFinalizer(obj interface{}, finalizer interface{})
 
 func setHeapEnd(newHeapEnd uintptr) {
 	// Heap is in custom GC so ignore for when called from wasm initialization.

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -85,6 +85,10 @@ func GC() {
 	// No-op.
 }
 
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// No-op.
+}
+
 func initHeap() {
 	// preinit() may have moved heapStart; reset heapptr
 	heapptr = heapStart

--- a/src/runtime/gc_none.go
+++ b/src/runtime/gc_none.go
@@ -26,6 +26,10 @@ func GC() {
 	// Unimplemented.
 }
 
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// Unimplemented.
+}
+
 func initHeap() {
 	// Nothing to initialize.
 }

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -88,13 +88,45 @@ func LockOSThread() {
 func UnlockOSThread() {
 }
 
+// Mark KeepAlive as noinline so that it is easily detectable as an intrinsic.
+//
+//go:noinline
+
+// KeepAlive marks its argument as currently reachable.
+// This ensures that the object is not freed, and its finalizer is not run,
+// before the point in the program where KeepAlive is called.
+//
+// A very simplified example showing where KeepAlive is required:
+//
+//	type File struct { d int }
+//	d, err := syscall.Open("/file/path", syscall.O_RDONLY, 0)
+//	// ... do something if err != nil ...
+//	p := &File{d}
+//	runtime.SetFinalizer(p, func(p *File) { syscall.Close(p.d) })
+//	var buf [10]byte
+//	n, err := syscall.Read(p.d, buf[:])
+//	// Ensure p is not finalized until Read returns.
+//	runtime.KeepAlive(p)
+//	// No more uses of p after this point.
+//
+// Without the KeepAlive call, the finalizer could run at the start of
+// syscall.Read, closing the file descriptor before syscall.Read makes
+// the actual system call.
+//
+// Note: KeepAlive should only be used to prevent finalizers from
+// running prematurely. In particular, when used with unsafe.Pointer,
+// the rules for valid uses of unsafe.Pointer still apply.
 func KeepAlive(x interface{}) {
-	// Unimplemented. Only required with SetFinalizer().
+	if alwaysFalse {
+		println(x)
+	}
 }
 
-func SetFinalizer(obj interface{}, finalizer interface{}) {
-	// Unimplemented.
-}
+// alwaysFalse is a boolean value that is always false.
+// The compiler cannot see that alwaysFalse is always false,
+// so it emits the test and keeps the call, giving the desired
+// escape analysis result. The test is cheaper than the call.
+var alwaysFalse bool
 
 //go:linkname godebug_setUpdate internal/godebug.setUpdate
 func godebug_setUpdate(update func(string, string)) {

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -88,45 +88,10 @@ func LockOSThread() {
 func UnlockOSThread() {
 }
 
-// Mark KeepAlive as noinline so that it is easily detectable as an intrinsic.
-//
 //go:noinline
-
-// KeepAlive marks its argument as currently reachable.
-// This ensures that the object is not freed, and its finalizer is not run,
-// before the point in the program where KeepAlive is called.
-//
-// A very simplified example showing where KeepAlive is required:
-//
-//	type File struct { d int }
-//	d, err := syscall.Open("/file/path", syscall.O_RDONLY, 0)
-//	// ... do something if err != nil ...
-//	p := &File{d}
-//	runtime.SetFinalizer(p, func(p *File) { syscall.Close(p.d) })
-//	var buf [10]byte
-//	n, err := syscall.Read(p.d, buf[:])
-//	// Ensure p is not finalized until Read returns.
-//	runtime.KeepAlive(p)
-//	// No more uses of p after this point.
-//
-// Without the KeepAlive call, the finalizer could run at the start of
-// syscall.Read, closing the file descriptor before syscall.Read makes
-// the actual system call.
-//
-// Note: KeepAlive should only be used to prevent finalizers from
-// running prematurely. In particular, when used with unsafe.Pointer,
-// the rules for valid uses of unsafe.Pointer still apply.
 func KeepAlive(x interface{}) {
-	if alwaysFalse {
-		println(x)
-	}
+	// Unimplemented.
 }
-
-// alwaysFalse is a boolean value that is always false.
-// The compiler cannot see that alwaysFalse is always false,
-// so it emits the test and keeps the call, giving the desired
-// escape analysis result. The test is cheaper than the call.
-var alwaysFalse bool
 
 //go:linkname godebug_setUpdate internal/godebug.setUpdate
 func godebug_setUpdate(update func(string, string)) {

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -88,9 +88,11 @@ func LockOSThread() {
 func UnlockOSThread() {
 }
 
-//go:noinline
 func KeepAlive(x interface{}) {
 	// Unimplemented.
+	// TODO: This function needs to be implemented in a way that LLVM doesn't optimize away the x
+	// parameter. This will likely need either a volatile operation or calling an assembly stub
+	// that simply returns.
 }
 
 //go:linkname godebug_setUpdate internal/godebug.setUpdate


### PR DESCRIPTION
In #3336, `SetFinalizer` was moved to common code out of GC implementations. This prevents custom-gc from trying to implement finalizers (I'd like to). There is a bit of copy-paste among GC implementations because of it, but especially with `gc_blocks` it's less than it could have been.

At the same time, this reimplements `KeepAlive` in the same way as Go - while the Go document does make a big deal about finalizers, close reading shows `ensures that the object is not freed`, which can be important with unsafe code. I don't think `KeepAlive` has a strong relation to `SetFinalizer` as is currently documented. In tinygo wasi's case, I believe this specifically means that the shadow stack slot for a variable is not reused by a different one until the call to `KeepAlive` (for non-wasi, same thing but registers?). However, I need help in knowing whether the `The compiler cannot see that alwaysFalse is always false,` note is valid for LLVM as well - intuitively for me, just `noinline` would be enough to ensure the variable is kept alive for the function call.