### PR TITLE
compiler: fix a race condition

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -869,13 +869,13 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 				if fn == nil {
 					continue // probably a generic method
 				}
-				if fn.Blocks == nil {
-					continue // external function
-				}
 				if member.Type().String() != member.String() {
 					// This is a member on a type alias. Do not build such a
 					// function.
 					continue
+				}
+				if fn.Blocks == nil {
+					continue // external function
 				}
 				if fn.Synthetic != "" && fn.Synthetic != "package initializer" {
 					// This function is a kind of wrapper function (created by


### PR DESCRIPTION
There was a mostly benign race condition in the compiler. The issue was that there is a check for type aliases (which can alias types in another function), but this check was _after_ accessing a property of the function that might not have been completed.

I don't think this can have any serious effects, as the function is skipped anyway, but such bugs should certainly be fixed.

---

Pretty sure this fixes https://github.com/tinygo-org/tinygo/issues/3506. I can't get any race conditions with this patch applied.