### PR TITLE
Switch interp tests to opaque pointers

### DIFF
--- a/interp/testdata/alloc.ll
+++ b/interp/testdata/alloc.ll
@@ -2,17 +2,17 @@ target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32--wasi"
 
 @"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00 " }
-@pointerFree12 = global i8* null
-@pointerFree7 = global i8* null
-@pointerFree3 = global i8* null
-@pointerFree0 = global i8* null
-@layout1 = global i8* null
-@layout2 = global i8* null
-@layout3 = global i8* null
-@layout4 = global i8* null
-@bigobj1 = global i8* null
+@pointerFree12 = global ptr null
+@pointerFree7 = global ptr null
+@pointerFree3 = global ptr null
+@pointerFree0 = global ptr null
+@layout1 = global ptr null
+@layout2 = global ptr null
+@layout3 = global ptr null
+@layout4 = global ptr null
+@bigobj1 = global ptr null
 
-declare i8* @runtime.alloc(i32, i8*) unnamed_addr
+declare ptr @runtime.alloc(i32, ptr) unnamed_addr
 
 define void @runtime.initAll() unnamed_addr {
   call void @main.init()
@@ -21,33 +21,33 @@ define void @runtime.initAll() unnamed_addr {
 
 define internal void @main.init() unnamed_addr {
   ; Object that's word-aligned.
-  %pointerFree12 = call i8* @runtime.alloc(i32 12, i8* inttoptr (i32 3 to i8*))
-  store i8* %pointerFree12, i8** @pointerFree12
+  %pointerFree12 = call ptr @runtime.alloc(i32 12, ptr inttoptr (i32 3 to ptr))
+  store ptr %pointerFree12, ptr @pointerFree12
   ; Object larger than a word but not word-aligned.
-  %pointerFree7 = call i8* @runtime.alloc(i32 7, i8* inttoptr (i32 3 to i8*))
-  store i8* %pointerFree7, i8** @pointerFree7
+  %pointerFree7 = call ptr @runtime.alloc(i32 7, ptr inttoptr (i32 3 to ptr))
+  store ptr %pointerFree7, ptr @pointerFree7
   ; Object smaller than a word (and of course not word-aligned).
-  %pointerFree3 = call i8* @runtime.alloc(i32 3, i8* inttoptr (i32 3 to i8*))
-  store i8* %pointerFree3, i8** @pointerFree3
+  %pointerFree3 = call ptr @runtime.alloc(i32 3, ptr inttoptr (i32 3 to ptr))
+  store ptr %pointerFree3, ptr @pointerFree3
   ; Zero-sized object.
-  %pointerFree0 = call i8* @runtime.alloc(i32 0, i8* inttoptr (i32 3 to i8*))
-  store i8* %pointerFree0, i8** @pointerFree0
+  %pointerFree0 = call ptr @runtime.alloc(i32 0, ptr inttoptr (i32 3 to ptr))
+  store ptr %pointerFree0, ptr @pointerFree0
 
   ; Object made out of 3 pointers.
-  %layout1 = call i8* @runtime.alloc(i32 12, i8* inttoptr (i32 67 to i8*))
-  store i8* %layout1, i8** @layout1
+  %layout1 = call ptr @runtime.alloc(i32 12, ptr inttoptr (i32 67 to ptr))
+  store ptr %layout1, ptr @layout1
   ; Array (or slice) of 5 slices.
-  %layout2 = call i8* @runtime.alloc(i32 60, i8* inttoptr (i32 71 to i8*))
-  store i8* %layout2, i8** @layout2
+  %layout2 = call ptr @runtime.alloc(i32 60, ptr inttoptr (i32 71 to ptr))
+  store ptr %layout2, ptr @layout2
   ; Oddly shaped object, using all bits in the layout integer.
-  %layout3 = call i8* @runtime.alloc(i32 104, i8* inttoptr (i32 2467830261 to i8*))
-  store i8* %layout3, i8** @layout3
+  %layout3 = call ptr @runtime.alloc(i32 104, ptr inttoptr (i32 2467830261 to ptr))
+  store ptr %layout3, ptr @layout3
   ; ...repeated.
-  %layout4 = call i8* @runtime.alloc(i32 312, i8* inttoptr (i32 2467830261 to i8*))
-  store i8* %layout4, i8** @layout4
+  %layout4 = call ptr @runtime.alloc(i32 312, ptr inttoptr (i32 2467830261 to ptr))
+  store ptr %layout4, ptr @layout4
 
   ; Large object that needs to be stored in a separate global.
-  %bigobj1 = call i8* @runtime.alloc(i32 248, i8* bitcast ({ i32, [8 x i8] }* @"runtime/gc.layout:62-2000000000000001" to i8*))
-  store i8* %bigobj1, i8** @bigobj1
+  %bigobj1 = call ptr @runtime.alloc(i32 248, ptr @"runtime/gc.layout:62-2000000000000001")
+  store ptr %bigobj1, ptr @bigobj1
   ret void
 }

--- a/interp/testdata/alloc.out.ll
+++ b/interp/testdata/alloc.out.ll
@@ -1,24 +1,24 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
 target triple = "wasm32--wasi"
 
-@pointerFree12 = local_unnamed_addr global i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"main$alloc", i32 0, i32 0)
-@pointerFree7 = local_unnamed_addr global i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"main$alloc.1", i32 0, i32 0)
-@pointerFree3 = local_unnamed_addr global i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"main$alloc.2", i32 0, i32 0)
-@pointerFree0 = local_unnamed_addr global i8* getelementptr inbounds ([0 x i8], [0 x i8]* @"main$alloc.3", i32 0, i32 0)
-@layout1 = local_unnamed_addr global i8* bitcast ([3 x i8*]* @"main$alloc.4" to i8*)
-@layout2 = local_unnamed_addr global i8* bitcast ([5 x { i8*, i32, i32 }]* @"main$alloc.5" to i8*)
-@layout3 = local_unnamed_addr global i8* bitcast ({ i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }* @"main$alloc.6" to i8*)
-@layout4 = local_unnamed_addr global i8* bitcast ([3 x { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }]* @"main$alloc.7" to i8*)
-@bigobj1 = local_unnamed_addr global i8* bitcast ({ i8*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i8* }* @"main$alloc.8" to i8*)
+@pointerFree12 = local_unnamed_addr global ptr @"main$alloc"
+@pointerFree7 = local_unnamed_addr global ptr @"main$alloc.1"
+@pointerFree3 = local_unnamed_addr global ptr @"main$alloc.2"
+@pointerFree0 = local_unnamed_addr global ptr @"main$alloc.3"
+@layout1 = local_unnamed_addr global ptr @"main$alloc.4"
+@layout2 = local_unnamed_addr global ptr @"main$alloc.5"
+@layout3 = local_unnamed_addr global ptr @"main$alloc.6"
+@layout4 = local_unnamed_addr global ptr @"main$alloc.7"
+@bigobj1 = local_unnamed_addr global ptr @"main$alloc.8"
 @"main$alloc" = internal global [12 x i8] zeroinitializer, align 4
 @"main$alloc.1" = internal global [7 x i8] zeroinitializer, align 4
 @"main$alloc.2" = internal global [3 x i8] zeroinitializer, align 4
 @"main$alloc.3" = internal global [0 x i8] zeroinitializer, align 4
