### PR TITLE
build/windows: trying to increase stack size for bash/make

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -99,7 +99,9 @@ jobs:
           scoop install wasmtime
       - name: Test TinyGo
         shell: bash
-        run: make test GOTESTFLAGS="-short"
+        run: |
+          ulimit -s unlimited
+          make test GOTESTFLAGS="-short"
       - name: Build TinyGo release tarball
         shell: bash
         run: make build/release -j4
@@ -154,7 +156,9 @@ jobs:
         run: 7z x release.zip -r
       - name: Smoke tests
         shell: bash
-        run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo
+        run: |
+          ulimit -s unlimited
+          make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
   stdlib-test-windows:
     runs-on: windows-2022
@@ -183,7 +187,9 @@ jobs:
         working-directory: build
         run: 7z x release.zip -r
       - name: Test stdlib packages
-        run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
+        run: |
+          ulimit -s unlimited
+          make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
   stdlib-wasi-test-windows:
     runs-on: windows-2022
@@ -219,4 +225,6 @@ jobs:
         working-directory: build
         run: 7z x release.zip -r
       - name: Test stdlib packages on wasi
-        run: make tinygo-test-wasi-fast TINYGO=$(PWD)/build/tinygo/bin/tinygo
+        run: |
+          ulimit -s unlimited
+          make tinygo-test-wasi-fast TINYGO=$(PWD)/build/tinygo/bin/tinygo


### PR DESCRIPTION
This PR attempts to increase stack size for bash/make. 

See https://github.com/microsoft/WSL/issues/633 and https://github.com/actions/runner-images/issues/3738