### PR TITLE
Improve `-size=full` for baremetal

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -371,7 +371,7 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 			if section.Flags&elf.SHF_ALLOC == 0 {
 				continue
 			}
-			if packageSymbolRegexp.MatchString(symbol.Name) {
+			if packageSymbolRegexp.MatchString(symbol.Name) || symbol.Name == "__isr_vector" {
 				addresses = append(addresses, addressLine{
 					Address:    symbol.Value,
 					Length:     symbol.Size,
@@ -834,6 +834,8 @@ func findPackagePath(path string, packagePathMap map[string]string) string {
 		} else if packageSymbolRegexp.MatchString(path) {
 			// Parse symbol names like main$alloc or runtime$string.
 			packagePath = path[:strings.LastIndex(path, "$")]
+		} else if path == "__isr_vector" {
+			packagePath = "C interrupt vector"
 		} else if path == "<Go type>" {
 			packagePath = "Go types"
 		} else if path == "<Go interface assert>" {

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -829,6 +829,8 @@ func findPackagePath(path string, packagePathMap map[string]string) string {
 			// package, with a "C" prefix. For example: "C compiler-rt" for the
 			// compiler runtime library from LLVM.
 			packagePath = "C " + strings.Split(strings.TrimPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "lib")), string(os.PathSeparator))[1]
+		} else if strings.HasPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project")) {
+			packagePath = "C compiler-rt"
 		} else if packageSymbolRegexp.MatchString(path) {
 			// Parse symbol names like main$alloc or runtime$string.
 			packagePath = path[:strings.LastIndex(path, "$")]

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -433,7 +433,6 @@ func (c *compilerContext) getGlobal(g *ssa.Global) llvm.Value {
 		llvmGlobal = llvm.AddGlobal(c.mod, llvmType, info.linkName)
 
 		// Set alignment from the //go:align comment.
-		var alignInBits uint32
 		alignment := c.targetData.ABITypeAlignment(llvmType)
 		if info.align > alignment {
 			alignment = info.align
@@ -444,7 +443,6 @@ func (c *compilerContext) getGlobal(g *ssa.Global) llvm.Value {
 			c.addError(g.Pos(), "global variable alignment must be a positive power of two")
 		} else {
 			// Set the alignment only when it is a power of two.
-			alignInBits = uint32(alignment) ^ uint32(alignment-1)
 			llvmGlobal.SetAlignment(alignment)
 		}
 
@@ -459,7 +457,7 @@ func (c *compilerContext) getGlobal(g *ssa.Global) llvm.Value {
 				Type:        c.getDIType(typ),
 				LocalToUnit: false,
 				Expr:        c.dibuilder.CreateExpression(nil),
-				AlignInBits: alignInBits,
+				AlignInBits: uint32(alignment) * 8,
 			})
 			llvmGlobal.AddMetadata(0, diglobal)
 		}

--- a/targets/cortex-m-qemu.s
+++ b/targets/cortex-m-qemu.s
@@ -23,6 +23,7 @@ Default_Handler:
 
 .section .isr_vector, "a", %progbits
 .global  __isr_vector
+__isr_vector:
     // Interrupt vector as defined by Cortex-M, starting with the stack top.
     // On reset, SP is initialized with *0x0 and PC is loaded with *0x4, loading
     // _stack_top and Reset_Handler.
@@ -54,3 +55,5 @@ Default_Handler:
     IRQ DebugMon_Handler
     IRQ PendSV_Handler
     IRQ SysTick_Handler
+
+.size __isr_vector, .-__isr_vector

--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -1422,6 +1422,9 @@ __isr_vector:
 	for _, intr := range device.Interrupts {
 		fmt.Fprintf(w, "    IRQ %s_IRQHandler\n", intr.Name)
 	}
+	w.WriteString(`
+.size __isr_vector, .-__isr_vector
+`)
 	return w.Flush()
 }
 

--- a/transform/testdata/stacksize.out.ll
+++ b/transform/testdata/stacksize.out.ll
@@ -1,7 +1,7 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-@"internal/task.stackSizes" = global [1 x i32] [i32 1024], section ".tinygo_stacksizes"
+@"internal/task.stackSizes" = global [1 x i32] [i32 1024], section ".tinygo_stacksizes", align 4
 @llvm.used = appending global [2 x i8*] [i8* bitcast ([1 x i32]* @"internal/task.stackSizes" to i8*), i8* bitcast (void (i8*)* @"runtime.run$1$gowrapper" to i8*)]
 
 declare i32 @"internal/task.getGoroutineStackSize"(i32, i8*, i8*)


### PR DESCRIPTION
This is a bunch of changes that improves `-size=full` a lot for baremetal binaries.
I've used `-target=microbit` as a benchmark, and this is the change:

```diff
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-    175       0       4      61 |     179      65 | (unknown)
-    198       0       0       0 |     198       0 | /home/ayke/src/tinygo/tinygo/llvm-project/compiler-rt/lib/builtins
-     28       0       0       0 |      28       0 | /home/ayke/src/tinygo/tinygo/llvm-project/compiler-rt/lib/builtins/arm
+      7       0       0       0 |       7       0 | (alignment)
+      0       0       4       6 |       4      10 | (unknown)
+    226       0       0       0 |     226       0 | C compiler-rt
+      0     168       0       0 |     168       0 | C interrupt vector
       6       0       4       0 |      10       4 | C nrfx
      14       0       0       0 |      14       0 | C picolibc
       0       0       0    2048 |       0    2048 | C stack
      92       0       0       0 |      92       0 | device/arm
      40       0       0       0 |      40       0 | device/nrf
-    304      48       0       0 |     352       0 | internal/task
+    304      48       0       4 |     352       4 | internal/task
      30       0       0     130 |      30     130 | machine
      38       6       0       0 |      44       0 | main
-   1494     155       0       1 |    1649       1 | runtime
+   1494     155       0      52 |    1649      52 | runtime
     132       0       0       0 |     132       0 | runtime/volatile
 ------------------------------- | --------------- | -------
-   2551     209       8    2240 |    2768    2248 | total
+   2383     377       8    2240 |    2768    2248 | total
```

The number of unknown flash bytes has gone from 179 to just 4, and I know where those last bytes are going (the stack size section).
Once `(unknown)` reaches zero, I'd like to add tests for this so that it doesn't regress again in the future.