### PR TITLE
FPU support for ARM Cortex-M targets

### DIFF
--- a/src/device/arm/scb.go
+++ b/src/device/arm/scb.go
@@ -66,6 +66,43 @@ const (
 	SCB_CPUID_IMPLEMENTER_Pos  = 0x18       // Position of IMPLEMENTER field.
 	SCB_CPUID_IMPLEMENTER_Msk  = 0xff000000 // Bit mask of IMPLEMENTER field.
 
+	SCB_CPACR_CP_ACCESS_DENIED = 0x00
+	SCB_CPACR_CP_PRIVILEGED    = 0x01
+	SCB_CPACR_CP_FULL_ACCESS   = 0xFF
+
+	SCB_CPACR_CP0_Pos    = 0x0
+	SCB_CPACR_CP0_Msk    = 0x3
+	SCB_CPACR_CP1_Pos    = 0x2
+	SCB_CPACR_CP1_Msk    = 0xc
+	SCB_CPACR_CP2_Pos    = 0x4
+	SCB_CPACR_CP2_Msk    = 0x30
+	SCB_CPACR_CP3_Pos    = 0x6
+	SCB_CPACR_CP3_Msk    = 0xc0
+	SCB_CPACR_CP4_Pos    = 0x8
+	SCB_CPACR_CP4_Msk    = 0x300
+	SCB_CPACR_CP5_Pos    = 0xa
+	SCB_CPACR_CP5_Msk    = 0xc00
+	SCB_CPACR_CP6_Pos    = 0xc
+	SCB_CPACR_CP6_Msk    = 0x3000
+	SCB_CPACR_CP7_Pos    = 0xe
+	SCB_CPACR_CP7_Msk    = 0xc000
+	SCB_CPACR_CP8_Pos    = 0x10
+	SCB_CPACR_CP8_Msk    = 0x30000
+	SCB_CPACR_CP9_Pos    = 0x12
+	SCB_CPACR_CP9_Msk    = 0xc0000
+	SCB_CPACR_CP10_Pos   = 0x14
+	SCB_CPACR_CP10_Msk   = 0x300000
+	SCB_CPACR_CP11_Pos   = 0x16
+	SCB_CPACR_CP11_Msk   = 0xc00000
+	SCB_CPACR_CP12_Pos   = 0x18
+	SCB_CPACR_CP12_Msk   = 0x3000000
+	SCB_CPACR_CP13_Pos   = 0x1a
+	SCB_CPACR_CP13_Msk   = 0xc000000
+	SCB_CPACR_D32DIS_Pos = 0x1c
+	SCB_CPACR_D32DIS_Msk = 0x30000000
+	SCB_CPACR_ASEDIS_Pos = 0x1e
+	SCB_CPACR_ASEDIS_Msk = 0xc0000000
+
 	// ICSR: Interrupt Control and State Register
 	SCB_ICSR_VECTACTIVE_Pos          = 0x0        // Position of VECTACTIVE field.
 	SCB_ICSR_VECTACTIVE_Msk          = 0x1ff      // Bit mask of VECTACTIVE field.

--- a/src/internal/task/task_stack_cortexm.S
+++ b/src/internal/task/task_stack_cortexm.S
@@ -40,7 +40,11 @@ tinygo_switchToScheduler:
     // Currently on the task stack (SP=PSP). We need to store the position on
     // the stack where the in-use registers will be stored.
     mov r1, sp
-    subs r1, #36
+#if defined(FPU_ENABLED)
+    subs r1, #41*4      // Includes the floating-point registers
+#else
+    subs r1, #9*4
+#endif
     str r1, [r0]
 
     b tinygo_swapTask
@@ -87,8 +91,18 @@ tinygo_swapTask:
     // will be the pc after returning back to the old task (in a different
     // invocation of swapTask).
     #if defined(__thumb2__)
-    push {r4-r11, lr}
-    .cfi_def_cfa_offset 9*4
+        #if defined(FPU_ENABLED)
+            vpush {s0-s31}              // Push the floating-point registers to the stack
+            .cfi_def_cfa_offset 32*4
+        #endif
+
+        push {r4-r11, lr}
+
+        #if defined(FPU_ENABLED)
+            .cfi_def_cfa_offset 41*4
+        #else
+            .cfi_def_cfa_offset 9*4
+        #endif
     #else
     mov r0, r8
     mov r1, r9
@@ -111,7 +125,12 @@ tinygo_swapTask:
     // Load state from new task and branch to the previous position in the
     // program.
     #if defined(__thumb2__)
-    pop {r4-r11, pc}
+    pop {r4-r11}
+    pop {r1}
+    #if defined(FPU_ENABLED)
+        vpop {s0-s31}               // Pop the floating-point registers from the stack
+    #endif
+    mov pc, r1                  // Jump to the instruct this task was to execute next
     #else
     pop {r4-r7}
     .cfi_def_cfa_offset 5*9

--- a/src/internal/task/task_stack_cortexm_fpu.go
+++ b/src/internal/task/task_stack_cortexm_fpu.go
@@ -1,4 +1,4 @@
-//go:build scheduler.tasks && cortexm && !fpu
+//go:build scheduler.tasks && cortexm && fpu
 
 package task
 
@@ -25,8 +25,8 @@ type calleeSavedRegs struct {
 	r9  uintptr
 	r10 uintptr
 	r11 uintptr
-
-	pc uintptr
+	pc  uintptr
+	s   [32]uintptr
 }
 
 // archInit runs architecture-specific setup for the goroutine startup.

--- a/src/runtime/asm_arm.S
+++ b/src/runtime/asm_arm.S
@@ -8,8 +8,16 @@ tinygo_scanCurrentStack:
     .cfi_startproc
     // Save callee-saved registers onto the stack.
     #if defined(__thumb2__)
-    push {r4-r11, lr}
-    .cfi_def_cfa_offset 9*4
+        #if defined(FPU_ENABLED)
+            vpush {s0-s31}              // Push the floating-point registers to the stack
+            .cfi_def_cfa_offset 32*4
+        #endif
+        push {r4-r11, lr}
+        #if defined(FPU_ENABLED)
+            .cfi_def_cfa_offset 41*4
+        #else
+            .cfi_def_cfa_offset 9*4
+        #endif
     #else
     mov r0, r8
     mov r1, r9

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -38,17 +38,3 @@ func preinit() {
 		src = unsafe.Pointer(uintptr(src) + 4)
 	}
 }
