### PR TITLE
build/linux: switch to ubuntu-20.04 for arm builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,7 +275,7 @@ jobs:
     # in that process to avoid doing lots of duplicate work and to avoid
     # complications around precompiled libraries such as compiler-rt shipped as
     # part of the release tarball.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: build-linux
     steps:
       - name: Checkout
@@ -391,7 +391,7 @@ jobs:
     # in that process to avoid doing lots of duplicate work and to avoid
     # complications around precompiled libraries such as compiler-rt shipped as
     # part of the release tarball.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: build-linux
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR switches to ubuntu-20.04 for arm builds since ubuntu-18.04 is deprecated for GH actions runner. See https://github.com/actions/runner-images/issues/6002