### PR TITLE
compiler: implement most math/bits functions

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -845,6 +845,11 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 				b.defineMathOp()
 				continue
 			}
+			if ok := b.defineMathBitsIntrinsic(); ok {
+				// Like a math intrinsic, the body of this function was replaced
+				// with a LLVM intrinsic.
+				continue
+			}
 			if member.Blocks == nil {
 				// Try to define this as an intrinsic function.
 				b.defineIntrinsicFunction()

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -464,6 +464,19 @@ func (b *builder) readStackPointer() llvm.Value {
 	return b.CreateCall(stacksave.GlobalValueType(), stacksave, nil, "")
 }
 
+// createZExtOrTrunc lets the input value fit in the output type bits, by zero
+// extending or truncating the integer.
+func (b *builder) createZExtOrTrunc(value llvm.Value, t llvm.Type) llvm.Value {
+	valueBits := value.Type().IntTypeWidth()
+	resultBits := t.IntTypeWidth()
+	if valueBits > resultBits {
+		value = b.CreateTrunc(value, t, "")
+	} else if valueBits < resultBits {
+		value = b.CreateZExt(value, t, "")
+	}
+	return value
+}
+
 // Reverse a slice of bytes. From the wiki:
 // https://github.com/golang/go/wiki/SliceTricks#reversing
 func reverseBytes(buf []byte) {


### PR DESCRIPTION
These functions can be implemented more efficiently using LLVM intrinsics (at the moment, they're implemented as regular Go code). That makes them the Go equivalent of functions like __builtin_clz which are also implemented using these LLVM intrinsics.

I believe the Go compiler does something very similar: IIRC it converts calls to these functions into optimal instructions for the given architecture.

I tested these by running `tinygo test math/bits` after ~uncommenting~ commenting the tests that would always fail (the *PanicZero and *PanicOverflow tests). We should either implement `-test.skip` or the ability to catch runtime panics to be able to test this automatically.

EDIT: s/uncommenting/commenting