### PR TITLE
Update transform tests with opaque pointers

### DIFF
--- a/transform/testdata/allocs.out.ll
+++ b/transform/testdata/allocs.out.ll
@@ -3,53 +3,47 @@ target triple = "armv7m-none-eabi"
 
 @runtime.zeroSizedAlloc = internal global i8 0, align 1
 
-declare nonnull i8* @runtime.alloc(i32, i8*)
+declare nonnull ptr @runtime.alloc(i32, ptr)
 
 define void @testInt() {
   %stackalloc.alloca = alloca [4 x i8], align 4
-  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
-  store i32 5, i32* %stackalloc, align 4
+  store [4 x i8] zeroinitializer, ptr %stackalloc.alloca, align 4
+  store i32 5, ptr %stackalloc.alloca, align 4
   ret void
 }
 
 define i16 @testArray() {
   %stackalloc.alloca = alloca [6 x i8], align 2
-  store [6 x i8] zeroinitializer, [6 x i8]* %stackalloc.alloca, align 2
-  %stackalloc = bitcast [6 x i8]* %stackalloc.alloca to i16*
-  %1 = getelementptr i16, i16* %stackalloc, i32 1
-  store i16 5, i16* %1, align 2
-  %2 = getelementptr i16, i16* %stackalloc, i32 2
-  %3 = load i16, i16* %2, align 2
-  ret i16 %3
+  store [6 x i8] zeroinitializer, ptr %stackalloc.alloca, align 2
+  %alloc.1 = getelementptr i16, ptr %stackalloc.alloca, i32 1
+  store i16 5, ptr %alloc.1, align 2
+  %alloc.2 = getelementptr i16, ptr %stackalloc.alloca, i32 2
+  %val = load i16, ptr %alloc.2, align 2
+  ret i16 %val
 }
 
 define void @testEscapingCall() {
-  %1 = call i8* @runtime.alloc(i32 4, i8* null)
-  %2 = bitcast i8* %1 to i32*
-  %3 = call i32* @escapeIntPtr(i32* %2)
+  %alloc = call ptr @runtime.alloc(i32 4, ptr null)
+  %val = call ptr @escapeIntPtr(ptr %alloc)
   ret void
 }
 
 define void @testEscapingCall2() {
-  %1 = call i8* @runtime.alloc(i32 4, i8* null)
-  %2 = bitcast i8* %1 to i32*
-  %3 = call i32* @escapeIntPtrSometimes(i32* %2, i32* %2)
+  %alloc = call ptr @runtime.alloc(i32 4, ptr null)
+  %val = call ptr @escapeIntPtrSometimes(ptr %alloc, ptr %alloc)
   ret void
 }
 
 define void @testNonEscapingCall() {
   %stackalloc.alloca = alloca [4 x i8], align 4
-  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
-  %1 = call i32* @noescapeIntPtr(i32* %stackalloc)
+  store [4 x i8] zeroinitializer, ptr %stackalloc.alloca, align 4
+  %val = call ptr @noescapeIntPtr(ptr %stackalloc.alloca)
   ret void
 }
 
-define i32* @testEscapingReturn() {
-  %1 = call i8* @runtime.alloc(i32 4, i8* null)
-  %2 = bitcast i8* %1 to i32*
-  ret i32* %2
+define ptr @testEscapingReturn() {
+  %alloc = call ptr @runtime.alloc(i32 4, ptr null)
+  ret ptr %alloc
 }
 
 define void @testNonEscapingLoop() {
@@ -58,24 +52,22 @@ entry:
   br label %loop
 
 loop:                                             ; preds = %loop, %entry
-  store [4 x i8] zeroinitializer, [4 x i8]* %stackalloc.alloca, align 4
-  %stackalloc = bitcast [4 x i8]* %stackalloc.alloca to i32*
-  %0 = call i32* @noescapeIntPtr(i32* %stackalloc)
-  %1 = icmp eq i32* null, %0
-  br i1 %1, label %loop, label %end
+  store [4 x i8] zeroinitializer, ptr %stackalloc.alloca, align 4
+  %ptr = call ptr @noescapeIntPtr(ptr %stackalloc.alloca)
+  %result = icmp eq ptr null, %ptr
+  br i1 %result, label %loop, label %end
 
 end:                                              ; preds = %loop
   ret void
 }
 
 define void @testZeroSizedAlloc() {
-  %1 = bitcast i8* @runtime.zeroSizedAlloc to i32*
-  %2 = call i32* @noescapeIntPtr(i32* %1)
+  %ptr = call ptr @noescapeIntPtr(ptr @runtime.zeroSizedAlloc)
   ret void
 }
 
-declare i32* @escapeIntPtr(i32*)
+declare ptr @escapeIntPtr(ptr)
 
-declare i32* @noescapeIntPtr(i32* nocapture)
+declare ptr @noescapeIntPtr(ptr nocapture)
 
-declare i32* @escapeIntPtrSometimes(i32* nocapture, i32*)
+declare ptr @escapeIntPtrSometimes(ptr nocapture, ptr)

--- a/transform/testdata/gc-stackslots.out.ll
+++ b/transform/testdata/gc-stackslots.out.ll
@@ -1,141 +1,134 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-unknown-wasm"
 
-%runtime.stackChainObject = type { %runtime.stackChainObject*, i32 }
-
-@runtime.stackChainStart = internal global %runtime.stackChainObject* null
+@runtime.stackChainStart = internal global ptr null
 @someGlobal = global i8 3
-@ptrGlobal = global i8** null
+@ptrGlobal = global ptr null
 
-declare void @runtime.trackPointer(i8* nocapture readonly)
+declare void @runtime.trackPointer(ptr nocapture readonly)
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*)
+declare noalias nonnull ptr @runtime.alloc(i32, ptr)
 
