### PR TITLE
build: always cache LLVM source/build even if the tests fail to avoid extra rebuilds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -29,11 +29,11 @@ jobs:
         with:
           go-version: '1.20'
           cache: true
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore LLVM source cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-macos-v2
+          key: llvm-source-15-macos-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -43,11 +43,22 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save LLVM source cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore LLVM build cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-macos-v3
+          key: llvm-build-15-macos-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -61,6 +72,12 @@ jobs:
           # build!
           make llvm-build
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save LLVM build cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+          path: llvm-build
       - name: Cache wasi-libc sysroot
         uses: actions/cache@v3
         id: cache-wasi-libc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,11 +39,11 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore LLVM source cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-alpine-v2
+          key: llvm-source-15-linux-alpine-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -53,11 +53,22 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save LLVM source cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore LLVM build cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-alpine-v3
+          key: llvm-build-15-linux-alpine-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -71,6 +82,12 @@ jobs:
           make llvm-build
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save LLVM build cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+          path: llvm-build
       - name: Cache Binaryen
         uses: actions/cache@v3
         id: cache-binaryen
@@ -168,11 +185,11 @@ jobs:
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore LLVM source cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-asserts-v2
+          key: llvm-source-15-linux-asserts-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -182,11 +199,22 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save LLVM source cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore LLVM build cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-asserts-v3
+          key: llvm-build-15-linux-asserts-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -198,6 +226,12 @@ jobs:
           make llvm-build ASSERT=1
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save LLVM build cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+          path: llvm-build
       - name: Cache Binaryen
         uses: actions/cache@v3
         id: cache-binaryen
@@ -254,11 +288,11 @@ jobs:
         with:
           go-version: '1.20'
           cache: true
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore LLVM source cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v2
+          key: llvm-source-15-linux-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -268,11 +302,22 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save LLVM source cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore LLVM build cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm-v3
+          key: llvm-build-15-linux-arm-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -286,6 +331,12 @@ jobs:
           make llvm-build CROSS=arm-linux-gnueabihf
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save LLVM build cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+          path: llvm-build
       - name: Cache Binaryen
         uses: actions/cache@v3
         id: cache-binaryen
@@ -354,11 +405,11 @@ jobs:
         with:
           go-version: '1.20'
           cache: true
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore LLVM source cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v2
+          key: llvm-source-15-linux-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -368,11 +419,22 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save LLVM source cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore LLVM build cache
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm64-v3
+          key: llvm-build-15-linux-arm64-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -384,6 +446,12 @@ jobs:
           make llvm-build CROSS=aarch64-linux-gnu
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save LLVM build cache
+        uses: actions/cache/save@v3
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+          path: llvm-build
       - name: Cache Binaryen
         uses: actions/cache@v3
         id: cache-binaryen

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-windows-v3
+          key: llvm-source-15-windows-v4
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -53,7 +53,7 @@ jobs:
         run: make llvm-source
       - name: Save cached LLVM source
         uses: actions/cache/save@v3
-        if: always()
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-windows-v4
+          key: llvm-build-15-windows-v5
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -81,7 +81,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save cached LLVM build
         uses: actions/cache/save@v3
-        if: always()
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,8 +18,9 @@ jobs:
       - name: Configure pagefile
         uses: al-cheb/configure-pagefile-action@v1.3
         with:
-          minimum-size: 4GB
-          maximum-size: 6GB
+          minimum-size: 8GB
+          maximum-size: 24GB
+          disk-root: "C:"
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-windows-v2
+          key: llvm-source-15-windows-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-windows-v3
+          key: llvm-build-15-windows-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -123,6 +123,12 @@ jobs:
     runs-on: windows-2022
     needs: build-windows
     steps:
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 8GB
+          maximum-size: 24GB
+          disk-root: "C:"
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'
@@ -154,6 +160,12 @@ jobs:
     runs-on: windows-2022
     needs: build-windows
     steps:
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 8GB
+          maximum-size: 24GB
+          disk-root: "C:"
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go
@@ -177,6 +189,12 @@ jobs:
     runs-on: windows-2022
     needs: build-windows
     steps:
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 8GB
+          maximum-size: 24GB
+          disk-root: "C:"
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           go-version: '1.20'
           cache: true
-      - name: Cache LLVM source
-        uses: actions/cache@v3
+      - name: Restore cached LLVM source
+        uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
           key: llvm-source-15-windows-v2
@@ -45,8 +45,19 @@ jobs:
       - name: Download LLVM source
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'
         run: make llvm-source
-      - name: Cache LLVM build
-        uses: actions/cache@v3
+      - name: Save cached LLVM source
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: llvm-source-15-windows-v2
+          path: |
+            llvm-project/clang/lib/Headers
+            llvm-project/clang/include
+            llvm-project/compiler-rt
+            llvm-project/lld/include
+            llvm-project/llvm/include
+      - name: Restore cached LLVM build
+        uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
           key: llvm-build-15-windows-v3
@@ -62,6 +73,12 @@ jobs:
           make llvm-build CCACHE=OFF
           # Remove unnecessary object files (to reduce cache size).
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+      - name: Save cached LLVM build
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: llvm-build-15-windows-v3
+          path: llvm-build
       - name: Cache wasi-libc sysroot
         uses: actions/cache@v3
         id: cache-wasi-libc

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,11 @@ jobs:
   build-windows:
     runs-on: windows-2022
     steps:
+      - name: Configure pagefile
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 4GB
+          maximum-size: 6GB
       - uses: brechtm/setup-scoop@v2
         with:
           scoop_update: 'false'
@@ -49,7 +54,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          key: llvm-source-15-windows-v2
+          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -77,7 +82,7 @@ jobs:
         uses: actions/cache/save@v3
         if: always()
         with:
-          key: llvm-build-15-windows-v3
+          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
       - name: Cache wasi-libc sysroot
         uses: actions/cache@v3


### PR DESCRIPTION
This PR modifies the GH actions builds to always cache LLVM source/build even if the tests fail to avoid extra rebuilds.

See https://github.com/actions/cache/tree/main/save#always-save-cache for details