### PR TITLE
Improve handling of multiple identical MCUs connected via USB

### DIFF
--- a/main.go
+++ b/main.go
@@ -1143,12 +1143,12 @@ func getDefaultPort(portFlag string, usbInterfaces []string) (port string, err e
 	}
 
 	if len(portCandidates) == 0 {
-		if len(usbInterfaces) > 0 {
-			return "", errors.New("unable to search for a default USB device - use -port flag, available ports are " + strings.Join(ports, ", "))
-		} else if len(ports) == 1 {
+		if len(ports) == 1 {
 			return ports[0], nil
-		} else {
+		} else if len(ports) > 1 {
 			return "", errors.New("multiple serial ports available - use -port flag, available ports are " + strings.Join(ports, ", "))
+		} else {
+			return "", errors.New("unable to search for a default USB device - use -port flag, available ports are " + strings.Join(ports, ", "))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -532,7 +532,12 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 		return fmt.Errorf("unknown flash method: %s", flashMethod)
 	}
 	if options.Monitor {
-		return Monitor("", options)
+		port, err := getDefaultPort(port, config.Target.SerialPort)
+		if err != nil {
+			return &commandError{"failed to locate port to monitor", port, err}
+		}
+
+		return Monitor(port, options)
 	}
 	return nil
 }


### PR DESCRIPTION
At least partially fixes #3637 

There are a few things:

1. Don't silently fail to flash if there is an error doing reset using the baud-rate trick because no port could be found

2. Improve error message when there are multiple candidate ports with same VID/PID by fixing the conditions when different errors are shown

3. Pass the port to the Monitor function after flashing (not this already works when using the `monitor` command)