### PR TITLE
ci: add AVR timers test

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -180,7 +180,8 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 			// Skip the ones that aren't.
 			switch name {
 			case "reflect.go":
-				// Reflect tests do not work due to type code issues.
+				// Reflect tests do not run correctly, probably because of the
+				// limited amount of memory.
 				continue
 
 			case "gc.go":
@@ -188,20 +189,16 @@ func runPlatTests(options compileopts.Options, tests []string, t *testing.T) {
 				continue
 
 			case "json.go", "stdlib.go", "testing.go":
-				// Breaks interp.
+				// Too big for AVR. Doesn't fit in flash/RAM.
 				continue
 
 			case "math.go":
-				// Stuck somewhere, not sure what's happening.
+				// Needs newer picolibc version (for sqrt).
 				continue
 
 			case "cgo/":
-				// CGo does not work on AVR.
-				continue
-
-			case "timers.go":
-				// Doesn't compile:
-				//   panic: compiler: could not store type code number inside interface type code
+				// CGo function pointers don't work on AVR (needs LLVM 16 and
+				// some compiler changes).
 				continue
 
 			default:


### PR DESCRIPTION
Add the timers test because they now work correctly on AVR, probably as a result of the reflect refactor: https://github.com/tinygo-org/tinygo/pull/2640

I've also updated a few of the other tests to indicate the new status and why they don't work. It's no longer because of compiler errors, but because of linker or runtime errors (which is at least some progress). For example, I found that testdata/reflect.go works if you disable `testAppendSlice` and increase the stack size.