### PR TITLE
runtime: implement KeepAlive using inline assembly

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -88,12 +88,9 @@ func LockOSThread() {
 func UnlockOSThread() {
 }
 
-func KeepAlive(x interface{}) {
-	// Unimplemented.
-	// TODO: This function needs to be implemented in a way that LLVM doesn't optimize away the x
-	// parameter. This will likely need either a volatile operation or calling an assembly stub
-	// that simply returns.
-}
+// KeepAlive makes sure the value in the interface is alive until at least the
+// point of the call.
+func KeepAlive(x interface{})
 
 var godebugUpdate func(string, string)
 

--- a/testdata/gc.go
+++ b/testdata/gc.go
@@ -1,5 +1,7 @@
 package main
 
+import "runtime"
+
 var xorshift32State uint32 = 1
 
 func xorshift32(x uint32) uint32 {
@@ -17,6 +19,7 @@ func randuint32() uint32 {
 
 func main() {
 	testNonPointerHeap()
+	testKeepAlive()
 }
 
 var scalarSlices [4][]byte
@@ -63,4 +66,11 @@ func testNonPointerHeap() {
 		}
 	}
 	println("ok")
+}
+
+func testKeepAlive() {
+	// There isn't much we can test, but at least we can test that
+	// runtime.KeepAlive compiles correctly.
+	var x int
+	runtime.KeepAlive(&x)
 }


### PR DESCRIPTION
See https://github.com/tinygo-org/tinygo/pull/3419 for context.

Note this doesn't keep the type struct alive. This is not currently needed as we don't generate type structs at runtime (they're all effectively const globals).