-@"main$alloc.4" = internal global [3 x i8*] zeroinitializer, align 4
-@"main$alloc.5" = internal global [5 x { i8*, i32, i32 }] zeroinitializer, align 4
-@"main$alloc.6" = internal global { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* } zeroinitializer, align 4
-@"main$alloc.7" = internal global [3 x { i8*, i8*, i8*, i32, i32, i8*, i8*, i32, i32, i32, i32, i32, i32, i8*, i8*, i32, i32, i32, i8*, i8*, i32, i32, i8*, i32, i32, i8* }] zeroinitializer, align 4
-@"main$alloc.8" = internal global { i8*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i8* } zeroinitializer, align 4
+@"main$alloc.4" = internal global [3 x ptr] zeroinitializer, align 4
+@"main$alloc.5" = internal global [5 x { ptr, i32, i32 }] zeroinitializer, align 4
+@"main$alloc.6" = internal global { ptr, ptr, ptr, i32, i32, ptr, ptr, i32, i32, i32, i32, i32, i32, ptr, ptr, i32, i32, i32, ptr, ptr, i32, i32, ptr, i32, i32, ptr } zeroinitializer, align 4
+@"main$alloc.7" = internal global [3 x { ptr, ptr, ptr, i32, i32, ptr, ptr, i32, i32, i32, i32, i32, i32, ptr, ptr, i32, i32, i32, ptr, ptr, i32, i32, ptr, i32, i32, ptr }] zeroinitializer, align 4
+@"main$alloc.8" = internal global { ptr, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, ptr } zeroinitializer, align 4
 
 define void @runtime.initAll() unnamed_addr {
   ret void

--- a/interp/testdata/basic.ll
+++ b/interp/testdata/basic.ll
@@ -5,7 +5,7 @@ target triple = "x86_64--linux"
 @main.nonConst1 = global [4 x i64] zeroinitializer
 @main.nonConst2 = global i64 0
 @main.someArray = global [8 x {i16, i32}] zeroinitializer
-@main.exportedValue = global [1 x i16*] [i16* @main.exposedValue1]
+@main.exportedValue = global [1 x ptr] [ptr @main.exposedValue1]
 @main.exportedConst = constant i64 42
 @main.exposedValue1 = global i16 0
 @main.exposedValue2 = global i16 0
@@ -24,7 +24,7 @@ entry:
 
 define void @main() unnamed_addr {
 entry:
-  %0 = load i64, i64* @main.v1
+  %0 = load i64, ptr @main.v1
   call void @runtime.printint64(i64 %0)
   call void @runtime.printnl()
   ret void
@@ -37,43 +37,43 @@ entry:
 
 define internal void @main.init() unnamed_addr {
 entry:
-  store i64 3, i64* @main.v1
+  store i64 3, ptr @main.v1
   call void @"main.init#1"()
 
   ; test the following pattern:
   ;     func someValue() int // extern function
   ;     var nonConst1 = [4]int{someValue(), 0, 0, 0}
   %value1 = call i64 @someValue()
-  %gep1 = getelementptr [4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0
-  store i64 %value1, i64* %gep1
+  %gep1 = getelementptr [4 x i64], ptr @main.nonConst1, i32 0, i32 0
+  store i64 %value1, ptr %gep1
 
   ; Test that the global really is marked dirty:
   ;     var nonConst2 = nonConst1[0]
-  %gep2 = getelementptr [4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0
-  %value2 = load i64, i64* %gep2
-  store i64 %value2, i64* @main.nonConst2
+  %gep2 = getelementptr [4 x i64], ptr @main.nonConst1, i32 0, i32 0
+  %value2 = load i64, ptr %gep2
+  store i64 %value2, ptr @main.nonConst2
 
   ; Test that the following GEP works:
   ;     var someArray
   ;     modifyExternal(&someArray[3].field1)
-  %gep3 = getelementptr [8 x {i16, i32}], [8 x {i16, i32}]* @main.someArray, i32 0, i32 3, i32 1
-  call void @modifyExternal(i32* %gep3)
+  %gep3 = getelementptr [8 x {i16, i32}], ptr @main.someArray, i32 0, i32 3, i32 1
+  call void @modifyExternal(ptr %gep3)
 
   ; Test that marking a value as external also marks all referenced values.
-  call void @modifyExternal(i32* bitcast ([1 x i16*]* @main.exportedValue to i32*))
-  store i16 5, i16* @main.exposedValue1
+  call void @modifyExternal(ptr @main.exportedValue)
+  store i16 5, ptr @main.exposedValue1
 
   ; Test that marking a constant as external still allows loading from it.
-  call void @readExternal(i32* bitcast (i64* @main.exportedConst to i32*))
-  %constLoad = load i64, i64 * @main.exportedConst
+  call void @readExternal(ptr @main.exportedConst)
+  %constLoad = load i64, ptr @main.exportedConst
   call void @runtime.printint64(i64 %constLoad)
 
   ; Test that this even propagates through functions.
-  call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
-  store i16 7, i16* @main.exposedValue2
+  call void @modifyExternal(ptr @willModifyGlobal)
+  store i16 7, ptr @main.exposedValue2
 
   ; Test that inline assembly is ignored.
-  call void @modifyExternal(i32* bitcast (void ()* @hasInlineAsm to i32*))
+  call void @modifyExternal(ptr @hasInlineAsm)
 
   ; Test switch statement.
   %switch1 = call i64 @testSwitch(i64 1) ; 1 returns 6
@@ -86,7 +86,7 @@ entry:
   %elt = extractvalue {i8, i32, {float, {i64, i16}}} %agg, 2, 1, 0
   call void @runtime.printint64(i64 %elt)
   %agg2 = insertvalue {i8, i32, {float, {i64, i16}}} %agg, i64 5, 2, 1, 0
-  store {i8, i32, {float, {i64, i16}}} %agg2, {i8, i32, {float, {i64, i16}}}* @main.insertedValue
+  store {i8, i32, {float, {i64, i16}}} %agg2, ptr @main.insertedValue
 
   ret void
 }
@@ -100,16 +100,16 @@ entry:
 
 declare i64 @someValue()
 
-declare void @modifyExternal(i32*)
+declare void @modifyExternal(ptr)
 
-declare void @readExternal(i32*)
+declare void @readExternal(ptr)
 
 ; This function will modify an external value. By passing this function as a
 ; function pointer to an external function, @main.exposedValue2 should be
 ; marked as external.
 define void @willModifyGlobal() {
 entry:
-  store i16 8, i16* @main.exposedValue2
+  store i16 8, ptr @main.exposedValue2
   ret void
 }
 

--- a/interp/testdata/basic.out.ll
+++ b/interp/testdata/basic.out.ll
@@ -4,7 +4,7 @@ target triple = "x86_64--linux"
 @main.nonConst1 = local_unnamed_addr global [4 x i64] zeroinitializer
 @main.nonConst2 = local_unnamed_addr global i64 0
 @main.someArray = global [8 x { i16, i32 }] zeroinitializer
-@main.exportedValue = global [1 x i16*] [i16* @main.exposedValue1]
+@main.exportedValue = global [1 x ptr] [ptr @main.exposedValue1]
 @main.exportedConst = constant i64 42
 @main.exposedValue1 = global i16 0
 @main.exposedValue2 = local_unnamed_addr global i16 0
@@ -19,17 +19,17 @@ entry:
   call void @runtime.printint64(i64 5)
   call void @runtime.printnl()
   %value1 = call i64 @someValue()
-  store i64 %value1, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0), align 8
-  %value2 = load i64, i64* getelementptr inbounds ([4 x i64], [4 x i64]* @main.nonConst1, i32 0, i32 0), align 8
-  store i64 %value2, i64* @main.nonConst2, align 8
-  call void @modifyExternal(i32* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ([8 x { i16, i32 }]* @main.someArray to i8*), i32 28) to i32*))
-  call void @modifyExternal(i32* bitcast ([1 x i16*]* @main.exportedValue to i32*))
-  store i16 5, i16* @main.exposedValue1, align 2
-  call void @readExternal(i32* bitcast (i64* @main.exportedConst to i32*))
+  store i64 %value1, ptr @main.nonConst1, align 8
+  %value2 = load i64, ptr @main.nonConst1, align 8
+  store i64 %value2, ptr @main.nonConst2, align 8
+  call void @modifyExternal(ptr getelementptr inbounds (i8, ptr @main.someArray, i32 28))
+  call void @modifyExternal(ptr @main.exportedValue)
+  store i16 5, ptr @main.exposedValue1, align 2
+  call void @readExternal(ptr @main.exportedConst)
   call void @runtime.printint64(i64 42)
-  call void @modifyExternal(i32* bitcast (void ()* @willModifyGlobal to i32*))
-  store i16 7, i16* @main.exposedValue2, align 2
-  call void @modifyExternal(i32* bitcast (void ()* @hasInlineAsm to i32*))
+  call void @modifyExternal(ptr @willModifyGlobal)
+  store i16 7, ptr @main.exposedValue2, align 2
+  call void @modifyExternal(ptr @hasInlineAsm)
   call void @runtime.printint64(i64 6)
   call void @runtime.printint64(i64 -1)
   %agg = call { i8, i32, { float, { i64, i16 } } } @nestedStruct()
@@ -42,7 +42,7 @@ entry:
   %agg2.insertvalue2 = insertvalue { i64, i16 } %agg2.agg1, i64 5, 0
   %agg2.insertvalue1 = insertvalue { float, { i64, i16 } } %agg2.agg0, { i64, i16 } %agg2.insertvalue2, 1
   %agg2.insertvalue0 = insertvalue { i8, i32, { float, { i64, i16 } } } %agg, { float, { i64, i16 } } %agg2.insertvalue1, 2
-  store { i8, i32, { float, { i64, i16 } } } %agg2.insertvalue0, { i8, i32, { float, { i64, i16 } } }* @main.insertedValue, align 8
+  store { i8, i32, { float, { i64, i16 } } } %agg2.insertvalue0, ptr @main.insertedValue, align 8
   ret void
 }
 
