### PR TITLE
ci: don't pass -v to `go test`

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -89,7 +89,7 @@ jobs:
         run: make wasi-libc
       - name: Test TinyGo
         shell: bash
-        run: make test GOTESTFLAGS="-v -short"
+        run: make test GOTESTFLAGS="-short"
       - name: Build TinyGo release tarball
         run: make release -j3
       - name: Test stdlib packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,7 @@ jobs:
           scoop install wasmtime
       - name: Test TinyGo
         shell: bash
-        run: make test GOTESTFLAGS="-v -short"
+        run: make test GOTESTFLAGS="-short"
       - name: Build TinyGo release tarball
         shell: bash
         run: make build/release -j4

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GO ?= go
 export GOROOT = $(shell $(GO) env GOROOT)
 
 # Flags to pass to go test.
-GOTESTFLAGS ?= -v
+GOTESTFLAGS ?=
 
 # md5sum binary
 MD5SUM = md5sum


### PR DESCRIPTION
It can be difficult to find what went wrong in a test. Omitting -v should make it easier to see the failing tests and the output for them (note that output is still printed for tests that fail).

Just something I've been running into and I'd like to change. Comments welcome.