### PR TITLE
machine/lorae5: correct mapping for I2C bus, add pin mapping to enable power

### DIFF
--- a/src/machine/board_lorae5.go
+++ b/src/machine/board_lorae5.go
@@ -10,6 +10,14 @@ import (
 const (
 	// We assume a LED is connected on PB5
 	LED = PB5 // Default LED
+
+	// Set the POWER_EN3V3 pin to high to turn
+	// on the 3.3V power for all peripherals
+	POWER_EN3V3 = PA9
+
+	// Set the POWER_EN5V pin to high to turn
+	// on the 5V bus power for all peripherals
+	POWER_EN5V = PB10
 )
 
 // SubGhz (SPI3)
@@ -22,11 +30,11 @@ const (
 
 // UARTS
 const (
-	//MCU USART1
+	// MCU USART1
 	UART1_TX_PIN = PB6
 	UART1_RX_PIN = PB7
 
-	//MCU USART2
+	// MCU USART2
 	UART2_TX_PIN = PA2
 	UART2_RX_PIN = PA3
 
@@ -34,15 +42,14 @@ const (
 	UART_TX_PIN = UART1_TX_PIN
 	UART_RX_PIN = UART1_RX_PIN
 
-	// I2C1 pins
-	// I2C1 is connected to Flash, Accelerometer, Env. Sensor, Crypto Element)
-	I2C1_SCL_PIN  = PA9
-	I2C1_SDA_PIN  = PA10
-	I2C1_ALT_FUNC = 4
+	// I2C2 pins
+	I2C2_SCL_PIN  = PB15
+	I2C2_SDA_PIN  = PA15
+	I2C2_ALT_FUNC = 4
 
-	// I2C0 alias for I2C1
-	I2C0_SDA_PIN = I2C1_SDA_PIN
-	I2C0_SCL_PIN = I2C1_SCL_PIN
+	// I2C0 alias for I2C2
+	I2C0_SDA_PIN = I2C2_SDA_PIN
+	I2C0_SCL_PIN = I2C2_SCL_PIN
 )
 
 var (
@@ -69,12 +76,14 @@ var (
 	}
 
 	// I2C Busses
-	I2C1 = &I2C{
-		Bus:             stm32.I2C1,
-		AltFuncSelector: I2C1_ALT_FUNC,
+	I2C2 = &I2C{
+		Bus:             stm32.I2C2,
+		AltFuncSelector: I2C2_ALT_FUNC,
 	}
 
-	I2C0 = I2C1
+	// Set "default" I2C bus to I2C2
+	I2C0 = I2C2
+
 	// SPI
 	SPI3 = SPI{
 		Bus: stm32.SPI3,


### PR DESCRIPTION
This PR corrects the lorae5 mapping for the I2C2 bus, and also adds pin mappings to enable power.