### PR TITLE
internal/task: disallow blocking inside an interrupt

### DIFF
--- a/src/internal/task/task_stack.go
+++ b/src/internal/task/task_stack.go
@@ -2,7 +2,10 @@
 
 package task
 
-import "unsafe"
+import (
+	"runtime/interrupt"
+	"unsafe"
+)
 
 //go:linkname runtimePanic runtime.runtimePanic
 func runtimePanic(str string)
@@ -44,6 +47,9 @@ func Pause() {
 	// valid. If it is not, a stack overflow has occured.
 	if *currentTask.state.canaryPtr != stackCanary {
 		runtimePanic("goroutine stack overflow")
+	}
+	if interrupt.In() {
+		runtimePanic("blocked inside interrupt")
 	}
 	currentTask.state.pause()
 }


### PR DESCRIPTION
Blocking inside an interrupt is always unsafe and will lead to all kinds of bad behavior (even if it might appear to work sometimes). So disallow it, just like allocating heap memory inside an interrupt is not allowed.

I suspect this will usually be caused by channel sends, like this:

```go
    ch <- someValue
```

The easy workaround is to make it a non-blocking send instead:

```go
    select {
    case ch <- someValue:
    default:
    }
```

This does mean the application might become a bit more complex to be able to deal with this case, but the alternative (undefined behavior) is IMHO much worse.

What this _doesn't_ catch is all instances of the above invalid channel send: if the channel send would not block it will work fine. This is a race condition, and we might want to tighten this further in the future to also catch such unlikely-to-be-safe channel operations. However it will catch things like `time.Sleep(...)` inside interrupts which is unlikely to work correctly.

I didn't measure the binary size impact but it's probably very small (similar to #1460).