### PR TITLE
fix bad qt py pin assignment

### DIFF
--- a/src/machine/board_qtpy.go
+++ b/src/machine/board_qtpy.go
@@ -29,7 +29,7 @@ const (
 
 // Analog pins
 const (
-	A0 = D1
+	A0 = D0
 	A1 = D1
 	A2 = D2
 	A3 = D3


### PR DESCRIPTION
We were confused when testing out this board and our A0 ended up being on A1!