### PR TITLE
reflect: fix Type.Name to return empty string for non-named types

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -923,7 +923,11 @@ func (t *rawType) Name() string {
 		return readStringZ(unsafe.Pointer(&ntype.name[0]))
 	}
 
-	return t.Kind().String()
+	if t.Kind() <= UnsafePointer {
+		return t.Kind().String()
+	}
+
+	return ""
 }
 
 func (t *rawType) Key() Type {


### PR DESCRIPTION

    // Name returns the type's name within its package for a defined type. 
    // For other (non-defined) types it returns the empty string.