-
-// The stack layout at the moment an interrupt occurs.
-// Registers can be accessed if the stack pointer is cast to a pointer to this
-// struct.
-type interruptStack struct {
-	R0  uintptr
-	R1  uintptr
-	R2  uintptr
-	R3  uintptr
-	R12 uintptr
-	LR  uintptr
-	PC  uintptr
-	PSR uintptr
-}

--- a/src/runtime/runtime_cortexm_interrupt.go
+++ b/src/runtime/runtime_cortexm_interrupt.go
@@ -1,0 +1,20 @@
+//go:build cortexm && !fpu
+
+package runtime
+
+// Disable the FPU during the call to main()
+const fpuEnabled = false
+
+// The stack layout at the moment an interrupt occurs.
+// Registers can be accessed if the stack pointer is cast to a pointer to this
+// struct.
+type interruptStack struct {
+	R0  uintptr
+	R1  uintptr
+	R2  uintptr
+	R3  uintptr
+	R12 uintptr
+	LR  uintptr
+	PC  uintptr
+	PSR uintptr
+}

--- a/src/runtime/runtime_cortexm_interrupt_fpu.go
+++ b/src/runtime/runtime_cortexm_interrupt_fpu.go
@@ -1,0 +1,37 @@
+//go:build cortexm && fpu
+
+package runtime
+
+// Grant full access to the FPU during the call to main()
+const fpuEnabled = true
+
+// The stack layout at the moment an interrupt occurs.
+// Registers can be accessed if the stack pointer is cast to a pointer to this
+// struct.
+type interruptStack struct {
+	R0    uintptr
+	R1    uintptr
+	R2    uintptr
+	R3    uintptr
+	R12   uintptr
+	LR    uintptr
+	PC    uintptr
+	PSR   uintptr
+	S0    uintptr
+	S1    uintptr
+	S2    uintptr
+	S3    uintptr
+	S4    uintptr
+	S5    uintptr
+	S6    uintptr
+	S7    uintptr
+	S8    uintptr
+	S9    uintptr
+	S10   uintptr
+	S11   uintptr
+	S12   uintptr
+	S13   uintptr
+	S14   uintptr
+	S15   uintptr
+	FPSCR uintptr
+}

