### PR TITLE
machine/rp2040: change calling order for device enumeration fix

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -127,10 +127,10 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 	// Bus is reset
 	if (status & rp.USBCTRL_REGS_INTS_BUS_RESET) > 0 {
 		rp.USBCTRL_REGS.SIE_STATUS.Set(rp.USBCTRL_REGS_SIE_STATUS_BUS_RESET)
-		rp.USBCTRL_REGS.ADDR_ENDP.Set(0)
-
-		initEndpoint(0, usb.ENDPOINT_TYPE_CONTROL)
 		fixRP2040UsbDeviceEnumeration()
+
+		rp.USBCTRL_REGS.ADDR_ENDP.Set(0)
+		initEndpoint(0, usb.ENDPOINT_TYPE_CONTROL)
 	}
 }
 


### PR DESCRIPTION
This PR changes the calling order for the device enumeration fix on the RP2040. I think it needs to be done first before anything else to work correctly.