### PR TITLE
build/linux: correct issue with duplicate name for LLVM source cache for arm/arm64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -296,7 +296,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v3
+          key: llvm-source-15-linux-arm-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -413,7 +413,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v3
+          key: llvm-source-15-linux-arm64-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include


### PR DESCRIPTION
This PR contains a needed fix that came out of #3462 

The Github actions build for linux has an issue with a duplicate name for the LLVM source cache for arm and arm64. This PR correct that problem.