### PR TITLE
Use `unsafe.Add` everywhere

### DIFF
--- a/compiler/testdata/pointer.go
+++ b/compiler/testdata/pointer.go
@@ -24,18 +24,3 @@ func pointerCastToUnsafe(x *int) unsafe.Pointer {
 func pointerCastToUnsafeNoop(x *byte) unsafe.Pointer {
 	return unsafe.Pointer(x)
 }
-
-// The compiler has support for a few special cast+add patterns that are
-// transformed into a single GEP.
-
-func pointerUnsafeGEPFixedOffset(ptr *byte) *byte {
-	return (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + 10))
-}
-
-func pointerUnsafeGEPByteOffset(ptr *byte, offset uintptr) *byte {
-	return (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + offset))
-}
-
-func pointerUnsafeGEPIntOffset(ptr *int32, offset uintptr) *int32 {
-	return (*int32)(unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + offset*4))
-}

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -43,40 +43,6 @@ entry:
   ret ptr %x
 }
 
-; Function Attrs: nounwind
-define hidden ptr @main.pointerUnsafeGEPFixedOffset(ptr dereferenceable_or_null(1) %ptr, ptr %context) unnamed_addr #1 {
-entry:
-  %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
-  %0 = getelementptr inbounds i8, ptr %ptr, i32 10
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #2
-  ret ptr %0
-}
-
-; Function Attrs: nounwind
-define hidden ptr @main.pointerUnsafeGEPByteOffset(ptr dereferenceable_or_null(1) %ptr, i32 %offset, ptr %context) unnamed_addr #1 {
-entry:
-  %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
-  %0 = getelementptr inbounds i8, ptr %ptr, i32 %offset
-  call void @runtime.trackPointer(ptr %0, ptr nonnull %stackalloc, ptr undef) #2
-  call void @runtime.trackPointer(ptr %0, ptr nonnull %stackalloc, ptr undef) #2
-  ret ptr %0
-}
-
-; Function Attrs: nounwind
-define hidden ptr @main.pointerUnsafeGEPIntOffset(ptr dereferenceable_or_null(4) %ptr, i32 %offset, ptr %context) unnamed_addr #1 {
-entry:
-  %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
-  %0 = shl i32 %offset, 2
-  %1 = getelementptr inbounds i8, ptr %ptr, i32 %0
-  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #2
-  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #2
-  ret ptr %1
-}
-
 attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #2 = { nounwind }

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -143,13 +143,13 @@ func (p Pin) configure(config PinConfig, signal uint32) {
 // outFunc returns the FUNCx_OUT_SEL_CFG register used for configuring the
 // output function selection.
 func (p Pin) outFunc() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.FUNC0_OUT_SEL_CFG)) + uintptr(p)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_OUT_SEL_CFG), uintptr(p)*4))
 }
 
 // inFunc returns the FUNCy_IN_SEL_CFG register used for configuring the input
 // function selection.
 func inFunc(signal uint32) *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.FUNC0_IN_SEL_CFG)) + uintptr(signal)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_IN_SEL_CFG), uintptr(signal)*4))
 }
 
 // Set the pin to high or low.

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -108,24 +108,24 @@ func (p Pin) Configure(config PinConfig) {
 // outFunc returns the FUNCx_OUT_SEL_CFG register used for configuring the
 // output function selection.
 func (p Pin) outFunc() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.FUNC0_OUT_SEL_CFG)) + uintptr(p)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_OUT_SEL_CFG), uintptr(p)*4))
 }
 
 // inFunc returns the FUNCy_IN_SEL_CFG register used for configuring the input
 // function selection.
 func inFunc(signal uint32) *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.FUNC0_IN_SEL_CFG)) + uintptr(signal)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_IN_SEL_CFG), uintptr(signal)*4))
 }
 
 // mux returns the I/O mux configuration register corresponding to the given
 // GPIO pin.
 func (p Pin) mux() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.IO_MUX.GPIO0)) + uintptr(p)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.IO_MUX.GPIO0), uintptr(p)*4))
 }
 
 // pin returns the PIN register corresponding to the given GPIO pin.
 func (p Pin) pin() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.GPIO.PIN0)) + uintptr(p)*4)))
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.PIN0), uintptr(p)*4))
 }
 
 // Set the pin to high or low.

