### PR TITLE
machine/usb/hid/mouse: add support for mouse back and forward

### DIFF
--- a/src/machine/usb/descriptor/hid.go
+++ b/src/machine/usb/descriptor/hid.go
@@ -164,14 +164,14 @@ var CDCHID = Descriptor{
 			0x85, 0x01, // Report ID (1)
 			0x05, 0x09, // Usage Page (Buttons)
 			0x19, 0x01, // Usage Minimum (01)
-			0x29, 0x03, // Usage Maximun (03)
+			0x29, 0x05, // Usage Maximun (05)
 			0x15, 0x00, // Logical Minimum (0)
 			0x25, 0x01, // Logical Maximum (1)
-			0x95, 0x03, // Report Count (3)
+			0x95, 0x05, // Report Count (5)
 			0x75, 0x01, // Report Size (1)
 			0x81, 0x02, // Input (Data, Variable, Absolute), ;3 button bits
 			0x95, 0x01, // Report Count (1)
-			0x75, 0x05, // Report Size (5)
+			0x75, 0x03, // Report Size (3)
 			0x81, 0x03, //
 			0x05, 0x01, // Usage Page (Generic Desktop)
 			0x09, 0x30, // Usage (X)

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -13,6 +13,8 @@ const (
 	Left Button = 1 << iota
 	Right
 	Middle
+	Back
+	Forward
 )
 
 type mouse struct {


### PR DESCRIPTION
This PR supports the following

```go
m.Click(mouse.Forward)
m.Click(mouse.Back)
```