### PR TITLE
machine/usb: provide ability to override USB VID, PID, Manufacturer name and Product name

### DIFF
--- a/src/examples/hid-keyboard/main.go
+++ b/src/examples/hid-keyboard/main.go
@@ -1,10 +1,21 @@
+// to override the USB Manufacturer or Product names:
+//
+// tinygo flash -target circuitplay-express -ldflags="-X main.usbManufacturer='TinyGopher Labs' -X main.usbProduct='GopherKeyboard'" examples/hid-keyboard
+//
+// you can also override the VID/PID. however, only set this if you know what you are doing,
+// since changing it can make it difficult to reflash some devices.
 package main
 
 import (
 	"machine"
+	"machine/usb"
 	"machine/usb/hid/keyboard"
+	"strconv"
 	"time"
 )
+
+var usbVID, usbPID string
+var usbManufacturer, usbProduct string
 
 func main() {
 	button := machine.BUTTON
@@ -17,5 +28,25 @@ func main() {
 			kb.Write([]byte("tinygo"))
 			time.Sleep(200 * time.Millisecond)
 		}
+	}
+}
+
+func init() {
+	if usbVID != "" {
+		vid, _ := strconv.ParseUint(usbVID, 0, 16)
+		usb.VendorID = uint16(vid)
+	}
+
+	if usbPID != "" {
+		pid, _ := strconv.ParseUint(usbPID, 0, 16)
+		usb.ProductID = uint16(pid)
+	}
+
+	if usbManufacturer != "" {
+		usb.Manufacturer = usbManufacturer
+	}
+
+	if usbProduct != "" {
+		usb.Product = usbProduct
 	}
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -33,6 +33,38 @@ var usbDescriptor = usb.DescriptorCDC
 
 var usbDescriptorConfig uint8 = usb.DescriptorConfigCDC
 
+func usbVendorID() uint16 {
+	if usb.VendorID != 0 {
+		return usb.VendorID
+	}
+
+	return usb_VID
+}
+
+func usbProductID() uint16 {
+	if usb.ProductID != 0 {
+		return usb.ProductID
+	}
+
+	return usb_PID
+}
+
+func usbManufacturer() string {
+	if usb.Manufacturer != "" {
+		return usb.Manufacturer
+	}
+
+	return usb_STRING_MANUFACTURER
+}
+
+func usbProduct() string {
+	if usb.Product != "" {
+		return usb.Product
+	}
+
+	return usb_STRING_PRODUCT
+}
+
 // strToUTF16LEDescriptor converts a utf8 string into a string descriptor
 // note: the following code only converts ascii characters to UTF16LE. In order
 // to do a "proper" conversion, we would need to pull in the 'unicode/utf16'
@@ -118,7 +150,7 @@ func sendDescriptor(setup usb.Setup) {
 			usbDescriptor = usb.DescriptorCDC
 		}
 
-		usbDescriptor.Configure(usb_VID, usb_PID)
+		usbDescriptor.Configure(usbVendorID(), usbProductID())
 		sendUSBPacket(0, usbDescriptor.Device, setup.WLength)
 		return
 
@@ -132,13 +164,13 @@ func sendDescriptor(setup usb.Setup) {
 			sendUSBPacket(0, usb_trans_buffer[:4], setup.WLength)
 
 		case usb.IPRODUCT:
-			b := usb_trans_buffer[:(len(usb_STRING_PRODUCT)<<1)+2]
-			strToUTF16LEDescriptor(usb_STRING_PRODUCT, b)
+			b := usb_trans_buffer[:(len(usbProduct())<<1)+2]
+			strToUTF16LEDescriptor(usbProduct(), b)
 			sendUSBPacket(0, b, setup.WLength)
 
 		case usb.IMANUFACTURER:
-			b := usb_trans_buffer[:(len(usb_STRING_MANUFACTURER)<<1)+2]
-			strToUTF16LEDescriptor(usb_STRING_MANUFACTURER, b)
+			b := usb_trans_buffer[:(len(usbManufacturer())<<1)+2]
+			strToUTF16LEDescriptor(usbManufacturer(), b)
 			sendUSBPacket(0, b, setup.WLength)
 
 		case usb.ISERIAL:

--- a/src/machine/usb/usb.go
+++ b/src/machine/usb/usb.go
@@ -126,3 +126,21 @@ func NewSetup(data []byte) Setup {
 	u.WLength = uint16(data[6]) | (uint16(data[7]) << 8)
 	return u
 }
+
+var (
+	// VendorID aka VID is the officially assigned vendor number
+	// for this USB device. Only set this if you know what you are doing,
+	// since changing it can make it difficult to reflash some devices.
+	VendorID uint16
+
+	// ProductID aka PID is the product number associated with the officially assigned
+	// vendor number for this USB device. Only set this if you know what you are doing,
+	// since changing it can make it difficult to reflash some devices.
+	ProductID uint16
+
+	// Manufacturer is the manufacturer name displayed for this USB device.
+	Manufacturer string
+
+	// Product is the product name displayed for this USB device.
+	Product string
+)


### PR DESCRIPTION
This PR adds a way to override the default USB VID, PID, Manufacturer name and Product name, for those boards that we have full USB support.

It should solve #3544 for your needs @sago35 @bgould and of course anyone else please take a look.