--- a/src/machine/machine_rp2040_pwm.go
+++ b/src/machine/machine_rp2040_pwm.go
@@ -50,7 +50,7 @@ type pwmGroup struct {
 //
 // 0x14 is the size of a pwmGroup.
 func getPWMGroup(index uintptr) *pwmGroup {
-	return (*pwmGroup)(unsafe.Pointer(uintptr(unsafe.Pointer(rp.PWM)) + 0x14*index))
+	return (*pwmGroup)(unsafe.Add(unsafe.Pointer(rp.PWM), 0x14*index))
 }
 
 // Hardware Pulse Width Modulation (PWM) API

--- a/src/reflect/swapper.go
+++ b/src/reflect/swapper.go
@@ -31,8 +31,8 @@ func Swapper(slice interface{}) func(i, j int) {
 		if uint(i) >= uint(header.len) || uint(j) >= uint(header.len) {
 			panic("reflect: slice index out of range")
 		}
-		val1 := unsafe.Pointer(uintptr(header.data) + uintptr(i)*size)
-		val2 := unsafe.Pointer(uintptr(header.data) + uintptr(j)*size)
+		val1 := unsafe.Add(header.data, uintptr(i)*size)
+		val2 := unsafe.Add(header.data, uintptr(j)*size)
 		memcpy(tmp, val1, size)
 		memcpy(val1, val2, size)
 		memcpy(val2, tmp, size)

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -243,13 +243,8 @@ func (ch *channel) push(value unsafe.Pointer) bool {
 
 	// copy value to buffer
 	memcpy(
-		unsafe.Pointer( // pointer to the base of the buffer + offset = pointer to destination element
-			uintptr(ch.buf)+
-				uintptr( // element size * equivalent slice index = offset
-					ch.elementSize* // element size (bytes)
-						ch.bufHead, // index of first available buffer entry
-				),
-		),
+		unsafe.Add(ch.buf, // pointer to the base of the buffer + offset = pointer to destination element
+			ch.elementSize*ch.bufHead), // element size * equivalent slice index = offset
 		value,
 		ch.elementSize,
 	)
@@ -274,7 +269,7 @@ func (ch *channel) pop(value unsafe.Pointer) bool {
 	}
 
 	// compute address of source
-	addr := unsafe.Pointer(uintptr(ch.buf) + (ch.elementSize * ch.bufTail))
+	addr := unsafe.Add(ch.buf, (ch.elementSize * ch.bufTail))
 
 	// copy value from buffer
 	memcpy(

--- a/src/runtime/dynamic_arm64.go
+++ b/src/runtime/dynamic_arm64.go
@@ -43,9 +43,9 @@ func dynamicLoader(base uintptr, dyn *dyn64) {
 			relasz = uint64(dyn.Val) / uint64(unsafe.Sizeof(rela64{}))
 		}
 
-		ptr := uintptr(unsafe.Pointer(dyn))
-		ptr += unsafe.Sizeof(dyn64{})
-		dyn = (*dyn64)(unsafe.Pointer(ptr))
+		ptr := unsafe.Pointer(dyn)
+		ptr = unsafe.Add(ptr, unsafe.Sizeof(dyn64{}))
+		dyn = (*dyn64)(ptr)
 	}
 
 	if rela == nil {
@@ -70,9 +70,9 @@ func dynamicLoader(base uintptr, dyn *dyn64) {
 			}
 		}
 
-		rptr := uintptr(unsafe.Pointer(rela))
-		rptr += unsafe.Sizeof(rela64{})
-		rela = (*rela64)(unsafe.Pointer(rptr))
+		rptr := unsafe.Pointer(rela)
+		rptr = unsafe.Add(rptr, unsafe.Sizeof(rela64{}))
+		rela = (*rela64)(rptr)
 		relasz--
 	}
 }

--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -146,7 +146,7 @@ func (b gcBlock) findNext() gcBlock {
 
 // State returns the current block state.
 func (b gcBlock) state() blockState {
-	stateBytePtr := (*uint8)(unsafe.Pointer(uintptr(metadataStart) + uintptr(b/blocksPerStateByte)))
+	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 	return blockState(*stateBytePtr>>((b%blocksPerStateByte)*stateBits)) & blockStateMask
 }
 
@@ -154,7 +154,7 @@ func (b gcBlock) state() blockState {
 // bits than the current state. Allowed transitions: from free to any state and
 // from head to mark.
 func (b gcBlock) setState(newState blockState) {
-	stateBytePtr := (*uint8)(unsafe.Pointer(uintptr(metadataStart) + uintptr(b/blocksPerStateByte)))
+	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 	*stateBytePtr |= uint8(newState << ((b % blocksPerStateByte) * stateBits))
 	if gcAsserts && b.state() != newState {
 		runtimePanic("gc: setState() was not successful")
@@ -163,7 +163,7 @@ func (b gcBlock) setState(newState blockState) {
 
 // markFree sets the block state to free, no matter what state it was in before.
 func (b gcBlock) markFree() {
-	stateBytePtr := (*uint8)(unsafe.Pointer(uintptr(metadataStart) + uintptr(b/blocksPerStateByte)))
+	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 	*stateBytePtr &^= uint8(blockStateMask << ((b % blocksPerStateByte) * stateBits))
 	if gcAsserts && b.state() != blockStateFree {
 		runtimePanic("gc: markFree() was not successful")
@@ -180,7 +180,7 @@ func (b gcBlock) unmark() {
 		runtimePanic("gc: unmark() on a block that is not marked")
 	}
 	clearMask := blockStateMask ^ blockStateHead // the bits to clear from the state
-	stateBytePtr := (*uint8)(unsafe.Pointer(uintptr(metadataStart) + uintptr(b/blocksPerStateByte)))
+	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 	*stateBytePtr &^= uint8(clearMask << ((b % blocksPerStateByte) * stateBits))
 	if gcAsserts && b.state() != blockStateHead {
 		runtimePanic("gc: unmark() was not successful")

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -34,7 +34,7 @@ func (i Interrupt) Enable() error {
 	esp.INTERRUPT_CORE0.CPU_INT_TYPE.SetBits(1 << i.num)
 
 	// Set default threshold to defaultThreshold
-	reg := (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0)) + uintptr(i.num)*4)))
+	reg := (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0), i.num*4))
 	reg.Set(defaultThreshold)
 
 	// Reset interrupt before reenabling
@@ -171,7 +171,7 @@ func handleInterrupt() {
 		mepc := riscv.MEPC.Get()
 		// Useing threshold to temporary disable this interrupts.
 		// FYI: using CPU interrupt enable bit make runtime to loose interrupts.
-		reg := (*volatile.Register32)(unsafe.Pointer((uintptr(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0)) + uintptr(interruptNumber)*4)))
+		reg := (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.INTERRUPT_CORE0.CPU_INT_PRI_0), interruptNumber*4))
 		thresholdSave := reg.Get()
 		reg.Set(disableThreshold)
 		riscv.Asm("fence")

--- a/src/runtime/memhash_fnv.go
+++ b/src/runtime/memhash_fnv.go
@@ -11,7 +11,7 @@ func hash32(ptr unsafe.Pointer, n, seed uintptr) uint32 {
 	var result uint32 = 2166136261 // FNV offset basis
 	result *= uint32(seed)
 	for i := uintptr(0); i < n; i++ {
-		c := *(*uint8)(unsafe.Pointer(uintptr(ptr) + i))
+		c := *(*uint8)(unsafe.Add(ptr, i))
 		result ^= uint32(c) // XOR with byte
 		result *= 16777619  // FNV prime
 	}
@@ -23,7 +23,7 @@ func hash64(ptr unsafe.Pointer, n, seed uintptr) uint64 {
 	var result uint64 = 14695981039346656037 // FNV offset basis
 	result *= uint64(seed)
 	for i := uintptr(0); i < n; i++ {
-		c := *(*uint8)(unsafe.Pointer(uintptr(ptr) + i))
+		c := *(*uint8)(unsafe.Add(ptr, i))
 		result ^= uint64(c)     // XOR with byte
 		result *= 1099511628211 // FNV prime
 	}

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -109,6 +109,6 @@ func markGlobals() {
 
 		// Move on to the next load command (wich may or may not be a
 		// LC_SEGMENT_64).
-		cmd = (*segmentLoadCommand)(unsafe.Pointer(uintptr(unsafe.Pointer(cmd)) + uintptr(cmd.cmdsize)))
+		cmd = (*segmentLoadCommand)(unsafe.Add(unsafe.Pointer(cmd), cmd.cmdsize))
 	}
 }

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -109,7 +109,7 @@ func markGlobals() {
 				markRoots(start, end)
 			}
 		}
-		headerPtr = unsafe.Pointer(uintptr(headerPtr) + uintptr(ehdr_start.phentsize))
+		headerPtr = unsafe.Add(headerPtr, ehdr_start.phentsize)
 	}
 }
 

