### PR TITLE
xiao-rp2040: Pins D4 & D5 are I2C1. Use pins D2 & D3 for I2C0.

### DIFF
--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -50,11 +50,11 @@ const (
 
 // I2C pins
 const (
-	I2C0_SDA_PIN Pin = D4
-	I2C0_SCL_PIN Pin = D5
+	I2C0_SDA_PIN Pin = D2
+	I2C0_SCL_PIN Pin = D3
 
-	I2C1_SDA_PIN Pin = NoPin
-	I2C1_SCL_PIN Pin = NoPin
+	I2C1_SDA_PIN Pin = D4
+	I2C1_SCL_PIN Pin = D5
 )
 
 // SPI pins


### PR DESCRIPTION
There is a bug where I2C0_SDA_PIN & I2C0_SCL_PIN are currently mapped to I2C1 pins.

rp2040 datasheet, page 13-14:
https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf

Function 3 contains the I2C functions:
```
I2C0 SDA  0, 4, 8, 12, 16, 20, 24, 28
I2C0 SCL  1, 5, 9, 13, 17, 21, 25, 29

I2C1 SDA  2, 6, 10, 14, 18, 22, 26
I2C1 SCL  3, 7, 11, 15, 19, 23, 27
```

The left side of the chip has pins D0-D6
https://wiki.seeedstudio.com/XIAO-RP2040

```
D0: GPIO26 - I2C1 SDA
D1: GPIO27 - I2C1 SCL
D2: GPIO28 - I2C0 SDA  <--
D3: GPIO29 - I2C0 SCL  <--
D4: GPIO6  - I2C1 SDA  <--
D5: GPIO7  - I2C1 SCL  <--
D6: GPIO0  - I2C0 SDA
```

In the diagrams "SDA" (D4) and "SCL" (D5) of I2C1 are featured, so it makes sense to leave those there and place I2C0 on the two pins above it (D2 & D3).