### PR TITLE
Update wasi-libc to SDK 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,10 @@ commands:
       - run: go install -tags=llvm<<parameters.llvm>> .
       - restore_cache:
           keys:
-            - wasi-libc-sysroot-systemclang-v6
+            - wasi-libc-sysroot-systemclang-v7
       - run: make wasi-libc
       - save_cache:
-          key: wasi-libc-sysroot-systemclang-v6
+          key: wasi-libc-sysroot-systemclang-v7
           paths:
             - lib/wasi-libc/sysroot
       - when:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v4
+          key: wasi-libc-sysroot-v5
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-alpine-v1
+          key: wasi-libc-sysroot-linux-alpine-v2
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
@@ -250,7 +250,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-linux-asserts-v5
+          key: wasi-libc-sysroot-linux-asserts-v6
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v4
+          key: wasi-libc-sysroot-v5
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/tinygo-org/cmsis-svd
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc
-	url = https://github.com/CraneStation/wasi-libc
+	url = https://github.com/WebAssembly/wasi-libc
 [submodule "lib/picolibc"]
 	path = lib/picolibc
 	url = https://github.com/keith-packard/picolibc.git

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -398,8 +398,7 @@ func Chmod(path string, mode uint32) (err error) {
 }
 
 func Getpagesize() int {
-	// per upstream
-	return 65536
+	return libc_getpagesize()
 }
 
 type Utsname struct {
@@ -427,6 +426,11 @@ func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno)
 
 // This is a stub, it is not functional.
 func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno)
+
+// int getpagesize(void);
+//
+//export getpagesize
+func libc_getpagesize() int
 
 // int stat(const char *path, struct stat * buf);
 //


### PR DESCRIPTION
The version 17 SDK adds `getpagesize`, so use it instead of hardcoding a number (even if their implementation is _also_ a hardcoded number.)