### PR TITLE
Add real ThinLTO mode

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -169,6 +169,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		CodeModel:       config.CodeModel(),
 		RelocationModel: config.RelocationModel(),
 		SizeLevel:       sizeLevel,
+		TinyGoVersion:   goenv.Version,
 
 		Scheduler:          config.Scheduler(),
 		AutomaticStackSize: config.AutomaticStackSize(),
@@ -305,7 +306,6 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				actionID := packageAction{
 					ImportPath:       pkg.ImportPath,
 					CompilerBuildID:  string(compilerBuildID),
-					TinyGoVersion:    goenv.Version,
 					LLVMVersion:      llvm.Version,
 					Config:           compilerConfig,
 					CFlags:           pkg.CFlags,

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -165,6 +165,14 @@ func (c *Config) OptLevels() (optLevel, sizeLevel int, inlinerThreshold uint) {
 	}
 }
 
+// LTO returns one of the possible LTO configurations: legacy or thin.
+func (c *Config) LTO() string {
+	if c.Options.LTO != "" {
+		return c.Options.LTO
+	}
+	return "legacy"
+}
+
 // PanicStrategy returns the panic strategy selected for this target. Valid
 // values are "print" (print the panic value, then exit) or "trap" (issue a trap
 // instruction).

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -14,6 +14,7 @@ var (
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
 	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
+	validLTOOptions           = []string{"legacy", "thin"}
 )
 
 // Options contains extra options to give to the compiler. These options are
