### PR TITLE
testing cleanups

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -541,7 +541,14 @@ func (c *Config) Emulator(format, binary string) ([]string, error) {
 
 type TestConfig struct {
 	CompileTestBinary bool
-	// TODO: Filter the test functions to run, include verbose flag, etc
+	CompileOnly       bool
+	Verbose           bool
+	Short             bool
+	RunRegexp         string
+	Count             int
+	BenchRegexp       string
+	BenchTime         string
+	BenchMem          bool
 }
 
 // filterTags removes predefined build tags for a target if a conflicting option

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -545,7 +545,7 @@ type TestConfig struct {
 	Verbose           bool
 	Short             bool
 	RunRegexp         string
-	Count             int
+	Count             *int
 	BenchRegexp       string
 	BenchTime         string
 	BenchMem          bool

--- a/corpus_test.go
+++ b/corpus_test.go
@@ -115,8 +115,9 @@ func TestCorpus(t *testing.T) {
 				var tags buildutil.TagsFlag
 				tags.Set(repo.Tags)
 				opts.Tags = []string(tags)
+				opts.TestConfig.Verbose = testing.Verbose()
 
-				passed, err := Test(path, out, out, &opts, false, testing.Verbose(), false, "", "", "", false, "")
+				passed, err := Test(path, out, out, &opts, "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}

--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func Build(pkgName, outpath string, options *compileopts.Options) error {
 
 // Test runs the tests in the given package. Returns whether the test passed and
 // possibly an error if the test failed to run.
-func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options, testCompileOnly, testVerbose, testShort bool, testRunRegexp string, testBenchRegexp string, testBenchTime string, testBenchMem bool, outpath string) (bool, error) {
+func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options, testCompileOnly, testVerbose, testShort bool, testRunRegexp string, testCount int, testBenchRegexp string, testBenchTime string, testBenchMem bool, outpath string) (bool, error) {
 	options.TestConfig.CompileTestBinary = true
 	config, err := builder.NewConfig(options)
 	if err != nil {
@@ -242,6 +242,9 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 	}
 	if testBenchMem {
 		flags = append(flags, "-test.benchmem")
+	}
+	if testCount != 1 {
+		flags = append(flags, "-test.count="+strconv.Itoa(testCount))
 	}
 
 	buf := bytes.Buffer{}
@@ -1405,6 +1408,7 @@ func main() {
 		flag.StringVar(&outpath, "o", "", "output filename")
 	}
 	var testCompileOnlyFlag, testVerboseFlag, testShortFlag *bool
+	var testCount *int
 	var testBenchRegexp *string
 	var testBenchTime *string
 	var testRunRegexp *string
@@ -1414,6 +1418,7 @@ func main() {
 		testVerboseFlag = flag.Bool("v", false, "verbose: print additional output")
 		testShortFlag = flag.Bool("short", false, "short: run smaller test suite to save time")
 		testRunRegexp = flag.String("run", "", "run: regexp of tests to run")
+		testCount = flag.Int("count", 1, "count: number of times to run tests/benchmarks `count` times")
 		testBenchRegexp = flag.String("bench", "", "run: regexp of benchmarks to run")
 		testBenchTime = flag.String("benchtime", "", "run each benchmark for duration `d`")
 		testBenchMem = flag.Bool("benchmem", false, "show memory stats for benchmarks")
@@ -1659,7 +1664,7 @@ func main() {
 				defer close(buf.done)
 				stdout := (*testStdout)(buf)
 				stderr := (*testStderr)(buf)
-				passed, err := Test(pkgName, stdout, stderr, options, *testCompileOnlyFlag, *testVerboseFlag, *testShortFlag, *testRunRegexp, *testBenchRegexp, *testBenchTime, *testBenchMem, outpath)
+				passed, err := Test(pkgName, stdout, stderr, options, *testCompileOnlyFlag, *testVerboseFlag, *testShortFlag, *testRunRegexp, *testCount, *testBenchRegexp, *testBenchTime, *testBenchMem, outpath)
 				if err != nil {
 					printCompilerError(func(args ...interface{}) {
 						fmt.Fprintln(stderr, args...)

--- a/main.go
+++ b/main.go
@@ -245,8 +245,8 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 	if testConfig.BenchMem {
 		flags = append(flags, "-test.benchmem")
 	}
-	if testConfig.Count != 1 {
-		flags = append(flags, "-test.count="+strconv.Itoa(testConfig.Count))
+	if testConfig.Count != nil && *testConfig.Count != 1 {
+		flags = append(flags, "-test.count="+strconv.Itoa(*testConfig.Count))
 	}
 
 	var buf bytes.Buffer
@@ -1420,7 +1420,7 @@ func main() {
 		flag.BoolVar(&testConfig.Verbose, "v", false, "verbose: print additional output")
 		flag.BoolVar(&testConfig.Short, "short", false, "short: run smaller test suite to save time")
 		flag.StringVar(&testConfig.RunRegexp, "run", "", "run: regexp of tests to run")
-		flag.IntVar(&testConfig.Count, "count", 1, "count: number of times to run tests/benchmarks `count` times")
+		testConfig.Count = flag.Int("count", 1, "count: number of times to run tests/benchmarks `count` times")
 		flag.StringVar(&testConfig.BenchRegexp, "bench", "", "run: regexp of benchmarks to run")
 		flag.StringVar(&testConfig.BenchTime, "benchtime", "", "run each benchmark for duration `d`")
 		flag.BoolVar(&testConfig.BenchMem, "benchmem", false, "show memory stats for benchmarks")

--- a/main_test.go
+++ b/main_test.go
@@ -425,7 +425,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/pass", out, out, &opts, false, false, false, "", "", "", false, "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/pass", out, out, &opts, "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -446,7 +446,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/fail", out, out, &opts, false, false, false, "", "", "", false, "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/fail", out, out, &opts, "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -473,7 +473,7 @@ func TestTest(t *testing.T) {
 
 				var output bytes.Buffer
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/nothing", io.MultiWriter(&output, out), out, &opts, false, false, false, "", "", "", false, "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/nothing", io.MultiWriter(&output, out), out, &opts, "")
 				if err != nil {
 					t.Errorf("test error: %v", err)
 				}
@@ -497,7 +497,7 @@ func TestTest(t *testing.T) {
 				defer out.Close()
 
 				opts := targ.opts
-				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/builderr", out, out, &opts, false, false, false, "", "", "", false, "")
+				passed, err := Test("github.com/tinygo-org/tinygo/tests/testing/builderr", out, out, &opts, "")
 				if err == nil {
 					t.Error("test did not error")
 				}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -26,6 +26,7 @@ var (
 	flagVerbose   bool
 	flagShort     bool
 	flagRunRegexp string
+	flagCount     int
 )
 
 var initRan bool
@@ -40,6 +41,7 @@ func Init() {
 	flag.BoolVar(&flagVerbose, "test.v", false, "verbose: print additional output")
 	flag.BoolVar(&flagShort, "test.short", false, "short: run smaller test suite to save time")
 	flag.StringVar(&flagRunRegexp, "test.run", "", "run: regexp of tests to run")
+	flag.IntVar(&flagCount, "test.count", 1, "run each test or benchmark `count` times")
 
 	initBenchmarkFlags()
 }
@@ -485,12 +487,14 @@ func runTests(matchString func(pat, str string) (bool, error), tests []InternalT
 		context: ctx,
 	}
 
-	tRunner(t, func(t *T) {
-		for _, test := range tests {
-			t.Run(test.Name, test.F)
-			ok = ok && !t.Failed()
-		}
-	})
+	for i := 0; i < flagCount; i++ {
+		tRunner(t, func(t *T) {
+			for _, test := range tests {
+				t.Run(test.Name, test.F)
+				ok = ok && !t.Failed()
+			}
+		})
+	}
 
 	return t.ran, ok
 }


### PR DESCRIPTION
Make the testing code a bit nicer:
* `-count` for running benchmarks multiple times
*  `-test.v` is now unbuffered so if your test crashes you see the output
