### PR TITLE
machine/samd51: implement Flash interface

### DIFF
--- a/src/machine/flash.go
+++ b/src/machine/flash.go
@@ -1,4 +1,4 @@
-//go:build nrf || nrf51 || nrf52 || nrf528xx || stm32f4 || stm32l4 || stm32wlx || atsamd21
+//go:build nrf || nrf51 || nrf52 || nrf528xx || stm32f4 || stm32l4 || stm32wlx || atsamd21 || atsamd51 || atsame5x
 
 package machine
 

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -187,6 +187,9 @@ func initClocks() {
 	// it's 32bit cycle counter for timing.
 	//CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 	//DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+	// Disable automatic NVM write operations
+	sam.NVMCTRL.SetCTRLA_WMODE(sam.NVMCTRL_CTRLA_WMODE_MAN)
 }
 
 func initRTC() {


### PR DESCRIPTION
This PR adds the implementation of the Flash interface for the samd51 processor in similar fashion to #3496 did for samd21.