### PR TITLE
compiler: only support //go:wasmimport on declared functions

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -291,7 +291,7 @@ func (info *functionInfo) parsePragmas(f *ssa.Function) {
 			case "//go:wasmimport":
 				// Import a WebAssembly function, for example a WASI function.
 				// For details, see: https://github.com/golang/go/issues/38248
-				if len(parts) != 3 {
+				if len(parts) != 3 || len(f.Blocks) != 0 {
 					continue
 				}
 				info.exported = true

--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -59,6 +59,13 @@ func functionInSection() {
 func exportedFunctionInSection() {
 }
 
+//go:wasmimport modulename import1
+func declaredImport()
+
+//go:wasmimport modulename import2
+func definedImport() {
+}
+
 // This function should not: it's only a declaration and not a definition.
 //
 //go:section .special_function_section

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -60,6 +60,14 @@ entry:
   ret void
 }
 
+declare void @main.declaredImport() #7
+
+; Function Attrs: nounwind
+define hidden void @main.definedImport(ptr %context) unnamed_addr #2 {
+entry:
+  ret void
+}
+
 declare void @main.undefinedFunctionNotInSection(ptr) #1
 
 attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
@@ -69,3 +77,4 @@ attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,
 attributes #4 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }
+attributes #7 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="modulename" "wasm-import-name"="import1" }


### PR DESCRIPTION
Don't support this pragma on defined functions. It is only meant for importing, not for exporting.

See https://github.com/tinygo-org/tinygo/pull/3589.