### PR TITLE
Refactor EnableInterrupts and DisableInterrupts

### DIFF
--- a/src/device/arm/arm.go
+++ b/src/device/arm/arm.go
@@ -29,6 +29,7 @@
 //	POSSIBILITY OF SUCH DAMAGE.
 package arm
 
+import "C"
 import (
 	"errors"
 	"runtime/volatile"
@@ -174,20 +175,15 @@ func SetPriority(irq uint32, priority uint32) {
 
 // DisableInterrupts disables all interrupts, and returns the old interrupt
 // state.
-func DisableInterrupts() uintptr {
-	return AsmFull(`
-		mrs {}, PRIMASK
-		cpsid i
-	`, nil)
-}
+//
+//export DisableInterrupts
+func DisableInterrupts() uintptr
 
 // EnableInterrupts enables all interrupts again. The value passed in must be
 // the mask returned by DisableInterrupts.
-func EnableInterrupts(mask uintptr) {
-	AsmFull("msr PRIMASK, {mask}", map[string]interface{}{
-		"mask": mask,
-	})
-}
+//
+//export EnableInterrupts
+func EnableInterrupts(mask uintptr)
 
 // Set up the system timer to generate periodic tick events.
 // This will cause SysTick_Handler to fire once per tick.

--- a/src/device/arm/interrupts.c
+++ b/src/device/arm/interrupts.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+
+void EnableInterrupts(uintptr_t mask) {
+    asm volatile(
+        "msr PRIMASK, %0"
+        :
+        : "r"(mask)
+        : "memory"
+    );
+}
+
+uintptr_t DisableInterrupts() {
+    uintptr_t mask;
+    asm volatile(
+        "mrs %0, PRIMASK\n\t"
+        "cpsid i"
+        : "=r"(mask)
+        :
+        : "memory"
+    );
+	return mask;
+}


### PR DESCRIPTION
Removes usage of AsmFull which required an optimization pass to remove the map parameter passed into it. This caused issues when compiling with -opt=0 where memory for the map was being allocated as an unintended side-effect of using AsmFull since no optimizations are enabled.