### PR TITLE
compiler: add alloc attributes to runtime.alloc

### DIFF
--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -10,32 +10,33 @@ target triple = "wasm32-unknown-wasi"
 @main.a = hidden global { ptr, i32, i32 } zeroinitializer, align 4
 @main.b = hidden global [2 x ptr] zeroinitializer, align 4
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.addInt(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.addInt(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = add i32 %x, %y
   ret i32 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.equalInt(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.equalInt(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq i32 %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.divInt(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.divInt(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -49,14 +50,14 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %5
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(ptr undef) #2
+  call void @runtime.divideByZeroPanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.divideByZeroPanic(ptr) #0
+declare void @runtime.divideByZeroPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden i32 @main.divUint(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.divUint(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -66,12 +67,12 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %1
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(ptr undef) #2
+  call void @runtime.divideByZeroPanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.remInt(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.remInt(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -85,12 +86,12 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %5
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(ptr undef) #2
+  call void @runtime.divideByZeroPanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.remUint(i32 %x, i32 %y, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.remUint(i32 %x, i32 %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq i32 %y, 0
   br i1 %0, label %divbyzero.throw, label %divbyzero.next
@@ -100,66 +101,66 @@ divbyzero.next:                                   ; preds = %entry
   ret i32 %1
 
 divbyzero.throw:                                  ; preds = %entry
-  call void @runtime.divideByZeroPanic(ptr undef) #2
+  call void @runtime.divideByZeroPanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatEQ(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatEQ(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp oeq float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatNE(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatNE(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp une float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatLower(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatLower(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp olt float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatLowerEqual(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatLowerEqual(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp ole float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatGreater(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatGreater(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp ogt float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.floatGreaterEqual(float %x, float %y, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.floatGreaterEqual(float %x, float %y, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fcmp oge float %x, %y
   ret i1 %0
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.complexReal(float %x.r, float %x.i, ptr %context) unnamed_addr #1 {
+define hidden float @main.complexReal(float %x.r, float %x.i, ptr %context) unnamed_addr #2 {
 entry:
   ret float %x.r
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.complexImag(float %x.r, float %x.i, ptr %context) unnamed_addr #1 {
+define hidden float @main.complexImag(float %x.r, float %x.i, ptr %context) unnamed_addr #2 {
 entry:
   ret float %x.i
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #1 {
+define hidden { float, float } @main.complexAdd(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fadd float %x.r, %y.r
   %1 = fadd float %x.i, %y.i
@@ -169,7 +170,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #1 {
+define hidden { float, float } @main.complexSub(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fsub float %x.r, %y.r
   %1 = fsub float %x.i, %y.i
@@ -179,7 +180,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #1 {
+define hidden { float, float } @main.complexMul(float %x.r, float %x.i, float %y.r, float %y.i, ptr %context) unnamed_addr #2 {
 entry:
   %0 = fmul float %x.r, %y.r
   %1 = fmul float %x.i, %y.i
@@ -193,27 +194,28 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.foo(ptr %context) unnamed_addr #1 {
+define hidden void @main.foo(ptr %context) unnamed_addr #2 {
 entry:
   %complit = alloca %main.kv.0, align 8
   %stackalloc = alloca i8, align 1
   store %main.kv.0 zeroinitializer, ptr %complit, align 8
-  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #3
   call void @"main.foo$1"(%main.kv.0 zeroinitializer, ptr undef)
   ret void
 }
 
 ; Function Attrs: nounwind
-define internal void @"main.foo$1"(%main.kv.0 %b, ptr %context) unnamed_addr #1 {
+define internal void @"main.foo$1"(%main.kv.0 %b, ptr %context) unnamed_addr #2 {
 entry:
   %b1 = alloca %main.kv.0, align 8
   %stackalloc = alloca i8, align 1
   store %main.kv.0 zeroinitializer, ptr %b1, align 8
-  call void @runtime.trackPointer(ptr nonnull %b1, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %b1, ptr nonnull %stackalloc, ptr undef) #3
   store %main.kv.0 %b, ptr %b1, align 8
   ret void
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -6,78 +6,79 @@ target triple = "wasm32-unknown-wasi"
 %runtime.channelBlockedList = type { ptr, ptr, ptr, { ptr, i32, i32 } }
 %runtime.chanSelectState = type { ptr, ptr }
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.chanIntSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
   store i32 3, ptr %chan.value, align 4
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  call void @runtime.chanSend(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #3
+  call void @runtime.chanSend(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
   ret void
 }
 
 ; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #2
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3
 
-declare void @runtime.chanSend(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #0
+declare void @runtime.chanSend(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #1
 
 ; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #2
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.chanIntRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %chan.value = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #3
+  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
   ret void
 }
 
-declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #0
+declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
   %complit = alloca {}, align 8
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #4
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #3
+  call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.chanZeroRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #3
+  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.selectZeroRecv(ptr dereferenceable_or_null(32) %ch1, ptr dereferenceable_or_null(32) %ch2, ptr %context) unnamed_addr #1 {
+define hidden void @main.selectZeroRecv(ptr dereferenceable_or_null(32) %ch1, ptr dereferenceable_or_null(32) %ch2, ptr %context) unnamed_addr #2 {
 entry:
   %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
   %select.send.value = alloca i32, align 4
@@ -90,7 +91,7 @@ entry:
   store ptr %ch2, ptr %0, align 8
   %.repack3 = getelementptr inbounds [2 x %runtime.chanSelectState], ptr %select.states.alloca, i32 0, i32 1, i32 1
   store ptr null, ptr %.repack3, align 4
-  %select.result = call { i32, i1 } @runtime.tryChanSelect(ptr undef, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr undef) #3
+  %select.result = call { i32, i1 } @runtime.tryChanSelect(ptr undef, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %select.states.alloca)
   %1 = extractvalue { i32, i1 } %select.result, 0
   %2 = icmp eq i32 %1, 0
@@ -107,9 +108,10 @@ select.body:                                      ; preds = %select.next
   br label %select.done
 }
 
-declare { i32, i1 } @runtime.tryChanSelect(ptr, ptr, i32, i32, ptr) #0
+declare { i32, i1 } @runtime.tryChanSelect(ptr, ptr, i32, i32, ptr) #1
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { argmemonly nocallback nofree nosync nounwind willreturn }
-attributes #3 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { argmemonly nocallback nofree nosync nounwind willreturn }
+attributes #4 = { nounwind }

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -7,6 +7,7 @@ target triple = "thumbv7m-unknown-unknown-eabi"
 %runtime._interface = type { ptr, ptr }
 %runtime._defer = type { i32, ptr }
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
 ; Function Attrs: nounwind
@@ -15,7 +16,7 @@ entry:
   ret void
 }
 
-declare void @main.external(ptr) #0
+declare void @main.external(ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.deferSimple(ptr %context) unnamed_addr #1 {
@@ -25,17 +26,17 @@ entry:
   store ptr null, ptr %deferPtr, align 4
   %deferframe.buf = alloca %runtime.deferFrame, align 4
   %0 = call ptr @llvm.stacksave()
-  call void @runtime.setupDeferFrame(ptr nonnull %deferframe.buf, ptr %0, ptr undef) #3
+  call void @runtime.setupDeferFrame(ptr nonnull %deferframe.buf, ptr %0, ptr undef) #4
   store i32 0, ptr %defer.alloca, align 4
   %defer.alloca.repack15 = getelementptr inbounds { i32, ptr }, ptr %defer.alloca, i32 0, i32 1
   store ptr null, ptr %defer.alloca.repack15, align 4
   store ptr %defer.alloca, ptr %deferPtr, align 4
-  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result = icmp eq i32 %setjmp, 0
   br i1 %setjmp.result, label %1, label %lpad
 
 1:                                                ; preds = %entry
-  call void @main.external(ptr undef) #3
+  call void @main.external(ptr undef) #4
   br label %rundefers.loophead
 
 rundefers.loophead:                               ; preds = %3, %1
@@ -53,7 +54,7 @@ rundefers.loop:                                   ; preds = %rundefers.loophead
   ]
 
 rundefers.callback0:                              ; preds = %rundefers.loop
-  %setjmp1 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp1 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result2 = icmp eq i32 %setjmp1, 0
   br i1 %setjmp.result2, label %3, label %lpad
 
@@ -65,11 +66,11 @@ rundefers.default:                                ; preds = %rundefers.loop
   unreachable
 
 rundefers.end:                                    ; preds = %rundefers.loophead
-  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #3
+  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #4
   ret void
 
 recover:                                          ; preds = %rundefers.end3
-  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #3
+  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #4
   ret void
 
 lpad:                                             ; preds = %rundefers.callback012, %rundefers.callback0, %entry
@@ -90,7 +91,7 @@ rundefers.loop5:                                  ; preds = %rundefers.loophead6
   ]
 
 rundefers.callback012:                            ; preds = %rundefers.loop5
-  %setjmp13 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp13 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result14 = icmp eq i32 %setjmp13, 0
   br i1 %setjmp.result14, label %5, label %lpad
 
@@ -106,20 +107,20 @@ rundefers.end3:                                   ; preds = %rundefers.loophead6
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
-declare ptr @llvm.stacksave() #2
+declare ptr @llvm.stacksave() #3
 
-declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(24), ptr, ptr) #0
+declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(24), ptr, ptr) #2
 
 ; Function Attrs: nounwind
 define internal void @"main.deferSimple$1"(ptr %context) unnamed_addr #1 {
 entry:
-  call void @runtime.printint32(i32 3, ptr undef) #3
+  call void @runtime.printint32(i32 3, ptr undef) #4
   ret void
 }
 
-declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(24), ptr) #0
+declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(24), ptr) #2
 
-declare void @runtime.printint32(i32, ptr) #0
+declare void @runtime.printint32(i32, ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.deferMultiple(ptr %context) unnamed_addr #1 {
@@ -130,7 +131,7 @@ entry:
   store ptr null, ptr %deferPtr, align 4
   %deferframe.buf = alloca %runtime.deferFrame, align 4
   %0 = call ptr @llvm.stacksave()
-  call void @runtime.setupDeferFrame(ptr nonnull %deferframe.buf, ptr %0, ptr undef) #3
+  call void @runtime.setupDeferFrame(ptr nonnull %deferframe.buf, ptr %0, ptr undef) #4
   store i32 0, ptr %defer.alloca, align 4
   %defer.alloca.repack22 = getelementptr inbounds { i32, ptr }, ptr %defer.alloca, i32 0, i32 1
   store ptr null, ptr %defer.alloca.repack22, align 4
@@ -139,12 +140,12 @@ entry:
   %defer.alloca2.repack23 = getelementptr inbounds { i32, ptr }, ptr %defer.alloca2, i32 0, i32 1
   store ptr %defer.alloca, ptr %defer.alloca2.repack23, align 4
   store ptr %defer.alloca2, ptr %deferPtr, align 4
-  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result = icmp eq i32 %setjmp, 0
   br i1 %setjmp.result, label %1, label %lpad
 
 1:                                                ; preds = %entry
-  call void @main.external(ptr undef) #3
+  call void @main.external(ptr undef) #4
   br label %rundefers.loophead
 
 rundefers.loophead:                               ; preds = %4, %3, %1
@@ -163,7 +164,7 @@ rundefers.loop:                                   ; preds = %rundefers.loophead
   ]
 
 rundefers.callback0:                              ; preds = %rundefers.loop
-  %setjmp3 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp3 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result4 = icmp eq i32 %setjmp3, 0
   br i1 %setjmp.result4, label %3, label %lpad
 
@@ -172,7 +173,7 @@ rundefers.callback0:                              ; preds = %rundefers.loop
   br label %rundefers.loophead
 
 rundefers.callback1:                              ; preds = %rundefers.loop
-  %setjmp5 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp5 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result6 = icmp eq i32 %setjmp5, 0
   br i1 %setjmp.result6, label %4, label %lpad
 
@@ -184,11 +185,11 @@ rundefers.default:                                ; preds = %rundefers.loop
   unreachable
 
 rundefers.end:                                    ; preds = %rundefers.loophead
-  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #3
+  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #4
   ret void
 
 recover:                                          ; preds = %rundefers.end7
-  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #3
+  call void @runtime.destroyDeferFrame(ptr nonnull %deferframe.buf, ptr undef) #4
   ret void
 
 lpad:                                             ; preds = %rundefers.callback119, %rundefers.callback016, %rundefers.callback1, %rundefers.callback0, %entry
@@ -210,7 +211,7 @@ rundefers.loop9:                                  ; preds = %rundefers.loophead1
   ]
 
 rundefers.callback016:                            ; preds = %rundefers.loop9
-  %setjmp17 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp17 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result18 = icmp eq i32 %setjmp17, 0
   br i1 %setjmp.result18, label %6, label %lpad
 
@@ -219,7 +220,7 @@ rundefers.callback016:                            ; preds = %rundefers.loop9
   br label %rundefers.loophead10
 
 rundefers.callback119:                            ; preds = %rundefers.loop9
-  %setjmp20 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #4
+  %setjmp20 = call i32 asm "\0Amovs r0, #0\0Amov r2, pc\0Astr r2, [r1, #4]", "={r0},{r1},~{r1},~{r2},~{r3},~{r4},~{r5},~{r6},~{r7},~{r8},~{r9},~{r10},~{r11},~{r12},~{lr},~{q0},~{q1},~{q2},~{q3},~{q4},~{q5},~{q6},~{q7},~{q8},~{q9},~{q10},~{q11},~{q12},~{q13},~{q14},~{q15},~{cpsr},~{memory}"(ptr nonnull %deferframe.buf) #5
   %setjmp.result21 = icmp eq i32 %setjmp20, 0
   br i1 %setjmp.result21, label %7, label %lpad
 
@@ -237,19 +238,20 @@ rundefers.end7:                                   ; preds = %rundefers.loophead1
 ; Function Attrs: nounwind
 define internal void @"main.deferMultiple$1"(ptr %context) unnamed_addr #1 {
 entry:
-  call void @runtime.printint32(i32 3, ptr undef) #3
+  call void @runtime.printint32(i32 3, ptr undef) #4
   ret void
 }
 
 ; Function Attrs: nounwind
 define internal void @"main.deferMultiple$2"(ptr %context) unnamed_addr #1 {
 entry:
-  call void @runtime.printint32(i32 5, ptr undef) #3
+  call void @runtime.printint32(i32 5, ptr undef) #4
   ret void
 }
 
-attributes #0 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
 attributes #1 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
-attributes #2 = { nocallback nofree nosync nounwind willreturn }
-attributes #3 = { nounwind }
-attributes #4 = { nounwind returns_twice }
+attributes #2 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
+attributes #3 = { nocallback nofree nosync nounwind willreturn }
+attributes #4 = { nounwind }
+attributes #5 = { nounwind returns_twice }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -3,18 +3,19 @@ source_filename = "float.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.f32tou32(float %v, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.f32tou32(float %v, ptr %context) unnamed_addr #2 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -26,25 +27,25 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.maxu32f(ptr %context) unnamed_addr #1 {
+define hidden float @main.maxu32f(ptr %context) unnamed_addr #2 {
 entry:
   ret float 0x41F0000000000000
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.maxu32tof32(ptr %context) unnamed_addr #1 {
+define hidden i32 @main.maxu32tof32(ptr %context) unnamed_addr #2 {
 entry:
   ret i32 -1
 }
 
 ; Function Attrs: nounwind
-define hidden { i32, i32, i32, i32 } @main.inftoi32(ptr %context) unnamed_addr #1 {
+define hidden { i32, i32, i32, i32 } @main.inftoi32(ptr %context) unnamed_addr #2 {
 entry:
   ret { i32, i32, i32, i32 } { i32 -1, i32 0, i32 2147483647, i32 -2147483648 }
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.u32tof32tou32(i32 %v, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.u32tof32tou32(i32 %v, ptr %context) unnamed_addr #2 {
 entry:
   %0 = uitofp i32 %v to float
   %withinmax = fcmp ole float %0, 0x41EFFFFFC0000000
@@ -54,7 +55,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden float @main.f32tou32tof32(float %v, ptr %context) unnamed_addr #1 {
+define hidden float @main.f32tou32tof32(float %v, ptr %context) unnamed_addr #2 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 0x41EFFFFFC0000000
@@ -67,7 +68,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.f32tou8(float %v, ptr %context) unnamed_addr #1 {
+define hidden i8 @main.f32tou8(float %v, ptr %context) unnamed_addr #2 {
 entry:
   %positive = fcmp oge float %v, 0.000000e+00
   %withinmax = fcmp ole float %v, 2.550000e+02
@@ -79,7 +80,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.f32toi8(float %v, ptr %context) unnamed_addr #1 {
+define hidden i8 @main.f32toi8(float %v, ptr %context) unnamed_addr #2 {
 entry:
   %abovemin = fcmp oge float %v, -1.280000e+02
   %belowmax = fcmp ole float %v, 1.270000e+02
@@ -92,5 +93,6 @@ entry:
   ret i8 %0
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -3,46 +3,48 @@ source_filename = "func.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.foo(ptr %callback.context, ptr %callback.funcptr, ptr %context) unnamed_addr #1 {
+define hidden void @main.foo(ptr %callback.context, ptr %callback.funcptr, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp eq ptr %callback.funcptr, null
   br i1 %0, label %fpcall.throw, label %fpcall.next
 
 fpcall.next:                                      ; preds = %entry
-  call void %callback.funcptr(i32 3, ptr %callback.context) #2
+  call void %callback.funcptr(i32 3, ptr %callback.context) #3
   ret void
 
 fpcall.throw:                                     ; preds = %entry
-  call void @runtime.nilPanic(ptr undef) #2
+  call void @runtime.nilPanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.nilPanic(ptr) #0
+declare void @runtime.nilPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.bar(ptr %context) unnamed_addr #1 {
+define hidden void @main.bar(ptr %context) unnamed_addr #2 {
 entry:
   call void @main.foo(ptr undef, ptr nonnull @main.someFunc, ptr undef)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.someFunc(i32 %arg0, ptr %context) unnamed_addr #1 {
+define hidden void @main.someFunc(i32 %arg0, ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -24,95 +24,96 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.type:basic:complex128" = linkonce_odr constant { i8, ptr } { i8 16, ptr @"reflect/types.type:pointer:basic:complex128" }, align 4
 @"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:basic:complex128" }, align 4
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newScalar(ptr %context) unnamed_addr #1 {
+define hidden void @main.newScalar(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %new = call ptr @runtime.alloc(i32 1, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #2
+  %new = call dereferenceable(1) ptr @runtime.alloc(i32 1, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new, ptr @main.scalar1, align 4
-  %new1 = call ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #2
+  %new1 = call dereferenceable(4) ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new1, ptr @main.scalar2, align 4
-  %new2 = call ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #2
+  %new2 = call dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new2, ptr @main.scalar3, align 4
-  %new3 = call ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new3, ptr nonnull %stackalloc, ptr undef) #2
+  %new3 = call dereferenceable(4) ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new3, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new3, ptr @main.scalar4, align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newArray(ptr %context) unnamed_addr #1 {
+define hidden void @main.newArray(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %new = call ptr @runtime.alloc(i32 3, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #2
+  %new = call dereferenceable(3) ptr @runtime.alloc(i32 3, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new, ptr @main.array1, align 4
-  %new1 = call ptr @runtime.alloc(i32 71, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #2
+  %new1 = call dereferenceable(71) ptr @runtime.alloc(i32 71, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new1, ptr @main.array2, align 4
-  %new2 = call ptr @runtime.alloc(i32 12, ptr nonnull inttoptr (i32 67 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #2
+  %new2 = call dereferenceable(12) ptr @runtime.alloc(i32 12, ptr nonnull inttoptr (i32 67 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new2, ptr @main.array3, align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.newStruct(ptr %context) unnamed_addr #1 {
+define hidden void @main.newStruct(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %new = call ptr @runtime.alloc(i32 0, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #2
+  %new = call ptr @runtime.alloc(i32 0, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new, ptr @main.struct1, align 4
-  %new1 = call ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #2
+  %new1 = call dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new1, ptr @main.struct2, align 4
-  %new2 = call ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-2000000000000001", ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #2
+  %new2 = call dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-2000000000000001", ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new2, ptr @main.struct3, align 4
-  %new3 = call ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-0001", ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new3, ptr nonnull %stackalloc, ptr undef) #2
+  %new3 = call dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-0001", ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new3, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new3, ptr @main.struct4, align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.newFuncValue(ptr %context) unnamed_addr #1 {
+define hidden ptr @main.newFuncValue(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %new = call ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 197 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #2
+  %new = call dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 197 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %new
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.makeSlice(ptr %context) unnamed_addr #1 {
+define hidden void @main.makeSlice(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %makeslice = call ptr @runtime.alloc(i32 5, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %makeslice, ptr nonnull %stackalloc, ptr undef) #2
+  %makeslice = call dereferenceable(5) ptr @runtime.alloc(i32 5, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %makeslice, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %makeslice, ptr @main.slice1, align 8
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice1, i32 0, i32 1), align 4
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice1, i32 0, i32 2), align 8
-  %makeslice1 = call ptr @runtime.alloc(i32 20, ptr nonnull inttoptr (i32 67 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %makeslice1, ptr nonnull %stackalloc, ptr undef) #2
+  %makeslice1 = call dereferenceable(20) ptr @runtime.alloc(i32 20, ptr nonnull inttoptr (i32 67 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %makeslice1, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %makeslice1, ptr @main.slice2, align 8
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice2, i32 0, i32 1), align 4
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice2, i32 0, i32 2), align 8
-  %makeslice3 = call ptr @runtime.alloc(i32 60, ptr nonnull inttoptr (i32 71 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %makeslice3, ptr nonnull %stackalloc, ptr undef) #2
+  %makeslice3 = call dereferenceable(60) ptr @runtime.alloc(i32 60, ptr nonnull inttoptr (i32 71 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %makeslice3, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %makeslice3, ptr @main.slice3, align 8
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice3, i32 0, i32 1), align 4
   store i32 5, ptr getelementptr inbounds ({ ptr, i32, i32 }, ptr @main.slice3, i32 0, i32 2), align 8
@@ -120,20 +121,21 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.makeInterface(double %v.r, double %v.i, ptr %context) unnamed_addr #1 {
+define hidden %runtime._interface @main.makeInterface(double %v.r, double %v.i, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %0 = call ptr @runtime.alloc(i32 16, ptr null, ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #2
+  %0 = call dereferenceable(16) ptr @runtime.alloc(i32 16, ptr null, ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #3
   store double %v.r, ptr %0, align 8
   %.repack1 = getelementptr inbounds { double, double }, ptr %0, i32 0, i32 1
   store double %v.i, ptr %.repack1, align 8
   %1 = insertvalue %runtime._interface { ptr @"reflect/types.type:basic:complex128", ptr undef }, ptr %0, 1
-  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:basic:complex128", ptr nonnull %stackalloc, ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:basic:complex128", ptr nonnull %stackalloc, ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #3
   ret %runtime._interface %1
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/go1.20.ll
+++ b/compiler/testdata/go1.20.ll
@@ -5,26 +5,27 @@ target triple = "wasm32-unknown-wasi"
 
 %runtime._string = type { ptr, i32 }
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.unsafeSliceData(ptr %s.data, i32 %s.len, i32 %s.cap, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.unsafeSliceData(ptr %s.data, i32 %s.len, i32 %s.cap, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %s.data, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %s.data, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %s.data
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.unsafeString(ptr dereferenceable_or_null(1) %ptr, i16 %len, ptr %context) unnamed_addr #1 {
+define hidden %runtime._string @main.unsafeString(ptr dereferenceable_or_null(1) %ptr, i16 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = icmp slt i16 %len, 0
@@ -38,24 +39,25 @@ unsafe.String.next:                               ; preds = %entry
   %5 = zext i16 %len to i32
   %6 = insertvalue %runtime._string undef, ptr %ptr, 0
   %7 = insertvalue %runtime._string %6, i32 %5, 1
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #3
   ret %runtime._string %7
 
 unsafe.String.throw:                              ; preds = %entry
-  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  call void @runtime.unsafeSlicePanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.unsafeSlicePanic(ptr) #0
+declare void @runtime.unsafeSlicePanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden ptr @main.unsafeStringData(ptr %s.data, i32 %s.len, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.unsafeStringData(ptr %s.data, i32 %s.len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %s.data, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %s.data, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %s.data
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
@@ -7,6 +7,7 @@ target triple = "thumbv7m-unknown-unknown-eabi"
 
 @"main$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
 ; Function Attrs: nounwind
@@ -18,30 +19,30 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.regularFunctionGoroutine(ptr %context) unnamed_addr #1 {
 entry:
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr undef) #8
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 %stacksize, ptr undef) #8
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr undef) #9
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 %stacksize, ptr undef) #9
   ret void
 }
 
-declare void @main.regularFunction(i32, ptr) #0
+declare void @main.regularFunction(i32, ptr) #2
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.regularFunction$gowrapper"(ptr %0) unnamed_addr #2 {
+define linkonce_odr void @"main.regularFunction$gowrapper"(ptr %0) unnamed_addr #3 {
 entry:
   %unpack.int = ptrtoint ptr %0 to i32
-  call void @main.regularFunction(i32 %unpack.int, ptr undef) #8
+  call void @main.regularFunction(i32 %unpack.int, ptr undef) #9
   ret void
 }
 
-declare i32 @"internal/task.getGoroutineStackSize"(i32, ptr) #0
+declare i32 @"internal/task.getGoroutineStackSize"(i32, ptr) #2
 
-declare void @"internal/task.start"(i32, ptr, i32, ptr) #0
+declare void @"internal/task.start"(i32, ptr, i32, ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.inlineFunctionGoroutine(ptr %context) unnamed_addr #1 {
 entry:
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr undef) #8
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 %stacksize, ptr undef) #8
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr undef) #9
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 %stacksize, ptr undef) #9
   ret void
 }
 
@@ -52,7 +53,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #3 {
+define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #4 {
 entry:
   %unpack.int = ptrtoint ptr %0 to i32
   call void @"main.inlineFunctionGoroutine$1"(i32 %unpack.int, ptr undef)
@@ -62,16 +63,16 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.closureFunctionGoroutine(ptr %context) unnamed_addr #1 {
 entry:
-  %n = call ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #8
+  %n = call dereferenceable(4) ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #9
   store i32 3, ptr %n, align 4
-  %0 = call ptr @runtime.alloc(i32 8, ptr null, ptr undef) #8
+  %0 = call dereferenceable(8) ptr @runtime.alloc(i32 8, ptr null, ptr undef) #9
   store i32 5, ptr %0, align 4
   %1 = getelementptr inbounds { i32, ptr }, ptr %0, i32 0, i32 1
   store ptr %n, ptr %1, align 4
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr undef) #8
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #8
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr undef) #9
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #9
   %2 = load i32, ptr %n, align 4
-  call void @runtime.printint32(i32 %2, ptr undef) #8
+  call void @runtime.printint32(i32 %2, ptr undef) #9
   ret void
 }
 
@@ -83,7 +84,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #4 {
+define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #5 {
 entry:
   %1 = load i32, ptr %0, align 4
   %2 = getelementptr inbounds { i32, ptr }, ptr %0, i32 0, i32 1
@@ -92,31 +93,31 @@ entry:
   ret void
 }
 
-declare void @runtime.printint32(i32, ptr) #0
+declare void @runtime.printint32(i32, ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.funcGoroutine(ptr %fn.context, ptr %fn.funcptr, ptr %context) unnamed_addr #1 {
 entry:
-  %0 = call ptr @runtime.alloc(i32 12, ptr null, ptr undef) #8
+  %0 = call dereferenceable(12) ptr @runtime.alloc(i32 12, ptr null, ptr undef) #9
   store i32 5, ptr %0, align 4
   %1 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 1
   store ptr %fn.context, ptr %1, align 4
   %2 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 2
   store ptr %fn.funcptr, ptr %2, align 4
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr undef) #8
-  call void @"internal/task.start"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #8
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr undef) #9
+  call void @"internal/task.start"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #9
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @main.funcGoroutine.gowrapper(ptr %0) unnamed_addr #5 {
+define linkonce_odr void @main.funcGoroutine.gowrapper(ptr %0) unnamed_addr #6 {
 entry:
   %1 = load i32, ptr %0, align 4
   %2 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 4
   %4 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 2
   %5 = load ptr, ptr %4, align 4
-  call void %5(i32 %1, ptr %3) #8
+  call void %5(i32 %1, ptr %3) #9
   ret void
 }
 
@@ -129,25 +130,25 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.copyBuiltinGoroutine(ptr %dst.data, i32 %dst.len, i32 %dst.cap, ptr %src.data, i32 %src.len, i32 %src.cap, ptr %context) unnamed_addr #1 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 1, ptr undef) #8
+  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 1, ptr undef) #9
   ret void
 }
 
-declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #0
+declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
 entry:
-  call void @runtime.chanClose(ptr %ch, ptr undef) #8
+  call void @runtime.chanClose(ptr %ch, ptr undef) #9
   ret void
 }
 
-declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #0
+declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.startInterfaceMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
 entry:
-  %0 = call ptr @runtime.alloc(i32 16, ptr null, ptr undef) #8
+  %0 = call dereferenceable(16) ptr @runtime.alloc(i32 16, ptr null, ptr undef) #9
   store ptr %itf.value, ptr %0, align 4
   %1 = getelementptr inbounds { ptr, %runtime._string, ptr }, ptr %0, i32 0, i32 1
   store ptr @"main$string", ptr %1, align 4
@@ -155,15 +156,15 @@ entry:
   store i32 4, ptr %.repack1, align 4
   %2 = getelementptr inbounds { ptr, %runtime._string, ptr }, ptr %0, i32 0, i32 2
   store ptr %itf.typecode, ptr %2, align 4
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr undef) #8
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #8
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr undef) #9
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #9
   ret void
 }
 
-declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr, ptr, i32, ptr, ptr) #6
+declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr, ptr, i32, ptr, ptr) #7
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(ptr %0) unnamed_addr #7 {
+define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(ptr %0) unnamed_addr #8 {
 entry:
   %1 = load ptr, ptr %0, align 4
   %2 = getelementptr inbounds { ptr, ptr, i32, ptr }, ptr %0, i32 0, i32 1
@@ -172,16 +173,17 @@ entry:
   %5 = load i32, ptr %4, align 4
   %6 = getelementptr inbounds { ptr, ptr, i32, ptr }, ptr %0, i32 0, i32 3
   %7 = load ptr, ptr %6, align 4
-  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr %1, ptr %3, i32 %5, ptr %7, ptr undef) #8
+  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr %1, ptr %3, i32 %5, ptr %7, ptr undef) #9
   ret void
 }
 
-attributes #0 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
 attributes #1 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
-attributes #2 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.regularFunction" }
-attributes #3 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
-attributes #4 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
-attributes #5 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper" }
-attributes #6 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
-attributes #7 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
-attributes #8 = { nounwind }
+attributes #2 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" }
+attributes #3 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.regularFunction" }
+attributes #4 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
+attributes #5 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
+attributes #6 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper" }
+attributes #7 = { "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
+attributes #8 = { nounwind "target-features"="+armv7-m,+hwdiv,+soft-float,+strict-align,+thumb-mode,-aes,-bf16,-cdecp0,-cdecp1,-cdecp2,-cdecp3,-cdecp4,-cdecp5,-cdecp6,-cdecp7,-crc,-crypto,-d32,-dotprod,-dsp,-fp-armv8,-fp-armv8d16,-fp-armv8d16sp,-fp-armv8sp,-fp16,-fp16fml,-fp64,-fpregs,-fullfp16,-hwdiv-arm,-i8mm,-lob,-mve,-mve.fp,-neon,-pacbti,-ras,-sb,-sha2,-vfp2,-vfp2sp,-vfp3,-vfp3d16,-vfp3d16sp,-vfp3sp,-vfp4,-vfp4d16,-vfp4d16sp,-vfp4sp" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
+attributes #9 = { nounwind }

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -7,158 +7,159 @@ target triple = "wasm32-unknown-wasi"
 
 @"main$string" = internal unnamed_addr constant [4 x i8] c"test", align 1
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.regularFunctionGoroutine(ptr %context) unnamed_addr #1 {
+define hidden void @main.regularFunctionGoroutine(ptr %context) unnamed_addr #2 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 16384, ptr undef) #8
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.regularFunction$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 16384, ptr undef) #9
   ret void
 }
 
-declare void @main.regularFunction(i32, ptr) #0
+declare void @main.regularFunction(i32, ptr) #1
 
-declare void @runtime.deadlock(ptr) #0
+declare void @runtime.deadlock(ptr) #1
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.regularFunction$gowrapper"(ptr %0) unnamed_addr #2 {
+define linkonce_odr void @"main.regularFunction$gowrapper"(ptr %0) unnamed_addr #3 {
 entry:
   %unpack.int = ptrtoint ptr %0 to i32
-  call void @main.regularFunction(i32 %unpack.int, ptr undef) #8
-  call void @runtime.deadlock(ptr undef) #8
+  call void @main.regularFunction(i32 %unpack.int, ptr undef) #9
+  call void @runtime.deadlock(ptr undef) #9
   unreachable
 }
 
-declare void @"internal/task.start"(i32, ptr, i32, ptr) #0
+declare void @"internal/task.start"(i32, ptr, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.inlineFunctionGoroutine(ptr %context) unnamed_addr #1 {
+define hidden void @main.inlineFunctionGoroutine(ptr %context) unnamed_addr #2 {
 entry:
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 16384, ptr undef) #8
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.inlineFunctionGoroutine$1$gowrapper" to i32), ptr nonnull inttoptr (i32 5 to ptr), i32 16384, ptr undef) #9
   ret void
 }
 
 ; Function Attrs: nounwind
-define internal void @"main.inlineFunctionGoroutine$1"(i32 %x, ptr %context) unnamed_addr #1 {
+define internal void @"main.inlineFunctionGoroutine$1"(i32 %x, ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #3 {
+define linkonce_odr void @"main.inlineFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #4 {
 entry:
   %unpack.int = ptrtoint ptr %0 to i32
   call void @"main.inlineFunctionGoroutine$1"(i32 %unpack.int, ptr undef)
-  call void @runtime.deadlock(ptr undef) #8
+  call void @runtime.deadlock(ptr undef) #9
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.closureFunctionGoroutine(ptr %context) unnamed_addr #1 {
+define hidden void @main.closureFunctionGoroutine(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %n = call ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #8
-  call void @runtime.trackPointer(ptr nonnull %n, ptr nonnull %stackalloc, ptr undef) #8
+  %n = call dereferenceable(4) ptr @runtime.alloc(i32 4, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #9
+  call void @runtime.trackPointer(ptr nonnull %n, ptr nonnull %stackalloc, ptr undef) #9
   store i32 3, ptr %n, align 4
-  call void @runtime.trackPointer(ptr nonnull %n, ptr nonnull %stackalloc, ptr undef) #8
-  call void @runtime.trackPointer(ptr nonnull @"main.closureFunctionGoroutine$1", ptr nonnull %stackalloc, ptr undef) #8
-  %0 = call ptr @runtime.alloc(i32 8, ptr null, ptr undef) #8
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #8
+  call void @runtime.trackPointer(ptr nonnull %n, ptr nonnull %stackalloc, ptr undef) #9
+  call void @runtime.trackPointer(ptr nonnull @"main.closureFunctionGoroutine$1", ptr nonnull %stackalloc, ptr undef) #9
+  %0 = call dereferenceable(8) ptr @runtime.alloc(i32 8, ptr null, ptr undef) #9
+  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #9
   store i32 5, ptr %0, align 4
   %1 = getelementptr inbounds { i32, ptr }, ptr %0, i32 0, i32 1
   store ptr %n, ptr %1, align 4
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 16384, ptr undef) #8
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 16384, ptr undef) #9
   %2 = load i32, ptr %n, align 4
-  call void @runtime.printint32(i32 %2, ptr undef) #8
+  call void @runtime.printint32(i32 %2, ptr undef) #9
   ret void
 }
 
 ; Function Attrs: nounwind
-define internal void @"main.closureFunctionGoroutine$1"(i32 %x, ptr %context) unnamed_addr #1 {
+define internal void @"main.closureFunctionGoroutine$1"(i32 %x, ptr %context) unnamed_addr #2 {
 entry:
   store i32 7, ptr %context, align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #4 {
+define linkonce_odr void @"main.closureFunctionGoroutine$1$gowrapper"(ptr %0) unnamed_addr #5 {
 entry:
   %1 = load i32, ptr %0, align 4
   %2 = getelementptr inbounds { i32, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 4
   call void @"main.closureFunctionGoroutine$1"(i32 %1, ptr %3)
-  call void @runtime.deadlock(ptr undef) #8
+  call void @runtime.deadlock(ptr undef) #9
   unreachable
 }
 
-declare void @runtime.printint32(i32, ptr) #0
+declare void @runtime.printint32(i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.funcGoroutine(ptr %fn.context, ptr %fn.funcptr, ptr %context) unnamed_addr #1 {
+define hidden void @main.funcGoroutine(ptr %fn.context, ptr %fn.funcptr, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %0 = call ptr @runtime.alloc(i32 12, ptr null, ptr undef) #8
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #8
+  %0 = call dereferenceable(12) ptr @runtime.alloc(i32 12, ptr null, ptr undef) #9
+  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #9
   store i32 5, ptr %0, align 4
   %1 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 1
   store ptr %fn.context, ptr %1, align 4
   %2 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 2
   store ptr %fn.funcptr, ptr %2, align 4
-  call void @"internal/task.start"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr nonnull %0, i32 16384, ptr undef) #8
+  call void @"internal/task.start"(i32 ptrtoint (ptr @main.funcGoroutine.gowrapper to i32), ptr nonnull %0, i32 16384, ptr undef) #9
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr void @main.funcGoroutine.gowrapper(ptr %0) unnamed_addr #5 {
+define linkonce_odr void @main.funcGoroutine.gowrapper(ptr %0) unnamed_addr #6 {
 entry:
   %1 = load i32, ptr %0, align 4
   %2 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 4
   %4 = getelementptr inbounds { i32, ptr, ptr }, ptr %0, i32 0, i32 2
   %5 = load ptr, ptr %4, align 4
-  call void %5(i32 %1, ptr %3) #8
-  call void @runtime.deadlock(ptr undef) #8
+  call void %5(i32 %1, ptr %3) #9
+  call void @runtime.deadlock(ptr undef) #9
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.recoverBuiltinGoroutine(ptr %context) unnamed_addr #1 {
+define hidden void @main.recoverBuiltinGoroutine(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.copyBuiltinGoroutine(ptr %dst.data, i32 %dst.len, i32 %dst.cap, ptr %src.data, i32 %src.len, i32 %src.cap, ptr %context) unnamed_addr #1 {
+define hidden void @main.copyBuiltinGoroutine(ptr %dst.data, i32 %dst.len, i32 %dst.cap, ptr %src.data, i32 %src.len, i32 %src.cap, ptr %context) unnamed_addr #2 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 1, ptr undef) #8
+  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 1, ptr undef) #9
   ret void
 }
 
-declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #0
+declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  call void @runtime.chanClose(ptr %ch, ptr undef) #8
+  call void @runtime.chanClose(ptr %ch, ptr undef) #9
   ret void
 }
 
-declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #0
+declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.startInterfaceMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden void @main.startInterfaceMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %0 = call ptr @runtime.alloc(i32 16, ptr null, ptr undef) #8
-  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #8
+  %0 = call dereferenceable(16) ptr @runtime.alloc(i32 16, ptr null, ptr undef) #9
+  call void @runtime.trackPointer(ptr nonnull %0, ptr nonnull %stackalloc, ptr undef) #9
   store ptr %itf.value, ptr %0, align 4
   %1 = getelementptr inbounds { ptr, %runtime._string, ptr }, ptr %0, i32 0, i32 1
   store ptr @"main$string", ptr %1, align 4
@@ -166,14 +167,14 @@ entry:
   store i32 4, ptr %.repack1, align 4
   %2 = getelementptr inbounds { ptr, %runtime._string, ptr }, ptr %0, i32 0, i32 2
   store ptr %itf.typecode, ptr %2, align 4
-  call void @"internal/task.start"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr nonnull %0, i32 16384, ptr undef) #8
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper" to i32), ptr nonnull %0, i32 16384, ptr undef) #9
   ret void
 }
 
-declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr, ptr, i32, ptr, ptr) #6
+declare void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr, ptr, i32, ptr, ptr) #7
 
 ; Function Attrs: nounwind
-define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(ptr %0) unnamed_addr #7 {
+define linkonce_odr void @"interface:{Print:func:{basic:string}{}}.Print$invoke$gowrapper"(ptr %0) unnamed_addr #8 {
 entry:
   %1 = load ptr, ptr %0, align 4
   %2 = getelementptr inbounds { ptr, ptr, i32, ptr }, ptr %0, i32 0, i32 1
@@ -182,17 +183,18 @@ entry:
   %5 = load i32, ptr %4, align 4
   %6 = getelementptr inbounds { ptr, ptr, i32, ptr }, ptr %0, i32 0, i32 3
   %7 = load ptr, ptr %6, align 4
-  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr %1, ptr %3, i32 %5, ptr %7, ptr undef) #8
-  call void @runtime.deadlock(ptr undef) #8
+  call void @"interface:{Print:func:{basic:string}{}}.Print$invoke"(ptr %1, ptr %3, i32 %5, ptr %7, ptr undef) #9
+  call void @runtime.deadlock(ptr undef) #9
   unreachable
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.regularFunction" }
-attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
-attributes #4 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
-attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper" }
-attributes #6 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
-attributes #7 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
-attributes #8 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.regularFunction" }
+attributes #4 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
+attributes #6 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper" }
+attributes #7 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
+attributes #8 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
+attributes #9 = { nounwind }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -17,56 +17,57 @@ target triple = "wasm32-unknown-wasi"
 @"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, ptr } { i8 20, ptr @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" }, align 4
 @"reflect/types.typeid:basic:int" = external constant i8
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.simpleType(ptr %context) unnamed_addr #1 {
+define hidden %runtime._interface @main.simpleType(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:basic:int", ptr nonnull %stackalloc, ptr undef) #6
-  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #6
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:basic:int", ptr nonnull %stackalloc, ptr undef) #7
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #7
   ret %runtime._interface { ptr @"reflect/types.type:basic:int", ptr null }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.pointerType(ptr %context) unnamed_addr #1 {
+define hidden %runtime._interface @main.pointerType(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:basic:int", ptr nonnull %stackalloc, ptr undef) #6
-  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #6
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:basic:int", ptr nonnull %stackalloc, ptr undef) #7
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #7
   ret %runtime._interface { ptr @"reflect/types.type:pointer:basic:int", ptr null }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.interfaceType(ptr %context) unnamed_addr #1 {
+define hidden %runtime._interface @main.interfaceType(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:named:error", ptr nonnull %stackalloc, ptr undef) #6
-  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #6
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:named:error", ptr nonnull %stackalloc, ptr undef) #7
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #7
   ret %runtime._interface { ptr @"reflect/types.type:pointer:named:error", ptr null }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._interface @main.anonymousInterfaceType(ptr %context) unnamed_addr #1 {
+define hidden %runtime._interface @main.anonymousInterfaceType(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}", ptr nonnull %stackalloc, ptr undef) #6
-  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #6
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}", ptr nonnull %stackalloc, ptr undef) #7
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #7
   ret %runtime._interface { ptr @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}", ptr null }
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isInt(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.isInt(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
-  %typecode = call i1 @runtime.typeAssert(ptr %itf.typecode, ptr nonnull @"reflect/types.typeid:basic:int", ptr undef) #6
+  %typecode = call i1 @runtime.typeAssert(ptr %itf.typecode, ptr nonnull @"reflect/types.typeid:basic:int", ptr undef) #7
   br i1 %typecode, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -76,12 +77,12 @@ typeassert.ok:                                    ; preds = %entry
   br label %typeassert.next
 }
 
-declare i1 @runtime.typeAssert(ptr, ptr dereferenceable_or_null(1), ptr) #0
+declare i1 @runtime.typeAssert(ptr, ptr dereferenceable_or_null(1), ptr) #1
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isError(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.isError(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr %itf.typecode) #6
+  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr %itf.typecode) #7
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -91,12 +92,12 @@ typeassert.ok:                                    ; preds = %entry
   br label %typeassert.next
 }
 
-declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr) #2
+declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr) #3
 
 ; Function Attrs: nounwind
-define hidden i1 @main.isStringer(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.isStringer(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(ptr %itf.typecode) #6
+  %0 = call i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(ptr %itf.typecode) #7
   br i1 %0, label %typeassert.ok, label %typeassert.next
 
 typeassert.next:                                  ; preds = %typeassert.ok, %entry
@@ -106,33 +107,34 @@ typeassert.ok:                                    ; preds = %entry
   br label %typeassert.next
 }
 
-declare i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(ptr) #3
+declare i1 @"interface:{String:func:{}{basic:string}}.$typeassert"(ptr) #4
 
 ; Function Attrs: nounwind
-define hidden i8 @main.callFooMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden i8 @main.callFooMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(ptr %itf.value, i32 3, ptr %itf.typecode, ptr undef) #6
+  %0 = call i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(ptr %itf.value, i32 3, ptr %itf.typecode, ptr undef) #7
   ret i8 %0
 }
 
-declare i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(ptr, i32, ptr, ptr) #4
+declare i8 @"interface:{String:func:{}{basic:string},main.foo:func:{basic:int}{basic:uint8}}.foo$invoke"(ptr, i32, ptr, ptr) #5
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.callErrorMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {
+define hidden %runtime._string @main.callErrorMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %0 = call %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(ptr %itf.value, ptr %itf.typecode, ptr undef) #6
+  %0 = call %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(ptr %itf.value, ptr %itf.typecode, ptr undef) #7
   %1 = extractvalue %runtime._string %0, 0
-  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #6
+  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #7
   ret %runtime._string %0
 }
 
-declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(ptr, ptr, ptr) #5
+declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(ptr, ptr, ptr) #6
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.Error() string" }
-attributes #3 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.String() string" }
-attributes #4 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
-attributes #5 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
-attributes #6 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #4 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.String() string" }
+attributes #5 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
+attributes #6 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #7 = { nounwind }

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -3,46 +3,48 @@ source_filename = "pointer.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden [0 x i32] @main.pointerDerefZero(ptr %x, ptr %context) unnamed_addr #1 {
+define hidden [0 x i32] @main.pointerDerefZero(ptr %x, ptr %context) unnamed_addr #2 {
 entry:
   ret [0 x i32] zeroinitializer
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.pointerCastFromUnsafe(ptr %x, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.pointerCastFromUnsafe(ptr %x, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %x
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.pointerCastToUnsafe(ptr dereferenceable_or_null(4) %x, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.pointerCastToUnsafe(ptr dereferenceable_or_null(4) %x, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %x
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.pointerCastToUnsafeNoop(ptr dereferenceable_or_null(1) %x, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.pointerCastToUnsafeNoop(ptr dereferenceable_or_null(1) %x, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %x, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %x
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -11,59 +11,61 @@ target triple = "wasm32-unknown-wasi"
 @undefinedGlobalNotInSection = external global i32, align 4
 @main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define void @extern_func() #2 {
+define void @extern_func() #3 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @somepkg.someFunction1(ptr %context) unnamed_addr #1 {
+define hidden void @somepkg.someFunction1(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
-declare void @somepkg.someFunction2(ptr) #0
+declare void @somepkg.someFunction2(ptr) #1
 
 ; Function Attrs: inlinehint nounwind
-define hidden void @main.inlineFunc(ptr %context) unnamed_addr #3 {
+define hidden void @main.inlineFunc(ptr %context) unnamed_addr #4 {
 entry:
   ret void
 }
 
 ; Function Attrs: noinline nounwind
-define hidden void @main.noinlineFunc(ptr %context) unnamed_addr #4 {
+define hidden void @main.noinlineFunc(ptr %context) unnamed_addr #5 {
 entry:
   ret void
 }
 
 ; Function Attrs: noinline nounwind
-define hidden void @main.functionInSection(ptr %context) unnamed_addr #4 section ".special_function_section" {
+define hidden void @main.functionInSection(ptr %context) unnamed_addr #5 section ".special_function_section" {
 entry:
   ret void
 }
 
 ; Function Attrs: noinline nounwind
-define void @exportedFunctionInSection() #5 section ".special_function_section" {
+define void @exportedFunctionInSection() #6 section ".special_function_section" {
 entry:
   ret void
 }
 
-declare void @main.undefinedFunctionNotInSection(ptr) #0
+declare void @main.undefinedFunctionNotInSection(ptr) #1
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
-attributes #3 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #4 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
+attributes #4 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -3,30 +3,31 @@ source_filename = "slice.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceLen(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.sliceLen(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #2 {
 entry:
   ret i32 %ints.len
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceCap(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.sliceCap(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #2 {
 entry:
   ret i32 %ints.cap
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceElement(ptr %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.sliceElement(ptr %ints.data, i32 %ints.len, i32 %ints.cap, i32 %index, ptr %context) unnamed_addr #2 {
 entry:
   %.not = icmp ult i32 %index, %ints.len
   br i1 %.not, label %lookup.next, label %lookup.throw
@@ -37,84 +38,84 @@ lookup.next:                                      ; preds = %entry
   ret i32 %1
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(ptr undef) #2
+  call void @runtime.lookupPanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.lookupPanic(ptr) #0
+declare void @runtime.lookupPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.sliceAppendValues(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.sliceAppendValues(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %varargs = call ptr @runtime.alloc(i32 12, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %varargs, ptr nonnull %stackalloc, ptr undef) #2
+  %varargs = call dereferenceable(12) ptr @runtime.alloc(i32 12, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %varargs, ptr nonnull %stackalloc, ptr undef) #3
   store i32 1, ptr %varargs, align 4
   %0 = getelementptr inbounds [3 x i32], ptr %varargs, i32 0, i32 1
   store i32 2, ptr %0, align 4
   %1 = getelementptr inbounds [3 x i32], ptr %varargs, i32 0, i32 2
   store i32 3, ptr %1, align 4
-  %append.new = call { ptr, i32, i32 } @runtime.sliceAppend(ptr %ints.data, ptr nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, ptr undef) #2
+  %append.new = call { ptr, i32, i32 } @runtime.sliceAppend(ptr %ints.data, ptr nonnull %varargs, i32 %ints.len, i32 %ints.cap, i32 3, i32 4, ptr undef) #3
   %append.newPtr = extractvalue { ptr, i32, i32 } %append.new, 0
   %append.newLen = extractvalue { ptr, i32, i32 } %append.new, 1
   %append.newCap = extractvalue { ptr, i32, i32 } %append.new, 2
   %2 = insertvalue { ptr, i32, i32 } undef, ptr %append.newPtr, 0
   %3 = insertvalue { ptr, i32, i32 } %2, i32 %append.newLen, 1
   %4 = insertvalue { ptr, i32, i32 } %3, i32 %append.newCap, 2
-  call void @runtime.trackPointer(ptr %append.newPtr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %append.newPtr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %4
 }
 
-declare { ptr, i32, i32 } @runtime.sliceAppend(ptr, ptr nocapture readonly, i32, i32, i32, i32, ptr) #0
+declare { ptr, i32, i32 } @runtime.sliceAppend(ptr, ptr nocapture readonly, i32, i32, i32, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.sliceAppendSlice(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %added.data, i32 %added.len, i32 %added.cap, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.sliceAppendSlice(ptr %ints.data, i32 %ints.len, i32 %ints.cap, ptr %added.data, i32 %added.len, i32 %added.cap, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %append.new = call { ptr, i32, i32 } @runtime.sliceAppend(ptr %ints.data, ptr %added.data, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, ptr undef) #2
+  %append.new = call { ptr, i32, i32 } @runtime.sliceAppend(ptr %ints.data, ptr %added.data, i32 %ints.len, i32 %ints.cap, i32 %added.len, i32 4, ptr undef) #3
   %append.newPtr = extractvalue { ptr, i32, i32 } %append.new, 0
   %append.newLen = extractvalue { ptr, i32, i32 } %append.new, 1
   %append.newCap = extractvalue { ptr, i32, i32 } %append.new, 2
   %0 = insertvalue { ptr, i32, i32 } undef, ptr %append.newPtr, 0
   %1 = insertvalue { ptr, i32, i32 } %0, i32 %append.newLen, 1
   %2 = insertvalue { ptr, i32, i32 } %1, i32 %append.newCap, 2
-  call void @runtime.trackPointer(ptr %append.newPtr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %append.newPtr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %2
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.sliceCopy(ptr %dst.data, i32 %dst.len, i32 %dst.cap, ptr %src.data, i32 %src.len, i32 %src.cap, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.sliceCopy(ptr %dst.data, i32 %dst.len, i32 %dst.cap, ptr %src.data, i32 %src.len, i32 %src.cap, ptr %context) unnamed_addr #2 {
 entry:
-  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 4, ptr undef) #2
+  %copy.n = call i32 @runtime.sliceCopy(ptr %dst.data, ptr %src.data, i32 %dst.len, i32 %src.len, i32 4, ptr undef) #3
   ret i32 %copy.n
 }
 
-declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #0
+declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.makeByteSlice(i32 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.makeByteSlice(i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %slice.maxcap = icmp slt i32 %len, 0
   br i1 %slice.maxcap, label %slice.throw, label %slice.next
 
 slice.next:                                       ; preds = %entry
-  %makeslice.buf = call ptr @runtime.alloc(i32 %len, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
+  %makeslice.buf = call ptr @runtime.alloc(i32 %len, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
   %0 = insertvalue { ptr, i32, i32 } undef, ptr %makeslice.buf, 0
   %1 = insertvalue { ptr, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { ptr, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(ptr undef) #2
+  call void @runtime.slicePanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.slicePanic(ptr) #0
+declare void @runtime.slicePanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.makeInt16Slice(i32 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.makeInt16Slice(i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %slice.maxcap = icmp slt i32 %len, 0
@@ -122,20 +123,20 @@ entry:
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 1
-  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
+  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
   %0 = insertvalue { ptr, i32, i32 } undef, ptr %makeslice.buf, 0
   %1 = insertvalue { ptr, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { ptr, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(ptr undef) #2
+  call void @runtime.slicePanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.makeArraySlice(i32 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.makeArraySlice(i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %slice.maxcap = icmp ugt i32 %len, 1431655765
@@ -143,20 +144,20 @@ entry:
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = mul i32 %len, 3
-  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
+  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
   %0 = insertvalue { ptr, i32, i32 } undef, ptr %makeslice.buf, 0
   %1 = insertvalue { ptr, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { ptr, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(ptr undef) #2
+  call void @runtime.slicePanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.makeInt32Slice(i32 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.makeInt32Slice(i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %slice.maxcap = icmp ugt i32 %len, 1073741823
@@ -164,39 +165,39 @@ entry:
 
 slice.next:                                       ; preds = %entry
   %makeslice.cap = shl i32 %len, 2
-  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
+  %makeslice.buf = call ptr @runtime.alloc(i32 %makeslice.cap, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
   %0 = insertvalue { ptr, i32, i32 } undef, ptr %makeslice.buf, 0
   %1 = insertvalue { ptr, i32, i32 } %0, i32 %len, 1
   %2 = insertvalue { ptr, i32, i32 } %1, i32 %len, 2
-  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull %makeslice.buf, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %2
 
 slice.throw:                                      ; preds = %entry
-  call void @runtime.slicePanic(ptr undef) #2
+  call void @runtime.slicePanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.Add32(ptr %p, i32 %len, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.Add32(ptr %p, i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = getelementptr i8, ptr %p, i32 %len
-  call void @runtime.trackPointer(ptr %0, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %0, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %0
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.Add64(ptr %p, i64 %len, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.Add64(ptr %p, i64 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = trunc i64 %len to i32
   %1 = getelementptr i8, ptr %p, i32 %0
-  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %1, ptr nonnull %stackalloc, ptr undef) #3
   ret ptr %1
 }
 
 ; Function Attrs: nounwind
-define hidden ptr @main.SliceToArray(ptr %s.data, i32 %s.len, i32 %s.cap, ptr %context) unnamed_addr #1 {
+define hidden ptr @main.SliceToArray(ptr %s.data, i32 %s.len, i32 %s.cap, ptr %context) unnamed_addr #2 {
 entry:
   %0 = icmp ult i32 %s.len, 4
   br i1 %0, label %slicetoarray.throw, label %slicetoarray.next
@@ -205,18 +206,18 @@ slicetoarray.next:                                ; preds = %entry
   ret ptr %s.data
 
 slicetoarray.throw:                               ; preds = %entry
-  call void @runtime.sliceToArrayPointerPanic(ptr undef) #2
+  call void @runtime.sliceToArrayPointerPanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.sliceToArrayPointerPanic(ptr) #0
+declare void @runtime.sliceToArrayPointerPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden ptr @main.SliceToArrayConst(ptr %context) unnamed_addr #1 {
+define hidden ptr @main.SliceToArrayConst(ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
-  %makeslice = call ptr @runtime.alloc(i32 24, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #2
-  call void @runtime.trackPointer(ptr nonnull %makeslice, ptr nonnull %stackalloc, ptr undef) #2
+  %makeslice = call dereferenceable(24) ptr @runtime.alloc(i32 24, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %makeslice, ptr nonnull %stackalloc, ptr undef) #3
   br i1 false, label %slicetoarray.throw, label %slicetoarray.next
 
 slicetoarray.next:                                ; preds = %entry
@@ -227,7 +228,7 @@ slicetoarray.throw:                               ; preds = %entry
 }
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.SliceInt(ptr dereferenceable_or_null(4) %ptr, i32 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.SliceInt(ptr dereferenceable_or_null(4) %ptr, i32 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = icmp ugt i32 %len, 1073741823
@@ -241,18 +242,18 @@ unsafe.Slice.next:                                ; preds = %entry
   %5 = insertvalue { ptr, i32, i32 } undef, ptr %ptr, 0
   %6 = insertvalue { ptr, i32, i32 } %5, i32 %len, 1
   %7 = insertvalue { ptr, i32, i32 } %6, i32 %len, 2
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %7
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  call void @runtime.unsafeSlicePanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.unsafeSlicePanic(ptr) #0
+declare void @runtime.unsafeSlicePanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.SliceUint16(ptr dereferenceable_or_null(1) %ptr, i16 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.SliceUint16(ptr dereferenceable_or_null(1) %ptr, i16 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = icmp eq ptr %ptr, null
@@ -265,16 +266,16 @@ unsafe.Slice.next:                                ; preds = %entry
   %4 = insertvalue { ptr, i32, i32 } undef, ptr %ptr, 0
   %5 = insertvalue { ptr, i32, i32 } %4, i32 %3, 1
   %6 = insertvalue { ptr, i32, i32 } %5, i32 %3, 2
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %6
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  call void @runtime.unsafeSlicePanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.SliceUint64(ptr dereferenceable_or_null(4) %ptr, i64 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.SliceUint64(ptr dereferenceable_or_null(4) %ptr, i64 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = icmp ugt i64 %len, 1073741823
@@ -289,16 +290,16 @@ unsafe.Slice.next:                                ; preds = %entry
   %6 = insertvalue { ptr, i32, i32 } undef, ptr %ptr, 0
   %7 = insertvalue { ptr, i32, i32 } %6, i32 %5, 1
   %8 = insertvalue { ptr, i32, i32 } %7, i32 %5, 2
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %8
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  call void @runtime.unsafeSlicePanic(ptr undef) #3
   unreachable
 }
 
 ; Function Attrs: nounwind
-define hidden { ptr, i32, i32 } @main.SliceInt64(ptr dereferenceable_or_null(4) %ptr, i64 %len, ptr %context) unnamed_addr #1 {
+define hidden { ptr, i32, i32 } @main.SliceInt64(ptr dereferenceable_or_null(4) %ptr, i64 %len, ptr %context) unnamed_addr #2 {
 entry:
   %stackalloc = alloca i8, align 1
   %0 = icmp ugt i64 %len, 1073741823
@@ -313,14 +314,15 @@ unsafe.Slice.next:                                ; preds = %entry
   %6 = insertvalue { ptr, i32, i32 } undef, ptr %ptr, 0
   %7 = insertvalue { ptr, i32, i32 } %6, i32 %5, 1
   %8 = insertvalue { ptr, i32, i32 } %7, i32 %5, 2
-  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr %ptr, ptr nonnull %stackalloc, ptr undef) #3
   ret { ptr, i32, i32 } %8
 
 unsafe.Slice.throw:                               ; preds = %entry
-  call void @runtime.unsafeSlicePanic(ptr undef) #2
+  call void @runtime.unsafeSlicePanic(ptr undef) #3
   unreachable
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -7,36 +7,37 @@ target triple = "wasm32-unknown-wasi"
 
 @"main$string" = internal unnamed_addr constant [3 x i8] c"foo", align 1
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.someString(ptr %context) unnamed_addr #1 {
+define hidden %runtime._string @main.someString(ptr %context) unnamed_addr #2 {
 entry:
   ret %runtime._string { ptr @"main$string", i32 3 }
 }
 
 ; Function Attrs: nounwind
-define hidden %runtime._string @main.zeroLengthString(ptr %context) unnamed_addr #1 {
+define hidden %runtime._string @main.zeroLengthString(ptr %context) unnamed_addr #2 {
 entry:
   ret %runtime._string zeroinitializer
 }
 
 ; Function Attrs: nounwind
-define hidden i32 @main.stringLen(ptr %s.data, i32 %s.len, ptr %context) unnamed_addr #1 {
+define hidden i32 @main.stringLen(ptr %s.data, i32 %s.len, ptr %context) unnamed_addr #2 {
 entry:
   ret i32 %s.len
 }
 
 ; Function Attrs: nounwind
-define hidden i8 @main.stringIndex(ptr %s.data, i32 %s.len, i32 %index, ptr %context) unnamed_addr #1 {
+define hidden i8 @main.stringIndex(ptr %s.data, i32 %s.len, i32 %index, ptr %context) unnamed_addr #2 {
 entry:
   %.not = icmp ult i32 %index, %s.len
   br i1 %.not, label %lookup.next, label %lookup.throw
@@ -47,40 +48,40 @@ lookup.next:                                      ; preds = %entry
   ret i8 %1
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(ptr undef) #2
+  call void @runtime.lookupPanic(ptr undef) #3
   unreachable
 }
 
-declare void @runtime.lookupPanic(ptr) #0
+declare void @runtime.lookupPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.stringCompareEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr undef) #2
+  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr undef) #3
   ret i1 %0
 }
 
-declare i1 @runtime.stringEqual(ptr, i32, ptr, i32, ptr) #0
+declare i1 @runtime.stringEqual(ptr, i32, ptr, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareUnequal(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.stringCompareUnequal(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr undef) #2
+  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr undef) #3
   %1 = xor i1 %0, true
   ret i1 %1
 }
 
 ; Function Attrs: nounwind
-define hidden i1 @main.stringCompareLarger(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #1 {
+define hidden i1 @main.stringCompareLarger(ptr %s1.data, i32 %s1.len, ptr %s2.data, i32 %s2.len, ptr %context) unnamed_addr #2 {
 entry:
-  %0 = call i1 @runtime.stringLess(ptr %s2.data, i32 %s2.len, ptr %s1.data, i32 %s1.len, ptr undef) #2
+  %0 = call i1 @runtime.stringLess(ptr %s2.data, i32 %s2.len, ptr %s1.data, i32 %s1.len, ptr undef) #3
   ret i1 %0
 }
 
-declare i1 @runtime.stringLess(ptr, i32, ptr, i32, ptr) #0
+declare i1 @runtime.stringLess(ptr, i32, ptr, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden i8 @main.stringLookup(ptr %s.data, i32 %s.len, i8 %x, ptr %context) unnamed_addr #1 {
+define hidden i8 @main.stringLookup(ptr %s.data, i32 %s.len, i8 %x, ptr %context) unnamed_addr #2 {
 entry:
   %0 = zext i8 %x to i32
   %.not = icmp ult i32 %0, %s.len
@@ -92,10 +93,11 @@ lookup.next:                                      ; preds = %entry
   ret i8 %2
 
 lookup.throw:                                     ; preds = %entry
-  call void @runtime.lookupPanic(ptr undef) #2
+  call void @runtime.lookupPanic(ptr undef) #3
   unreachable
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind }

--- a/compiler/testdata/zeromap.ll
+++ b/compiler/testdata/zeromap.ll
@@ -5,18 +5,19 @@ target triple = "wasm32-unknown-wasi"
 
 %main.hasPadding = type { i1, i32, i1 }
 
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(ptr %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: noinline nounwind
-define hidden i32 @main.testZeroGet(ptr dereferenceable_or_null(40) %m, i1 %s.b1, i32 %s.i, i1 %s.b2, ptr %context) unnamed_addr #2 {
+define hidden i32 @main.testZeroGet(ptr dereferenceable_or_null(40) %m, i1 %s.b1, i32 %s.i, i1 %s.b2, ptr %context) unnamed_addr #3 {
 entry:
   %hashmap.key = alloca %main.hasPadding, align 8
   %hashmap.value = alloca i32, align 4
@@ -26,16 +27,16 @@ entry:
   %2 = insertvalue %main.hasPadding %1, i1 %s.b2, 2
   %stackalloc = alloca i8, align 1
   store %main.hasPadding zeroinitializer, ptr %s, align 8
-  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #4
+  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #5
   store %main.hasPadding %2, ptr %s, align 8
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   call void @llvm.lifetime.start.p0(i64 12, ptr nonnull %hashmap.key)
   store %main.hasPadding %2, ptr %hashmap.key, align 8
   %3 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
-  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #5
   %4 = getelementptr inbounds i8, ptr %hashmap.key, i32 9
-  call void @runtime.memzero(ptr nonnull %4, i32 3, ptr undef) #4
-  %5 = call i1 @runtime.hashmapBinaryGet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, i32 4, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %4, i32 3, ptr undef) #5
+  %5 = call i1 @runtime.hashmapBinaryGet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, i32 4, ptr undef) #5
   call void @llvm.lifetime.end.p0(i64 12, ptr nonnull %hashmap.key)
   %6 = load i32, ptr %hashmap.value, align 4
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %hashmap.value)
@@ -43,17 +44,17 @@ entry:
 }
 
 ; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #4
 
-declare void @runtime.memzero(ptr, i32, ptr) #0
+declare void @runtime.memzero(ptr, i32, ptr) #1
 
-declare i1 @runtime.hashmapBinaryGet(ptr dereferenceable_or_null(40), ptr, ptr, i32, ptr) #0
+declare i1 @runtime.hashmapBinaryGet(ptr dereferenceable_or_null(40), ptr, ptr, i32, ptr) #1
 
 ; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #4
 
 ; Function Attrs: noinline nounwind
-define hidden void @main.testZeroSet(ptr dereferenceable_or_null(40) %m, i1 %s.b1, i32 %s.i, i1 %s.b2, ptr %context) unnamed_addr #2 {
+define hidden void @main.testZeroSet(ptr dereferenceable_or_null(40) %m, i1 %s.b1, i32 %s.i, i1 %s.b2, ptr %context) unnamed_addr #3 {
 entry:
   %hashmap.key = alloca %main.hasPadding, align 8
   %hashmap.value = alloca i32, align 4
@@ -63,26 +64,26 @@ entry:
   %2 = insertvalue %main.hasPadding %1, i1 %s.b2, 2
   %stackalloc = alloca i8, align 1
   store %main.hasPadding zeroinitializer, ptr %s, align 8
-  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #4
+  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #5
   store %main.hasPadding %2, ptr %s, align 8
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   store i32 5, ptr %hashmap.value, align 4
   call void @llvm.lifetime.start.p0(i64 12, ptr nonnull %hashmap.key)
   store %main.hasPadding %2, ptr %hashmap.key, align 8
   %3 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
-  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #5
   %4 = getelementptr inbounds i8, ptr %hashmap.key, i32 9
-  call void @runtime.memzero(ptr nonnull %4, i32 3, ptr undef) #4
-  call void @runtime.hashmapBinarySet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %4, i32 3, ptr undef) #5
+  call void @runtime.hashmapBinarySet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, ptr undef) #5
   call void @llvm.lifetime.end.p0(i64 12, ptr nonnull %hashmap.key)
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %hashmap.value)
   ret void
 }
 
-declare void @runtime.hashmapBinarySet(ptr dereferenceable_or_null(40), ptr, ptr, ptr) #0
+declare void @runtime.hashmapBinarySet(ptr dereferenceable_or_null(40), ptr, ptr, ptr) #1
 
 ; Function Attrs: noinline nounwind
-define hidden i32 @main.testZeroArrayGet(ptr dereferenceable_or_null(40) %m, [2 x %main.hasPadding] %s, ptr %context) unnamed_addr #2 {
+define hidden i32 @main.testZeroArrayGet(ptr dereferenceable_or_null(40) %m, [2 x %main.hasPadding] %s, ptr %context) unnamed_addr #3 {
 entry:
   %hashmap.key = alloca [2 x %main.hasPadding], align 8
   %hashmap.value = alloca i32, align 4
@@ -91,7 +92,7 @@ entry:
   store %main.hasPadding zeroinitializer, ptr %s1, align 8
   %s1.repack2 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
   store %main.hasPadding zeroinitializer, ptr %s1.repack2, align 4
-  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #4
+  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #5
   %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
   store %main.hasPadding %s.elt, ptr %s1, align 8
   %s1.repack3 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
@@ -105,14 +106,14 @@ entry:
   %s.elt9 = extractvalue [2 x %main.hasPadding] %s, 1
   store %main.hasPadding %s.elt9, ptr %hashmap.key.repack8, align 4
   %0 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
-  call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #5
   %1 = getelementptr inbounds i8, ptr %hashmap.key, i32 9
-  call void @runtime.memzero(ptr nonnull %1, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %1, i32 3, ptr undef) #5
   %2 = getelementptr inbounds i8, ptr %hashmap.key, i32 13
-  call void @runtime.memzero(ptr nonnull %2, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %2, i32 3, ptr undef) #5
   %3 = getelementptr inbounds i8, ptr %hashmap.key, i32 21
-  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #4
-  %4 = call i1 @runtime.hashmapBinaryGet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, i32 4, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #5
+  %4 = call i1 @runtime.hashmapBinaryGet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, i32 4, ptr undef) #5
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %hashmap.key)
   %5 = load i32, ptr %hashmap.value, align 4
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %hashmap.value)
@@ -120,7 +121,7 @@ entry:
 }
 
 ; Function Attrs: noinline nounwind
-define hidden void @main.testZeroArraySet(ptr dereferenceable_or_null(40) %m, [2 x %main.hasPadding] %s, ptr %context) unnamed_addr #2 {
+define hidden void @main.testZeroArraySet(ptr dereferenceable_or_null(40) %m, [2 x %main.hasPadding] %s, ptr %context) unnamed_addr #3 {
 entry:
   %hashmap.key = alloca [2 x %main.hasPadding], align 8
   %hashmap.value = alloca i32, align 4
@@ -129,7 +130,7 @@ entry:
   store %main.hasPadding zeroinitializer, ptr %s1, align 8
   %s1.repack2 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
   store %main.hasPadding zeroinitializer, ptr %s1.repack2, align 4
-  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #4
+  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #5
   %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
   store %main.hasPadding %s.elt, ptr %s1, align 8
   %s1.repack3 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
@@ -144,27 +145,28 @@ entry:
   %s.elt9 = extractvalue [2 x %main.hasPadding] %s, 1
   store %main.hasPadding %s.elt9, ptr %hashmap.key.repack8, align 4
   %0 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
-  call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #5
   %1 = getelementptr inbounds i8, ptr %hashmap.key, i32 9
-  call void @runtime.memzero(ptr nonnull %1, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %1, i32 3, ptr undef) #5
   %2 = getelementptr inbounds i8, ptr %hashmap.key, i32 13
-  call void @runtime.memzero(ptr nonnull %2, i32 3, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %2, i32 3, ptr undef) #5
   %3 = getelementptr inbounds i8, ptr %hashmap.key, i32 21
-  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #4
-  call void @runtime.hashmapBinarySet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, ptr undef) #4
+  call void @runtime.memzero(ptr nonnull %3, i32 3, ptr undef) #5
+  call void @runtime.hashmapBinarySet(ptr %m, ptr nonnull %hashmap.key, ptr nonnull %hashmap.value, ptr undef) #5
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %hashmap.key)
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %hashmap.value)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.main(ptr %context) unnamed_addr #1 {
+define hidden void @main.main(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { argmemonly nocallback nofree nosync nounwind willreturn }
-attributes #4 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #4 = { argmemonly nocallback nofree nosync nounwind willreturn }
+attributes #5 = { nounwind }

--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -25,7 +25,7 @@ func (a ADC) Configure(ADCConfig) {
 // Get returns the current value of a ADC pin in the range 0..0xffff.
 func (a ADC) Get() uint16 {
 	var pwmPin uint32
-	var value int16
+	var rawValue volatile.Register16
 
 	switch a.Pin {
 	case 2:
@@ -78,7 +78,7 @@ func (a ADC) Get() uint16 {
 	nrf.SAADC.CH[0].PSELP.Set(pwmPin)
 
 	// Destination for sample result.
-	nrf.SAADC.RESULT.PTR.Set(uint32(uintptr(unsafe.Pointer(&value))))
+	nrf.SAADC.RESULT.PTR.Set(uint32(uintptr(unsafe.Pointer(&rawValue))))
 	nrf.SAADC.RESULT.MAXCNT.Set(1) // One sample
 
 	// Start tasks.
@@ -104,6 +104,7 @@ func (a ADC) Get() uint16 {
 	// Disable the ADC.
 	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Disabled << nrf.SAADC_ENABLE_ENABLE_Pos)
 
+	value := int16(rawValue.Get())
 	if value < 0 {
 		value = 0
 	}

--- a/transform/testdata/allocs2.go
+++ b/transform/testdata/allocs2.go
@@ -18,7 +18,7 @@ func main() {
 	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 19
 	returnIntSlice(s3)
 
-	_ = make([]int, getUnknownNumber()) // OUT: object allocated on the heap: size is not constant
+	useSlice(make([]int, getUnknownNumber())) // OUT: object allocated on the heap: size is not constant
 
 	s4 := make([]byte, 300) // OUT: object allocated on the heap: object size 300 exceeds maximum stack allocation size 256
 	readByteSlice(s4)
@@ -82,3 +82,5 @@ func getComplex128() complex128
 func useInterface(interface{})
 
 func callVariadic(...int)
+
+func useSlice([]int)


### PR DESCRIPTION
This gives a small improvement now, and is needed to be able to use the Heap2Stack transform that's available in the Attributor pass. This Heap2Stack transform could replace our custom OptimizeAllocs pass.

Most of the changes are just IR that changed, the actual change is relatively small.

To give an example of why this is useful, here is the code size before this change:

    $ tinygo build -o test -size=short ./testdata/stdlib.go
       code    data     bss |   flash     ram
      95620    1812     968 |   97432    2780

    $ tinygo build -o test -size=short ./testdata/stdlib.go
       code    data     bss |   flash     ram
      95380    1812     968 |   97192    2780

That's a 0.25% reduction. Not a whole lot, but nice for such a small patch.