### PR TITLE
reflect: TypeOf(nil) should be nil

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -465,6 +465,9 @@ func (t *rawType) isNamed() bool {
 }
 
 func TypeOf(i interface{}) Type {
+	if i == nil {
+		return nil
+	}
 	typecode, _ := decomposeInterface(i)
 	return (*rawType)(typecode)
 }

--- a/src/reflect/value_test.go
+++ b/src/reflect/value_test.go
@@ -313,6 +313,14 @@ func TestAddr(t *testing.T) {
 	}
 }
 
+func TestNilType(t *testing.T) {
+	var a any = nil
+	typ := TypeOf(a)
+	if typ != nil {
+		t.Errorf("Type of any{nil} is not nil")
+	}
+}
+
 func equal[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
```
~/go/src/github.com/dgryski/bug/refnil $ go run main.go
true
~/go/src/github.com/dgryski/bug/refnil $ tinygo run main.go
false
~/go/src/github.com/dgryski/bug/refnil $ cat main.go
package main

import "reflect"

func main() {
	var a any = nil
	t := reflect.TypeOf(a)
	println(t == nil)
}
```