### PR TITLE
compiler,reflect: support making **T, [...]T -> []T

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,7 +43,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4556, 272, 0, 2252},
 		{"microbit", "examples/serial", 2680, 380, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6109, 1471, 116, 6816},
+		{"wioterminal", "examples/pininterrupt", 6113, 1515, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -184,6 +184,7 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 		case *types.Pointer:
 			typeFieldTypes = append(typeFieldTypes,
 				types.NewVar(token.NoPos, nil, "numMethods", types.Typ[types.Uint16]),
+				types.NewVar(token.NoPos, nil, "ptrTo", types.Typ[types.UnsafePointer]),
 				types.NewVar(token.NoPos, nil, "elementType", types.Typ[types.UnsafePointer]),
 			)
 		case *types.Array:
@@ -279,8 +280,20 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 				c.getTypeCode(typ.Elem()),                  // elementType
 			}
 		case *types.Pointer:
+			// We want to create T, *T, and **T
+			// If we're a pointer to a concrete type, add a ptrTo field.
+			// That gives us **T.  Anything higher (ptr-to-ptr-to-ptr...) gets a zero.
+			var ptrptr llvm.Value
+			if _, ok := typ.Elem().Underlying().(*types.Pointer); !ok {
+				ptrptr = c.getTypeCode(types.NewPointer(typ))
+			} else {
+				// ptr to a pointer gets nil
+				ptrptr = llvm.ConstPointerNull(c.getLLVMType(types.Typ[types.UnsafePointer]))
+			}
+
 			typeFields = []llvm.Value{
 				llvm.ConstInt(c.ctx.Int16Type(), uint64(ms.Len()), false), // numMethods
+				ptrptr,
 				c.getTypeCode(typ.Elem()),
 			}
 		case *types.Array:

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -193,6 +193,7 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 				types.NewVar(token.NoPos, nil, "ptrTo", types.Typ[types.UnsafePointer]),
 				types.NewVar(token.NoPos, nil, "elementType", types.Typ[types.UnsafePointer]),
 				types.NewVar(token.NoPos, nil, "length", types.Typ[types.Uintptr]),
+				types.NewVar(token.NoPos, nil, "sliceOf", types.Typ[types.UnsafePointer]),
 			)
 		case *types.Map:
 			typeFieldTypes = append(typeFieldTypes,
@@ -302,6 +303,7 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 				c.getTypeCode(types.NewPointer(typ)),                   // ptrTo
 				c.getTypeCode(typ.Elem()),                              // elementType
 				llvm.ConstInt(c.uintptrType, uint64(typ.Len()), false), // length
+				c.getTypeCode(types.NewSlice(typ.Elem())),              // slicePtr
 			}
 		case *types.Map:
 			typeFields = []llvm.Value{

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -22,7 +22,8 @@ target triple = "wasm32-unknown-wasi"
 @"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00 " }
 @"runtime/gc.layout:62-0001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00\00" }
 @"reflect/types.type:basic:complex128" = linkonce_odr constant { i8, ptr } { i8 16, ptr @"reflect/types.type:pointer:basic:complex128" }, align 4
-@"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:basic:complex128" }, align 4
+@"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr @"reflect/types.type:pointer:pointer:basic:complex128", ptr @"reflect/types.type:basic:complex128" }, align 4
+@"reflect/types.type:pointer:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr null, ptr @"reflect/types.type:pointer:basic:complex128" }, align 4
 
 ; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -7,13 +7,17 @@ target triple = "wasm32-unknown-wasi"
 %runtime._string = type { ptr, i32 }
 
 @"reflect/types.type:basic:int" = linkonce_odr constant { i8, ptr } { i8 2, ptr @"reflect/types.type:pointer:basic:int" }, align 4
-@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:basic:int" }, align 4
-@"reflect/types.type:pointer:named:error" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:named:error" }, align 4
+@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr @"reflect/types.type:pointer:pointer:basic:int", ptr @"reflect/types.type:basic:int" }, align 4
+@"reflect/types.type:pointer:pointer:basic:int" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr null, ptr @"reflect/types.type:pointer:basic:int" }, align 4
+@"reflect/types.type:pointer:named:error" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr @"reflect/types.type:pointer:pointer:named:error", ptr @"reflect/types.type:named:error" }, align 4
+@"reflect/types.type:pointer:pointer:named:error" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr null, ptr @"reflect/types.type:pointer:named:error" }, align 4
 @"reflect/types.type:named:error" = linkonce_odr constant { i8, i16, ptr, ptr, ptr, [7 x i8] } { i8 52, i16 1, ptr @"reflect/types.type:pointer:named:error", ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}", ptr @"reflect/types.type.pkgpath.empty", [7 x i8] c".error\00" }, align 4
 @"reflect/types.type.pkgpath.empty" = linkonce_odr unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, ptr } { i8 20, ptr @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }, align 4
-@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
-@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 21, i16 0, ptr @"reflect/types.type:interface:{String:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr @"reflect/types.type:pointer:pointer:interface:{Error:func:{}{basic:string}}", ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr null, ptr @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr @"reflect/types.type:pointer:pointer:interface:{String:func:{}{basic:string}}", ptr @"reflect/types.type:interface:{String:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr, ptr } { i8 21, i16 0, ptr null, ptr @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" }, align 4
 @"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, ptr } { i8 20, ptr @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" }, align 4
 @"reflect/types.typeid:basic:int" = external constant i8
 

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -415,6 +415,7 @@ type elemType struct {
 type ptrType struct {
 	rawType
 	numMethod uint16
+	ptrTo     *rawType
 	elem      *rawType
 }
 
@@ -500,6 +501,9 @@ func pointerTo(t *rawType) *rawType {
 	case Pointer:
 		// TODO(dgryski): This is blocking https://github.com/tinygo-org/tinygo/issues/3131
 		// We need to be able to create types that match existing types to prevent typecode equality.
+		if ptrTo := (*ptrType)(unsafe.Pointer(t)).ptrTo; ptrTo != nil {
+			return ptrTo
+		}
 		panic("reflect: cannot make **T type")
 	case Struct:
 		return (*structType)(unsafe.Pointer(t)).ptrTo

--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -29,6 +29,7 @@
 //     ptrTo        *typeStruct
 //     elem         *typeStruct // element type of the array
 //     arrayLen     uintptr     // length of the array (this is part of the type)
+//     slicePtr     *typeStruct // pointer to []T type
 // - map types (this is still missing the key and element types)
 //     meta         uint8
 //     nmethods     uint16 (0)
@@ -425,6 +426,7 @@ type arrayType struct {
 	ptrTo     *rawType
 	elem      *rawType
 	arrayLen  uintptr
+	slicePtr  *rawType
 }
 
 type mapType struct {


### PR DESCRIPTION
Hacky solution.  Uses a bunch of extra space for things that probably won't be needed.  Should probably be hidden behind a compiler option until we something better.  Marking as draft.   Putting here so I don't lose it.