### PR TITLE
builder: add link to compatibility matrix

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -34,6 +34,8 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 		return nil, fmt.Errorf("could not read version from GOROOT (%v): %v", goroot, err)
 	}
 	if major != 1 || minor < 18 || minor > 20 {
+		// Note: when this gets updated, also update the Go compatibility matrix:
+		// https://github.com/tinygo-org/tinygo-site/blob/dev/content/docs/reference/go-compat-matrix.md
 		return nil, fmt.Errorf("requires go version 1.18 through 1.20, got go%d.%d", major, minor)
 	}
 


### PR DESCRIPTION
For context, see: https://github.com/tinygo-org/tinygo-site/pull/327

It only needs to be updated every half year, so it's not too bad, and it could be very useful to some people.