--- a/src/runtime/os_windows.go
+++ b/src/runtime/os_windows.go
@@ -73,7 +73,7 @@ func markGlobals() {
 	}
 
 	// Find the PE header at offset 0x3C.
-	pe := (*peHeader)(unsafe.Pointer(uintptr(unsafe.Pointer(module)) + uintptr(module.peHeader)))
+	pe := (*peHeader)(unsafe.Add(unsafe.Pointer(module), module.peHeader))
 	if gcAsserts && pe.magic != 0x00004550 { // 0x4550 is "PE"
 		runtimePanic("cannot find PE header")
 	}
@@ -87,7 +87,7 @@ func markGlobals() {
 			end := uintptr(unsafe.Pointer(module)) + uintptr(section.virtualAddress) + uintptr(section.virtualSize)
 			markRoots(start, end)
 		}
-		section = (*peSection)(unsafe.Pointer(uintptr(unsafe.Pointer(section)) + unsafe.Sizeof(peSection{})))
+		section = (*peSection)(unsafe.Add(unsafe.Pointer(section), unsafe.Sizeof(peSection{})))
 	}
 }
 

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -57,8 +57,8 @@ func malloc(size uintptr) unsafe.Pointer
 // Compare two same-size buffers for equality.
 func memequal(x, y unsafe.Pointer, n uintptr) bool {
 	for i := uintptr(0); i < n; i++ {
-		cx := *(*uint8)(unsafe.Pointer(uintptr(x) + i))
-		cy := *(*uint8)(unsafe.Pointer(uintptr(y) + i))
+		cx := *(*uint8)(unsafe.Add(x, i))
+		cy := *(*uint8)(unsafe.Add(y, i))
 		if cx != cy {
 			return false
 		}

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -54,7 +54,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	}
 
 	// Initialize .data: global variables initialized from flash.
@@ -62,8 +62,8 @@ func preinit() {
 	dst := unsafe.Pointer(&_sdata)
 	for dst != unsafe.Pointer(&_edata) {
 		*(*uint32)(dst) = *(*uint32)(src)
-		dst = unsafe.Pointer(uintptr(dst) + 4)
-		src = unsafe.Pointer(uintptr(src) + 4)
+		dst = unsafe.Add(dst, 4)
+		src = unsafe.Add(src, 4)
 	}
 }
 

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -52,7 +52,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint8)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 1)
+		ptr = unsafe.Add(ptr, 1)
 	}
 }
 

