### PR TITLE
build/linux, docker: improvements to CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 build/
 llvm-*/
+.github
+.circleci
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,21 +69,31 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/tinygo-org/bluetooth/actions/workflows/linux.yml/dispatches \
           -d '{"ref": "dev"}'
-      - name: Trigger TinyFS repo build on CircleCI
+      - name: Trigger TinyFS repo build on Github Actions
         run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinyfs/pipeline' \
-            --header 'Content-Type: application/json' \
-            -d '{"branch": "dev"}' \
-            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
-      - name: Trigger TinyFont repo build on CircleCI
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/tinyfs/actions/workflows/build.yml/dispatches \
+          -d '{"ref": "dev"}'
+      - name: Trigger TinyFont repo build on Github Actions
         run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinyfont/pipeline' \
-            --header 'Content-Type: application/json' \
-            -d '{"branch": "dev"}' \
-            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
-      - name: Trigger TinyDraw repo build on CircleCI
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/tinyfont/actions/workflows/build.yml/dispatches \
+          -d '{"ref": "dev"}'
+      - name: Trigger TinyDraw repo build on Github Actions
         run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/tinygo-org/tinydraw/pipeline' \
-            --header 'Content-Type: application/json' \
-            -d '{"branch": "dev"}' \
-            -u "${{ secrets.CIRCLECI_API_TOKEN }}"
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/tinydraw/actions/workflows/build.yml/dispatches \
+          -d '{"ref": "dev"}'
+      - name: Trigger TinyTerm repo build on Github Actions
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.GHA_ACCESS_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/tinygo-org/tinyterm/actions/workflows/build.yml/dispatches \
+          -d '{"ref": "dev"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-contexts: tinygo-llvm-build=docker-image://tinygo/llvm-15
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Trigger Drivers repo build on Github Actions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -139,7 +139,9 @@ jobs:
           cache: true
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
+          curl https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.0/wasmtime-v5.0.0-x86_64-linux.tar.xz -o wasmtime-v5.0.0-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v5.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v5.0.0-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v3
@@ -183,7 +185,9 @@ jobs:
           node-version: '14'
       - name: Install wasmtime
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
+          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.0/wasmtime-v5.0.0-x86_64-linux.tar.xz -o wasmtime-v5.0.0-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v5.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v5.0.0-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3


### PR DESCRIPTION
This PR includes 3 different improvements to the CI process.

The first is to switch from using the wasmtime installer to just downloading and copying the file directly from the bytecodealliance Github repo to avoid all too frequent errors on that.

The second is to switch all builds of TinyGo ecosystem packages such as TinyFont, TinyTerm, etc to trigger GH actions builds no more CircleCI there. 

The third is to use a pre-built docker container with LLVM for the docker dev build to speedup the building process and avoid getting unexpected LLVM rebuilds for no good reason.