### PR TITLE
reflect: use direct calls to runtime string functions

### DIFF
--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1209,7 +1209,7 @@ func cvtFloat(v Value, t *rawType) Value {
 	return makeFloat(v.flags, v.Float(), t)
 }
 
-//go:linkname stringToBytes runtime.stringToBytesTyped
+//go:linkname stringToBytes runtime.stringToBytes
 func stringToBytes(x string) []byte
 
 func cvtStringBytes(v Value, t *rawType) Value {
@@ -1221,7 +1221,7 @@ func cvtStringBytes(v Value, t *rawType) Value {
 	}
 }
 
-//go:linkname stringFromBytes runtime.stringFromBytesTyped
+//go:linkname stringFromBytes runtime.stringFromBytes
 func stringFromBytes(x []byte) string
 
 func cvtBytesString(v Value, t *rawType) Value {

--- a/src/runtime/string.go
+++ b/src/runtime/string.go
@@ -77,16 +77,6 @@ func stringFromBytes(x struct {
 	return _string{ptr: (*byte)(buf), length: x.len}
 }
 
-func stringFromBytesTyped(x []byte) string {
-	slice := *(*struct {
-		ptr *byte
-		len uintptr
-		cap uintptr
-	})(unsafe.Pointer(&x))
-	s := stringFromBytes(slice)
-	return *(*string)(unsafe.Pointer(&s))
-}
-
 // Convert a string to a []byte slice.
 func stringToBytes(x _string) (slice struct {
 	ptr *byte
@@ -99,12 +89,6 @@ func stringToBytes(x _string) (slice struct {
 	slice.len = x.length
 	slice.cap = x.length
 	return
-}
-
-func stringToBytesTyped(x string) []byte {
-	s := *(*_string)(unsafe.Pointer(&x))
-	slice := stringToBytes(s)
-	return *(*[]byte)(unsafe.Pointer(&slice))
 }
 
 // Convert a []rune slice to a string.


### PR DESCRIPTION
The runtime.stringFromBytesTyped and runtime.stringToBytesTyped functions aren't really necessary, because they have the same LLVM IR signature. Therefore, remove them and link directly to the functions that the compiler uses internally.

Context: https://github.com/tinygo-org/tinygo/pull/3543#discussion_r1144038917