### PR TITLE
Switch WASI emulator from wasmtime to wazero

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,10 +120,6 @@ jobs:
         with:
           go-version: '1.19'
           cache: true
-      - name: Install wasmtime
-        run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v3
         with:
@@ -164,10 +160,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14'
-      - name: Install wasmtime
-        run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Cache LLVM source
         uses: actions/cache@v3
         id: cache-llvm-source

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,9 +71,6 @@ jobs:
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
         run: make wasi-libc
-      - name: Install wasmtime
-        run: |
-          scoop install wasmtime
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-v -short"
@@ -160,7 +157,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          scoop install binaryen wasmtime
+          scoop install binaryen
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Go

--- a/main.go
+++ b/main.go
@@ -761,6 +761,12 @@ func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, c
 				"runtime": runtimeGlobals,
 			}
 		}
+	} else if strings.Contains(config.Target.Emulator, "wazero") {
+		// wazero needs some special flags to pass environment variables
+		for _, v := range environmentVars {
+			args = append(args, "-env", v)
+		}
+		args = append(args, cmdArgs...)
 	} else {
 		// Pass environment variables and command line parameters as usual.
 		// This also works on qemu-aarch64 etc.

--- a/main_test.go
+++ b/main_test.go
@@ -404,7 +404,7 @@ func TestTest(t *testing.T) {
 			targ{"EmulatedCortexM3", optionsFromTarget("cortex-m-qemu", sema)},
 			targ{"EmulatedRISCV", optionsFromTarget("riscv-qemu", sema)},
 
-			// Node/Wasmtime
+			// Node/wazero
 			targ{"WASM", optionsFromTarget("wasm", sema)},
 			targ{"WASI", optionsFromTarget("wasi", sema)},
 		)

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -22,9 +22,9 @@ func _start() {
 }
 
 // Read the command line arguments from WASI.
-// For example, they can be passed to a program with wasmtime like this:
+// For example, they can be passed to a program with wazero like this:
 //
-//	wasmtime run ./program.wasm arg1 arg2
+//	wazero run ./program.wasm arg1 arg2
 func init() {
 	__wasm_call_ctors()
 }

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -21,6 +21,6 @@
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator":      "wasmtime --mapdir=/tmp::{tmpDir} {}",
+	"emulator":      "go run github.com/tetratelabs/wazero/cmd/wazero@v1.0.0-pre.8 run -mount=.:/ -mount={tmpDir}:/tmp {}",
 	"wasm-abi":      "generic"
 }


### PR DESCRIPTION
wasmtime must be installed separately, but all TinyGo users have Go installed, so wazero can be used to emulate wasi without any installation step at all with the help of `go run`. This should really improve the UX of `tinygo test`.

All the directory hacks for wasmtime can also be removed. Why is this? Because @codefromthecrypt developed CLI features specifically while [targeting](https://github.com/tetratelabs/wazero/blob/main/.github/workflows/integration.yaml#L123) TinyGo's test suite - TinyGo is a first-class target for wazero and its UX will continue to matter to wazero (I guess, sorry for speaking for you @codefromthecrypt :P).