### PR TITLE
examples/wasm: update export example to show the use of the go:wasmimport directive

### DIFF
--- a/src/examples/wasm/README.md
+++ b/src/examples/wasm/README.md
@@ -2,10 +2,10 @@
 
 The examples here show two different ways of using WebAssembly with TinyGo:
 
-1. Defining and exporting functions via the `//export <name>` directive. See
-[the export folder](./export) for an example of this.  Additionally, the Wasm
-module (which has a default value of `env`) can be specified using
-`//go:wasm-module <module>`.
+1. Defining and exporting functions via the `//go:wasmimport <module>` directive. See
+[the export folder](./export) for an example of this.  This exports the function to the Wasm
+module (which has a default value of `env`). You can also use the Go directive
+`//go:export <module>`.
 1. Defining and executing a `func main()`. This is similar to how the Go
 standard library implementation works. See [the main folder](./main) for an
 example of this.

--- a/src/examples/wasm/export/wasm.go
+++ b/src/examples/wasm/export/wasm.go
@@ -8,12 +8,12 @@ import (
 func main() {
 }
 
-//export add
+//go:wasmimport add
 func add(a, b int) int {
 	return a + b
 }
 
-//export update
+//go:wasmimport update
 func update() {
 	document := js.Global().Get("document")
 	aStr := document.Call("getElementById", "a").Get("value").String()


### PR DESCRIPTION
This PR updates the wasm "export" example to show the use of the `go:wasmimport` directive. See #3165 for details.