### PR TITLE
docker: correct path for GHCR dev container build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           images: |
             tinygo/tinygo-dev
-            ghcr.io/${{ github.repository }}/tinygo-dev
+            ghcr.io/${{ github.repository_owner }}/tinygo-dev
           tags: |
             type=sha,format=long
             type=raw,value=latest


### PR DESCRIPTION
This PR corrects the path for the Docker dev container build pushed to GHCR. 

It is currently `ghcr.io/tinygo-org/tinygo/tinygo-dev` and it should be just `ghcr.io/tinygo-org/tinygo-dev`