### PR TITLE
Rp2040 uart flush - resolves #3537

### DIFF
--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -131,3 +131,9 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	}
 	uart.Receive(byte((uart.Bus.UARTDR.Get() & 0xFF)))
 }
+
+// Flush blocks until all bytes in UART transmit buffer have been sent over the wire.
+func (uart *UART) Flush() {
+	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_BUSY) {
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/tinygo-org/tinygo/issues/3537

Below are comparisons. First white signal is UART. Notice it shares the SPI busy time. When calling Flush before an SPI transaction it no longer shares busy time.

### Before
![beforeflush](https://user-images.githubusercontent.com/26156425/224487841-6bde23ff-225a-419f-9987-62c1870ae4f3.png)

### After
![afterflush](https://user-images.githubusercontent.com/26156425/224487843-89c541f0-6209-4d9d-8804-1896a677fde1.png)
