### PR TITLE
Track string code size

### DIFF
--- a/compiler/atomic.go
+++ b/compiler/atomic.go
@@ -13,8 +13,8 @@ import (
 func (b *builder) createAtomicOp(name string) llvm.Value {
 	switch name {
 	case "AddInt32", "AddInt64", "AddUint32", "AddUint64", "AddUintptr":
-		ptr := b.getValue(b.fn.Params[0])
-		val := b.getValue(b.fn.Params[1])
+		ptr := b.getValue(b.fn.Params[0], getPos(b.fn))
+		val := b.getValue(b.fn.Params[1], getPos(b.fn))
 		if strings.HasPrefix(b.Triple, "avr") {
 			// AtomicRMW does not work on AVR as intended:
 			// - There are some register allocation issues (fixed by https://reviews.llvm.org/D97127 which is not yet in a usable LLVM release)
@@ -33,8 +33,8 @@ func (b *builder) createAtomicOp(name string) llvm.Value {
 		// Return the new value, not the original value returned by atomicrmw.
 		return b.CreateAdd(oldVal, val, "")
 	case "SwapInt32", "SwapInt64", "SwapUint32", "SwapUint64", "SwapUintptr", "SwapPointer":
-		ptr := b.getValue(b.fn.Params[0])
-		val := b.getValue(b.fn.Params[1])
+		ptr := b.getValue(b.fn.Params[0], getPos(b.fn))
+		val := b.getValue(b.fn.Params[1], getPos(b.fn))
 		isPointer := val.Type().TypeKind() == llvm.PointerTypeKind
 		if isPointer {
 			// atomicrmw only supports integers, so cast to an integer.
@@ -48,21 +48,21 @@ func (b *builder) createAtomicOp(name string) llvm.Value {
 		}
 		return oldVal
 	case "CompareAndSwapInt32", "CompareAndSwapInt64", "CompareAndSwapUint32", "CompareAndSwapUint64", "CompareAndSwapUintptr", "CompareAndSwapPointer":
-		ptr := b.getValue(b.fn.Params[0])
-		old := b.getValue(b.fn.Params[1])
-		newVal := b.getValue(b.fn.Params[2])
+		ptr := b.getValue(b.fn.Params[0], getPos(b.fn))
+		old := b.getValue(b.fn.Params[1], getPos(b.fn))
+		newVal := b.getValue(b.fn.Params[2], getPos(b.fn))
 		tuple := b.CreateAtomicCmpXchg(ptr, old, newVal, llvm.AtomicOrderingSequentiallyConsistent, llvm.AtomicOrderingSequentiallyConsistent, true)
 		swapped := b.CreateExtractValue(tuple, 1, "")
 		return swapped
 	case "LoadInt32", "LoadInt64", "LoadUint32", "LoadUint64", "LoadUintptr", "LoadPointer":
-		ptr := b.getValue(b.fn.Params[0])
+		ptr := b.getValue(b.fn.Params[0], getPos(b.fn))
 		val := b.CreateLoad(b.getLLVMType(b.fn.Signature.Results().At(0).Type()), ptr, "")
 		val.SetOrdering(llvm.AtomicOrderingSequentiallyConsistent)
 		val.SetAlignment(b.targetData.PrefTypeAlignment(val.Type())) // required
 		return val
 	case "StoreInt32", "StoreInt64", "StoreUint32", "StoreUint64", "StoreUintptr", "StorePointer":
-		ptr := b.getValue(b.fn.Params[0])
-		val := b.getValue(b.fn.Params[1])
+		ptr := b.getValue(b.fn.Params[0], getPos(b.fn))
+		val := b.getValue(b.fn.Params[1], getPos(b.fn))
 		if strings.HasPrefix(b.Triple, "avr") {
 			// SelectionDAGBuilder is currently missing the "are unaligned atomics allowed" check for stores.
 			vType := val.Type()

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1863,6 +1863,14 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 func (b *builder) getValue(expr ssa.Value, pos token.Pos) llvm.Value {
 	switch expr := expr.(type) {
 	case *ssa.Const:
+		if pos == token.NoPos {
+			// If the position isn't known, at least try to find in which file
+			// it is defined.
+			file := b.program.Fset.File(b.fn.Pos())
+			if file != nil {
+				pos = file.Pos(0)
+			}
+		}
 		return b.createConst(expr, pos)
 	case *ssa.Function:
 		if b.getFunctionInfo(expr).exported {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2837,6 +2837,18 @@ func (c *compilerContext) createConst(expr *ssa.Const, pos token.Pos) llvm.Value
 				global.SetGlobalConstant(true)
 				global.SetUnnamedAddr(true)
 				global.SetAlignment(1)
+				if c.Debug {
+					// Unfortunately, expr.Pos() is always token.NoPos.
+					position := c.program.Fset.Position(pos)
+					diglobal := c.dibuilder.CreateGlobalVariableExpression(llvm.Metadata{}, llvm.DIGlobalVariableExpression{
+						File:        c.getDIFile(position.Filename),
+						Line:        position.Line,
+						Type:        c.getDIType(types.NewArray(types.Typ[types.Byte], int64(len(str)))),
+						LocalToUnit: true,
+						Expr:        c.dibuilder.CreateExpression(nil),
+					})
+					global.AddMetadata(0, diglobal)
+				}
 				zero := llvm.ConstInt(c.ctx.Int32Type(), 0, false)
 				strPtr = llvm.ConstInBoundsGEP(globalType, global, []llvm.Value{zero, zero})
 			} else {

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -267,13 +267,13 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 
 		// Collect all values to be put in the struct (starting with
 		// runtime._defer fields, followed by the call parameters).
-		itf := b.getValue(instr.Call.Value) // interface
+		itf := b.getValue(instr.Call.Value, getPos(instr)) // interface
 		typecode := b.CreateExtractValue(itf, 0, "invoke.func.typecode")
 		receiverValue := b.CreateExtractValue(itf, 1, "invoke.func.receiver")
 		values = []llvm.Value{callback, next, typecode, receiverValue}
 		valueTypes = append(valueTypes, b.i8ptrType, b.i8ptrType)
 		for _, arg := range instr.Call.Args {
-			val := b.getValue(arg)
+			val := b.getValue(arg, getPos(instr))
 			values = append(values, val)
 			valueTypes = append(valueTypes, val.Type())
 		}
@@ -290,7 +290,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		// runtime._defer fields).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := b.getValue(param)
+			llvmParam := b.getValue(param, getPos(instr))
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
@@ -302,7 +302,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		// pointer.
 		// TODO: ignore this closure entirely and put pointers to the free
 		// variables directly in the defer struct, avoiding a memory allocation.
-		closure := b.getValue(instr.Call.Value)
+		closure := b.getValue(instr.Call.Value, getPos(instr))
 		context := b.CreateExtractValue(closure, 0, "")
 
 		// Get the callback number.
@@ -318,7 +318,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		// context pointer).
 		values = []llvm.Value{callback, next}
 		for _, param := range instr.Call.Args {
-			llvmParam := b.getValue(param)
+			llvmParam := b.getValue(param, getPos(instr))
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}
@@ -330,7 +330,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		var argValues []llvm.Value
 		for _, arg := range instr.Call.Args {
 			argTypes = append(argTypes, arg.Type())
-			argValues = append(argValues, b.getValue(arg))
+			argValues = append(argValues, b.getValue(arg, getPos(instr)))
 		}
 
 		if _, ok := b.deferBuiltinFuncs[instr.Call.Value]; !ok {
@@ -353,7 +353,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		}
 
 	} else {
-		funcValue := b.getValue(instr.Call.Value)
+		funcValue := b.getValue(instr.Call.Value, getPos(instr))
 
 		if _, ok := b.deferExprFuncs[instr.Call.Value]; !ok {
 			b.deferExprFuncs[instr.Call.Value] = len(b.allDeferFuncs)
@@ -368,7 +368,7 @@ func (b *builder) createDefer(instr *ssa.Defer) {
 		values = []llvm.Value{callback, next, funcValue}
 		valueTypes = append(valueTypes, funcValue.Type())
 		for _, param := range instr.Call.Args {
-			llvmParam := b.getValue(param)
+			llvmParam := b.getValue(param, getPos(instr))
 			values = append(values, llvmParam)
 			valueTypes = append(valueTypes, llvmParam.Type())
 		}

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -134,7 +134,7 @@ func (b *builder) parseMakeClosure(expr *ssa.MakeClosure) (llvm.Value, error) {
 	boundVars := make([]llvm.Value, len(expr.Bindings))
 	for i, binding := range expr.Bindings {
 		// The context stores the bound variables.
-		llvmBoundVar := b.getValue(binding)
+		llvmBoundVar := b.getValue(binding, getPos(expr))
 		boundVars[i] = llvmBoundVar
 	}
 

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -475,7 +475,7 @@ func (c *compilerContext) getMethodSignature(method *types.Func) llvm.Value {
 // Type asserts on concrete types are trivial: just compare type numbers. Type
 // asserts on interfaces are more difficult, see the comments in the function.
 func (b *builder) createTypeAssert(expr *ssa.TypeAssert) llvm.Value {
-	itf := b.getValue(expr.X)
+	itf := b.getValue(expr.X, getPos(expr))
 	assertedType := b.getLLVMType(expr.AssertedType)
 
 	actualTypeNum := b.CreateExtractValue(itf, 0, "interface.type")

--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -24,7 +24,7 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	// Note that bound functions are allowed if the function has a pointer
 	// receiver and is a global. This is rather strict but still allows for
 	// idiomatic Go code.
-	funcValue := b.getValue(instr.Args[1])
+	funcValue := b.getValue(instr.Args[1], getPos(instr))
 	if funcValue.IsAConstant().IsNil() {
 		// Try to determine the cause of the non-constantness for a nice error
 		// message.

--- a/compiler/intrinsics.go
+++ b/compiler/intrinsics.go
@@ -58,7 +58,7 @@ func (b *builder) createMemoryCopyImpl() {
 	}
 	var params []llvm.Value
 	for _, param := range b.fn.Params {
-		params = append(params, b.getValue(param))
+		params = append(params, b.getValue(param, getPos(b.fn)))
 	}
 	params = append(params, llvm.ConstInt(b.ctx.Int1Type(), 0, false))
 	b.CreateCall(llvmFn.GlobalValueType(), llvmFn, params, "")
@@ -80,9 +80,9 @@ func (b *builder) createMemoryZeroImpl() {
 		llvmFn = llvm.AddFunction(b.mod, fnName, fnType)
 	}
 	params := []llvm.Value{
-		b.getValue(b.fn.Params[0]),
+		b.getValue(b.fn.Params[0], getPos(b.fn)),
 		llvm.ConstInt(b.ctx.Int8Type(), 0, false),
-		b.getValue(b.fn.Params[1]),
+		b.getValue(b.fn.Params[1], getPos(b.fn)),
 		llvm.ConstInt(b.ctx.Int1Type(), 0, false),
 	}
 	b.CreateCall(llvmFn.GlobalValueType(), llvmFn, params, "")
@@ -95,7 +95,7 @@ func (b *builder) createKeepAliveImpl() {
 	b.createFunctionStart(true)
 
 	// Get the underlying value of the interface value.
-	interfaceValue := b.getValue(b.fn.Params[0])
+	interfaceValue := b.getValue(b.fn.Params[0], getPos(b.fn))
 	pointerValue := b.CreateExtractValue(interfaceValue, 1, "")
 
 	// Create an equivalent of the following C code, which is basically just a
@@ -149,7 +149,7 @@ func (b *builder) defineMathOp() {
 	// Create a call to the intrinsic.
 	args := make([]llvm.Value, len(b.fn.Params))
 	for i, param := range b.fn.Params {
-		args[i] = b.getValue(param)
+		args[i] = b.getValue(param, getPos(b.fn))
 	}
 	result := b.CreateCall(llvmFn.GlobalValueType(), llvmFn, args, "")
 	b.CreateRet(result)

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -46,7 +46,7 @@ func (b *builder) createMakeMap(expr *ssa.MakeMap) (llvm.Value, error) {
 	sizeHint := llvm.ConstInt(b.uintptrType, 8, false)
 	algEnum := llvm.ConstInt(b.ctx.Int8Type(), alg, false)
 	if expr.Reserve != nil {
-		sizeHint = b.getValue(expr.Reserve)
+		sizeHint = b.getValue(expr.Reserve, getPos(expr))
 		var err error
 		sizeHint, err = b.createConvert(expr.Reserve.Type(), types.Typ[types.Uintptr], sizeHint, expr.Pos())
 		if err != nil {

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -14,7 +14,7 @@ import (
 // and returns the result as a single integer (the system call result). The
 // result is not further interpreted.
 func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
-	num := b.getValue(call.Args[0])
+	num := b.getValue(call.Args[0], getPos(call))
 	switch {
 	case b.GOARCH == "amd64" && b.GOOS == "linux":
 		// Sources:
@@ -37,7 +37,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 				"{r12}",
 				"{r13}",
 			}[i]
-			llvmValue := b.getValue(arg)
+			llvmValue := b.getValue(arg, getPos(call))
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -64,7 +64,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 				"{edi}",
 				"{ebp}",
 			}[i]
-			llvmValue := b.getValue(arg)
+			llvmValue := b.getValue(arg, getPos(call))
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -89,7 +89,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 				"{r5}",
 				"{r6}",
 			}[i]
-			llvmValue := b.getValue(arg)
+			llvmValue := b.getValue(arg, getPos(call))
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -119,7 +119,7 @@ func (b *builder) createRawSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 				"{x4}",
 				"{x5}",
 			}[i]
-			llvmValue := b.getValue(arg)
+			llvmValue := b.getValue(arg, getPos(call))
 			args = append(args, llvmValue)
 			argTypes = append(argTypes, llvmValue.Type())
 		}
@@ -177,12 +177,12 @@ func (b *builder) createSyscall(call *ssa.CallCommon) (llvm.Value, error) {
 		var paramTypes []llvm.Type
 		var params []llvm.Value
 		for _, val := range call.Args[2:] {
-			param := b.getValue(val)
+			param := b.getValue(val, getPos(call))
 			params = append(params, param)
 			paramTypes = append(paramTypes, param.Type())
 		}
 		llvmType := llvm.FunctionType(b.uintptrType, paramTypes, false)
-		fn := b.getValue(call.Args[0])
+		fn := b.getValue(call.Args[0], getPos(call))
 		fnPtr := b.CreateIntToPtr(fn, llvm.PointerType(llvmType, 0), "")
 
 		// Prepare some functions that will be called later.

--- a/compiler/volatile.go
+++ b/compiler/volatile.go
@@ -9,7 +9,7 @@ import "go/types"
 // runtime/volatile.LoadT().
 func (b *builder) createVolatileLoad() {
 	b.createFunctionStart(true)
-	addr := b.getValue(b.fn.Params[0])
+	addr := b.getValue(b.fn.Params[0], getPos(b.fn))
 	b.createNilCheck(b.fn.Params[0], addr, "deref")
 	valType := b.getLLVMType(b.fn.Params[0].Type().(*types.Pointer).Elem())
 	val := b.CreateLoad(valType, addr, "")
@@ -21,8 +21,8 @@ func (b *builder) createVolatileLoad() {
 // runtime/volatile.StoreT().
 func (b *builder) createVolatileStore() {
 	b.createFunctionStart(true)
-	addr := b.getValue(b.fn.Params[0])
-	val := b.getValue(b.fn.Params[1])
+	addr := b.getValue(b.fn.Params[0], getPos(b.fn))
+	val := b.getValue(b.fn.Params[1], getPos(b.fn))
 	b.createNilCheck(b.fn.Params[0], addr, "deref")
 	store := b.CreateStore(val, addr)
 	store.SetVolatile(true)


### PR DESCRIPTION
This PR adds debuginfo information to strings, which allows them to be tracked in `-size=full`. Here is the diff of testdata/stdlib.go, for which around 4kB of string data is now correctly attributed to packages:

```diff
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-  41738       0   20103  103790 |   61841  123893 | (unknown)
+  41738       0   16087  103790 |   57825  119877 | (unknown)
       0       0    1428       0 |    1428    1428 | Go types
     221       0       0       0 |     221       0 | errors
-  15422       0       0       0 |   15422       0 | fmt
+  15422       0     120       0 |   15542     120 | fmt
      91       0       0       0 |      91       0 | internal/bytealg
-   3655       0       0       0 |    3655       0 | internal/fmtsort
-    467       0       0       0 |     467       0 | internal/itoa
-   1166       0       0       4 |    1166       4 | internal/task
-   1222       0       0       0 |    1222       0 | io/fs
-   1163       0       0       0 |    1163       0 | main
+   3655       0      21       0 |    3676      21 | internal/fmtsort
+    467       0       1       0 |     468       1 | internal/itoa
+      0       0      38       0 |      38      38 | internal/oserror
+   1166       0      14       4 |    1180      18 | internal/task
+   1222       0      25       0 |    1247      25 | io/fs
+   1163       0      97       0 |    1260      97 | main
      32       0       0       0 |      32       0 | math
-    317       0      64       0 |     381      64 | math/bits
+    317       0     320       0 |     637     320 | math/bits
     460       0    4856       0 |    5316    4856 | math/rand
-    773       0       0      12 |     773      12 | os
-  10690       0       0       0 |   10690       0 | reflect
-  15012       0       4     219 |   15016     223 | runtime
+    773       0      37      12 |     810      49 | os
+  10690       0     613       0 |   11303     613 | reflect
+  15012       0     293     219 |   15305     512 | runtime
       8       0       0       0 |       8       0 | runtime/volatile
    1540       0       0       0 |    1540       0 | sort
-  14105       0     184       0 |   14289     184 | strconv
-   1366       0       0       0 |    1366       0 | strings
-    820       0       0       0 |     820       0 | sync
-   2010       0       0       0 |    2010       0 | syscall
-  33064       0      76      76 |   33140     152 | time
+  14105       0    1971       0 |   16076    1971 | strconv
+   1366       0      56       0 |    1422      56 | strings
+    820       0      30       0 |     850      30 | sync
+   2010       0       6       0 |    2016       6 | syscall
+  33064       0     702      76 |   33766     778 | time
    1417       0     256       0 |    1673     256 | unicode/utf8
 ------------------------------- | --------------- | -------
  146759       0   26971  104101 |  173730  131072 | total
```