### PR TITLE
windows: disable parallelism on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -1508,6 +1508,15 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
+	// Limit the number of threads to one.
+	// This is an attempted workaround for the crashes we're seeing in CI on
+	// Windows. If this change helps, it indicates there is a concurrency issue.
+	// If it doesn't, then there is something else going on. Either way, this
+	// should be removed once the test is done.
+	if runtime.GOOS == "windows" {
+		runtime.GOMAXPROCS(1)
+	}
+
 	switch command {
 	case "build":
 		pkgName := "."


### PR DESCRIPTION
This is an attempt to figure out why the Windows CI keeps crashing. It should be removed before the next release, by which point we should know whether this has helped or not.

---

You might say I'm getting desperate looking for solutions.