### PR TITLE
Print source location for panics when using `-monitor`

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,9 +41,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 4556, 272, 0, 2252},
-		{"microbit", "examples/serial", 2680, 380, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6109, 1471, 116, 6816},
+		{"hifive1b", "examples/echo", 4612, 276, 0, 2252},
+		{"microbit", "examples/serial", 2724, 384, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 6159, 1477, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/main.go
+++ b/main.go
@@ -532,7 +532,7 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 		return fmt.Errorf("unknown flash method: %s", flashMethod)
 	}
 	if options.Monitor {
-		return Monitor("", options)
+		return Monitor(result.Executable, "", options)
 	}
 	return nil
 }
@@ -1720,7 +1720,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "monitor":
-		err := Monitor(*port, options)
+		err := Monitor("", *port, options)
 		handleCompilerError(err)
 	case "targets":
 		dir := filepath.Join(goenv.Get("TINYGOROOT"), "targets")

--- a/monitor.go
+++ b/monitor.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"debug/dwarf"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"errors"
 	"fmt"
+	"go/token"
+	"io"
 	"os"
 	"os/signal"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/mattn/go-tty"
@@ -13,7 +22,7 @@ import (
 )
 
 // Monitor connects to the given port and reads/writes the serial port.
-func Monitor(port string, options *compileopts.Options) error {
+func Monitor(executable, port string, options *compileopts.Options) error {
 	config, err := builder.NewConfig(options)
 	if err != nil {
 		return err
@@ -74,17 +83,31 @@ func Monitor(port string, options *compileopts.Options) error {
 
 	go func() {
 		buf := make([]byte, 100*1024)
+		var line []byte
 		for {
 			n, err := p.Read(buf)
 			if err != nil {
 				errCh <- fmt.Errorf("read error: %w", err)
 				return
 			}
-
-			if n == 0 {
-				continue
+			start := 0
+			for i, c := range buf[:n] {
+				if c == '\n' {
+					os.Stdout.Write(buf[start : i+1])
+					start = i + 1
+					address := extractPanicAddress(line)
+					if address != 0 {
+						loc, err := addressToLine(executable, address)
+						if err == nil && loc.IsValid() {
+							fmt.Printf("[tinygo: panic at %s]\n", loc.String())
+						}
+					}
+					line = line[:0]
+				} else {
+					line = append(line, c)
+				}
 			}
-			fmt.Printf("%v", string(buf[:n]))
+			os.Stdout.Write(buf[start:n])
 		}
 	}()
 
@@ -103,4 +126,110 @@ func Monitor(port string, options *compileopts.Options) error {
 	}()
 
 	return <-errCh
+}
+
+var addressMatch = regexp.MustCompile(`^panic: runtime error at 0x([0-9a-f]+): `)
+
+// Extract the address from the "panic: runtime error at" message.
+func extractPanicAddress(line []byte) uint64 {
+	matches := addressMatch.FindSubmatch(line)
+	if matches != nil {
+		address, err := strconv.ParseUint(string(matches[1]), 16, 64)
+		if err == nil {
+			return address
+		}
+	}
+	return 0
+}
+
+// Convert an address in the binary to a source address location.
+func addressToLine(executable string, address uint64) (token.Position, error) {
+	data, err := readDWARF(executable)
+	if err != nil {
+		return token.Position{}, err
+	}
+	r := data.Reader()
+
+	for {
+		e, err := r.Next()
+		if err != nil {
+			return token.Position{}, err
+		}
+		if e == nil {
+			break
+		}
+		switch e.Tag {
+		case dwarf.TagCompileUnit:
+			r.SkipChildren()
+			lr, err := data.LineReader(e)
+			if err != nil {
+				return token.Position{}, err
+			}
+			var lineEntry = dwarf.LineEntry{
+				EndSequence: true,
+			}
+			for {
+				// Read the next .debug_line entry.
+				prevLineEntry := lineEntry
+				err := lr.Next(&lineEntry)
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return token.Position{}, err
+				}
+
+				if prevLineEntry.EndSequence && lineEntry.Address == 0 {
+					// Tombstone value. This symbol has been removed, for
+					// example by the --gc-sections linker flag. It is still
+					// here in the debug information because the linker can't
+					// just remove this reference.
+					// Read until the next EndSequence so that this sequence is
+					// skipped.
+					// For more details, see (among others):
+					// https://reviews.llvm.org/D84825
+					for {
+						err := lr.Next(&lineEntry)
+						if err != nil {
+							return token.Position{}, err
+						}
+						if lineEntry.EndSequence {
+							break
+						}
+					}
+				}
+
+				if !prevLineEntry.EndSequence {
+					// The chunk describes the code from prevLineEntry to
+					// lineEntry.
+					if prevLineEntry.Address <= address && lineEntry.Address > address {
+						return token.Position{
+							Filename: prevLineEntry.File.Name,
+							Line:     prevLineEntry.Line,
+							Column:   prevLineEntry.Column,
+						}, nil
+					}
+				}
+			}
+		}
+	}
+
+	return token.Position{}, nil // location not found
+}
+
+// Read the DWARF debug information from a given file (in various formats).
+func readDWARF(executable string) (*dwarf.Data, error) {
+	f, err := os.Open(executable)
+	if err != nil {
+		return nil, err
+	}
+	if file, err := elf.NewFile(f); err == nil {
+		return file.DWARF()
+	} else if file, err := macho.NewFile(f); err == nil {
+		return file.DWARF()
+	} else if file, err := pe.NewFile(f); err == nil {
+		return file.DWARF()
+	} else {
+		return nil, errors.New("unknown binary format")
+	}
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/tinygo-org/tinygo/builder"
+	"github.com/tinygo-org/tinygo/compileopts"
+)
+
+func TestTraceback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// We care about testing the ELF format, which is only used on Linux
+		// (not on MacOS or Windows).
+		t.Skip("Test only works on Linux")
+	}
+
+	// Build a small binary that only panics.
+	tmpdir := t.TempDir()
+	config, err := builder.NewConfig(&compileopts.Options{
+		GOOS:          runtime.GOOS,
+		GOARCH:        runtime.GOARCH,
+		Opt:           "z",
+		InterpTimeout: time.Minute,
+		Debug:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := builder.Build("testdata/trivialpanic.go", ".elf", tmpdir, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run this binary, and capture the output.
+	buf := &bytes.Buffer{}
+	cmd := exec.Command(result.Binary)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	cmd.Run() // this will return an error because of the panic, ignore it
+
+	// Extract the "runtime error at" address.
+	line := bytes.TrimSpace(buf.Bytes())
+	address := extractPanicAddress(line)
+	if address == 0 {
+		t.Fatalf("could not extract panic address from %#v", string(line))
+	}
+
+	// Look up the source location for this address.
+	location, err := addressToLine(result.Executable, address)
+	if err != nil {
+		t.Fatal("could not read source location:", err)
+	}
+
+	// Verify that the source location is as expected.
+	if filepath.Base(location.Filename) != "trivialpanic.go" {
+		t.Errorf("expected path to end with trivialpanic.go, got %#v", location.Filename)
+	}
+	if location.Line != 6 {
+		t.Errorf("expected panic location to be line 6, got line %d", location.Line)
+	}
+}

--- a/src/runtime/arch-has-returnaddr.go
+++ b/src/runtime/arch-has-returnaddr.go
@@ -1,0 +1,10 @@
+//go:build !(avr || tinygo.wasm)
+
+package runtime
+
+import "unsafe"
+
+const hasReturnAddr = true
+
+//export llvm.returnaddress
+func returnAddress(level uint32) unsafe.Pointer

--- a/src/runtime/arch-no-returnaddr.go
+++ b/src/runtime/arch-no-returnaddr.go
@@ -1,0 +1,11 @@
+//go:build avr || tinygo.wasm
+
+package runtime
+
+import "unsafe"
+
+const hasReturnAddr = false
+
+func returnAddress(level uint32) unsafe.Pointer {
+	return nil
+}

--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -7,6 +7,8 @@ const TargetBits = 32
 
 const deferExtraRegs = 0
 
+const callInstSize = 5 // "call someFunction" is 5 bytes
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 15) &^ 15

--- a/src/runtime/arch_amd64.go
+++ b/src/runtime/arch_amd64.go
@@ -7,6 +7,8 @@ const TargetBits = 64
 
 const deferExtraRegs = 0
 
+const callInstSize = 5 // "call someFunction" is 5 bytes
+
 // Align a pointer.
 // Note that some amd64 instructions (like movaps) expect 16-byte aligned
 // memory, thus the result must be 16-byte aligned.

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -9,6 +9,8 @@ const TargetBits = 32
 
 const deferExtraRegs = 0
 
+const callInstSize = 4 // "bl someFunction" is 4 bytes
+
 // Align on the maximum alignment for this platform (double).
 func align(ptr uintptr) uintptr {
 	return (ptr + 7) &^ 7

--- a/src/runtime/arch_arm64.go
+++ b/src/runtime/arch_arm64.go
@@ -7,6 +7,8 @@ const TargetBits = 64
 
 const deferExtraRegs = 0
 
+const callInstSize = 4 // "bl someFunction" is 4 bytes
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 15) &^ 15

--- a/src/runtime/arch_avr.go
+++ b/src/runtime/arch_avr.go
@@ -11,6 +11,8 @@ const TargetBits = 8
 
 const deferExtraRegs = 1 // the frame pointer (Y register) also needs to be stored
 
+const callInstSize = 2 // "call" is 4 bytes, "rcall" is 2 bytes
+
 // Align on a word boundary.
 func align(ptr uintptr) uintptr {
 	// No alignment necessary on the AVR.

--- a/src/runtime/arch_cortexm.go
+++ b/src/runtime/arch_cortexm.go
@@ -13,6 +13,8 @@ const TargetBits = 32
 
 const deferExtraRegs = 0
 
+const callInstSize = 4 // "bl someFunction" is 4 bytes
+
 // Align on word boundary.
 func align(ptr uintptr) uintptr {
 	return (ptr + 7) &^ 7

--- a/src/runtime/arch_tinygoriscv.go
+++ b/src/runtime/arch_tinygoriscv.go
@@ -6,6 +6,8 @@ import "device/riscv"
 
 const deferExtraRegs = 0
 
+const callInstSize = 4 // 8 without relaxation, maybe 4 with relaxation
+
 // RISC-V has a maximum alignment of 16 bytes (both for RV32 and for RV64).
 // Source: https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf
 func align(ptr uintptr) uintptr {

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -13,6 +13,8 @@ const TargetBits = 32
 
 const deferExtraRegs = 0
 
+const callInstSize = 1 // unknown and irrelevant (llvm.returnaddress doesn't work), so make something up
+
 //go:extern __heap_base
 var heapStartSymbol [0]byte
 

--- a/src/runtime/arch_xtensa.go
+++ b/src/runtime/arch_xtensa.go
@@ -9,6 +9,8 @@ const TargetBits = 32
 
 const deferExtraRegs = 0
 
+const callInstSize = 3 // "callx0 someFunction" (and similar) is 3 bytes
+
 // The largest alignment according to the Xtensa ABI is 8 (long long, double).
 func align(ptr uintptr) uintptr {
 	return (ptr + 7) &^ 7

--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -278,7 +278,7 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	}
 
 	if interrupt.In() {
-		runtimePanic("alloc in interrupt")
+		runtimePanicAt(returnAddress(0), "alloc in interrupt")
 	}
 
 	gcTotalAlloc += uint64(size)
@@ -318,7 +318,7 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 					// Unfortunately the heap could not be increased. This
 					// happens on baremetal systems for example (where all
 					// available RAM has already been dedicated to the heap).
-					runtimePanic("out of memory")
+					runtimePanicAt(returnAddress(0), "out of memory")
 				}
 			}
 		}

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -54,7 +54,19 @@ func _panic(message interface{}) {
 
 // Cause a runtime panic, which is (currently) always a string.
 func runtimePanic(msg string) {
-	printstring("panic: runtime error: ")
+	// As long as this function is inined, llvm.returnaddress(0) will return
+	// something sensible.
+	runtimePanicAt(returnAddress(0), msg)
+}
+
+func runtimePanicAt(addr unsafe.Pointer, msg string) {
+	if hasReturnAddr {
+		printstring("panic: runtime error at ")
+		printptr(uintptr(addr) - callInstSize)
+		printstring(": ")
+	} else {
+		printstring("panic: runtime error: ")
+	}
 	println(msg)
 	abort()
 }
@@ -119,52 +131,52 @@ func _recover(useParentFrame bool) interface{} {
 
 // Panic when trying to dereference a nil pointer.
 func nilPanic() {
-	runtimePanic("nil pointer dereference")
+	runtimePanicAt(returnAddress(0), "nil pointer dereference")
 }
 
 // Panic when trying to add an entry to a nil map
 func nilMapPanic() {
-	runtimePanic("assignment to entry in nil map")
+	runtimePanicAt(returnAddress(0), "assignment to entry in nil map")
 }
 
 // Panic when trying to acces an array or slice out of bounds.
 func lookupPanic() {
-	runtimePanic("index out of range")
+	runtimePanicAt(returnAddress(0), "index out of range")
 }
 
 // Panic when trying to slice a slice out of bounds.
 func slicePanic() {
-	runtimePanic("slice out of range")
+	runtimePanicAt(returnAddress(0), "slice out of range")
 }
 
 // Panic when trying to convert a slice to an array pointer (Go 1.17+) and the
 // slice is shorter than the array.
 func sliceToArrayPointerPanic() {
-	runtimePanic("slice smaller than array")
+	runtimePanicAt(returnAddress(0), "slice smaller than array")
 }
 
 // Panic when calling unsafe.Slice() (Go 1.17+) or unsafe.String() (Go 1.20+)
 // with a len that's too large (which includes if the ptr is nil and len is
 // nonzero).
 func unsafeSlicePanic() {
-	runtimePanic("unsafe.Slice/String: len out of range")
+	runtimePanicAt(returnAddress(0), "unsafe.Slice/String: len out of range")
 }
 
 // Panic when trying to create a new channel that is too big.
 func chanMakePanic() {
-	runtimePanic("new channel is too big")
+	runtimePanicAt(returnAddress(0), "new channel is too big")
 }
 
 // Panic when a shift value is negative.
 func negativeShiftPanic() {
-	runtimePanic("negative shift")
+	runtimePanicAt(returnAddress(0), "negative shift")
 }
 
 // Panic when there is a divide by zero.
 func divideByZeroPanic() {
-	runtimePanic("divide by zero")
+	runtimePanicAt(returnAddress(0), "divide by zero")
 }
 
 func blockingPanic() {
-	runtimePanic("trying to do blocking operation in exported function")
+	runtimePanicAt(returnAddress(0), "trying to do blocking operation in exported function")
 }

--- a/testdata/trivialpanic.go
+++ b/testdata/trivialpanic.go
@@ -1,0 +1,7 @@
+package main
+
+var n *int
+
+func main() {
+	println(*n) // this will panic
+}


### PR DESCRIPTION
This PR adds the ability to print source locations for runtime panics. Here is an example:

    $ tinygo flash -target=circuitplay-bluefruit -monitor ./examples/heartrate
    Connected to /dev/ttyACM0. Press Ctrl-C to exit.
    tick 00:00.810
    tick 00:01.587
    tick 00:02.387
    tick 00:03.244
    panic: runtime error at 0x00027c4d: alloc in interrupt
    [tinygo: panic at /home/ayke/src/tinygo/bluetooth/adapter_sd.go:74:4]

To be clear, this path isn't stored on the microcontroller. It's stored as part of the build, and `-monitor` just looks up the path from the panic message.

Possible enhancements:

  - Print such an address for regular panics as well. I'm not sure that's so useful, as it's usually a lot easier to look up panics just by their message.
  - Use runtimePanicAt (instead of runtimePanic) in other locations, if that proves to be beneficial.
  - Print the TinyGo-generated output in some other color, to distinguish it from the regular console output.
  - Print more details when panicking (registers, stack values), and print an actual backtrace.