### PR TITLE
runtime (scheduler/wasm): implement JS exit handling

### DIFF
--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -23,7 +23,7 @@ func run() {
 	go func() {
 		initAll()
 		callMain()
-		schedulerDone = true
+		postMain()
 	}()
 	scheduler()
 }

--- a/src/runtime/scheduler_end_other.go
+++ b/src/runtime/scheduler_end_other.go
@@ -1,0 +1,9 @@
+//go:build wasi || !wasm
+
+package runtime
+
+func postMain() {
+	if hasScheduler {
+		schedulerDone = true
+	}
+}

--- a/src/runtime/scheduler_end_wasm_js.go
+++ b/src/runtime/scheduler_end_wasm_js.go
@@ -1,0 +1,7 @@
+//go:build wasm && !wasi
+
+package runtime
+
+func postMain() {
+	proc_exit(0)
+}

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -23,6 +23,7 @@ func run() {
 	initHeap()
 	initAll()
 	callMain()
+	postMain()
 }
 
 const hasScheduler = false


### PR DESCRIPTION
This change resolves the go.run promise when main returns or syscall.Exit is called. It forces the exit by throwing an exception from within proc_exit, which is then caught outside wasm.

TODO: update browser testing code to use the promise.

Related to #3422 