### PR TITLE
compiler: support all kinds of recursive types

### DIFF
--- a/testdata/slice.go
+++ b/testdata/slice.go
@@ -6,6 +6,8 @@ type MySlice [32]byte
 
 type myUint8 uint8
 
+type RecursiveSlice []RecursiveSlice
+
 // Indexing into slice with named type (regression test).
 var array = [4]int{
 	myUint8(2): 3,
@@ -160,6 +162,10 @@ func main() {
 	for _, c := range named {
 		assert(c == 0)
 	}
+
+	// Test recursive slices.
+	rs := []RecursiveSlice(nil)
+	println("len:", len(rs))
 }
 
 func printslice(name string, s []int) {

--- a/testdata/slice.txt
+++ b/testdata/slice.txt
@@ -16,3 +16,4 @@ bytes: len=6 cap=6 data: 1 2 3 102 111 111
 slice to array pointer: 1 -2 20 4
 unsafe.Add array: 1 5 8 4
 unsafe.Slice array: 3 3 9 15 4
+len: 0


### PR DESCRIPTION
Previously we only supported recursive types in structs. But there can be other kinds of recursive types, like slices:

    type RecursiveSlice []RecursiveSlice

This doesn't involve structs, so it led to infinite recursion in the compiler. This fix avoids recursion at the proper level: at the place where the named type is defined.