### PR TITLE
build: test net on linux & mac only (random CI fails on windows)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,6 @@ TEST_PACKAGES_FAST = \
 	internal/profile \
 	math \
 	math/cmplx \
-	net \
 	net/http/internal/ascii \
 	net/mail \
 	os \
@@ -355,6 +354,7 @@ TEST_PACKAGES_LINUX := \
 	image \
 	io/ioutil \
 	mime/quotedprintable \
+	net \
 	strconv \
 	testing/fstest \
 	text/tabwriter \


### PR DESCRIPTION
This is a far from ideal answer to https://github.com/tinygo-org/tinygo/issues/3603, but it's causing a lot of need to re-build PRs for no benefit (given no-one has located the root-cause of the PR breaks caused by the net package on Windows).

This change still tests the package on Linux & Mac, providing some protection against regressions.