### PR TITLE
compiler: add llvm.ident metadata

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -169,6 +169,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		CodeModel:       config.CodeModel(),
 		RelocationModel: config.RelocationModel(),
 		SizeLevel:       sizeLevel,
+		TinyGoVersion:   goenv.Version,
 
 		Scheduler:          config.Scheduler(),
 		AutomaticStackSize: config.AutomaticStackSize(),
@@ -305,7 +306,6 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				actionID := packageAction{
 					ImportPath:       pkg.ImportPath,
 					CompilerBuildID:  string(compilerBuildID),
-					TinyGoVersion:    goenv.Version,
 					LLVMVersion:      llvm.Version,
 					Config:           compilerConfig,
 					CFlags:           pkg.CFlags,

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -47,6 +47,7 @@ type Config struct {
 	CodeModel       string
 	RelocationModel string
 	SizeLevel       int
+	TinyGoVersion   string // for llvm.ident
 
 	// Various compiler options that determine how code is generated.
 	Scheduler          string
@@ -321,6 +322,14 @@ func CompilePackage(moduleName string, pkg *loader.Package, ssaPkg *ssa.Package,
 				llvm.ConstInt(c.ctx.Int32Type(), 4, false).ConstantAsMetadata(),
 			}),
 		)
+		if c.TinyGoVersion != "" {
+			// It is necessary to set llvm.ident, otherwise debugging on MacOS
+			// won't work.
+			c.mod.AddNamedMetadataOperand("llvm.ident",
+				c.ctx.MDNode(([]llvm.Metadata{
+					c.ctx.MDString("TinyGo version " + c.TinyGoVersion),
+				})))
+		}
 		c.dibuilder.Finalize()
 		c.dibuilder.Destroy()
 	}


### PR DESCRIPTION
This metadata is emitted by Clang and I found it is important for source level debugging on MacOS. This patch does not get source level debugging to work yet (for that, it seems like packages need to be built separately), but it is a step in the right direction.

Extracted from #3489 because it isn't really related to ThinLTO.