--- a/src/runtime/runtime_cortexm.go
+++ b/src/runtime/runtime_cortexm.go
@@ -26,7 +26,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	}
 
 	// Initialize .data: global variables initialized from flash.
@@ -34,8 +34,8 @@ func preinit() {
 	dst := unsafe.Pointer(&_sdata)
 	for dst != unsafe.Pointer(&_edata) {
 		*(*uint32)(dst) = *(*uint32)(src)
-		dst = unsafe.Pointer(uintptr(dst) + 4)
-		src = unsafe.Pointer(uintptr(src) + 4)
+		dst = unsafe.Add(dst, 4)
+		src = unsafe.Add(src, 4)
 	}
 }
 

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -78,7 +78,7 @@ func interruptInit() {
 	priReg := &esp.INTERRUPT_CORE0.CPU_INT_PRI_1
 	for i := 0; i < 31; i++ {
 		priReg.Set(0)
-		priReg = (*volatile.Register32)(unsafe.Pointer(uintptr(unsafe.Pointer(priReg)) + uintptr(4)))
+		priReg = (*volatile.Register32)(unsafe.Add(unsafe.Pointer(priReg), 4))
 	}
 
 	// default threshold for interrupts is 5

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -32,7 +32,7 @@ func clearbss() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	}
 }
 

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -76,7 +76,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	}
 }
 

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -109,7 +109,7 @@ func write(fd int32, buf *byte, count int) int {
 	// TODO: Proper handling write
 	for i := 0; i < count; i++ {
 		putchar(*buf)
-		buf = (*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(buf)) + 1))
+		buf = (*byte)(unsafe.Add(unsafe.Pointer(buf), 1))
 	}
 	return count
 }

