### PR TITLE
docker: add .git entry to .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 build/
 llvm-*/
-
+.git


### PR DESCRIPTION
THis PR adds `.git` to the .dockerignore file so that the `dev` image does not return the error `error obtaining VCS status: exit status 128` when being run on environments such as Github actions where the directory where the files are checked out to are on the "host" and not inside the container itself.