### PR TITLE
main: support qemu-user debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -644,7 +644,7 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 	case "qemu-user":
 		port = ":1234"
 		// Run in an emulator.
-		args := append(emulator[1:], "-g", "1234")
+		args := append([]string{"-g", "1234"}, emulator[1:]...)
 		daemon = executeCommand(config.Options, emulator[0], args...)
 		daemon.Stdout = os.Stdout
 		daemon.Stderr = os.Stderr


### PR DESCRIPTION
Running binaries in QEMU (when debugging on Linux for example) did not work correctly as qemu-user expects the `-g` flag to be first on the command line before the program name. Putting it after will make it a command line parameter for the emulated program, which is not what we want.

I don't think this ever worked correctly. But now it works for me to debug issues with #3103:

![Screenshot_20230218_201218](https://user-images.githubusercontent.com/729697/219884054-ef357899-451d-42fa-80fe-012335f2f504.png)

(Using lldb here as Arch Linux doesn't package gdb-multiarch. The bug turned out to be using the esp register on amd64 which of course won't work).