### PR TITLE
Improve `-size=full` for wasm

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -117,7 +117,7 @@ var (
 	//   alloc:  heap allocations during init interpretation
 	//   pack:   data created when storing a constant in an interface for example
 	//   string: buffer behind strings
-	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|embedfsfiles|embedfsslice|embedslice|pack|string)(\.[0-9]+)?$`)
+	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|embedfsslice|embedslice|pack|string)(\.[0-9]+)?$`)
 )
 
 // readProgramSizeFromDWARF reads the source location for each line of code and

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -117,7 +117,7 @@ var (
 	//   alloc:  heap allocations during init interpretation
 	//   pack:   data created when storing a constant in an interface for example
 	//   string: buffer behind strings
-	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|embedfsslice|pack|string)(\.[0-9]+)?$`)
+	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|pack|string)(\.[0-9]+)?$`)
 )
 
 // readProgramSizeFromDWARF reads the source location for each line of code and

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -117,7 +117,7 @@ var (
 	//   alloc:  heap allocations during init interpretation
 	//   pack:   data created when storing a constant in an interface for example
 	//   string: buffer behind strings
-	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|embedfsslice|embedslice|pack|string)(\.[0-9]+)?$`)
+	packageSymbolRegexp = regexp.MustCompile(`\$(alloc|embedfsslice|pack|string)(\.[0-9]+)?$`)
 )
 
 // readProgramSizeFromDWARF reads the source location for each line of code and

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -970,6 +970,19 @@ func (c *compilerContext) createEmbedGlobal(member *ssa.Global, global llvm.Valu
 		global.SetInitializer(sliceObj)
 		global.SetVisibility(llvm.HiddenVisibility)
 
+		if c.Debug {
+			// Add debug info to the slice backing array.
+			position := c.program.Fset.Position(member.Pos())
+			diglobal := c.dibuilder.CreateGlobalVariableExpression(llvm.Metadata{}, llvm.DIGlobalVariableExpression{
+				File:        c.getDIFile(position.Filename),
+				Line:        position.Line,
+				Type:        c.getDIType(types.NewArray(types.Typ[types.Byte], int64(len(file.Data)))),
+				LocalToUnit: true,
+				Expr:        c.dibuilder.CreateExpression(nil),
+			})
+			bufferGlobal.AddMetadata(0, diglobal)
+		}
+
 	case *types.Struct:
 		// Assume this is an embed.FS struct:
 		// https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/embed/embed.go;l=148

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1071,6 +1071,17 @@ func (c *compilerContext) createEmbedGlobal(member *ssa.Global, global llvm.Valu
 		sliceGlobal.SetGlobalConstant(true)
 		sliceGlobal.SetUnnamedAddr(true)
 		sliceGlobal.SetAlignment(c.targetData.ABITypeAlignment(sliceInitializer.Type()))
+		if c.Debug {
+			position := c.program.Fset.Position(member.Pos())
+			diglobal := c.dibuilder.CreateGlobalVariableExpression(llvm.Metadata{}, llvm.DIGlobalVariableExpression{
+				File:        c.getDIFile(position.Filename),
+				Line:        position.Line,
+				Type:        c.getDIType(types.NewSlice(embedFileStructType)),
+				LocalToUnit: true,
+				Expr:        c.dibuilder.CreateExpression(nil),
+			})
+			sliceGlobal.AddMetadata(0, diglobal)
+		}
 
 		// Define the embed.FS struct. It has only one field: the files (as a
 		// *[]embed.file).


### PR DESCRIPTION
Here are three commits that improve `-size=full` when using `//go:embed` in WebAssembly.
This is more of an experiment to see whether it works in principle, I'd like to make more impactful changes like these in the future.

Here are 13 bytes attributed to the correct package that were previously unknown:

```diff
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-  11171       0    1297  128738 |   12468  130035 | (unknown)
+  11171       0    1284  128738 |   12455  130022 | (unknown)
       0       0       8       0 |       8       8 | /home/ayke/src/tinygo/tinygo/testdata/embed/a/b
       0       0     540       0 |     540     540 | Go types
    3560       0       0       0 |    3560       0 | embed
     103       0       0       0 |     103       0 | errors
    1087       0       0       4 |    1087       4 | internal/task
     810       0       0       0 |     810       0 | io/fs
-   1438       0      13       0 |    1451      13 | main
+   1438       0      26       0 |    1464      26 | main
   10715       0      12     172 |   10727     184 | runtime
       8       0       0       0 |       8       0 | runtime/volatile
     727       0       0       0 |     727       0 | strings
     203       0       0       0 |     203       0 | sync
    8567       0       0      32 |    8567      32 | syscall/js
     176       0       0       0 |     176       0 | unicode
     967       0     256       0 |    1223     256 | unicode/utf8
 ------------------------------- | --------------- | -------
   39532       0    2126  128946 |   41658  131072 | total
```

---

~Looks like this doesn't quite work in LLVM 14 yet. Making this a draft until we drop support for LLVM 14.~ actually that looks more like a flaky test.