@@ -25,6 +26,7 @@ type Options struct {
 	GOARM           string // environment variable (only used with GOARCH=arm)
 	Target          string
 	Opt             string
+	LTO             string
 	GC              string
 	PanicStrategy   string
 	Scheduler       string
@@ -104,6 +106,12 @@ func (o *Options) Verify() error {
 	if o.Opt != "" {
 		if !isInArray(validOptOptions, o.Opt) {
 			return fmt.Errorf("invalid -opt=%s: valid values are %s", o.Opt, strings.Join(validOptOptions, ", "))
+		}
+	}
+
+	if o.LTO != "" {
+		if !isInArray(validLTOOptions, o.LTO) {
+			return fmt.Errorf("invalid -lto=%s: valid values are %s", o.LTO, strings.Join(validLTOOptions, ", "))
 		}
 	}
 

--- a/compiler/alias.go
+++ b/compiler/alias.go
@@ -34,7 +34,9 @@ var stdlibAliases = map[string]string{
 // createAlias implements the function (in the builder) as a call to the alias
 // function.
 func (b *builder) createAlias(alias llvm.Value) {
-	b.llvmFn.SetVisibility(llvm.HiddenVisibility)
+	if !b.LTO {
+		b.llvmFn.SetVisibility(llvm.HiddenVisibility)
+	}
 	b.llvmFn.SetUnnamedAddr(true)
 
 	if b.Debug {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -47,6 +47,7 @@ type Config struct {
 	CodeModel       string
 	RelocationModel string
 	SizeLevel       int
+	TinyGoVersion   string // for llvm.ident
 
 	// Various compiler options that determine how code is generated.
 	Scheduler          string
@@ -321,6 +322,14 @@ func CompilePackage(moduleName string, pkg *loader.Package, ssaPkg *ssa.Package,
 				llvm.ConstInt(c.ctx.Int32Type(), 4, false).ConstantAsMetadata(),
 			}),
 		)
+		if c.TinyGoVersion != "" {
+			// It is necessary to set llvm.ident, otherwise debugging on MacOS
+			// won't work.
+			c.mod.AddNamedMetadataOperand("llvm.ident",
+				c.ctx.MDNode(([]llvm.Metadata{
+					c.ctx.MDString("TinyGo version " + c.TinyGoVersion),
+				})))
+		}
 		c.dibuilder.Finalize()
 		c.dibuilder.Destroy()
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -55,6 +55,7 @@ type Config struct {
 	DefaultStackSize   uint64
 	NeedsStackObjects  bool
 	Debug              bool // Whether to emit debug information in the LLVM module.
+	LTO                bool // non-legacy LTO (meaning: package bitcode is merged by the linker)
 }
 
 // compilerContext contains function-independent data that should still be
@@ -897,7 +898,9 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 				c.createEmbedGlobal(member, global, files)
 			} else if !info.extern {
 				global.SetInitializer(llvm.ConstNull(global.GlobalValueType()))
-				global.SetVisibility(llvm.HiddenVisibility)
+				if !c.LTO {
+					global.SetVisibility(llvm.HiddenVisibility)
+				}
 				if info.section != "" {
 					global.SetSection(info.section)
 				}
@@ -944,7 +947,9 @@ func (c *compilerContext) createEmbedGlobal(member *ssa.Global, global llvm.Valu
 		}
 		strObj := c.getEmbedFileString(files[0])
 		global.SetInitializer(strObj)
-		global.SetVisibility(llvm.HiddenVisibility)
+		if !c.LTO {
+			global.SetVisibility(llvm.HiddenVisibility)
+		}
 
 	case *types.Slice:
 		if typ.Elem().Underlying().(*types.Basic).Kind() != types.Byte {
@@ -968,7 +973,9 @@ func (c *compilerContext) createEmbedGlobal(member *ssa.Global, global llvm.Valu
 		sliceLen := llvm.ConstInt(c.uintptrType, file.Size, false)
 		sliceObj := c.ctx.ConstStruct([]llvm.Value{slicePtr, sliceLen, sliceLen}, false)
 		global.SetInitializer(sliceObj)
-		global.SetVisibility(llvm.HiddenVisibility)
+		if !c.LTO {
+			global.SetVisibility(llvm.HiddenVisibility)
+		}
 
 	case *types.Struct:
 		// Assume this is an embed.FS struct:
@@ -1051,7 +1058,9 @@ func (c *compilerContext) createEmbedGlobal(member *ssa.Global, global llvm.Valu
 		globalInitializer := llvm.ConstNull(c.getLLVMType(member.Type().(*types.Pointer).Elem()))
 		globalInitializer = c.builder.CreateInsertValue(globalInitializer, sliceGlobal, 0, "")
 		global.SetInitializer(globalInitializer)
-		global.SetVisibility(llvm.HiddenVisibility)
+		if !c.LTO {
+			global.SetVisibility(llvm.HiddenVisibility)
+		}
 		global.SetAlignment(c.targetData.ABITypeAlignment(globalInitializer.Type()))
 	}
 }
@@ -1098,7 +1107,8 @@ func (b *builder) createFunctionStart(intrinsic bool) {
 		// assertion error in llvm-project/llvm/include/llvm/IR/GlobalValue.h:236
 		// is thrown.
 		if b.llvmFn.Linkage() != llvm.InternalLinkage &&
-			b.llvmFn.Linkage() != llvm.PrivateLinkage {
+			b.llvmFn.Linkage() != llvm.PrivateLinkage &&
+			!b.LTO {
 			b.llvmFn.SetVisibility(llvm.HiddenVisibility)
 		}
 		b.llvmFn.SetUnnamedAddr(true)

--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -45,7 +45,9 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	globalLLVMType := b.getLLVMType(globalType)
 	globalName := b.fn.Package().Pkg.Path() + "$interrupt" + strconv.FormatInt(id.Int64(), 10)
 	global := llvm.AddGlobal(b.mod, globalLLVMType, globalName)
-	global.SetVisibility(llvm.HiddenVisibility)
+	if !b.LTO {
+		global.SetVisibility(llvm.HiddenVisibility)
+	}
 	global.SetGlobalConstant(true)
 	global.SetUnnamedAddr(true)
 	initializer := llvm.ConstNull(globalLLVMType)

--- a/main.go
+++ b/main.go
@@ -1357,6 +1357,7 @@ func main() {
 	command := os.Args[1]
 
 	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, s, z")
+	lto := flag.String("lto", "legacy", "LTO mode: legacy or thin")
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, conservative)")
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, tasks, asyncify)")
@@ -1459,6 +1460,7 @@ func main() {
 		Target:          *target,
 		StackSize:       stackSize,
 		Opt:             *opt,
+		LTO:             *lto,
 		GC:              *gc,
 		PanicStrategy:   *panicStrategy,
 		Scheduler:       *scheduler,

--- a/main_test.go
+++ b/main_test.go
@@ -105,6 +105,13 @@ func TestBuild(t *testing.T) {
 			runTestWithConfig("print.go", t, opts, nil, nil)
 		})
 
+		t.Run("lto=thin", func(t *testing.T) {
+			t.Parallel()
+			opts := optionsFromTarget("", sema)
+			opts.LTO = "thin"
+			runTestWithConfig("init.go", t, opts, nil, nil)
+		})
+
 		t.Run("ldflags", func(t *testing.T) {
 			t.Parallel()
 			opts := optionsFromTarget("", sema)


### PR DESCRIPTION
We use ThinLTO for linking, but we use it in a way that doesn't give most of its benefits: we merge all the bitcode files into a single LLVM module and run some optimizations on it before linking. Therefore, this works more like a traditional "full" LTO link rather than a true thin link.

This PR adds a new experimental `-lto=thin` option to do a true ThinLTO link. The main benefit is that linking will be a lot faster especially for large programs consisting of many packages.

At the moment, it only works for programs that don't do interface type asserts and don't call interface methods. It also probably won't work on WebAssembly and baremetal systems. But it's part of a larger goal towards a truly incremental build system: https://github.com/tinygo-org/tinygo/issues/2870
Once interface type asserts and method calls are converted to a [vtable-like implementation](https://research.swtch.com/interfaces), most programs should just work on linux/darwin/windows.