### PR TITLE
cortexm: add "gdb" as a debugger

### DIFF
--- a/targets/cortex-m.json
+++ b/targets/cortex-m.json
@@ -26,5 +26,5 @@
 		"src/internal/task/task_stack_cortexm.S",
 		"src/runtime/asm_arm.S"
 	],
-	"gdb": ["gdb-multiarch", "arm-none-eabi-gdb"]
+	"gdb": ["gdb-multiarch", "arm-none-eabi-gdb", "gdb"]
 }


### PR DESCRIPTION
At least on Arch Linux ARM, there is no gdb-multiarch or something, just "gdb" and it works for 32-bit ARM as well.