--- a/src/runtime/runtime_tinygoriscv.go
+++ b/src/runtime/runtime_tinygoriscv.go
@@ -24,7 +24,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint32)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 4)
+		ptr = unsafe.Add(ptr, 4)
 	}
 
 	// Initialize .data: global variables initialized from flash.
@@ -32,7 +32,7 @@ func preinit() {
 	dst := unsafe.Pointer(&_sdata)
 	for dst != unsafe.Pointer(&_edata) {
 		*(*uint32)(dst) = *(*uint32)(src)
-		dst = unsafe.Pointer(uintptr(dst) + 4)
-		src = unsafe.Pointer(uintptr(src) + 4)
+		dst = unsafe.Add(dst, 4)
+		src = unsafe.Add(src, 4)
 	}
 }

--- a/src/runtime/runtime_tinygoriscv64.go
+++ b/src/runtime/runtime_tinygoriscv64.go
@@ -24,7 +24,7 @@ func preinit() {
 	ptr := unsafe.Pointer(&_sbss)
 	for ptr != unsafe.Pointer(&_ebss) {
 		*(*uint64)(ptr) = 0
-		ptr = unsafe.Pointer(uintptr(ptr) + 8)
+		ptr = unsafe.Add(ptr, 8)
 	}
 
 	// Initialize .data: global variables initialized from flash.
@@ -32,7 +32,7 @@ func preinit() {
 	dst := unsafe.Pointer(&_sdata)
 	for dst != unsafe.Pointer(&_edata) {
 		*(*uint64)(dst) = *(*uint64)(src)
-		dst = unsafe.Pointer(uintptr(dst) + 8)
-		src = unsafe.Pointer(uintptr(src) + 8)
+		dst = unsafe.Add(dst, 8)
+		src = unsafe.Add(src, 8)
 	}
 }

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -106,7 +106,7 @@ func os_runtime_args() []string {
 			arg.length = length
 			arg.ptr = (*byte)(*argv)
 			// This is the Go equivalent of "argv++" in C.
-			argv = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(argv)) + unsafe.Sizeof(argv)))
+			argv = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(argv), unsafe.Sizeof(argv)))
 		}
 	}
 	return args
@@ -129,7 +129,7 @@ func syscall_runtime_envs() []string {
 	numEnvs := 0
 	for *env != nil {
 		numEnvs++
-		env = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(env)) + unsafe.Sizeof(environ)))
+		env = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(env), unsafe.Sizeof(environ)))
 	}
 
 	// Create a string slice of all environment variables.
