### PR TITLE
machine/atsamd51: remove extra BK0RDY clear

### DIFF
--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -142,8 +142,9 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 		setup := usb.NewSetup(udd_ep_out_cache_buffer[0][:])
 
 		// Clear the Bank 0 ready flag on Control OUT
-		setEPSTATUSCLR(0, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
+		usbEndpointDescriptors[0].DeviceDescBank[0].ADDR.Set(uint32(uintptr(unsafe.Pointer(&udd_ep_out_cache_buffer[0]))))
 		usbEndpointDescriptors[0].DeviceDescBank[0].PCKSIZE.ClearBits(usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
+		setEPSTATUSCLR(0, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
 
 		ok := false
 		if (setup.BmRequestType & usb.REQUEST_TYPE) == usb.REQUEST_STANDARD {
@@ -346,15 +347,6 @@ func sendUSBPacket(ep uint32, data []byte, maxsize uint16) {
 
 func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error) {
 	var b [cdcLineInfoSize]byte
-
-	// address
-	usbEndpointDescriptors[0].DeviceDescBank[0].ADDR.Set(uint32(uintptr(unsafe.Pointer(&udd_ep_out_cache_buffer[0]))))
-
-	// set byte count to zero
-	usbEndpointDescriptors[0].DeviceDescBank[0].PCKSIZE.ClearBits(usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
-
-	// set ready for next data
-	setEPSTATUSCLR(0, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
 
 	// Wait until OUT transfer is ready.
 	timeout := 300000


### PR DESCRIPTION
Before the modification, handleUSBIRQ() clears BK0RDY first, and then handleUSBSetAddress() clears it as well.
If there is a USB reception after the first BK0RDY clear, the data is lost.


https://github.com/tinygo-org/tinygo/blob/v0.27.0/src/machine/machine_atsamd51_usb.go#L145-L146

https://github.com/tinygo-org/tinygo/blob/v0.27.0/src/machine/machine_atsamd51_usb.go#L291-L292
