### PR TITLE
Fail earlier if Go is not available

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -190,6 +190,9 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 	lprogram, err := loader.Load(config, pkgName, config.ClangHeaders, types.Config{
 		Sizes: compiler.Sizes(machine),
 	})
+	if err != nil {
+		return BuildResult{}, err
+	}
 	result := BuildResult{
 		ModuleRoot: lprogram.MainPkg().Module.Dir,
 		MainDir:    lprogram.MainPkg().Dir,
@@ -198,9 +201,6 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 	if result.ModuleRoot == "" {
 		// If there is no module root, just the regular root.
 		result.ModuleRoot = lprogram.MainPkg().Root
-	}
-	if err != nil { // failed to load AST
-		return result, err
 	}
 	err = lprogram.Parse()
 	if err != nil {


### PR DESCRIPTION
Before:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x10032da5d]

goroutine 1 [running]:
github.com/tinygo-org/tinygo/loader.(*Program).MainPkg(...)
	/Users/runner/work/tinygo/tinygo/loader/loader.go:295
github.com/tinygo-org/tinygo/builder.Build({0x1045f9ea9, 0x1}, {0x0, 0x0}, {0xc00014c280, 0x41}, 0xc0001ea5a0)
	/Users/runner/work/tinygo/tinygo/builder/build.go:194 +0x119d
main.Build({0x1045f9ea9, 0x1}, {0x0, 0x0}, 0xc0001f8000)
	/Users/runner/work/tinygo/tinygo/main.go:168 +0x26f
main.main()
	/Users/runner/work/tinygo/tinygo/main.go:1525 +0x3476
```

After:

```
error: failed to run `go list`: fork/exec /usr/local/Cellar/go/1.20.1/libexec/bin/go: permission denied
```