@@ -55,13 +55,13 @@ entry:
 
 declare i64 @someValue() local_unnamed_addr
 
-declare void @modifyExternal(i32*) local_unnamed_addr
+declare void @modifyExternal(ptr) local_unnamed_addr
 
-declare void @readExternal(i32*) local_unnamed_addr
+declare void @readExternal(ptr) local_unnamed_addr
 
 define void @willModifyGlobal() {
 entry:
-  store i16 8, i16* @main.exposedValue2, align 2
+  store i16 8, ptr @main.exposedValue2, align 2
   ret void
 }
 

--- a/interp/testdata/consteval.ll
+++ b/interp/testdata/consteval.ll
@@ -5,7 +5,7 @@ target triple = "x86_64--linux"
 @ptrToIntResult = global i8 0
 @icmpResult = global i8 0
 @someArray = internal global {i16, i8, i8} zeroinitializer
-@someArrayPointer = global i8* zeroinitializer
+@someArrayPointer = global ptr zeroinitializer
 
 define void @runtime.initAll() {
   call void @main.init()
@@ -21,45 +21,45 @@ define internal void @main.init() {
 }
 
 define internal void @testIntToPtr() {
-  %nil = icmp eq i8* inttoptr (i64 1024 to i8*), null
+  %nil = icmp eq ptr inttoptr (i64 1024 to ptr), null
   br i1 %nil, label %a, label %b
 a:
   ; should not be reached
-  store i8 1, i8* @intToPtrResult
+  store i8 1, ptr @intToPtrResult
   ret void
 b:
   ; should be reached
-  store i8 2, i8* @intToPtrResult
+  store i8 2, ptr @intToPtrResult
   ret void
 }
 
 define internal void @testPtrToInt() {
-  %zero = icmp eq i64 ptrtoint (i8* @ptrToIntResult to i64), 0
+  %zero = icmp eq i64 ptrtoint (ptr @ptrToIntResult to i64), 0
   br i1 %zero, label %a, label %b
 a:
   ; should not be reached
-  store i8 1, i8* @ptrToIntResult
+  store i8 1, ptr @ptrToIntResult
   ret void
 b:
   ; should be reached
-  store i8 2, i8* @ptrToIntResult
+  store i8 2, ptr @ptrToIntResult
   ret void
 }
 
 define internal void @testConstGEP() {
-  store i8* getelementptr inbounds (i8, i8* bitcast ({i16, i8, i8}* @someArray to i8*), i32 2), i8** @someArrayPointer
+  store ptr getelementptr inbounds (i8, ptr @someArray, i32 2), ptr @someArrayPointer
   ret void
 }
 
 define internal void @testICmp() {
-  br i1 icmp eq (i64 ptrtoint (i8* @ptrToIntResult to i64), i64 0), label %equal, label %unequal
+  br i1 icmp eq (i64 ptrtoint (ptr @ptrToIntResult to i64), i64 0), label %equal, label %unequal
 equal:
   ; should not be reached
-  store i8 1, i8* @icmpResult
+  store i8 1, ptr @icmpResult
   ret void
 unequal:
   ; should be reached
-  store i8 2, i8* @icmpResult
+  store i8 2, ptr @icmpResult
   ret void
   ret void
 }

--- a/interp/testdata/consteval.out.ll
+++ b/interp/testdata/consteval.out.ll
@@ -5,7 +5,7 @@ target triple = "x86_64--linux"
 @ptrToIntResult = local_unnamed_addr global i8 2
 @icmpResult = local_unnamed_addr global i8 2
 @someArray = internal global { i16, i8, i8 } zeroinitializer
-@someArrayPointer = local_unnamed_addr global i8* getelementptr inbounds ({ i16, i8, i8 }, { i16, i8, i8 }* @someArray, i64 0, i32 1)
+@someArrayPointer = local_unnamed_addr global ptr getelementptr inbounds ({ i16, i8, i8 }, ptr @someArray, i64 0, i32 1)
 
 define void @runtime.initAll() local_unnamed_addr {
   ret void

--- a/interp/testdata/interface.ll
+++ b/interp/testdata/interface.ll
@@ -3,14 +3,14 @@ target triple = "x86_64--linux"
 
 @main.v1 = global i1 0
 @main.v2 = global i1 0
-@"reflect/types.type:named:main.foo" = private constant { i8, i8*, i8* } { i8 34, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:named:main.foo", i32 0, i32 0), i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:named:main.foo" = external constant { i8, i8* }
+@"reflect/types.type:named:main.foo" = private constant { i8, ptr, ptr } { i8 34, ptr @"reflect/types.type:pointer:named:main.foo", ptr @"reflect/types.type:basic:int" }, align 4
+@"reflect/types.type:pointer:named:main.foo" = external constant { i8, ptr }
 @"reflect/types.typeid:named:main.foo" = external constant i8
-@"reflect/types.type:basic:int" = private constant { i8, i8* } { i8 2, i8* getelementptr inbounds ({ i8, i8* }, { i8, i8* }* @"reflect/types.type:pointer:basic:int", i32 0, i32 0) }, align 4
-@"reflect/types.type:pointer:basic:int" = external constant { i8, i8* }
+@"reflect/types.type:basic:int" = private constant { i8, ptr } { i8 2, ptr @"reflect/types.type:pointer:basic:int" }, align 4
+@"reflect/types.type:pointer:basic:int" = external constant { i8, ptr }
 
 
-declare i1 @runtime.typeAssert(i8*, i8*, i8*, i8*)
+declare i1 @runtime.typeAssert(ptr, ptr, ptr, ptr)
 
 define void @runtime.initAll() unnamed_addr {
 entry:
@@ -21,9 +21,9 @@ entry:
 define internal void @main.init() unnamed_addr {
 entry:
   ; Test type asserts.
-  %typecode = call i1 @runtime.typeAssert(i8* getelementptr inbounds ({ i8, i8*, i8* }, { i8, i8*, i8* }* @"reflect/types.type:named:main.foo", i32 0, i32 0), i8* @"reflect/types.typeid:named:main.foo", i8* undef, i8* null)
-  store i1 %typecode, i1* @main.v1
-  %typecode2 = call i1 @runtime.typeAssert(i8* null, i8* @"reflect/types.typeid:named:main.foo", i8* undef, i8* null)
-  store i1 %typecode2, i1* @main.v2
+  %typecode = call i1 @runtime.typeAssert(ptr @"reflect/types.type:named:main.foo", ptr @"reflect/types.typeid:named:main.foo", ptr undef, ptr null)
+  store i1 %typecode, ptr @main.v1
+  %typecode2 = call i1 @runtime.typeAssert(ptr null, ptr @"reflect/types.typeid:named:main.foo", ptr undef, ptr null)
+  store i1 %typecode2, ptr @main.v2
   ret void
 }

--- a/interp/testdata/phi.ll
+++ b/interp/testdata/phi.ll
@@ -25,7 +25,7 @@ for.loop:
   br i1 %icmp, label %for.done, label %for.loop
 
 for.done:
-  store i8 %a, i8* @main.phiNodesResultA
-  store i8 %b, i8* @main.phiNodesResultB
+  store i8 %a, ptr @main.phiNodesResultA
+  store i8 %b, ptr @main.phiNodesResultB
   ret void
 }

--- a/interp/testdata/revert.ll
+++ b/interp/testdata/revert.ll
@@ -3,7 +3,7 @@ target triple = "x86_64--linux"
 
 declare void @externalCall(i64)
 
-declare i64 @ptrHash(i8* nocapture)
+declare i64 @ptrHash(ptr nocapture)
 
 @foo.knownAtRuntime = global i64 0
 @bar.knownAtRuntime = global i64 0
@@ -17,60 +17,60 @@ declare i64 @ptrHash(i8* nocapture)
 
 define void @runtime.initAll() unnamed_addr {
 entry:
-  call void @baz.init(i8* undef)
-  call void @foo.init(i8* undef)
-  call void @bar.init(i8* undef)
-  call void @main.init(i8* undef)
-  call void @x.init(i8* undef)
-  call void @y.init(i8* undef)
-  call void @z.init(i8* undef)
+  call void @baz.init(ptr undef)
+  call void @foo.init(ptr undef)
+  call void @bar.init(ptr undef)
+  call void @main.init(ptr undef)
+  call void @x.init(ptr undef)
+  call void @y.init(ptr undef)
+  call void @z.init(ptr undef)
   ret void
 }
 
-define internal void @foo.init(i8* %context) unnamed_addr {
-  store i64 5, i64* @foo.knownAtRuntime
+define internal void @foo.init(ptr %context) unnamed_addr {
+  store i64 5, ptr @foo.knownAtRuntime
   unreachable ; this triggers a revert of @foo.init.
 }
 
-define internal void @bar.init(i8* %context) unnamed_addr {
-  %val = load i64, i64* @foo.knownAtRuntime
-  store i64 %val, i64* @bar.knownAtRuntime
+define internal void @bar.init(ptr %context) unnamed_addr {
+  %val = load i64, ptr @foo.knownAtRuntime
+  store i64 %val, ptr @bar.knownAtRuntime
   ret void
 }
 
-define internal void @baz.init(i8* %context) unnamed_addr {
+define internal void @baz.init(ptr %context) unnamed_addr {
   ; Test extractvalue/insertvalue with more than one index.
-  %val = load [3 x {i64, i32}], [3 x {i64, i32}]* @baz.someGlobal
+  %val = load [3 x {i64, i32}], ptr @baz.someGlobal
   %part = extractvalue [3 x {i64, i32}] %val, 0, 1
   %val2 = insertvalue [3 x {i64, i32}] %val, i32 5, 2, 1
   unreachable ; trigger revert
 }
 
-define internal void @main.init(i8* %context) unnamed_addr {
+define internal void @main.init(ptr %context) unnamed_addr {
 entry:
   call void @externalCall(i64 3)
   ret void
 }
 
 
-define internal void @x.init(i8* %context) unnamed_addr {
+define internal void @x.init(ptr %context) unnamed_addr {
   ; Test atomic and volatile memory accesses.
-  store atomic i32 1, i32* @x.atomicNum seq_cst, align 4
-  %x = load atomic i32, i32* @x.atomicNum seq_cst, align 4
-  store i32 %x, i32* @x.atomicNum
-  %y = load volatile i32, i32* @x.volatileNum
-  store volatile i32 %y, i32* @x.volatileNum
+  store atomic i32 1, ptr @x.atomicNum seq_cst, align 4
+  %x = load atomic i32, ptr @x.atomicNum seq_cst, align 4
+  store i32 %x, ptr @x.atomicNum
+  %y = load volatile i32, ptr @x.volatileNum
+  store volatile i32 %y, ptr @x.volatileNum
   ret void
 }
 
-define internal void @y.init(i8* %context) unnamed_addr {
+define internal void @y.init(ptr %context) unnamed_addr {
 entry:
   br label %loop
 
 loop:
   ; Test a wait-loop.
   ; This function must be reverted.
-  %val = load atomic i32, i32* @y.ready seq_cst, align 4
+  %val = load atomic i32, ptr @y.ready seq_cst, align 4
   %ready = icmp eq i32 %val, 1
   br i1 %ready, label %end, label %loop
 
@@ -78,27 +78,25 @@ end:
   ret void
 }
 
-define internal void @z.init(i8* %context) unnamed_addr {
-  %bloom = bitcast i64* @z.bloom to i8*
-
+define internal void @z.init(ptr %context) unnamed_addr {
   ; This can be safely expanded.
-  call void @z.setArr(i8* %bloom, i64 1, i8* %bloom)
+  call void @z.setArr(ptr @z.bloom, i64 1, ptr @z.bloom)
 
   ; This call should be reverted to prevent unrolling.
-  call void @z.setArr(i8* bitcast ([32 x i8]* @z.arr to i8*), i64 32, i8* %bloom)
+  call void @z.setArr(ptr @z.arr, i64 32, ptr @z.bloom)
 
   ret void
 }
 
-define internal void @z.setArr(i8* %arr, i64 %n, i8* %context) unnamed_addr {
+define internal void @z.setArr(ptr %arr, i64 %n, ptr %context) unnamed_addr {
 entry:
   br label %loop
 
 loop:
   %prev = phi i64 [ %n, %entry ], [ %idx, %loop ]
   %idx = sub i64 %prev, 1
-  %elem = getelementptr i8, i8* %arr, i64 %idx
-  call void @z.set(i8* %elem, i8* %context)
+  %elem = getelementptr i8, ptr %arr, i64 %idx
+  call void @z.set(ptr %elem, ptr %context)
   %done = icmp eq i64 %idx, 0
   br i1 %done, label %end, label %loop
 
@@ -106,14 +104,13 @@ end:
   ret void
 }
 
-define internal void @z.set(i8* %ptr, i8* %context) unnamed_addr {
+define internal void @z.set(ptr %ptr, ptr %context) unnamed_addr {
   ; Insert the pointer into the Bloom filter.
-  %hash = call i64 @ptrHash(i8* %ptr)
+  %hash = call i64 @ptrHash(ptr %ptr)
   %index = lshr i64 %hash, 58
   %bit = shl i64 1, %index
-  %bloom = bitcast i8* %context to i64*
-  %old = load i64, i64* %bloom
+  %old = load i64, ptr %context
   %new = or i64 %old, %bit
-  store i64 %new, i64* %bloom
+  store i64 %new, ptr %context
   ret void
 }

--- a/interp/testdata/revert.out.ll
+++ b/interp/testdata/revert.out.ll
@@ -13,41 +13,41 @@ target triple = "x86_64--linux"
 
 declare void @externalCall(i64) local_unnamed_addr
 
-declare i64 @ptrHash(i8* nocapture) local_unnamed_addr
+declare i64 @ptrHash(ptr nocapture) local_unnamed_addr
 
 define void @runtime.initAll() unnamed_addr {
 entry:
-  call fastcc void @baz.init(i8* undef)
-  call fastcc void @foo.init(i8* undef)
-  %val = load i64, i64* @foo.knownAtRuntime, align 8
-  store i64 %val, i64* @bar.knownAtRuntime, align 8
+  call fastcc void @baz.init(ptr undef)
+  call fastcc void @foo.init(ptr undef)
+  %val = load i64, ptr @foo.knownAtRuntime, align 8
+  store i64 %val, ptr @bar.knownAtRuntime, align 8
   call void @externalCall(i64 3)
-  store atomic i32 1, i32* @x.atomicNum seq_cst, align 4
-  %x = load atomic i32, i32* @x.atomicNum seq_cst, align 4
-  store i32 %x, i32* @x.atomicNum, align 4
-  %y = load volatile i32, i32* @x.volatileNum, align 4
-  store volatile i32 %y, i32* @x.volatileNum, align 4
-  call fastcc void @y.init(i8* undef)
-  call fastcc void @z.set(i8* bitcast (i64* @z.bloom to i8*), i8* bitcast (i64* @z.bloom to i8*))
-  call fastcc void @z.setArr(i8* getelementptr inbounds ([32 x i8], [32 x i8]* @z.arr, i32 0, i32 0), i64 32, i8* bitcast (i64* @z.bloom to i8*))
+  store atomic i32 1, ptr @x.atomicNum seq_cst, align 4
+  %x = load atomic i32, ptr @x.atomicNum seq_cst, align 4
+  store i32 %x, ptr @x.atomicNum, align 4
+  %y = load volatile i32, ptr @x.volatileNum, align 4
+  store volatile i32 %y, ptr @x.volatileNum, align 4
+  call fastcc void @y.init(ptr undef)
+  call fastcc void @z.set(ptr @z.bloom, ptr @z.bloom)
+  call fastcc void @z.setArr(ptr @z.arr, i64 32, ptr @z.bloom)
   ret void
 }
 
-define internal fastcc void @foo.init(i8* %context) unnamed_addr {
-  store i64 5, i64* @foo.knownAtRuntime, align 8
+define internal fastcc void @foo.init(ptr %context) unnamed_addr {
+  store i64 5, ptr @foo.knownAtRuntime, align 8
   unreachable
 }
 
-define internal fastcc void @baz.init(i8* %context) unnamed_addr {
+define internal fastcc void @baz.init(ptr %context) unnamed_addr {
   unreachable
 }
 
-define internal fastcc void @y.init(i8* %context) unnamed_addr {
+define internal fastcc void @y.init(ptr %context) unnamed_addr {
 entry:
   br label %loop
 
 loop:                                             ; preds = %loop, %entry
-  %val = load atomic i32, i32* @y.ready seq_cst, align 4
+  %val = load atomic i32, ptr @y.ready seq_cst, align 4
   %ready = icmp eq i32 %val, 1
   br i1 %ready, label %end, label %loop
 
@@ -55,15 +55,15 @@ end:                                              ; preds = %loop
   ret void
 }
 
-define internal fastcc void @z.setArr(i8* %arr, i64 %n, i8* %context) unnamed_addr {
+define internal fastcc void @z.setArr(ptr %arr, i64 %n, ptr %context) unnamed_addr {
 entry:
   br label %loop
-            
+
 loop:                                             ; preds = %loop, %entry
   %prev = phi i64 [ %n, %entry ], [ %idx, %loop ]
   %idx = sub i64 %prev, 1
-  %elem = getelementptr i8, i8* %arr, i64 %idx
-  call fastcc void @z.set(i8* %elem, i8* %context)
+  %elem = getelementptr i8, ptr %arr, i64 %idx
+  call fastcc void @z.set(ptr %elem, ptr %context)
   %done = icmp eq i64 %idx, 0
   br i1 %done, label %end, label %loop
 
@@ -71,13 +71,12 @@ end:                                              ; preds = %loop
   ret void
 }
 
-define internal fastcc void @z.set(i8* %ptr, i8* %context) unnamed_addr {
-  %hash = call i64 @ptrHash(i8* %ptr)
+define internal fastcc void @z.set(ptr %ptr, ptr %context) unnamed_addr {
+  %hash = call i64 @ptrHash(ptr %ptr)
   %index = lshr i64 %hash, 58
   %bit = shl i64 1, %index
-  %bloom = bitcast i8* %context to i64*
-  %old = load i64, i64* %bloom, align 8
+  %old = load i64, ptr %context, align 8
   %new = or i64 %old, %bit
-  store i64 %new, i64* %bloom, align 8
+  store i64 %new, ptr %context, align 8
   ret void
 }

--- a/interp/testdata/slice-copy.ll
+++ b/interp/testdata/slice-copy.ll
@@ -2,15 +2,15 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--linux"
 
 @main.uint8SliceSrc.buf = internal global [2 x i8] c"\03d"
-@main.uint8SliceSrc = internal unnamed_addr global { i8*, i64, i64 } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* @main.uint8SliceSrc.buf, i32 0, i32 0), i64 2, i64 2 }
-@main.uint8SliceDst = internal unnamed_addr global { i8*, i64, i64 } zeroinitializer
+@main.uint8SliceSrc = internal unnamed_addr global { ptr, i64, i64 } { ptr @main.uint8SliceSrc.buf, i64 2, i64 2 }
+@main.uint8SliceDst = internal unnamed_addr global { ptr, i64, i64 } zeroinitializer
 @main.int16SliceSrc.buf = internal global [3 x i16] [i16 5, i16 123, i16 1024]
-@main.int16SliceSrc = internal unnamed_addr global { i16*, i64, i64 } { i16* getelementptr inbounds ([3 x i16], [3 x i16]* @main.int16SliceSrc.buf, i32 0, i32 0), i64 3, i64 3 }
-@main.int16SliceDst = internal unnamed_addr global { i16*, i64, i64 } zeroinitializer
+@main.int16SliceSrc = internal unnamed_addr global { ptr, i64, i64 } { ptr @main.int16SliceSrc.buf, i64 3, i64 3 }
+@main.int16SliceDst = internal unnamed_addr global { ptr, i64, i64 } zeroinitializer
 
-declare i64 @runtime.sliceCopy(i8* %dst, i8* %src, i64 %dstLen, i64 %srcLen, i64 %elemSize) unnamed_addr
+declare i64 @runtime.sliceCopy(ptr %dst, ptr %src, i64 %dstLen, i64 %srcLen, i64 %elemSize) unnamed_addr
 
-declare i8* @runtime.alloc(i64, i8*) unnamed_addr
+declare ptr @runtime.alloc(i64, ptr) unnamed_addr
 
 declare void @runtime.printuint8(i8)
 
@@ -25,23 +25,23 @@ entry:
 define void @main() unnamed_addr {
 entry:
   ; print(uintSliceSrc[0])
-  %uint8SliceSrc.buf = load i8*, i8** getelementptr inbounds ({ i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceSrc, i64 0, i32 0)
-  %uint8SliceSrc.val = load i8, i8* %uint8SliceSrc.buf
+  %uint8SliceSrc.buf = load ptr, ptr @main.uint8SliceSrc
+  %uint8SliceSrc.val = load i8, ptr %uint8SliceSrc.buf
   call void @runtime.printuint8(i8 %uint8SliceSrc.val)
 
   ; print(uintSliceDst[0])
-  %uint8SliceDst.buf = load i8*, i8** getelementptr inbounds ({ i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceDst, i64 0, i32 0)
-  %uint8SliceDst.val = load i8, i8* %uint8SliceDst.buf
+  %uint8SliceDst.buf = load ptr, ptr @main.uint8SliceDst
+  %uint8SliceDst.val = load i8, ptr %uint8SliceDst.buf
   call void @runtime.printuint8(i8 %uint8SliceDst.val)
 
   ; print(int16SliceSrc[0])
-  %int16SliceSrc.buf = load i16*, i16** getelementptr inbounds ({ i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceSrc, i64 0, i32 0)
-  %int16SliceSrc.val = load i16, i16* %int16SliceSrc.buf
+  %int16SliceSrc.buf = load ptr, ptr @main.int16SliceSrc
+  %int16SliceSrc.val = load i16, ptr %int16SliceSrc.buf
   call void @runtime.printint16(i16 %int16SliceSrc.val)
 
   ; print(int16SliceDst[0])
-  %int16SliceDst.buf = load i16*, i16** getelementptr inbounds ({ i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceDst, i64 0, i32 0)
-  %int16SliceDst.val = load i16, i16* %int16SliceDst.buf
+  %int16SliceDst.buf = load ptr, ptr @main.int16SliceDst
+  %int16SliceDst.val = load i16, ptr %int16SliceDst.buf
   call void @runtime.printint16(i16 %int16SliceDst.val)
   ret void
 }
@@ -50,37 +50,34 @@ define internal void @main.init() unnamed_addr {
 entry:
   ; equivalent of:
   ;     uint8SliceDst = make([]uint8, len(uint8SliceSrc))
-  %uint8SliceSrc = load { i8*, i64, i64 }, { i8*, i64, i64 }* @main.uint8SliceSrc
-  %uint8SliceSrc.len = extractvalue { i8*, i64, i64 } %uint8SliceSrc, 1
-  %uint8SliceDst.buf = call i8* @runtime.alloc(i64 %uint8SliceSrc.len, i8* null)
-  %0 = insertvalue { i8*, i64, i64 } undef, i8* %uint8SliceDst.buf, 0
-  %1 = insertvalue { i8*, i64, i64 } %0, i64 %uint8SliceSrc.len, 1
-  %2 = insertvalue { i8*, i64, i64 } %1, i64 %uint8SliceSrc.len, 2
-  store { i8*, i64, i64 } %2, { i8*, i64, i64 }* @main.uint8SliceDst
+  %uint8SliceSrc = load { ptr, i64, i64 }, ptr @main.uint8SliceSrc
+  %uint8SliceSrc.len = extractvalue { ptr, i64, i64 } %uint8SliceSrc, 1
+  %uint8SliceDst.buf = call ptr @runtime.alloc(i64 %uint8SliceSrc.len, ptr null)
+  %0 = insertvalue { ptr, i64, i64 } undef, ptr %uint8SliceDst.buf, 0
+  %1 = insertvalue { ptr, i64, i64 } %0, i64 %uint8SliceSrc.len, 1
+  %2 = insertvalue { ptr, i64, i64 } %1, i64 %uint8SliceSrc.len, 2
+  store { ptr, i64, i64 } %2, ptr @main.uint8SliceDst
 
   ; equivalent of:
   ;     copy(uint8SliceDst, uint8SliceSrc)
-  %uint8SliceSrc.buf = extractvalue { i8*, i64, i64 } %uint8SliceSrc, 0
-  %copy.n = call i64 @runtime.sliceCopy(i8* %uint8SliceDst.buf, i8* %uint8SliceSrc.buf, i64 %uint8SliceSrc.len, i64 %uint8SliceSrc.len, i64 1)
+  %uint8SliceSrc.buf = extractvalue { ptr, i64, i64 } %uint8SliceSrc, 0
+  %copy.n = call i64 @runtime.sliceCopy(ptr %uint8SliceDst.buf, ptr %uint8SliceSrc.buf, i64 %uint8SliceSrc.len, i64 %uint8SliceSrc.len, i64 1)
 
   ; equivalent of:
   ;     int16SliceDst = make([]int16, len(int16SliceSrc))
-  %int16SliceSrc = load { i16*, i64, i64 }, { i16*, i64, i64 }* @main.int16SliceSrc
-  %int16SliceSrc.len = extractvalue { i16*, i64, i64 } %int16SliceSrc, 1
+  %int16SliceSrc = load { ptr, i64, i64 }, ptr @main.int16SliceSrc
+  %int16SliceSrc.len = extractvalue { ptr, i64, i64 } %int16SliceSrc, 1
   %int16SliceSrc.len.bytes = mul i64 %int16SliceSrc.len, 2
-  %int16SliceDst.buf.raw = call i8* @runtime.alloc(i64 %int16SliceSrc.len.bytes, i8* null)
-  %int16SliceDst.buf = bitcast i8* %int16SliceDst.buf.raw to i16*
-  %3 = insertvalue { i16*, i64, i64 } undef, i16* %int16SliceDst.buf, 0
-  %4 = insertvalue { i16*, i64, i64 } %3, i64 %int16SliceSrc.len, 1
-  %5 = insertvalue { i16*, i64, i64 } %4, i64 %int16SliceSrc.len, 2
-  store { i16*, i64, i64 } %5, { i16*, i64, i64 }* @main.int16SliceDst
+  %int16SliceDst.buf = call ptr @runtime.alloc(i64 %int16SliceSrc.len.bytes, ptr null)
+  %3 = insertvalue { ptr, i64, i64 } undef, ptr %int16SliceDst.buf, 0
+  %4 = insertvalue { ptr, i64, i64 } %3, i64 %int16SliceSrc.len, 1
+  %5 = insertvalue { ptr, i64, i64 } %4, i64 %int16SliceSrc.len, 2
+  store { ptr, i64, i64 } %5, ptr @main.int16SliceDst
 
   ; equivalent of:
   ;     copy(int16SliceDst, int16SliceSrc)
-  %int16SliceSrc.buf = extractvalue { i16*, i64, i64 } %int16SliceSrc, 0
-  %int16SliceSrc.buf.i8ptr = bitcast i16* %int16SliceSrc.buf to i8*
-  %int16SliceDst.buf.i8ptr = bitcast i16* %int16SliceDst.buf to i8*
-  %copy.n2 = call i64 @runtime.sliceCopy(i8* %int16SliceDst.buf.i8ptr, i8* %int16SliceSrc.buf.i8ptr, i64 %int16SliceSrc.len, i64 %int16SliceSrc.len, i64 2)
+  %int16SliceSrc.buf = extractvalue { ptr, i64, i64 } %int16SliceSrc, 0
+  %copy.n2 = call i64 @runtime.sliceCopy(ptr %int16SliceDst.buf, ptr %int16SliceSrc.buf, i64 %int16SliceSrc.len, i64 %int16SliceSrc.len, i64 2)
 
   ret void
 }


### PR DESCRIPTION
Similar to #3566; it is necessary to do this for LLVM 16, as it switched to opaque pointers in output by default, and LLVM 17 will support _only_ opaque pointers.

I'm not 100% certain on the changes in the source files, but it does appear to be passing tests for me at least. I assumed that a) all `bitcast` could be dropped since they'd just be `ptr`->`ptr` anyway, and b) `getelementptr` could be dropped _iff_ the indices were all 0, but since a lot of that input gets optimized away in the output, I didn't have a good reference to confirm these assumptions.