--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -13,7 +13,6 @@
 		"-Werror",
 		"-fshort-enums",
 		"-fomit-frame-pointer",
-		"-mfloat-abi=soft",
 		"-fno-exceptions", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables",
 		"-ffunction-sections", "-fdata-sections"
 	],

--- a/targets/cortex-m0.json
+++ b/targets/cortex-m0.json
@@ -2,5 +2,8 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0",
+	"cflags": [
+		"-mfloat-abi=soft"
+	],
 	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m0plus.json
+++ b/targets/cortex-m0plus.json
@@ -2,5 +2,8 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv6m-unknown-unknown-eabi",
 	"cpu": "cortex-m0plus",
+	"cflags": [
+		"-mfloat-abi=soft"
+	],
 	"features": "+armv6-m,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m3.json
+++ b/targets/cortex-m3.json
@@ -2,5 +2,8 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7m-unknown-unknown-eabi",
 	"cpu": "cortex-m3",
+	"cflags": [
+		"-mfloat-abi=soft"
+	],
 	"features": "+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m33.json
+++ b/targets/cortex-m33.json
@@ -2,5 +2,8 @@
     "inherits": ["cortex-m"],
     "llvm-target": "thumbv8m.main-unknown-unknown-eabi",
     "cpu": "cortex-m33",
+    "cflags": [
+        "-mfloat-abi=soft"
+    ],
     "features": "+armv8-m.main,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m4-fpu.json
+++ b/targets/cortex-m4-fpu.json
@@ -1,0 +1,11 @@
+{
+	"inherits": ["cortex-m"],
+	"build-tags": ["fpu"],
+	"llvm-target": "thumbv7em-unknown-unknown-eabihf",
+	"cpu": "cortex-m4",
+	"cflags": [
+		"-mfloat-abi=hard",
+		"-DFPU_ENABLED"
+	],
+	"features": "+armv7e-m,+dsp,+fp16,+hwdiv,+strict-align,+thumb-mode,+vfp2sp,+vfp3d16sp,+vfp4d16sp,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16fml,-fp64,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp3,-vfp3d16,-vfp3sp,-vfp4,-vfp4d16,-vfp4sp"
+}

--- a/targets/cortex-m4.json
+++ b/targets/cortex-m4.json
@@ -2,5 +2,8 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m4",
+	"cflags": [
+		"-mfloat-abi=soft"
+	],
 	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }

--- a/targets/cortex-m7.json
+++ b/targets/cortex-m7.json
@@ -2,5 +2,8 @@
 	"inherits": ["cortex-m"],
 	"llvm-target": "thumbv7em-unknown-unknown-eabi",
 	"cpu": "cortex-m7",
+	"cflags": [
+		"-mfloat-abi=soft"
+	],
 	"features": "+armv7e-m,+dsp,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp"
 }


### PR DESCRIPTION
Adds FPU support to the scheduler by allowing the FPU registers to be saved during a context switch. The target must have the `fpu` build tag and `FPU_ENABLED` preprocessor define set. Otherwise, the smaller stack frame is used and the non-FPU context save/restore routine will be performed.