@@ -144,7 +144,7 @@ func syscall_runtime_envs() []string {
 			length: length,
 		}
 		envs = append(envs, *(*string)(unsafe.Pointer(&s)))
-		env = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(env)) + unsafe.Sizeof(environ)))
+		env = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(env), unsafe.Sizeof(environ)))
 	}
 
 	return envs

--- a/src/runtime/runtime_windows.go
+++ b/src/runtime/runtime_windows.go
@@ -85,7 +85,7 @@ func os_runtime_args() []string {
 			arg.length = length
 			arg.ptr = (*byte)(*argv)
 			// This is the Go equivalent of "argv++" in C.
-			argv = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(argv)) + unsafe.Sizeof(argv)))
+			argv = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(argv), unsafe.Sizeof(argv)))
 		}
 	}
 	return args

--- a/src/runtime/slice.go
+++ b/src/runtime/slice.go
@@ -37,7 +37,7 @@ func sliceAppend(srcBuf, elemsBuf unsafe.Pointer, srcLen, srcCap, elemsLen uintp
 	}
 
 	// The slice fits (after possibly allocating a new one), append it in-place.
-	memmove(unsafe.Pointer(uintptr(srcBuf)+srcLen*elemSize), elemsBuf, elemsLen*elemSize)
+	memmove(unsafe.Add(srcBuf, srcLen*elemSize), elemsBuf, elemsLen*elemSize)
 	return srcBuf, srcLen + elemsLen, srcCap
 }
 

--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -61,7 +61,7 @@ func stringConcat(x, y _string) _string {
 		length := x.length + y.length
 		buf := alloc(length, nil)
 		memcpy(buf, unsafe.Pointer(x.ptr), x.length)
-		memcpy(unsafe.Pointer(uintptr(buf)+x.length), unsafe.Pointer(y.ptr), y.length)
+		memcpy(unsafe.Add(buf, x.length), unsafe.Pointer(y.ptr), y.length)
 		return _string{ptr: (*byte)(buf), length: length}
 	}
 }
@@ -107,7 +107,7 @@ func stringFromRunes(runeSlice []rune) (s _string) {
 	for _, r := range runeSlice {
 		array, numBytes := encodeUTF8(r)
 		for _, c := range array[:numBytes] {
-			*(*byte)(unsafe.Pointer(uintptr(unsafe.Pointer(s.ptr)) + index)) = c
+			*(*byte)(unsafe.Add(unsafe.Pointer(s.ptr), index)) = c
 			index++
 		}
 	}
@@ -243,7 +243,7 @@ func isContinuation(b byte) bool {
 func cgo_CString(s _string) unsafe.Pointer {
 	buf := malloc(s.length + 1)
 	memcpy(buf, unsafe.Pointer(s.ptr), s.length)
-	*(*byte)(unsafe.Pointer(uintptr(buf) + s.length)) = 0 // trailing 0 byte
+	*(*byte)(unsafe.Add(buf, s.length)) = 0 // trailing 0 byte
 	return buf
 }
 

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -258,7 +258,7 @@ func Environ() []string {
 	for environ := libc_environ; *environ != nil; {
 		length += libc_strlen(*environ)
 		vars++
-		environ = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(environ)) + unsafe.Sizeof(environ)))
+		environ = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(environ), unsafe.Sizeof(environ)))
 	}
 
 	// allocate our backing slice for the strings
@@ -287,7 +287,7 @@ func Environ() []string {
 		// add s to our list of environment variables
 		envs = append(envs, s)
 		// environ++
-		environ = (*unsafe.Pointer)(unsafe.Pointer(uintptr(unsafe.Pointer(environ)) + unsafe.Sizeof(environ)))
+		environ = (*unsafe.Pointer)(unsafe.Add(unsafe.Pointer(environ), unsafe.Sizeof(environ)))
 	}
 	return envs
 }


### PR DESCRIPTION
1. Replace all `unsafe.Pointer(uintptr(v) + idx)` instances with just `unsafe.Add(v, idx)`.
2. Remove the optimization that was previously needed to make that case more efficient. This reduces code complexity.