### PR TITLE
docs: update readme for brevity and to add more info about WebAssembly, macOS, and Windows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-Copyright (c) 2018-2022 The TinyGo Authors. All rights reserved.
+Copyright (c) 2018-2023 The TinyGo Authors. All rights reserved.
 
 TinyGo includes portions of the Go standard library.
-Copyright (c) 2009-2022 The Go Authors. All rights reserved.
+Copyright (c) 2009-2023 The Go Authors. All rights reserved.
 
 TinyGo includes portions of LLVM, which is under the Apache License v2.0 with
 LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Linux](https://github.com/tinygo-org/tinygo/actions/workflows/linux.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/tinygo/actions/workflows/linux.yml) [![macOS](https://github.com/tinygo-org/tinygo/actions/workflows/build-macos.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/tinygo/actions/workflows/build-macos.yml) [![Windows](https://github.com/tinygo-org/tinygo/actions/workflows/windows.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/tinygo/actions/workflows/windows.yml) [![Docker](https://github.com/tinygo-org/tinygo/actions/workflows/docker.yml/badge.svg?branch=dev)](https://github.com/tinygo-org/tinygo/actions/workflows/docker.yml) [![CircleCI](https://circleci.com/gh/tinygo-org/tinygo/tree/dev.svg?style=svg)](https://circleci.com/gh/tinygo-org/tinygo/tree/dev)
 
-TinyGo is a Go compiler intended for use in small places such as microcontrollers, WebAssembly (Wasm), and command-line tools.
+TinyGo is a Go compiler intended for use in small places such as microcontrollers, WebAssembly (wasm/wasi), and command-line tools.
 
 It reuses libraries used by the [Go language tools](https://golang.org/pkg/go/) alongside [LLVM](http://llvm.org) to provide an alternative way to compile programs written in the Go programming language.
+
+## Embedded
 
 Here is an example program that blinks the built-in LED when run directly on any supported board with onboard LED:
 
@@ -35,115 +37,62 @@ The above program can be compiled and run without modification on an Arduino Uno
 tinygo flash -target arduino examples/blinky1
 ```
 
+## WebAssembly
+
+TinyGo is very useful for compiling programs both for use in browsers (WASM) as well as for use on servers and other edge devices (WASI).
+
+TinyGo programs can run in Fastly Compute@Edge (https://developer.fastly.com/learning/compute/go/), Fermyon Spin (https://developer.fermyon.com/spin/go-components), wazero (https://wazero.io/languages/tinygo/) and many other WebAssembly runtimes.
+
+Here is a small TinyGo program for use by a WASI host application:
+
+```go
+package main
+
+//go:wasm-module yourmodulename
+//export add
+func add(x, y uint32) uint32 {
+	return x + y
+}
+
+// main is required for the `wasi` target, even if it isn't used.
+func main() {}
+```
+
+This compiles the above TinyGo program for use on any WASI runtime:
+
+```shell
+tinygo build -o main.wasm -target=wasi main.go
+```
+
 ## Installation
 
 See the [getting started instructions](https://tinygo.org/getting-started/) for information on how to install TinyGo, as well as how to run the TinyGo compiler using our Docker container.
 
-## Supported boards/targets
+## Supported targets
 
-You can compile TinyGo programs for microcontrollers, WebAssembly and Linux.
+### Embedded
 
-The following 94 microcontroller boards are currently supported:
+You can compile TinyGo programs for over 94 different microcontroller boards.
 
-* [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)
-* [Adafruit Circuit Playground Express](https://www.adafruit.com/product/3333)
-* [Adafruit CLUE](https://www.adafruit.com/product/4500)
-* [Adafruit Feather M0](https://www.adafruit.com/product/2772)
-* [Adafruit Feather M0 Express](https://www.adafruit.com/product/3403)
-* [Adafruit Feather M4](https://www.adafruit.com/product/3857)
-* [Adafruit Feather M4 CAN](https://www.adafruit.com/product/4759)
-* [Adafruit Feather nRF52840 Express](https://www.adafruit.com/product/4062)
-* [Adafruit Feather nRF52840 Sense](https://www.adafruit.com/product/4516)
-* [Adafruit Feather RP2040](https://www.adafruit.com/product/4884)
-* [Adafruit Feather STM32F405 Express](https://www.adafruit.com/product/4382)
-* [Adafruit Grand Central M4](https://www.adafruit.com/product/4064)
-* [Adafruit ItsyBitsy M0](https://www.adafruit.com/product/3727)
-* [Adafruit ItsyBitsy M4](https://www.adafruit.com/product/3800)
-* [Adafruit ItsyBitsy nRF52840](https://www.adafruit.com/product/4481)
-* [Adafruit KB2040](https://www.adafruit.com/product/5302)
-* [Adafruit MacroPad RP2040](https://www.adafruit.com/product/5100)
-* [Adafruit Matrix Portal M4](https://www.adafruit.com/product/4745)
-* [Adafruit Metro M4 Express Airlift](https://www.adafruit.com/product/4000)
-* [Adafruit PyBadge](https://www.adafruit.com/product/4200)
-* [Adafruit PyGamer](https://www.adafruit.com/product/4242)
-* [Adafruit PyPortal](https://www.adafruit.com/product/4116)
-* [Adafruit QT Py](https://www.adafruit.com/product/4600)
-* [Adafruit QT Py RP2040](https://www.adafruit.com/product/4900)
-* [Adafruit Trinket M0](https://www.adafruit.com/product/3500)
-* [Adafruit Trinkey QT2040](https://adafruit.com/product/5056)
-* [Arduino Mega 1280](https://www.arduino.cc/en/Main/arduinoBoardMega/)
-* [Arduino Mega 2560](https://store.arduino.cc/arduino-mega-2560-rev3)
-* [Arduino MKR1000](https://store.arduino.cc/arduino-mkr1000-wifi)
-* [Arduino MKR WiFi 1010](https://store.arduino.cc/usa/mkr-wifi-1010)
-* [Arduino Nano](https://store.arduino.cc/arduino-nano)
-* [Arduino Nano 33 BLE](https://store.arduino.cc/nano-33-ble)
-* [Arduino Nano 33 BLE Sense](https://store.arduino.cc/nano-33-ble-sense)
-* [Arduino Nano 33 IoT](https://store.arduino.cc/nano-33-iot)
-* [Arduino Nano RP2040 Connect](https://store.arduino.cc/nano-rp2040-connect)
-* [Arduino Uno](https://store.arduino.cc/arduino-uno-rev3)
-* [Arduino Zero](https://store.arduino.cc/usa/arduino-zero)
-* [BBC micro:bit](https://microbit.org/)
-* [BBC micro:bit v2](https://microbit.org/new-microbit/)
-* [blues wireless Swan](https://blues.io/products/swan/)
-* [Digispark](http://digistump.com/products/1)
-* [Dragino LoRaWAN GPS Tracker LGT-92](http://www.dragino.com/products/lora-lorawan-end-node/item/142-lgt-92.html)
-* [ESP32 - Core board](https://www.espressif.com/en/products/socs/esp32)
-* [ESP32 - mini32](https://www.espressif.com/en/products/socs/esp32)
-* [ESP32-C3-12f](https://www.espressif.com/en/products/socs/esp32-c3)
-* [ESP8266 - d1mini](https://www.espressif.com/en/products/socs/esp8266)
-* [ESP8266 - NodeMCU](https://www.espressif.com/en/products/socs/esp8266)
-* [Game Boy Advance](https://en.wikipedia.org/wiki/Game_Boy_Advance)
-* [iLabs Challenger RP2040 LoRa](https://ilabs.se/product/challenger-rp2040-lora/)
-* [M5Stack](https://docs.m5stack.com/en/core/basic)
-* [M5Stack Core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit)
-* [M5Stamp C3](https://docs.m5stack.com/en/core/stamp_c3)
-* [Makerdiary nRF52840-MDK](https://wiki.makerdiary.com/nrf52840-mdk/)
-* [Makerdiary nRF52840-MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)
-* [MCH2022 badge](https://badge.team/docs/badges/mch2022/)
-* [Microchip SAM E54 Xplained Pro](https://www.microchip.com/developmenttools/productdetails/atsame54-xpro)
-* [nice!nano](https://docs.nicekeyboards.com/#/nice!nano/)
-* [Nintendo Switch](https://www.nintendo.com/switch/)
-* [Nordic Semiconductor PCA10031](https://www.nordicsemi.com/eng/Products/nRF51-Dongle)
-* [Nordic Semiconductor PCA10040](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52-DK)
-* [Nordic Semiconductor PCA10056](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
-* [Nordic Semiconductor pca10059](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle)
-* [Particle Argon](https://docs.particle.io/datasheets/wi-fi/argon-datasheet/)
-* [Particle Boron](https://docs.particle.io/datasheets/cellular/boron-datasheet/)
-* [Particle Xenon](https://docs.particle.io/datasheets/discontinued/xenon-datasheet/)
-* [Phytec reel board](https://www.phytec.eu/product-eu/internet-of-things/reelboard/)
-* [Pimoroni Badger2040](https://shop.pimoroni.com/products/badger-2040)
-* [Pimoroni Tufty2040](https://shop.pimoroni.com/products/tufty-2040)
-* [PineTime DevKit](https://www.pine64.org/pinetime/)
-* [PJRC Teensy 3.6](https://www.pjrc.com/store/teensy36.html)
-* [PJRC Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
-* [PJRC Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
-* [ProductivityOpen P1AM-100](https://facts-engineering.github.io/modules/P1AM-100/P1AM-100.html)
-* [Raspberry Pi Pico](https://www.raspberrypi.org/products/raspberry-pi-pico/)
-* [Raytac MDBT50Q-RX Dongle (with TinyUF2 bootloader)](https://www.adafruit.com/product/5199)
-* [Seeed Seeeduino XIAO](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
-* [Seeed XIAO BLE](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html)
-* [Seeed XIAO ESP32C3](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)
-* [Seeed XIAO RP2040](https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html)
-* [Seeed LoRa-E5 Development Kit](https://www.seeedstudio.com/LoRa-E5-Dev-Kit-p-4868.html)
-* [Seeed Sipeed MAix BiT](https://www.seeedstudio.com/Sipeed-MAix-BiT-for-RISC-V-AI-IoT-p-2872.html)
-* [Seeed Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html)
-* [SiFIve HiFive1 Rev B](https://www.sifive.com/boards/hifive1-rev-b)
-* [Sparkfun Thing Plus RP2040](https://www.sparkfun.com/products/17745)
-* [ST Micro "Nucleo" F103RB](https://www.st.com/en/evaluation-tools/nucleo-f103rb.html)
-* [ST Micro "Nucleo" F722ZE](https://www.st.com/en/evaluation-tools/nucleo-f722ze.html)
-* [ST Micro "Nucleo" L031K6](https://www.st.com/ja/evaluation-tools/nucleo-l031k6.html)
-* [ST Micro "Nucleo" L432KC](https://www.st.com/ja/evaluation-tools/nucleo-l432kc.html)
-* [ST Micro "Nucleo" L552ZE](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html)
-* [ST Micro "Nucleo" WL55JC](https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html)
-* [ST Micro STM32F103XX "Bluepill"](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill)
-* [ST Micro STM32F407 "Discovery"](https://www.st.com/en/evaluation-tools/stm32f4discovery.html)
-* [ST Micro STM32F469 "Discovery"](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/32f469idiscovery.html)
-* [The Things Industries Generic Node Sensor Edition](https://www.genericnode.com/docs/sensor-edition/)
-* [Waveshare RP2040-Zero](https://www.waveshare.com/wiki/RP2040-Zero)
-* [X9 Pro smartwatch](https://github.com/curtpw/nRF5x-device-reverse-engineering/tree/master/X9-nrf52832-activity-tracker/)
+For more information, please see https://tinygo.org/docs/reference/microcontrollers/
 
+### WebAssembly
 
-For more information, see [this list of boards](https://tinygo.org/microcontrollers/). Pull requests for additional support are welcome!
+TinyGo programs can be compiled for both WASM and WASI targets.
+
+For more information, see https://tinygo.org/docs/guides/webassembly/
+
+### Operating Systems
+
+You can also compile programs for Linux, macOS, and Windows targets.
+
+For more information:
+
+- Linux https://tinygo.org/docs/guides/linux/
+
+- macOS https://tinygo.org/docs/guides/macos/
+
+- Windows https://tinygo.org/docs/guides/windows/
 
 ## Currently supported features:
 


### PR DESCRIPTION
This PR is to update the README to make it a bit shorter, since there are so many MCU boards. It also is to bring WebAssembly support a bit more into the spotlight.