-define i8* @getPointer() {
-  ret i8* @someGlobal
+define ptr @getPointer() {
+  ret ptr @someGlobal
 }
 
-define i8* @needsStackSlots() {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8* } { %runtime.stackChainObject* null, i32 1, i8* null }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %ptr = call i8* @runtime.alloc(i32 4, i8* null)
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %ptr, i8** %4, align 4
+define ptr @needsStackSlots() {
+  %gc.stackobject = alloca { ptr, i32, ptr }, align 8
+  store { ptr, i32, ptr } { ptr null, i32 1, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %ptr = call ptr @runtime.alloc(i32 4, ptr null)
+  %3 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %ptr, ptr %3, align 4
   call void @someArbitraryFunction()
-  %val = load i8, i8* @someGlobal, align 1
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  ret i8* %ptr
+  %val = load i8, ptr @someGlobal, align 1
+  store ptr %1, ptr @runtime.stackChainStart, align 4
+  ret ptr %ptr
 }
 
-define i8* @needsStackSlots2() {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* } { %runtime.stackChainObject* null, i32 5, i8* null, i8* null, i8* null, i8* null, i8* null }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %ptr1 = call i8* @getPointer()
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 4
-  store i8* %ptr1, i8** %4, align 4
-  %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 3
-  store i8* %ptr1, i8** %5, align 4
-  %6 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %ptr1, i8** %6, align 4
-  %ptr2 = getelementptr i8, i8* @someGlobal, i32 0
-  %7 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 5
-  store i8* %ptr2, i8** %7, align 4
-  %unused = call i8* @runtime.alloc(i32 4, i8* null)
-  %8 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 6
-  store i8* %unused, i8** %8, align 4
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  ret i8* %ptr1
+define ptr @needsStackSlots2() {
+  %gc.stackobject = alloca { ptr, i32, ptr, ptr, ptr, ptr, ptr }, align 8
+  store { ptr, i32, ptr, ptr, ptr, ptr, ptr } { ptr null, i32 5, ptr null, ptr null, ptr null, ptr null, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %ptr1 = call ptr @getPointer()
+  %3 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 4
+  store ptr %ptr1, ptr %3, align 4
+  %4 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 3
+  store ptr %ptr1, ptr %4, align 4
+  %5 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %ptr1, ptr %5, align 4
+  %ptr2 = getelementptr i8, ptr @someGlobal, i32 0
+  %6 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 5
+  store ptr %ptr2, ptr %6, align 4
+  %unused = call ptr @runtime.alloc(i32 4, ptr null)
+  %7 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 6
+  store ptr %unused, ptr %7, align 4
+  store ptr %1, ptr @runtime.stackChainStart, align 4
+  ret ptr %ptr1
 }
 
-define i8* @noAllocatingFunction() {
-  %ptr = call i8* @getPointer()
-  ret i8* %ptr
+define ptr @noAllocatingFunction() {
+  %ptr = call ptr @getPointer()
+  ret ptr %ptr
 }
 
-define i8* @fibNext(i8* %x, i8* %y) {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8* } { %runtime.stackChainObject* null, i32 1, i8* null }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %x.val = load i8, i8* %x, align 1
-  %y.val = load i8, i8* %y, align 1
+define ptr @fibNext(ptr %x, ptr %y) {
+  %gc.stackobject = alloca { ptr, i32, ptr }, align 8
+  store { ptr, i32, ptr } { ptr null, i32 1, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %x.val = load i8, ptr %x, align 1
+  %y.val = load i8, ptr %y, align 1
   %out.val = add i8 %x.val, %y.val
-  %out.alloc = call i8* @runtime.alloc(i32 1, i8* null)
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %out.alloc, i8** %4, align 4
-  store i8 %out.val, i8* %out.alloc, align 1
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  ret i8* %out.alloc
+  %out.alloc = call ptr @runtime.alloc(i32 1, ptr null)
+  %3 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %out.alloc, ptr %3, align 4
+  store i8 %out.val, ptr %out.alloc, align 1
+  store ptr %1, ptr @runtime.stackChainStart, align 4
+  ret ptr %out.alloc
 }
 
-define i8* @allocLoop() {
+define ptr @allocLoop() {
 entry:
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* } { %runtime.stackChainObject* null, i32 5, i8* null, i8* null, i8* null, i8* null, i8* null }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, align 4
-  %0 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %1 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %0, %runtime.stackChainObject** %1, align 4
-  %2 = bitcast { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %2, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %entry.x = call i8* @runtime.alloc(i32 1, i8* null)
-  %3 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %entry.x, i8** %3, align 4
-  %entry.y = call i8* @runtime.alloc(i32 1, i8* null)
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 3
-  store i8* %entry.y, i8** %4, align 4
-  store i8 1, i8* %entry.y, align 1
+  %gc.stackobject = alloca { ptr, i32, ptr, ptr, ptr, ptr, ptr }, align 8
+  store { ptr, i32, ptr, ptr, ptr, ptr, ptr } { ptr null, i32 5, ptr null, ptr null, ptr null, ptr null, ptr null }, ptr %gc.stackobject, align 4
+  %0 = load ptr, ptr @runtime.stackChainStart, align 4
+  %1 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %0, ptr %1, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %entry.x = call ptr @runtime.alloc(i32 1, ptr null)
+  %2 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %entry.x, ptr %2, align 4
+  %entry.y = call ptr @runtime.alloc(i32 1, ptr null)
+  %3 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 3
+  store ptr %entry.y, ptr %3, align 4
+  store i8 1, ptr %entry.y, align 1
   br label %loop
 
 loop:                                             ; preds = %loop, %entry
-  %prev.y = phi i8* [ %entry.y, %entry ], [ %prev.x, %loop ]
-  %prev.x = phi i8* [ %entry.x, %entry ], [ %next.x, %loop ]
-  %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 5
-  store i8* %prev.y, i8** %5, align 4
-  %6 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 4
-  store i8* %prev.x, i8** %6, align 4
-  %next.x = call i8* @fibNext(i8* %prev.x, i8* %prev.y)
-  %7 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8*, i8*, i8*, i8* }* %gc.stackobject, i32 0, i32 6
-  store i8* %next.x, i8** %7, align 4
-  %next.x.val = load i8, i8* %next.x, align 1
+  %prev.y = phi ptr [ %entry.y, %entry ], [ %prev.x, %loop ]
+  %prev.x = phi ptr [ %entry.x, %entry ], [ %next.x, %loop ]
+  %4 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 5
+  store ptr %prev.y, ptr %4, align 4
+  %5 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 4
+  store ptr %prev.x, ptr %5, align 4
+  %next.x = call ptr @fibNext(ptr %prev.x, ptr %prev.y)
+  %6 = getelementptr { ptr, i32, ptr, ptr, ptr, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 6
+  store ptr %next.x, ptr %6, align 4
+  %next.x.val = load i8, ptr %next.x, align 1
   %loop.done = icmp ult i8 40, %next.x.val
   br i1 %loop.done, label %end, label %loop
 
 end:                                              ; preds = %loop
-  store %runtime.stackChainObject* %0, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  ret i8* %next.x
+  store ptr %0, ptr @runtime.stackChainStart, align 4
+  ret ptr %next.x
 }
 
-declare [32 x i8]* @arrayAlloc()
+declare ptr @arrayAlloc()
 
 define void @testGEPBitcast() {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8*, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8*, i8* } { %runtime.stackChainObject* null, i32 2, i8* null, i8* null }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %arr = call [32 x i8]* @arrayAlloc()
-  %arr.bitcast = getelementptr [32 x i8], [32 x i8]* %arr, i32 0, i32 0
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %arr.bitcast, i8** %4, align 4
-  %other = call i8* @runtime.alloc(i32 1, i8* null)
-  %5 = getelementptr { %runtime.stackChainObject*, i32, i8*, i8* }, { %runtime.stackChainObject*, i32, i8*, i8* }* %gc.stackobject, i32 0, i32 3
-  store i8* %other, i8** %5, align 4
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
+  %gc.stackobject = alloca { ptr, i32, ptr, ptr }, align 8
+  store { ptr, i32, ptr, ptr } { ptr null, i32 2, ptr null, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %arr = call ptr @arrayAlloc()
+  %arr.bitcast = getelementptr [32 x i8], ptr %arr, i32 0, i32 0
+  %3 = getelementptr { ptr, i32, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %arr.bitcast, ptr %3, align 4
+  %other = call ptr @runtime.alloc(i32 1, ptr null)
+  %4 = getelementptr { ptr, i32, ptr, ptr }, ptr %gc.stackobject, i32 0, i32 3
+  store ptr %other, ptr %4, align 4
+  store ptr %1, ptr @runtime.stackChainStart, align 4
   ret void
 }
 
@@ -144,35 +137,32 @@ define void @someArbitraryFunction() {
 }
 
 define void @earlyPopRegression() {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8* } { %runtime.stackChainObject* null, i32 1, i8* null }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %x.alloc = call i8* @runtime.alloc(i32 4, i8* null)
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %x.alloc, i8** %4, align 4
-  %x = bitcast i8* %x.alloc to i8**
-  call void @allocAndSave(i8** %x)
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
+  %gc.stackobject = alloca { ptr, i32, ptr }, align 8
+  store { ptr, i32, ptr } { ptr null, i32 1, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %x.alloc = call ptr @runtime.alloc(i32 4, ptr null)
+  %3 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %x.alloc, ptr %3, align 4
+  call void @allocAndSave(ptr %x.alloc)
+  store ptr %1, ptr @runtime.stackChainStart, align 4
   ret void
 }
 
-define void @allocAndSave(i8** %x) {
-  %gc.stackobject = alloca { %runtime.stackChainObject*, i32, i8* }, align 8
-  store { %runtime.stackChainObject*, i32, i8* } { %runtime.stackChainObject* null, i32 1, i8* null }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, align 4
-  %1 = load %runtime.stackChainObject*, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %2 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 0
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** %2, align 4
-  %3 = bitcast { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject to %runtime.stackChainObject*
-  store %runtime.stackChainObject* %3, %runtime.stackChainObject** @runtime.stackChainStart, align 4
-  %y = call i8* @runtime.alloc(i32 4, i8* null)
-  %4 = getelementptr { %runtime.stackChainObject*, i32, i8* }, { %runtime.stackChainObject*, i32, i8* }* %gc.stackobject, i32 0, i32 2
-  store i8* %y, i8** %4, align 4
-  store i8* %y, i8** %x, align 4
-  store i8** %x, i8*** @ptrGlobal, align 4
-  store %runtime.stackChainObject* %1, %runtime.stackChainObject** @runtime.stackChainStart, align 4
+define void @allocAndSave(ptr %x) {
+  %gc.stackobject = alloca { ptr, i32, ptr }, align 8
+  store { ptr, i32, ptr } { ptr null, i32 1, ptr null }, ptr %gc.stackobject, align 4
+  %1 = load ptr, ptr @runtime.stackChainStart, align 4
+  %2 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 0
+  store ptr %1, ptr %2, align 4
+  store ptr %gc.stackobject, ptr @runtime.stackChainStart, align 4
+  %y = call ptr @runtime.alloc(i32 4, ptr null)
+  %3 = getelementptr { ptr, i32, ptr }, ptr %gc.stackobject, i32 0, i32 2
+  store ptr %y, ptr %3, align 4
+  store ptr %y, ptr %x, align 4
+  store ptr %x, ptr @ptrGlobal, align 4
+  store ptr %1, ptr @runtime.stackChainStart, align 4
   ret void
 }

--- a/transform/testdata/interface.ll
+++ b/transform/testdata/interface.ll
@@ -1,70 +1,70 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-@"reflect/types.type:basic:uint8" = linkonce_odr constant { i8, i8* } { i8 8, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:basic:uint8", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:basic:uint8" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:uint8", i32 0, i32 0) }, align 4
+@"reflect/types.type:basic:uint8" = linkonce_odr constant { i8, ptr } { i8 8, ptr @"reflect/types.type:pointer:basic:uint8" }, align 4
+@"reflect/types.type:pointer:basic:uint8" = linkonce_odr constant { i8, ptr } { i8 21, ptr @"reflect/types.type:basic:uint8" }, align 4
 @"reflect/types.typeid:basic:uint8" = external constant i8
 @"reflect/types.typeid:basic:int16" = external constant i8
-@"reflect/types.type:basic:int" = linkonce_odr constant { i8, i8* } { i8 2, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0) }, align 4
+@"reflect/types.type:basic:int" = linkonce_odr constant { i8, ptr } { i8 2, ptr @"reflect/types.type:pointer:basic:int" }, align 4
+@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, ptr } { i8 21, ptr @"reflect/types.type:basic:int" }, align 4
 @"reflect/methods.NeverImplementedMethod()" = linkonce_odr constant i8 0
 @"reflect/methods.Double() int" = linkonce_odr constant i8 0
-@"Number$methodset" = linkonce_odr unnamed_addr constant { i32, [1 x i8*], { i32 (i8*, i8*)* } } { i32 1, [1 x i8*] [i8* @"reflect/methods.Double() int"], { i32 (i8*, i8*)* } { i32 (i8*, i8*)* @"(Number).Double$invoke" } }
-@"reflect/types.type:named:Number" = linkonce_odr constant { i8*, i8, i8*, i8* } { i8* bitcast ({ i32, [1 x i8*], { i32 (i8*, i8*)* } }* @"Number$methodset" to i8*), i8 34, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:named:Number", i32 0, i32 0), i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:Number" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8*, i8, i8*, i8* }, { i8*, i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 1) }, align 4
+@"Number$methodset" = linkonce_odr unnamed_addr constant { i32, [1 x ptr], { ptr } } { i32 1, [1 x ptr] [ptr @"reflect/methods.Double() int"], { ptr } { ptr @"(Number).Double$invoke" } }
+@"reflect/types.type:named:Number" = linkonce_odr constant { ptr, i8, ptr, ptr } { ptr @"Number$methodset", i8 34, ptr @"reflect/types.type:pointer:named:Number", ptr @"reflect/types.type:basic:int" }, align 4
+@"reflect/types.type:pointer:named:Number" = linkonce_odr constant { i8, ptr } { i8 21, ptr getelementptr inbounds ({ ptr, i8, ptr, ptr }, ptr @"reflect/types.type:named:Number", i32 0, i32 1) }, align 4
 
-declare i1 @runtime.typeAssert(i8*, i8*)
+declare i1 @runtime.typeAssert(ptr, ptr)
 declare void @runtime.printuint8(i8)
 declare void @runtime.printint16(i16)
 declare void @runtime.printint32(i32)
 declare void @runtime.printptr(i32)
 declare void @runtime.printnl()
-declare void @runtime.nilPanic(i8*)
+declare void @runtime.nilPanic(ptr)
 
 define void @printInterfaces() {
-  call void @printInterface(i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0), i8* inttoptr (i32 5 to i8*))
-  call void @printInterface(i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:uint8", i32 0, i32 0), i8* inttoptr (i8 120 to i8*))
-  call void @printInterface(i8* getelementptr inbounds ({ i8*, i8, i8*, i8* }, { i8*, i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 1), i8* inttoptr (i32 3 to i8*))
+  call void @printInterface(ptr @"reflect/types.type:basic:int", ptr inttoptr (i32 5 to ptr))
+  call void @printInterface(ptr @"reflect/types.type:basic:uint8", ptr inttoptr (i8 120 to ptr))
+  call void @printInterface(ptr getelementptr inbounds ({ ptr, i8, ptr, ptr }, ptr @"reflect/types.type:named:Number", i32 0, i32 1), ptr inttoptr (i32 3 to ptr))
 
   ret void
 }
 
-define void @printInterface(i8* %typecode, i8* %value) {
-  %isUnmatched = call i1 @Unmatched$typeassert(i8* %typecode)
+define void @printInterface(ptr %typecode, ptr %value) {
+  %isUnmatched = call i1 @Unmatched$typeassert(ptr %typecode)
   br i1 %isUnmatched, label %typeswitch.Unmatched, label %typeswitch.notUnmatched
 
 typeswitch.Unmatched:
-  %unmatched = ptrtoint i8* %value to i32
+  %unmatched = ptrtoint ptr %value to i32
   call void @runtime.printptr(i32 %unmatched)
   call void @runtime.printnl()
   ret void
 
 typeswitch.notUnmatched:
-  %isDoubler = call i1 @Doubler$typeassert(i8* %typecode)
+  %isDoubler = call i1 @Doubler$typeassert(ptr %typecode)
   br i1 %isDoubler, label %typeswitch.Doubler, label %typeswitch.notDoubler
 
 typeswitch.Doubler:
-  %doubler.result = call i32 @"Doubler.Double$invoke"(i8* %value, i8* %typecode, i8* undef)
+  %doubler.result = call i32 @"Doubler.Double$invoke"(ptr %value, ptr %typecode, ptr undef)
   call void @runtime.printint32(i32 %doubler.result)
   ret void
 
 typeswitch.notDoubler:
-  %isByte = call i1 @runtime.typeAssert(i8* %typecode, i8* nonnull @"reflect/types.typeid:basic:uint8")
+  %isByte = call i1 @runtime.typeAssert(ptr %typecode, ptr nonnull @"reflect/types.typeid:basic:uint8")
   br i1 %isByte, label %typeswitch.byte, label %typeswitch.notByte
 
 typeswitch.byte:
-  %byte = ptrtoint i8* %value to i8
+  %byte = ptrtoint ptr %value to i8
   call void @runtime.printuint8(i8 %byte)
   call void @runtime.printnl()
   ret void
 
 typeswitch.notByte:
   ; this is a type assert that always fails
-  %isInt16 = call i1 @runtime.typeAssert(i8* %typecode, i8* nonnull @"reflect/types.typeid:basic:int16")
+  %isInt16 = call i1 @runtime.typeAssert(ptr %typecode, ptr nonnull @"reflect/types.typeid:basic:int16")
   br i1 %isInt16, label %typeswitch.int16, label %typeswitch.notInt16
 
 typeswitch.int16:
-  %int16 = ptrtoint i8* %value to i16
+  %int16 = ptrtoint ptr %value to i16
   call void @runtime.printint16(i16 %int16)
   call void @runtime.printnl()
   ret void
@@ -73,22 +73,22 @@ typeswitch.notInt16:
   ret void
 }
 
-define i32 @"(Number).Double"(i32 %receiver, i8* %context) {
+define i32 @"(Number).Double"(i32 %receiver, ptr %context) {
   %ret = mul i32 %receiver, 2
   ret i32 %ret
 }
 
-define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %context) {
-  %receiver = ptrtoint i8* %receiverPtr to i32
-  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* undef)
+define i32 @"(Number).Double$invoke"(ptr %receiverPtr, ptr %context) {
+  %receiver = ptrtoint ptr %receiverPtr to i32
+  %ret = call i32 @"(Number).Double"(i32 %receiver, ptr undef)
   ret i32 %ret
 }
 
-declare i32 @"Doubler.Double$invoke"(i8* %receiver, i8* %typecode, i8* %context) #0
+declare i32 @"Doubler.Double$invoke"(ptr %receiver, ptr %typecode, ptr %context) #0
 
-declare i1 @Doubler$typeassert(i8* %typecode) #1
+declare i1 @Doubler$typeassert(ptr %typecode) #1
 
-declare i1 @Unmatched$typeassert(i8* %typecode) #2
+declare i1 @Unmatched$typeassert(ptr %typecode) #2
 
 attributes #0 = { "tinygo-invoke"="reflect/methods.Double() int" "tinygo-methods"="reflect/methods.Double() int" }
 attributes #1 = { "tinygo-methods"="reflect/methods.Double() int" }

--- a/transform/testdata/interface.out.ll
+++ b/transform/testdata/interface.out.ll
@@ -1,12 +1,12 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-@"reflect/types.type:basic:uint8" = linkonce_odr constant { i8, i8* } { i8 8, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:basic:uint8", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:basic:uint8" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:uint8", i32 0, i32 0) }, align 4
-@"reflect/types.type:basic:int" = linkonce_odr constant { i8, i8* } { i8 2, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:Number" = linkonce_odr constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 0) }, align 4
-@"reflect/types.type:named:Number" = linkonce_odr constant { i8, i8*, i8* } { i8 34, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:named:Number", i32 0, i32 0), i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0) }, align 4
+@"reflect/types.type:basic:uint8" = linkonce_odr constant { i8, ptr } { i8 8, ptr @"reflect/types.type:pointer:basic:uint8" }, align 4
+@"reflect/types.type:pointer:basic:uint8" = linkonce_odr constant { i8, ptr } { i8 21, ptr @"reflect/types.type:basic:uint8" }, align 4
+@"reflect/types.type:basic:int" = linkonce_odr constant { i8, ptr } { i8 2, ptr @"reflect/types.type:pointer:basic:int" }, align 4
+@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, ptr } { i8 21, ptr @"reflect/types.type:basic:int" }, align 4
+@"reflect/types.type:pointer:named:Number" = linkonce_odr constant { i8, ptr } { i8 21, ptr @"reflect/types.type:named:Number" }, align 4
+@"reflect/types.type:named:Number" = linkonce_odr constant { i8, ptr, ptr } { i8 34, ptr @"reflect/types.type:pointer:named:Number", ptr @"reflect/types.type:basic:int" }, align 4
 
 declare void @runtime.printuint8(i8)
 
@@ -18,40 +18,40 @@ declare void @runtime.printptr(i32)
 
 declare void @runtime.printnl()
 
-declare void @runtime.nilPanic(i8*)
+declare void @runtime.nilPanic(ptr)
 
 define void @printInterfaces() {
-  call void @printInterface(i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0), i8* inttoptr (i32 5 to i8*))
-  call void @printInterface(i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:uint8", i32 0, i32 0), i8* inttoptr (i8 120 to i8*))
-  call void @printInterface(i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 0), i8* inttoptr (i32 3 to i8*))
+  call void @printInterface(ptr @"reflect/types.type:basic:int", ptr inttoptr (i32 5 to ptr))
+  call void @printInterface(ptr @"reflect/types.type:basic:uint8", ptr inttoptr (i8 120 to ptr))
+  call void @printInterface(ptr @"reflect/types.type:named:Number", ptr inttoptr (i32 3 to ptr))
   ret void
 }
 
-define void @printInterface(i8* %typecode, i8* %value) {
-  %isUnmatched = call i1 @"Unmatched$typeassert"(i8* %typecode)
+define void @printInterface(ptr %typecode, ptr %value) {
+  %isUnmatched = call i1 @"Unmatched$typeassert"(ptr %typecode)
   br i1 %isUnmatched, label %typeswitch.Unmatched, label %typeswitch.notUnmatched
 
 typeswitch.Unmatched:                             ; preds = %0
-  %unmatched = ptrtoint i8* %value to i32
+  %unmatched = ptrtoint ptr %value to i32
   call void @runtime.printptr(i32 %unmatched)
   call void @runtime.printnl()
   ret void
 
 typeswitch.notUnmatched:                          ; preds = %0
-  %isDoubler = call i1 @"Doubler$typeassert"(i8* %typecode)
+  %isDoubler = call i1 @"Doubler$typeassert"(ptr %typecode)
   br i1 %isDoubler, label %typeswitch.Doubler, label %typeswitch.notDoubler
 
 typeswitch.Doubler:                               ; preds = %typeswitch.notUnmatched
-  %doubler.result = call i32 @"Doubler.Double$invoke"(i8* %value, i8* %typecode, i8* undef)
+  %doubler.result = call i32 @"Doubler.Double$invoke"(ptr %value, ptr %typecode, ptr undef)
   call void @runtime.printint32(i32 %doubler.result)
   ret void
 
 typeswitch.notDoubler:                            ; preds = %typeswitch.notUnmatched
-  %typeassert.ok = icmp eq i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:uint8", i32 0, i32 0), %typecode
+  %typeassert.ok = icmp eq ptr @"reflect/types.type:basic:uint8", %typecode
   br i1 %typeassert.ok, label %typeswitch.byte, label %typeswitch.notByte
 
 typeswitch.byte:                                  ; preds = %typeswitch.notDoubler
-  %byte = ptrtoint i8* %value to i8
+  %byte = ptrtoint ptr %value to i8
   call void @runtime.printuint8(i8 %byte)
   call void @runtime.printnl()
   ret void
@@ -60,7 +60,7 @@ typeswitch.notByte:                               ; preds = %typeswitch.notDoubl
   br i1 false, label %typeswitch.int16, label %typeswitch.notInt16
 
 typeswitch.int16:                                 ; preds = %typeswitch.notByte
-  %int16 = ptrtoint i8* %value to i16
+  %int16 = ptrtoint ptr %value to i16
   call void @runtime.printint16(i16 %int16)
   call void @runtime.printnl()
   ret void
@@ -69,34 +69,34 @@ typeswitch.notInt16:                              ; preds = %typeswitch.notByte
   ret void
 }
 
-define i32 @"(Number).Double"(i32 %receiver, i8* %context) {
+define i32 @"(Number).Double"(i32 %receiver, ptr %context) {
   %ret = mul i32 %receiver, 2
   ret i32 %ret
 }
 
-define i32 @"(Number).Double$invoke"(i8* %receiverPtr, i8* %context) {
-  %receiver = ptrtoint i8* %receiverPtr to i32
-  %ret = call i32 @"(Number).Double"(i32 %receiver, i8* undef)
+define i32 @"(Number).Double$invoke"(ptr %receiverPtr, ptr %context) {
+  %receiver = ptrtoint ptr %receiverPtr to i32
+  %ret = call i32 @"(Number).Double"(i32 %receiver, ptr undef)
   ret i32 %ret
 }
 
-define internal i32 @"Doubler.Double$invoke"(i8* %receiver, i8* %actualType, i8* %context) unnamed_addr #0 {
+define internal i32 @"Doubler.Double$invoke"(ptr %receiver, ptr %actualType, ptr %context) unnamed_addr #0 {
 entry:
-  %"named:Number.icmp" = icmp eq i8* %actualType, getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 0)
+  %"named:Number.icmp" = icmp eq ptr %actualType, @"reflect/types.type:named:Number"
   br i1 %"named:Number.icmp", label %"named:Number", label %"named:Number.next"
 
 "named:Number":                                   ; preds = %entry
-  %0 = call i32 @"(Number).Double$invoke"(i8* %receiver, i8* undef)
+  %0 = call i32 @"(Number).Double$invoke"(ptr %receiver, ptr undef)
   ret i32 %0
 
 "named:Number.next":                              ; preds = %entry
-  call void @runtime.nilPanic(i8* undef)
+  call void @runtime.nilPanic(ptr undef)
   unreachable
 }
 
-define internal i1 @"Doubler$typeassert"(i8* %actualType) unnamed_addr #1 {
+define internal i1 @"Doubler$typeassert"(ptr %actualType) unnamed_addr #1 {
 entry:
-  %"named:Number.icmp" = icmp eq i8* %actualType, getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:Number", i32 0, i32 0)
+  %"named:Number.icmp" = icmp eq ptr %actualType, @"reflect/types.type:named:Number"
   br i1 %"named:Number.icmp", label %then, label %"named:Number.next"
 
 then:                                             ; preds = %entry
@@ -106,7 +106,7 @@ then:                                             ; preds = %entry
   ret i1 false
 }
 
-define internal i1 @"Unmatched$typeassert"(i8* %actualType) unnamed_addr #2 {
+define internal i1 @"Unmatched$typeassert"(ptr %actualType) unnamed_addr #2 {
 entry:
   ret i1 false
 

--- a/transform/testdata/interrupt.ll
+++ b/transform/testdata/interrupt.ll
@@ -1,39 +1,39 @@
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7em-none-eabi"
 
-%machine.UART = type { %machine.RingBuffer* }
+%machine.UART = type { ptr }
 %machine.RingBuffer = type { [128 x %"runtime/volatile.Register8"], %"runtime/volatile.Register8", %"runtime/volatile.Register8" }
 %"runtime/volatile.Register8" = type { i8 }
-%"runtime/interrupt.handle" = type { i8*, i32, %"runtime/interrupt.Interrupt" }
+%"runtime/interrupt.handle" = type { ptr, i32, %"runtime/interrupt.Interrupt" }
 %"runtime/interrupt.Interrupt" = type { i32 }
 
-@"runtime/interrupt.$interrupt2" = private unnamed_addr constant %"runtime/interrupt.handle" { i8* bitcast (%machine.UART* @machine.UART0 to i8*), i32 ptrtoint (void (i32, i8*)* @"(*machine.UART).handleInterrupt$bound" to i32), %"runtime/interrupt.Interrupt" { i32 2 } }
-@machine.UART0 = internal global %machine.UART { %machine.RingBuffer* @"machine$alloc.335" }
+@"runtime/interrupt.$interrupt2" = private unnamed_addr constant %"runtime/interrupt.handle" { ptr @machine.UART0, i32 ptrtoint (ptr @"(*machine.UART).handleInterrupt$bound" to i32), %"runtime/interrupt.Interrupt" { i32 2 } }
+@machine.UART0 = internal global %machine.UART { ptr @"machine$alloc.335" }
 @"machine$alloc.335" = internal global %machine.RingBuffer zeroinitializer
 
-declare void @"runtime/interrupt.callHandlers"(i32, i8*) local_unnamed_addr
+declare void @"runtime/interrupt.callHandlers"(i32, ptr) local_unnamed_addr
 
-declare void @"device/arm.EnableIRQ"(i32, i8* nocapture readnone)
+declare void @"device/arm.EnableIRQ"(i32, ptr nocapture readnone)
 
-declare void @"device/arm.SetPriority"(i32, i32, i8* nocapture readnone)
+declare void @"device/arm.SetPriority"(i32, i32, ptr nocapture readnone)
 
 declare void @"runtime/interrupt.use"(%"runtime/interrupt.Interrupt")
 
-define void @runtime.initAll(i8* nocapture readnone) unnamed_addr {
+define void @runtime.initAll(ptr nocapture readnone) unnamed_addr {
 entry:
-  call void @"device/arm.SetPriority"(i32 ptrtoint (%"runtime/interrupt.handle"* @"runtime/interrupt.$interrupt2" to i32), i32 192, i8* undef)
-  call void @"device/arm.EnableIRQ"(i32 ptrtoint (%"runtime/interrupt.handle"* @"runtime/interrupt.$interrupt2" to i32), i8* undef)
-  call void @"runtime/interrupt.use"(%"runtime/interrupt.Interrupt" { i32 ptrtoint (%"runtime/interrupt.handle"* @"runtime/interrupt.$interrupt2" to i32) })
+  call void @"device/arm.SetPriority"(i32 ptrtoint (ptr @"runtime/interrupt.$interrupt2" to i32), i32 192, ptr undef)
+  call void @"device/arm.EnableIRQ"(i32 ptrtoint (ptr @"runtime/interrupt.$interrupt2" to i32), ptr undef)
+  call void @"runtime/interrupt.use"(%"runtime/interrupt.Interrupt" { i32 ptrtoint (ptr @"runtime/interrupt.$interrupt2" to i32) })
   ret void
 }
 
 define void @UARTE0_UART0_IRQHandler() {
-  call void @"runtime/interrupt.callHandlers"(i32 2, i8* undef)
+  call void @"runtime/interrupt.callHandlers"(i32 2, ptr undef)
   ret void
 }
 
 define void @NFCT_IRQHandler() {
-  call void @"runtime/interrupt.callHandlers"(i32 5, i8* undef)
+  call void @"runtime/interrupt.callHandlers"(i32 5, ptr undef)
   ret void
 }
 
@@ -45,22 +45,21 @@ entry:
   ]
 
 switch.body2:
-  call void @"runtime/interrupt.callHandlers"(i32 2, i8* undef)
+  call void @"runtime/interrupt.callHandlers"(i32 2, ptr undef)
   ret void
 
 switch.body5:
-  call void @"runtime/interrupt.callHandlers"(i32 5, i8* undef)
+  call void @"runtime/interrupt.callHandlers"(i32 5, ptr undef)
   ret void
 
 switch.done:
   ret void
 }
 
-define internal void @"(*machine.UART).handleInterrupt$bound"(i32, i8* nocapture %context) {
+define internal void @"(*machine.UART).handleInterrupt$bound"(i32, ptr nocapture %context) {
 entry:
-  %unpack.ptr = bitcast i8* %context to %machine.UART*
-  call void @"(*machine.UART).handleInterrupt"(%machine.UART* %unpack.ptr, i32 %0, i8* undef)
+  call void @"(*machine.UART).handleInterrupt"(ptr %context, i32 %0, ptr undef)
   ret void
 }
 
-declare void @"(*machine.UART).handleInterrupt"(%machine.UART* nocapture, i32, i8* nocapture readnone)
+declare void @"(*machine.UART).handleInterrupt"(ptr nocapture, i32, ptr nocapture readnone)

--- a/transform/testdata/interrupt.out.ll
+++ b/transform/testdata/interrupt.out.ll
@@ -1,31 +1,31 @@
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7em-none-eabi"
 
-%machine.UART = type { %machine.RingBuffer* }
+%machine.UART = type { ptr }
 %machine.RingBuffer = type { [128 x %"runtime/volatile.Register8"], %"runtime/volatile.Register8", %"runtime/volatile.Register8" }
 %"runtime/volatile.Register8" = type { i8 }
 %"runtime/interrupt.Interrupt" = type { i32 }
 
-@machine.UART0 = internal global %machine.UART { %machine.RingBuffer* @"machine$alloc.335" }
+@machine.UART0 = internal global %machine.UART { ptr @"machine$alloc.335" }
 @"machine$alloc.335" = internal global %machine.RingBuffer zeroinitializer
 
-declare void @"runtime/interrupt.callHandlers"(i32, i8*) local_unnamed_addr
+declare void @"runtime/interrupt.callHandlers"(i32, ptr) local_unnamed_addr
 
-declare void @"device/arm.EnableIRQ"(i32, i8* nocapture readnone)
+declare void @"device/arm.EnableIRQ"(i32, ptr nocapture readnone)
 
-declare void @"device/arm.SetPriority"(i32, i32, i8* nocapture readnone)
+declare void @"device/arm.SetPriority"(i32, i32, ptr nocapture readnone)
 
 declare void @"runtime/interrupt.use"(%"runtime/interrupt.Interrupt")
 
-define void @runtime.initAll(i8* nocapture readnone %0) unnamed_addr {
+define void @runtime.initAll(ptr nocapture readnone %0) unnamed_addr {
 entry:
-  call void @"device/arm.SetPriority"(i32 2, i32 192, i8* undef)
-  call void @"device/arm.EnableIRQ"(i32 2, i8* undef)
+  call void @"device/arm.SetPriority"(i32 2, i32 192, ptr undef)
+  call void @"device/arm.EnableIRQ"(i32 2, ptr undef)
   ret void
 }
 
 define void @UARTE0_UART0_IRQHandler() {
-  call void @"(*machine.UART).handleInterrupt$bound"(i32 2, i8* bitcast (%machine.UART* @machine.UART0 to i8*))
+  call void @"(*machine.UART).handleInterrupt$bound"(i32 2, ptr @machine.UART0)
   ret void
 }
 
@@ -37,7 +37,7 @@ entry:
   ]
 
 switch.body2:                                     ; preds = %entry
-  call void @"(*machine.UART).handleInterrupt$bound"(i32 2, i8* bitcast (%machine.UART* @machine.UART0 to i8*))
+  call void @"(*machine.UART).handleInterrupt$bound"(i32 2, ptr @machine.UART0)
   ret void
 
 switch.body5:                                     ; preds = %entry
@@ -47,11 +47,10 @@ switch.done:                                      ; preds = %entry
   ret void
 }
 
-define internal void @"(*machine.UART).handleInterrupt$bound"(i32 %0, i8* nocapture %context) {
+define internal void @"(*machine.UART).handleInterrupt$bound"(i32 %0, ptr nocapture %context) {
 entry:
-  %unpack.ptr = bitcast i8* %context to %machine.UART*
-  call void @"(*machine.UART).handleInterrupt"(%machine.UART* %unpack.ptr, i32 %0, i8* undef)
+  call void @"(*machine.UART).handleInterrupt"(ptr %context, i32 %0, ptr undef)
   ret void
 }
 
-declare void @"(*machine.UART).handleInterrupt"(%machine.UART* nocapture, i32, i8* nocapture readnone)
+declare void @"(*machine.UART).handleInterrupt"(ptr nocapture, i32, ptr nocapture readnone)

--- a/transform/testdata/maps.ll
+++ b/transform/testdata/maps.ll
@@ -1,28 +1,25 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-%runtime.hashmap = type { %runtime.hashmap*, i8*, i32, i8, i8, i8 }
-
 @answer = constant [6 x i8] c"answer"
 
 ; func(keySize, valueSize uint8, sizeHint uintptr) *runtime.hashmap
-declare nonnull %runtime.hashmap* @runtime.hashmapMake(i8, i8, i32)
+declare nonnull ptr @runtime.hashmapMake(i8, i8, i32)
 
 ; func(map[string]int, string, unsafe.Pointer)
-declare void @runtime.hashmapStringSet(%runtime.hashmap* nocapture, i8*, i32, i8* nocapture readonly)
+declare void @runtime.hashmapStringSet(ptr nocapture, ptr, i32, ptr nocapture readonly)
 
 ; func(map[string]int, string, unsafe.Pointer)
-declare i1 @runtime.hashmapStringGet(%runtime.hashmap* nocapture, i8*, i32, i8* nocapture)
+declare i1 @runtime.hashmapStringGet(ptr nocapture, ptr, i32, ptr nocapture)
 
 define void @testUnused() {
     ; create the map
-    %map = call %runtime.hashmap* @runtime.hashmapMake(i8 4, i8 4, i32 0)
+    %map = call ptr @runtime.hashmapMake(i8 4, i8 4, i32 0)
     ; create the value to be stored
     %hashmap.value = alloca i32
-    store i32 42, i32* %hashmap.value
+    store i32 42, ptr %hashmap.value
     ; store the value
-    %hashmap.value.bitcast = bitcast i32* %hashmap.value to i8*
-    call void @runtime.hashmapStringSet(%runtime.hashmap* %map, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @answer, i32 0, i32 0), i32 6, i8* %hashmap.value.bitcast)
+    call void @runtime.hashmapStringSet(ptr %map, ptr @answer, i32 6, ptr %hashmap.value)
     ret void
 }
 
@@ -30,26 +27,24 @@ define void @testUnused() {
 ; return 42), but isn't at the moment.
 define i32 @testReadonly() {
     ; create the map
-    %map = call %runtime.hashmap* @runtime.hashmapMake(i8 4, i8 4, i32 0)
+    %map = call ptr @runtime.hashmapMake(i8 4, i8 4, i32 0)
 
     ; create the value to be stored
     %hashmap.value = alloca i32
-    store i32 42, i32* %hashmap.value
+    store i32 42, ptr %hashmap.value
 
     ; store the value
-    %hashmap.value.bitcast = bitcast i32* %hashmap.value to i8*
-    call void @runtime.hashmapStringSet(%runtime.hashmap* %map, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @answer, i32 0, i32 0), i32 6, i8* %hashmap.value.bitcast)
+    call void @runtime.hashmapStringSet(ptr %map, ptr @answer, i32 6, ptr %hashmap.value)
 
     ; load the value back
     %hashmap.value2 = alloca i32
-    %hashmap.value2.bitcast = bitcast i32* %hashmap.value2 to i8*
-    %commaOk = call i1 @runtime.hashmapStringGet(%runtime.hashmap* %map, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @answer, i32 0, i32 0), i32 6, i8* %hashmap.value2.bitcast)
-    %loadedValue = load i32, i32* %hashmap.value2
+    %commaOk = call i1 @runtime.hashmapStringGet(ptr %map, ptr @answer, i32 6, ptr %hashmap.value2)
+    %loadedValue = load i32, ptr %hashmap.value2
 
     ret i32 %loadedValue
 }
 
-define %runtime.hashmap* @testUsed() {
-    %1 = call %runtime.hashmap* @runtime.hashmapMake(i8 4, i8 4, i32 0)
-    ret %runtime.hashmap* %1
+define ptr @testUsed() {
+    %1 = call ptr @runtime.hashmapMake(i8 4, i8 4, i32 0)
+    ret ptr %1
 }

--- a/transform/testdata/maps.out.ll
+++ b/transform/testdata/maps.out.ll
@@ -1,34 +1,30 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-%runtime.hashmap = type { %runtime.hashmap*, i8*, i32, i8, i8, i8 }
-
 @answer = constant [6 x i8] c"answer"
 
-declare nonnull %runtime.hashmap* @runtime.hashmapMake(i8, i8, i32)
+declare nonnull ptr @runtime.hashmapMake(i8, i8, i32)
 
-declare void @runtime.hashmapStringSet(%runtime.hashmap* nocapture, i8*, i32, i8* nocapture readonly)
+declare void @runtime.hashmapStringSet(ptr nocapture, ptr, i32, ptr nocapture readonly)
 
-declare i1 @runtime.hashmapStringGet(%runtime.hashmap* nocapture, i8*, i32, i8* nocapture)
+declare i1 @runtime.hashmapStringGet(ptr nocapture, ptr, i32, ptr nocapture)
 
 define void @testUnused() {
   ret void
 }
 
 define i32 @testReadonly() {
-  %map = call %runtime.hashmap* @runtime.hashmapMake(i8 4, i8 4, i32 0)
+  %map = call ptr @runtime.hashmapMake(i8 4, i8 4, i32 0)
   %hashmap.value = alloca i32, align 4
-  store i32 42, i32* %hashmap.value, align 4
-  %hashmap.value.bitcast = bitcast i32* %hashmap.value to i8*
-  call void @runtime.hashmapStringSet(%runtime.hashmap* %map, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @answer, i32 0, i32 0), i32 6, i8* %hashmap.value.bitcast)
+  store i32 42, ptr %hashmap.value, align 4
+  call void @runtime.hashmapStringSet(ptr %map, ptr @answer, i32 6, ptr %hashmap.value)
   %hashmap.value2 = alloca i32, align 4
-  %hashmap.value2.bitcast = bitcast i32* %hashmap.value2 to i8*
-  %commaOk = call i1 @runtime.hashmapStringGet(%runtime.hashmap* %map, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @answer, i32 0, i32 0), i32 6, i8* %hashmap.value2.bitcast)
-  %loadedValue = load i32, i32* %hashmap.value2, align 4
+  %commaOk = call i1 @runtime.hashmapStringGet(ptr %map, ptr @answer, i32 6, ptr %hashmap.value2)
+  %loadedValue = load i32, ptr %hashmap.value2, align 4
   ret i32 %loadedValue
 }
 
-define %runtime.hashmap* @testUsed() {
-  %1 = call %runtime.hashmap* @runtime.hashmapMake(i8 4, i8 4, i32 0)
-  ret %runtime.hashmap* %1
+define ptr @testUsed() {
+  %1 = call ptr @runtime.hashmapMake(i8 4, i8 4, i32 0)
+  ret ptr %1
 }

--- a/transform/testdata/panic.ll
+++ b/transform/testdata/panic.ll
@@ -3,12 +3,12 @@ target triple = "armv7m-none-eabi"
 
 @"runtime.lookupPanic$string" = constant [18 x i8] c"index out of range"
 
-declare void @runtime.runtimePanic(i8*, i32)
+declare void @runtime.runtimePanic(ptr, i32)
 
-declare void @runtime._panic(i32, i8*)
+declare void @runtime._panic(i32, ptr)
 
 define void @runtime.lookupPanic() {
-  call void @runtime.runtimePanic(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @"runtime.lookupPanic$string", i64 0, i64 0), i32 18)
+  call void @runtime.runtimePanic(ptr @"runtime.lookupPanic$string", i32 18)
   ret void
 }
 
@@ -16,7 +16,7 @@ define void @runtime.lookupPanic() {
 ;     func someFunc(x interface{}) {
 ;         panic(x)
 ;     }
-define void @someFunc(i32 %typecode, i8* %value) {
-  call void @runtime._panic(i32 %typecode, i8* %value)
+define void @someFunc(i32 %typecode, ptr %value) {
+  call void @runtime._panic(i32 %typecode, ptr %value)
   unreachable
 }

--- a/transform/testdata/panic.out.ll
+++ b/transform/testdata/panic.out.ll
@@ -3,19 +3,19 @@ target triple = "armv7m-none-eabi"
 
 @"runtime.lookupPanic$string" = constant [18 x i8] c"index out of range"
 
-declare void @runtime.runtimePanic(i8*, i32)
+declare void @runtime.runtimePanic(ptr, i32)
 
-declare void @runtime._panic(i32, i8*)
+declare void @runtime._panic(i32, ptr)
 
 define void @runtime.lookupPanic() {
   call void @llvm.trap()
-  call void @runtime.runtimePanic(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @"runtime.lookupPanic$string", i64 0, i64 0), i32 18)
+  call void @runtime.runtimePanic(ptr @"runtime.lookupPanic$string", i32 18)
   ret void
 }
 
-define void @someFunc(i32 %typecode, i8* %value) {
+define void @someFunc(i32 %typecode, ptr %value) {
   call void @llvm.trap()
-  call void @runtime._panic(i32 %typecode, i8* %value)
+  call void @runtime._panic(i32 %typecode, ptr %value)
   unreachable
 }
 

--- a/transform/testdata/reflect-implements.ll
+++ b/transform/testdata/reflect-implements.ll
@@ -1,13 +1,13 @@
 target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
 target triple = "i686--linux"
 
-%runtime._interface = type { i8*, i8* }
+%runtime._interface = type { ptr, ptr }
 
-@"reflect/types.type:named:error" = internal constant { i8, i8*, i8* } { i8 52, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:named:error", i32 0, i32 0), i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = internal constant { i8, i8* } { i8 20, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = internal constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:error" = internal constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:error", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:reflect.rawType" = internal constant { i8*, i8, i8* } { i8* null, i8 21, i8* null }, align 4
+@"reflect/types.type:named:error" = internal constant { i8, ptr, ptr } { i8 52, ptr @"reflect/types.type:pointer:named:error", ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = internal constant { i8, ptr } { i8 20, ptr @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = internal constant { i8, ptr } { i8 21, ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:named:error" = internal constant { i8, ptr } { i8 21, ptr @"reflect/types.type:named:error" }, align 4
+@"reflect/types.type:pointer:named:reflect.rawType" = internal constant { ptr, i8, ptr } { ptr null, i8 21, ptr null }, align 4
 @"reflect/methods.Implements(reflect.Type) bool" = internal constant i8 0, align 1
 
 ; var errorType = reflect.TypeOf((*error)(nil)).Elem()
@@ -17,9 +17,9 @@ target triple = "i686--linux"
 ; The type itself is stored in %typ.value, %typ.typecode just refers to the
 ; type of reflect.Type. This function can be optimized because errorType is
 ; known at compile time (after the interp pass has run).
-define i1 @main.isError(i8* %typ.typecode, i8* %typ.value, i8* %context) {
+define i1 @main.isError(ptr %typ.typecode, ptr %typ.value, ptr %context) {
 entry:
-  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i8* getelementptr inbounds ({ i8*, i8, i8* }, { i8*, i8, i8* }* @"reflect/types.type:pointer:named:reflect.rawType", i32 0, i32 1), i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:error", i32 0, i32 0), i8* %typ.typecode, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(ptr %typ.value, ptr getelementptr inbounds ({ ptr, i8, ptr }, ptr @"reflect/types.type:pointer:named:reflect.rawType", i32 0, i32 1), ptr @"reflect/types.type:named:error", ptr %typ.typecode, ptr undef)
   ret i1 %result
 }
 
@@ -28,14 +28,14 @@ entry:
 ; func isUnknown(typ, itf reflect.Type) bool {
 ;   return typ.Implements(itf)
 ; }
-define i1 @main.isUnknown(i8* %typ.typecode, i8* %typ.value, i8* %itf.typecode, i8* %itf.value, i8* %context) {
+define i1 @main.isUnknown(ptr %typ.typecode, ptr %typ.value, ptr %itf.typecode, ptr %itf.value, ptr %context) {
 entry:
-  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i8* %itf.typecode, i8* %itf.value, i8* %typ.typecode, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(ptr %typ.value, ptr %itf.typecode, ptr %itf.value, ptr %typ.typecode, ptr undef)
   ret i1 %result
 }
 
-declare i1 @"reflect.Type.Implements$invoke"(i8*, i8*, i8*, i8*, i8*) #0
-declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i8* %0) #1
+declare i1 @"reflect.Type.Implements$invoke"(ptr, ptr, ptr, ptr, ptr) #0
+declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr %0) #1
 
 attributes #0 = { "tinygo-invoke"="reflect/methods.Implements(reflect.Type) bool" "tinygo-methods"="reflect/methods.Align() int; reflect/methods.Implements(reflect.Type) bool" }
 attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }

--- a/transform/testdata/reflect-implements.out.ll
+++ b/transform/testdata/reflect-implements.out.ll
@@ -1,28 +1,28 @@
 target datalayout = "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128"
 target triple = "i686--linux"
 
-@"reflect/types.type:named:error" = internal constant { i8, i8*, i8* } { i8 52, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:named:error", i32 0, i32 0), i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = internal constant { i8, i8* } { i8 20, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = internal constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:interface:{Error:func:{}{basic:string}}", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:error" = internal constant { i8, i8* } { i8 21, i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:error", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:reflect.rawType" = internal constant { i8*, i8, i8* } { i8* null, i8 21, i8* null }, align 4
+@"reflect/types.type:named:error" = internal constant { i8, ptr, ptr } { i8 52, ptr @"reflect/types.type:pointer:named:error", ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:interface:{Error:func:{}{basic:string}}" = internal constant { i8, ptr } { i8 20, ptr @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = internal constant { i8, ptr } { i8 21, ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:named:error" = internal constant { i8, ptr } { i8 21, ptr @"reflect/types.type:named:error" }, align 4
+@"reflect/types.type:pointer:named:reflect.rawType" = internal constant { ptr, i8, ptr } { ptr null, i8 21, ptr null }, align 4
 @"reflect/methods.Implements(reflect.Type) bool" = internal constant i8 0, align 1
 
-define i1 @main.isError(i8* %typ.typecode, i8* %typ.value, i8* %context) {
+define i1 @main.isError(ptr %typ.typecode, ptr %typ.value, ptr %context) {
 entry:
-  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i8* %typ.value)
+  %0 = call i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr %typ.value)
   ret i1 %0
 }
 
-define i1 @main.isUnknown(i8* %typ.typecode, i8* %typ.value, i8* %itf.typecode, i8* %itf.value, i8* %context) {
+define i1 @main.isUnknown(ptr %typ.typecode, ptr %typ.value, ptr %itf.typecode, ptr %itf.value, ptr %context) {
 entry:
-  %result = call i1 @"reflect.Type.Implements$invoke"(i8* %typ.value, i8* %itf.typecode, i8* %itf.value, i8* %typ.typecode, i8* undef)
+  %result = call i1 @"reflect.Type.Implements$invoke"(ptr %typ.value, ptr %itf.typecode, ptr %itf.value, ptr %typ.typecode, ptr undef)
   ret i1 %result
 }
 
-declare i1 @"reflect.Type.Implements$invoke"(i8*, i8*, i8*, i8*, i8*) #0
+declare i1 @"reflect.Type.Implements$invoke"(ptr, ptr, ptr, ptr, ptr) #0
 
-declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(i8*) #1
+declare i1 @"interface:{Error:func:{}{basic:string}}.$typeassert"(ptr) #1
 
 attributes #0 = { "tinygo-invoke"="reflect/methods.Implements(reflect.Type) bool" "tinygo-methods"="reflect/methods.Align() int; reflect/methods.Implements(reflect.Type) bool" }
 attributes #1 = { "tinygo-methods"="reflect/methods.Error() string" }

--- a/transform/testdata/stacksize.ll
+++ b/transform/testdata/stacksize.ll
@@ -1,15 +1,15 @@
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
-declare i32 @"internal/task.getGoroutineStackSize"(i32, i8*, i8*)
+declare i32 @"internal/task.getGoroutineStackSize"(i32, ptr, ptr)
 
-declare void @"runtime.run$1$gowrapper"(i8*)
+declare void @"runtime.run$1$gowrapper"(ptr)
 
-declare void @"internal/task.start"(i32, i8*, i32)
+declare void @"internal/task.start"(i32, ptr, i32)
 
 define void @Reset_Handler() {
 entry:
-  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (void (i8*)* @"runtime.run$1$gowrapper" to i32), i8* undef, i8* undef)
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"runtime.run$1$gowrapper" to i32), i8* undef, i32 %stacksize)
+  %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"runtime.run$1$gowrapper" to i32), ptr undef, ptr undef)
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"runtime.run$1$gowrapper" to i32), ptr undef, i32 %stacksize)
   ret void
 }

--- a/transform/testdata/stacksize.out.ll
+++ b/transform/testdata/stacksize.out.ll
@@ -2,17 +2,17 @@ target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv7m-none-eabi"
 
 @"internal/task.stackSizes" = global [1 x i32] [i32 1024], section ".tinygo_stacksizes", align 4
-@llvm.used = appending global [2 x i8*] [i8* bitcast ([1 x i32]* @"internal/task.stackSizes" to i8*), i8* bitcast (void (i8*)* @"runtime.run$1$gowrapper" to i8*)]
+@llvm.used = appending global [2 x ptr] [ptr @"internal/task.stackSizes", ptr @"runtime.run$1$gowrapper"]
 
-declare i32 @"internal/task.getGoroutineStackSize"(i32, i8*, i8*)
+declare i32 @"internal/task.getGoroutineStackSize"(i32, ptr, ptr)
 
-declare void @"runtime.run$1$gowrapper"(i8*)
+declare void @"runtime.run$1$gowrapper"(ptr)
 
-declare void @"internal/task.start"(i32, i8*, i32)
+declare void @"internal/task.start"(i32, ptr, i32)
 
 define void @Reset_Handler() {
 entry:
-  %stacksize1 = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @"internal/task.stackSizes", i32 0, i32 0), align 4
-  call void @"internal/task.start"(i32 ptrtoint (void (i8*)* @"runtime.run$1$gowrapper" to i32), i8* undef, i32 %stacksize1)
+  %stacksize1 = load i32, ptr @"internal/task.stackSizes", align 4
+  call void @"internal/task.start"(i32 ptrtoint (ptr @"runtime.run$1$gowrapper" to i32), ptr undef, i32 %stacksize1)
   ret void
 }

--- a/transform/testdata/stringequal.ll
+++ b/transform/testdata/stringequal.ll
@@ -3,17 +3,17 @@ target triple = "armv7m-none-eabi"
 
 @zeroString = constant [0 x i8] zeroinitializer
 
-declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*)
+declare i1 @runtime.stringEqual(ptr, i32, ptr, i32, ptr)
 
-define i1 @main.stringCompareEqualConstantZero(i8* %s1.data, i32 %s1.len, i8* %context) {
+define i1 @main.stringCompareEqualConstantZero(ptr %s1.data, i32 %s1.len, ptr %context) {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* getelementptr inbounds ([0 x i8], [0 x i8]* @zeroString, i32 0, i32 0), i32 0, i8* undef)
+  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr @zeroString, i32 0, ptr undef)
   ret i1 %0
 }
 
-define i1 @main.stringCompareUnequalConstantZero(i8* %s1.data, i32 %s1.len, i8* %context) {
+define i1 @main.stringCompareUnequalConstantZero(ptr %s1.data, i32 %s1.len, ptr %context) {
 entry:
-  %0 = call i1 @runtime.stringEqual(i8* %s1.data, i32 %s1.len, i8* getelementptr inbounds ([0 x i8], [0 x i8]* @zeroString, i32 0, i32 0), i32 0, i8* undef)
+  %0 = call i1 @runtime.stringEqual(ptr %s1.data, i32 %s1.len, ptr @zeroString, i32 0, ptr undef)
   %1 = xor i1 %0, true
   ret i1 %1
 }

--- a/transform/testdata/stringequal.out.ll
+++ b/transform/testdata/stringequal.out.ll
@@ -3,15 +3,15 @@ target triple = "armv7m-none-eabi"
 
 @zeroString = constant [0 x i8] zeroinitializer
 
-declare i1 @runtime.stringEqual(i8*, i32, i8*, i32, i8*)
+declare i1 @runtime.stringEqual(ptr, i32, ptr, i32, ptr)
 
-define i1 @main.stringCompareEqualConstantZero(i8* %s1.data, i32 %s1.len, i8* %context) {
+define i1 @main.stringCompareEqualConstantZero(ptr %s1.data, i32 %s1.len, ptr %context) {
 entry:
   %0 = icmp eq i32 %s1.len, 0
   ret i1 %0
 }
 
-define i1 @main.stringCompareUnequalConstantZero(i8* %s1.data, i32 %s1.len, i8* %context) {
+define i1 @main.stringCompareUnequalConstantZero(ptr %s1.data, i32 %s1.len, ptr %context) {
 entry:
   %0 = icmp eq i32 %s1.len, 0
   %1 = xor i1 %0, true

--- a/transform/testdata/stringtobytes.ll
+++ b/transform/testdata/stringtobytes.ll
@@ -3,30 +3,30 @@ target triple = "x86_64--linux"
 
 @str = constant [6 x i8] c"foobar"
 
-declare { i8*, i64, i64 } @runtime.stringToBytes(i8*, i64)
+declare { ptr, i64, i64 } @runtime.stringToBytes(ptr, i64)
 
-declare void @printSlice(i8* nocapture readonly, i64, i64)
+declare void @printSlice(ptr nocapture readonly, i64, i64)
 
-declare void @writeToSlice(i8* nocapture, i64, i64)
+declare void @writeToSlice(ptr nocapture, i64, i64)
 
 ; Test that runtime.stringToBytes can be fully optimized away.
 define void @testReadOnly() {
 entry:
-  %0 = call fastcc { i8*, i64, i64 } @runtime.stringToBytes(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 0), i64 6)
-  %1 = extractvalue { i8*, i64, i64 } %0, 0
-  %2 = extractvalue { i8*, i64, i64 } %0, 1
-  %3 = extractvalue { i8*, i64, i64 } %0, 2
-  call fastcc void @printSlice(i8* %1, i64 %2, i64 %3)
+  %0 = call fastcc { ptr, i64, i64 } @runtime.stringToBytes(ptr @str, i64 6)
+  %1 = extractvalue { ptr, i64, i64 } %0, 0
+  %2 = extractvalue { ptr, i64, i64 } %0, 1
+  %3 = extractvalue { ptr, i64, i64 } %0, 2
+  call fastcc void @printSlice(ptr %1, i64 %2, i64 %3)
   ret void
 }
 
 ; Test that even though the slice is written to, some values can be propagated.
 define void @testReadWrite() {
 entry:
-  %0 = call fastcc { i8*, i64, i64 } @runtime.stringToBytes(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 0), i64 6)
-  %1 = extractvalue { i8*, i64, i64 } %0, 0
-  %2 = extractvalue { i8*, i64, i64 } %0, 1
-  %3 = extractvalue { i8*, i64, i64 } %0, 2
-  call fastcc void @writeToSlice(i8* %1, i64 %2, i64 %3)
+  %0 = call fastcc { ptr, i64, i64 } @runtime.stringToBytes(ptr @str, i64 6)
+  %1 = extractvalue { ptr, i64, i64 } %0, 0
+  %2 = extractvalue { ptr, i64, i64 } %0, 1
+  %3 = extractvalue { ptr, i64, i64 } %0, 2
+  call fastcc void @writeToSlice(ptr %1, i64 %2, i64 %3)
   ret void
 }

--- a/transform/testdata/stringtobytes.out.ll
+++ b/transform/testdata/stringtobytes.out.ll
@@ -3,22 +3,22 @@ target triple = "x86_64--linux"
 
 @str = constant [6 x i8] c"foobar"
 
-declare { i8*, i64, i64 } @runtime.stringToBytes(i8*, i64)
+declare { ptr, i64, i64 } @runtime.stringToBytes(ptr, i64)
 
-declare void @printSlice(i8* nocapture readonly, i64, i64)
+declare void @printSlice(ptr nocapture readonly, i64, i64)
 
-declare void @writeToSlice(i8* nocapture, i64, i64)
+declare void @writeToSlice(ptr nocapture, i64, i64)
 
 define void @testReadOnly() {
 entry:
-  call fastcc void @printSlice(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 0), i64 6, i64 6)
+  call fastcc void @printSlice(ptr @str, i64 6, i64 6)
   ret void
 }
 
 define void @testReadWrite() {
 entry:
-  %0 = call fastcc { i8*, i64, i64 } @runtime.stringToBytes(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 0), i64 6)
-  %1 = extractvalue { i8*, i64, i64 } %0, 0
-  call fastcc void @writeToSlice(i8* %1, i64 6, i64 6)
+  %0 = call fastcc { ptr, i64, i64 } @runtime.stringToBytes(ptr @str, i64 6)
+  %1 = extractvalue { ptr, i64, i64 } %0, 0
+  call fastcc void @writeToSlice(ptr %1, i64 6, i64 6)
   ret void
 }

--- a/transform/testdata/wasm-abi.ll
+++ b/transform/testdata/wasm-abi.ll
@@ -1,19 +1,19 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-unknown-wasm"
 
-declare i64 @externalCall(i8*, i32, i64)
+declare i64 @externalCall(ptr, i32, i64)
 
-define internal i64 @testCall(i8* %ptr, i32 %len, i64 %foo) {
-  %val = call i64 @externalCall(i8* %ptr, i32 %len, i64 %foo)
+define internal i64 @testCall(ptr %ptr, i32 %len, i64 %foo) {
+  %val = call i64 @externalCall(ptr %ptr, i32 %len, i64 %foo)
   ret i64 %val
 }
 
-define internal i64 @testCallNonEntry(i8* %ptr, i32 %len) {
+define internal i64 @testCallNonEntry(ptr %ptr, i32 %len) {
 entry:
   br label %bb1
 
 bb1:
-  %val = call i64 @externalCall(i8* %ptr, i32 %len, i64 3)
+  %val = call i64 @externalCall(ptr %ptr, i32 %len, i64 3)
   ret i64 %val
 }
 

--- a/transform/testdata/wasm-abi.out.ll
+++ b/transform/testdata/wasm-abi.out.ll
@@ -1,27 +1,27 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32-unknown-unknown-wasm"
 
-declare i64 @"externalCall$i64wrap"(i8*, i32, i64)
+declare i64 @"externalCall$i64wrap"(ptr, i32, i64)
 
-define internal i64 @testCall(i8* %ptr, i32 %len, i64 %foo) {
+define internal i64 @testCall(ptr %ptr, i32 %len, i64 %foo) {
   %i64asptr = alloca i64, align 8
   %i64asptr1 = alloca i64, align 8
-  store i64 %foo, i64* %i64asptr1, align 8
-  call void @externalCall(i64* %i64asptr, i8* %ptr, i32 %len, i64* %i64asptr1)
-  %retval = load i64, i64* %i64asptr, align 8
+  store i64 %foo, ptr %i64asptr1, align 8
+  call void @externalCall(ptr %i64asptr, ptr %ptr, i32 %len, ptr %i64asptr1)
+  %retval = load i64, ptr %i64asptr, align 8
   ret i64 %retval
 }
 
-define internal i64 @testCallNonEntry(i8* %ptr, i32 %len) {
+define internal i64 @testCallNonEntry(ptr %ptr, i32 %len) {
 entry:
   %i64asptr = alloca i64, align 8
   %i64asptr1 = alloca i64, align 8
   br label %bb1
 
 bb1:                                              ; preds = %entry
-  store i64 3, i64* %i64asptr1, align 8
-  call void @externalCall(i64* %i64asptr, i8* %ptr, i32 %len, i64* %i64asptr1)
-  %retval = load i64, i64* %i64asptr, align 8
+  store i64 3, ptr %i64asptr1, align 8
+  call void @externalCall(ptr %i64asptr, ptr %ptr, i32 %len, ptr %i64asptr1)
+  %retval = load i64, ptr %i64asptr, align 8
   ret i64 %retval
 }
 
@@ -35,11 +35,11 @@ define internal void @callExportedFunction(i64 %foo) {
   ret void
 }
 
-declare void @externalCall(i64*, i8*, i32, i64*)
+declare void @externalCall(ptr, ptr, i32, ptr)
 
-define void @exportedFunction(i64* %0) {
+define void @exportedFunction(ptr %0) {
 entry:
-  %i64 = load i64, i64* %0, align 8
+  %i64 = load i64, ptr %0, align 8
   call void @"exportedFunction$i64wrap"(i64 %i64)
   ret void
 }


### PR DESCRIPTION
Just a maintenance update. Support for non-opaque pointers will be dropped by LLVM at some point, and opaque pointers make it easier to modify these tests.