### PR TITLE
machine/rp2040: correct issues with i2c/spi pin validation

### DIFF
--- a/src/machine/machine_rp2040_i2c.go
+++ b/src/machine/machine_rp2040_i2c.go
@@ -103,21 +103,23 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 			config.SDA = I2C1_SDA_PIN
 		}
 	}
-	var okSDA, okSCL bool
+	var okSCL, okSDA bool
 	switch i2c.Bus {
 	case rp.I2C0:
-		okSDA = config.SDA%4 == 0
-		okSCL = (config.SCL+1)%4 == 0
-	case rp.I2C1:
-		okSDA = (config.SDA+2)%4 == 0
 		okSCL = (config.SCL+3)%4 == 0
+		okSDA = (config.SDA+4)%4 == 0
+	case rp.I2C1:
+		okSCL = (config.SCL+1)%4 == 0
+		okSDA = (config.SDA+2)%4 == 0
 	}
 
-	if !okSDA {
-		return errInvalidI2CSDA
-	} else if !okSCL {
+	switch {
+	case !okSCL:
 		return errInvalidI2CSCL
+	case !okSDA:
+		return errInvalidI2CSDA
 	}
+
 	if config.Frequency == 0 {
 		config.Frequency = defaultBaud
 	}

--- a/src/machine/machine_rp2040_spi.go
+++ b/src/machine/machine_rp2040_spi.go
@@ -181,22 +181,24 @@ func (spi SPI) Configure(config SPIConfig) error {
 	var okSDI, okSDO, okSCK bool
 	switch spi.Bus {
 	case rp.SPI0:
-		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 17
+		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 16
 		okSDO = config.SDO == 3 || config.SDO == 7 || config.SDO == 19
 		okSCK = config.SCK == 2 || config.SCK == 6 || config.SCK == 18
 	case rp.SPI1:
-		okSDI = config.SDI == 8 || config.SDI == 12
-		okSDO = config.SDO == 11 || config.SDO == 15
-		okSDO = config.SCK == 10 || config.SCK == 14
+		okSDI = config.SDI == 8 || config.SDI == 12 || config.SDI == 28
+		okSDO = config.SDO == 11 || config.SDO == 15 || config.SDO == 27
+		okSCK = config.SCK == 10 || config.SCK == 14 || config.SCK == 26
 	}
 
-	if !okSDI {
+	switch {
+	case !okSDI:
 		return errSPIInvalidSDI
-	} else if !okSDO {
+	case !okSDO:
 		return errSPIInvalidSDO
-	} else if !okSCK {
+	case !okSCK:
 		return errSPIInvalidSCK
 	}
+
 	if config.DataBits < 4 || config.DataBits > 16 {
 		config.DataBits = 8
 	}


### PR DESCRIPTION
This PR corrects an issue with i2c pin validation introduced in https://github.com/tinygo-org/tinygo/pull/3443