### PR TITLE
rp2040: provide better errors for invalid pins on i2c and spi

### DIFF
--- a/src/machine/machine_rp2040_i2c.go
+++ b/src/machine/machine_rp2040_i2c.go
@@ -57,6 +57,8 @@ var (
 	ErrInvalidTgtAddr     = errors.New("invalid target i2c address not in 0..0x80 or is reserved")
 	ErrI2CGeneric         = errors.New("i2c error")
 	ErrRP2040I2CDisable   = errors.New("i2c rp2040 peripheral timeout in disable")
+	errInvalidI2CSDA      = errors.New("invalid I2C SDA pin")
+	errInvalidI2CSCL      = errors.New("invalid I2C SCL pin")
 )
 
 // Tx performs a write and then a read transfer placing the result in
@@ -110,10 +112,11 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 		okSDA = (config.SDA+2)%4 == 0
 		okSCL = (config.SCL+3)%4 == 0
 	}
+
 	if !okSDA {
-		return errors.New("invalid I2C SDA pin")
+		return errInvalidI2CSDA
 	} else if !okSCL {
-		return errors.New("invalid I2C SCL pin")
+		return errInvalidI2CSCL
 	}
 	if config.Frequency == 0 {
 		config.Frequency = defaultBaud

--- a/src/machine/machine_rp2040_spi.go
+++ b/src/machine/machine_rp2040_spi.go
@@ -162,7 +162,7 @@ func (spi SPI) GetBaudRate() uint32 {
 // No pin configuration is needed of SCK, SDO and SDI needed after calling Configure.
 func (spi SPI) Configure(config SPIConfig) error {
 	const defaultBaud uint32 = 115200
-	if config.SCK == 0 {
+	if config.SCK == 0 && config.SDO == 0 && config.SDI == 0 {
 		// set default pins if config zero valued or invalid clock pin supplied.
 		switch spi.Bus {
 		case rp.SPI0:
@@ -174,6 +174,24 @@ func (spi SPI) Configure(config SPIConfig) error {
 			config.SDO = SPI1_SDO_PIN
 			config.SDI = SPI1_SDI_PIN
 		}
+	}
+	var okSDI, okSDO, okSCK bool
+	switch spi.Bus {
+	case rp.SPI0:
+		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 17
+		okSDO = config.SDO == 3 || config.SDO == 7 || config.SDO == 19
+		okSCK = config.SCK == 2 || config.SCK == 6 || config.SCK == 18
+	case rp.SPI1:
+		okSDI = config.SDI == 8 || config.SDI == 12
+		okSDO = config.SDO == 11 || config.SDO == 15
+		okSDO = config.SCK == 10 || config.SCK == 14
+	}
+	if !okSDI {
+		return errors.New("invalid SPI SDI pin")
+	} else if !okSDO {
+		return errors.New("invalid SPI SDO pin")
+	} else if !okSCK {
+		return errors.New("invalid SPI SCK pin")
 	}
 	if config.DataBits < 4 || config.DataBits > 16 {
 		config.DataBits = 8

--- a/src/machine/machine_rp2040_spi.go
+++ b/src/machine/machine_rp2040_spi.go
@@ -40,6 +40,9 @@ var (
 	ErrLSBNotSupported = errors.New("SPI LSB unsupported on PL022")
 	ErrSPITimeout      = errors.New("SPI timeout")
 	ErrSPIBaud         = errors.New("SPI baud too low or above 66.5Mhz")
+	errSPIInvalidSDI   = errors.New("invalid SPI SDI pin")
+	errSPIInvalidSDO   = errors.New("invalid SPI SDO pin")
+	errSPIInvalidSCK   = errors.New("invalid SPI SCK pin")
 )
 
 type SPI struct {
@@ -186,12 +189,13 @@ func (spi SPI) Configure(config SPIConfig) error {
 		okSDO = config.SDO == 11 || config.SDO == 15
 		okSDO = config.SCK == 10 || config.SCK == 14
 	}
+
 	if !okSDI {
-		return errors.New("invalid SPI SDI pin")
+		return errSPIInvalidSDI
 	} else if !okSDO {
-		return errors.New("invalid SPI SDO pin")
+		return errSPIInvalidSDO
 	} else if !okSCK {
-		return errors.New("invalid SPI SCK pin")
+		return errSPIInvalidSCK
 	}
 	if config.DataBits < 4 || config.DataBits > 16 {
 		config.DataBits = 8


### PR DESCRIPTION
As title says, it should be easier to get better errors on invalid pin configuration. Would prevent issues like https://github.com/tinygo-org/tinygo/issues/3394