### PR TITLE
compiler: only define the package path once

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -181,13 +181,16 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 				pkgpathName = "reflect/types.type.pkgpath:" + pkgpath
 			}
 
-			pkgpathInitializer := c.ctx.ConstString(pkgpath+"\x00", false)
-			pkgpathGlobal := llvm.AddGlobal(c.mod, pkgpathInitializer.Type(), pkgpathName)
-			pkgpathGlobal.SetInitializer(pkgpathInitializer)
-			pkgpathGlobal.SetAlignment(1)
-			pkgpathGlobal.SetUnnamedAddr(true)
-			pkgpathGlobal.SetLinkage(llvm.LinkOnceODRLinkage)
-			pkgpathGlobal.SetGlobalConstant(true)
+			pkgpathGlobal := c.mod.NamedGlobal(pkgpathName)
+			if pkgpathGlobal.IsNil() {
+				pkgpathInitializer := c.ctx.ConstString(pkgpath+"\x00", false)
+				pkgpathGlobal = llvm.AddGlobal(c.mod, pkgpathInitializer.Type(), pkgpathName)
+				pkgpathGlobal.SetInitializer(pkgpathInitializer)
+				pkgpathGlobal.SetAlignment(1)
+				pkgpathGlobal.SetUnnamedAddr(true)
+				pkgpathGlobal.SetLinkage(llvm.LinkOnceODRLinkage)
+				pkgpathGlobal.SetGlobalConstant(true)
+			}
 			pkgpathPtr := llvm.ConstGEP(pkgpathGlobal.GlobalValueType(), pkgpathGlobal, []llvm.Value{
 				llvm.ConstInt(c.ctx.Int32Type(), 0, false),
 				llvm.ConstInt(c.ctx.Int32Type(), 0, false),


### PR DESCRIPTION
Previously the compiler would create multiple package path globals. This is not intended: the intention is to only create one per package path.

This change (somewhat to my surprise) does not change binary size in any significant way. I suspect this is because the pacakge paths are merged together at a later compilation stage because they're marked as `unnamed_addr`.