### PR TITLE
WIP:riscv64-qemu target

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -34,6 +34,7 @@ func TestClangAttributes(t *testing.T) {
 		"k210",
 		"nintendoswitch",
 		"riscv-qemu",
+		"riscv64-qemu",
 		"wasi",
 		"wasm",
 	}

--- a/targets/riscv64-qemu.json
+++ b/targets/riscv64-qemu.json
@@ -1,0 +1,8 @@
+{
+	"inherits": ["riscv64"],
+	"features": "+a,+c,+m,-relax,-save-restore",
+	"build-tags": ["virt", "qemu"],
+	"default-stack-size": 4096,
+	"linkerscript": "targets/riscv64-qemu.ld",
+	"emulator": "qemu-system-riscv32 -machine virt -nographic -bios none -kernel {}"
+}

--- a/targets/riscv64-qemu.ld
+++ b/targets/riscv64-qemu.ld
@@ -1,0 +1,16 @@
+
+/* Memory map:
+ * https://github.com/qemu/qemu/blob/master/hw/riscv/virt.c
+ * RAM and flash are set to 1MB each. That should be enough for the foreseeable
+ * future. QEMU does not seem to limit the flash/RAM size and in fact doesn't
+ * seem to differentiate between it.
+ */
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x20000000, LENGTH = 0x100000
+    RAM (xrw)       : ORIGIN = 0x80000000, LENGTH = 0x100000
+}
+
+_stack_size = 2K;
+
+INCLUDE "targets/riscv.ld"


### PR DESCRIPTION
    tinygo build -target riscv64-qemu -monitor .
    tinygo:ld.lld: error: /home/rminnich/.cache/tinygo/thinlto/llvmcache-933570AB9628376F0C2EAD9666A92A793D143BE9:\
    (function (reflect.Value).Complex: .text.(reflect.Value).Complex+0x76): relocation R_RISCV_HI20 out of range: \
    524291 is not in [-524288, 524287]; references reflect$string.170
    >>> referenced by value.go:0 (/home/rminnich/tinygo/src/reflect/value.go:0)
    >>> defined in /home/rminnich/.cache/tinygo/thinlto/llvmcache-933570AB9628376F0C2EAD9666A92A793D143BE9

    what's odd is that it the number is
    524291 is 0x80003
    
    I had to dump the llvm output to see the 0xffff_ffff bits.