### PR TITLE
machine/rp2040: change uart to allow for a single pin

### DIFF
--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -41,8 +41,12 @@ func (uart *UART) Configure(config UARTConfig) error {
 		rp.UART0_UARTCR_TXE)
 
 	// set GPIO mux to UART for the pins
-	config.TX.Configure(PinConfig{Mode: PinUART})
-	config.RX.Configure(PinConfig{Mode: PinUART})
+	if config.TX != NoPin {
+		config.TX.Configure(PinConfig{Mode: PinUART})
+	}
+	if config.RX != NoPin {
+		config.RX.Configure(PinConfig{Mode: PinUART})
+	}
 
 	// Enable RX IRQ.
 	uart.Interrupt.SetPriority(0x80)


### PR DESCRIPTION
This PR allows the RP2040's UART to be used only for either transmitting or receiving.
This is especially useful when using a device such as the XIAO-RP2040, which has a small number of pins.