### PR TITLE
fix benchmark logging

### DIFF
--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -160,6 +160,7 @@ func (b *B) ReportAllocs() {
 // runN runs a single benchmark for the specified number of iterations.
 func (b *B) runN(n int) {
 	b.N = n
+	runtime.GC()
 	b.ResetTimer()
 	b.StartTimer()
 	b.benchFunc(b)
@@ -214,7 +215,6 @@ func (b *B) doBench() BenchmarkResult {
 // of benchmark iterations until the benchmark runs for the requested benchtime.
 // run1 must have been called on b.
 func (b *B) launch() {
-	runtime.GC()
 	// Run the benchmark for at least the specified amount of time.
 	if b.benchTime.n > 0 {
 		b.runN(b.benchTime.n)

--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -378,7 +379,8 @@ func runBenchmarks(matchString func(pat, str string) (bool, error), benchmarks [
 	}
 	main := &B{
 		common: common{
-			name: "Main",
+			output: &logger{},
+			name:   "Main",
 		},
 		benchTime: benchTime,
 		benchFunc: func(b *B) {
@@ -416,6 +418,12 @@ func (b *B) processBench(ctx *benchContext) {
 				results += "\t" + r.MemString()
 			}
 			fmt.Println(results)
+
+			// Print any benchmark output
+			if b.output.Len() > 0 {
+				fmt.Printf("--- BENCH: %s\n", benchName)
+				b.output.WriteTo(os.Stdout)
+			}
 		}
 	}
 }
@@ -436,8 +444,9 @@ func (b *B) Run(name string, f func(b *B)) bool {
 	b.hasSub = true
 	sub := &B{
 		common: common{
-			name:  benchName,
-			level: b.level + 1,
+			output: &logger{},
+			name:   benchName,
+			level:  b.level + 1,
 		},
 		benchFunc: f,
 		benchTime: b.benchTime,

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -95,6 +95,10 @@ func (l *logger) WriteTo(w io.Writer) (int64, error) {
 
 }
 
+func (l *logger) Len() int {
+	return l.b.Len()
+}
+
 // Short reports whether the -test.short flag is set.
 func Short() bool {
 	return flagShort


### PR DESCRIPTION
The verbosity fix in https://github.com/tinygo-org/tinygo/pull/3625 broke `b.Log()` output.  This fixes the segfault and prints the benchmark output afterwards properly.