### PR TITLE
examples: replace fmt with encoding/hex in usb-midi example

### DIFF
--- a/src/examples/usb-midi/main.go
+++ b/src/examples/usb-midi/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"machine"
 	"machine/usb/midi"
+
+	"encoding/hex"
 	"time"
 )
 
@@ -20,7 +21,7 @@ func main() {
 	m := midi.Port()
 	m.SetHandler(func(b []byte) {
 		led.Set(!led.Get())
-		fmt.Printf("% X\r\n", b)
+		println(hex.EncodeToString(b))
 		m.Write(b)
 	})
 


### PR DESCRIPTION
This PR correct `examples/usb-midi` to replace `fmt` with `encoding/hex` as mentioned in https://github.com/tinygo-org/tinygo/pull/3636