### PR TITLE
machine/usb/descriptor: refactor HID report descriptor creation

### DIFF
--- a/src/machine/usb/descriptor/cdc.go
+++ b/src/machine/usb/descriptor/cdc.go
@@ -152,7 +152,7 @@ var InterfaceCDCData = InterfaceType{
 
 var CDC = Descriptor{
 	Device: DeviceCDC.Bytes(),
-	Configuration: appendSlices([][]byte{
+	Configuration: Append([][]byte{
 		ConfigurationCDC.Bytes(),
 		InterfaceAssociationCDC.Bytes(),
 		InterfaceCDCControl.Bytes(),

--- a/src/machine/usb/descriptor/descriptor.go
+++ b/src/machine/usb/descriptor/descriptor.go
@@ -46,7 +46,7 @@ func (d *Descriptor) Configure(idVendor, idProduct uint16) {
 	conf.TotalLength(uint16(len(d.Configuration)))
 }
 
-func appendSlices[T any](slices [][]T) []T {
+func Append[T any](slices [][]T) []T {
 	var size, pos int
 
 	for _, s := range slices {

--- a/src/machine/usb/descriptor/hid.go
+++ b/src/machine/usb/descriptor/hid.go
@@ -130,73 +130,78 @@ var CDCHID = Descriptor{
 		EndpointEP4IN.Bytes(),
 	}),
 	HID: map[uint16][]byte{
-		2: []byte{
-			0x05, 0x01, // Usage Page (Generic Desktop)
-			0x09, 0x06, // Usage (Keyboard)
-			0xa1, 0x01, // Collection (Application)
-			0x85, 0x02, // Report ID (2)
-			0x05, 0x07, // Usage Page (KeyCodes)
-			0x19, 0xe0, // Usage Minimum (224)
-			0x29, 0xe7, // Usage Maximum (231)
-			0x15, 0x00, // Logical Minimum (0)
-			0x25, 0x01, // Logical Maximum (1)
-			0x75, 0x01, // Report Size (1)
-			0x95, 0x08, // Report Count (8)
-			0x81, 0x02, // Input (Data, Variable, Absolute), Modifier byte
-			0x95, 0x01, // Report Count (1)
-			0x75, 0x08, // Report Size (8)
-			0x81, 0x03, //
-			0x95, 0x06, // Report Count (6)
-			0x75, 0x08, // Report Size (8)
-			0x15, 0x00, // Logical Minimum (0),
-			0x25, 0xFF, //
-			0x05, 0x07, // Usage Page (KeyCodes)
-			0x19, 0x00, // Usage Minimum (0)
-			0x29, 0xFF, // Usage Maximum (255)
-			0x81, 0x00, // Input (Data, Array), Key arrays (6 bytes)
-			0xc0, // End Collection
+		2: appendSlices([][]byte{
+			HIDUsagePageGenericDesktop,
+			HIDUsageDesktopKeyboard,
+			HIDCollectionApplication,
+			HIDReportID(2),
 
-			0x05, 0x01, // Usage Page (Generic Desktop)
-			0x09, 0x02, // Usage (Mouse)
-			0xa1, 0x01, // Collection (Application)
-			0x09, 0x01, // Usage (Pointer)
-			0xa1, 0x00, // Collection (Physical)
-			0x85, 0x01, // Report ID (1)
-			0x05, 0x09, // Usage Page (Buttons)
-			0x19, 0x01, // Usage Minimum (01)
-			0x29, 0x05, // Usage Maximun (05)
-			0x15, 0x00, // Logical Minimum (0)
-			0x25, 0x01, // Logical Maximum (1)
-			0x95, 0x05, // Report Count (5)
-			0x75, 0x01, // Report Size (1)
-			0x81, 0x02, // Input (Data, Variable, Absolute), ;3 button bits
-			0x95, 0x01, // Report Count (1)
-			0x75, 0x03, // Report Size (3)
-			0x81, 0x03, //
-			0x05, 0x01, // Usage Page (Generic Desktop)
-			0x09, 0x30, // Usage (X)
-			0x09, 0x31, // Usage (Y)
-			0x09, 0x38, //
-			0x15, 0x81, // Logical Minimum (-127)
-			0x25, 0x7f, // Logical Maximum (127)
-			0x75, 0x08, // Report Size (8)
-			0x95, 0x03, // Report Count (3)
-			0x81, 0x06, // Input (Data, Variable, Relative), 2 position bytes (X & Y)
-			0xc0, // End Collection
-			0xc0, // End Collection
+			HIDUsagePageKeyboard,
+			HIDUsageMinimum(224),
+			HIDUsageMaximum(231),
+			HIDLogicalMinimum(0),
+			HIDLogicalMaximum(1),
+			HIDReportSize(1),
+			HIDReportCount(8),
+			HIDInputDataVarAbs,
+			HIDReportCount(1),
+			HIDReportSize(8),
+			HIDInputConstVarAbs,
+			HIDReportCount(6),
+			HIDReportSize(8),
+			HIDLogicalMinimum(0),
+			HIDLogicalMaximum(255),
 
-			0x05, 0x0C, // Usage Page (Consumer)
-			0x09, 0x01, // Usage (Consumer Control)
-			0xA1, 0x01, // Collection (Application)
-			0x85, 0x03, // Report ID (3)
-			0x15, 0x00, // Logical Minimum (0)
-			0x26, 0xFF, 0x1F, // Logical Maximum (8191)
-			0x19, 0x00, // Usage Minimum (Unassigned)
-			0x2A, 0xFF, 0x1F, // Usage Maximum (0x1FFF)
-			0x75, 0x10, // Report Size (16)
-			0x95, 0x01, // Report Count (1)
-			0x81, 0x00, // Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
-			0xC0, // End Collection
-		},
+			HIDUsagePageKeyboard,
+			HIDUsageMinimum(0),
+			HIDUsageMaximum(255),
+			HIDInputDataAryAbs,
+			HIDEndCollection,
+
+			HIDUsagePageGenericDesktop,
+			HIDUsageDesktopMouse,
+			HIDCollectionApplication,
+			HIDUsageDesktopPointer,
+			HIDCollectionPhysical,
+			HIDReportID(1),
+
+			HIDUsagePageButton,
+			HIDUsageMinimum(1),
+			HIDUsageMaximum(5),
+			HIDLogicalMinimum(0),
+			HIDLogicalMaximum(1),
+			HIDReportCount(5),
+			HIDReportSize(1),
+			HIDInputDataVarAbs,
+			HIDReportCount(1),
+			HIDReportSize(3),
+			HIDInputConstVarAbs,
+
+			HIDUsagePageGenericDesktop,
+			HIDUsageDesktopX,
+			HIDUsageDesktopY,
+			HIDUsageDesktopWheel,
+			HIDLogicalMinimum(-127),
+			HIDLogicalMaximum(127),
+			HIDReportSize(8),
+			HIDReportCount(3),
+			HIDInputDataVarRel,
+			HIDEndCollection,
+			HIDEndCollection,
+
+			HIDUsagePageConsumer,
+			HIDUsageConsumerControl,
+			HIDCollectionApplication,
+			HIDReportID(3),
+			HIDLogicalMinimum(0),
+			[]byte{
+				0x26, 0xFF, 0x1F, // Logical Maximum (8191)
+				0x19, 0x00, // Usage Minimum (Unassigned)
+				0x2A, 0xFF, 0x1F, // Usage Maximum (0x1FFF)
+			},
+			HIDReportSize(16),
+			HIDReportCount(1),
+			HIDInputDataAryAbs,
+			HIDEndCollection}),
 	},
 }

--- a/src/machine/usb/descriptor/hid.go
+++ b/src/machine/usb/descriptor/hid.go
@@ -156,7 +156,7 @@ var CDCHID = Descriptor{
 			HIDUsageMinimum(0),
 			HIDUsageMaximum(255),
 			HIDInputDataAryAbs,
-			HIDEndCollection,
+			HIDCollectionEnd,
 
 			HIDUsagePageGenericDesktop,
 			HIDUsageDesktopMouse,
@@ -186,22 +186,20 @@ var CDCHID = Descriptor{
 			HIDReportSize(8),
 			HIDReportCount(3),
 			HIDInputDataVarRel,
-			HIDEndCollection,
-			HIDEndCollection,
+			HIDCollectionEnd,
+			HIDCollectionEnd,
 
 			HIDUsagePageConsumer,
 			HIDUsageConsumerControl,
 			HIDCollectionApplication,
 			HIDReportID(3),
 			HIDLogicalMinimum(0),
-			[]byte{
-				0x26, 0xFF, 0x1F, // Logical Maximum (8191)
-				0x19, 0x00, // Usage Minimum (Unassigned)
-				0x2A, 0xFF, 0x1F, // Usage Maximum (0x1FFF)
-			},
+			HIDLogicalMaximum(8191),
+			HIDUsageMinimum(0),
+			HIDUsageMaximum(0x1FFF),
 			HIDReportSize(16),
 			HIDReportCount(1),
 			HIDInputDataAryAbs,
-			HIDEndCollection}),
+			HIDCollectionEnd}),
 	},
 }

--- a/src/machine/usb/descriptor/hid.go
+++ b/src/machine/usb/descriptor/hid.go
@@ -113,7 +113,7 @@ var ClassHID = ClassHIDType{
 
 var CDCHID = Descriptor{
 	Device: DeviceCDC.Bytes(),
-	Configuration: appendSlices([][]byte{
+	Configuration: Append([][]byte{
 		ConfigurationCDCHID.Bytes(),
 		InterfaceAssociationCDC.Bytes(),
 		InterfaceCDCControl.Bytes(),
@@ -130,7 +130,7 @@ var CDCHID = Descriptor{
 		EndpointEP4IN.Bytes(),
 	}),
 	HID: map[uint16][]byte{
-		2: appendSlices([][]byte{
+		2: Append([][]byte{
 			HIDUsagePageGenericDesktop,
 			HIDUsageDesktopKeyboard,
 			HIDCollectionApplication,

--- a/src/machine/usb/descriptor/hidreport.go
+++ b/src/machine/usb/descriptor/hidreport.go
@@ -1,130 +1,201 @@
 package descriptor
 
-var (
-	HIDUsagePageGenericDesktop     = []byte{0x05, 0x01}
-	HIDUsagePageSimulationControls = []byte{0x05, 0x02}
-	HIDUsagePageVRControls         = []byte{0x05, 0x03}
-	HIDUsagePageSportControls      = []byte{0x05, 0x04}
-	HIDUsagePageGameControls       = []byte{0x05, 0x05}
-	HIDUsagePageGenericControls    = []byte{0x05, 0x06}
-	HIDUsagePageKeyboard           = []byte{0x05, 0x07}
-	HIDUsagePageLED                = []byte{0x05, 0x08}
-	HIDUsagePageButton             = []byte{0x05, 0x09}
-	HIDUsagePageOrdinal            = []byte{0x05, 0x0A}
-	HIDUsagePageTelephony          = []byte{0x05, 0x0B}
-	HIDUsagePageConsumer           = []byte{0x05, 0x0C}
-	HIDUsagePageDigitizers         = []byte{0x05, 0x0D}
-	HIDUsagePageHaptics            = []byte{0x05, 0x0E}
-	HIDUsagePagePhysicalInput      = []byte{0x05, 0x0F}
-	HIDUsagePageUnicode            = []byte{0x05, 0x10}
-	HIDUsagePageSoC                = []byte{0x05, 0x11}
-	HIDUsagePageEyeHeadTrackers    = []byte{0x05, 0x12}
-	HIDUsagePageAuxDisplay         = []byte{0x05, 0x14}
-	HIDUsagePageSensors            = []byte{0x05, 0x20}
-	HIDUsagePageMedicalInstrument  = []byte{0x05, 0x40}
-	HIDUsagePageBrailleDisplay     = []byte{0x05, 0x41}
-	HIDUsagePageLighting           = []byte{0x05, 0x59}
-	HIDUsagePageMonitor            = []byte{0x05, 0x80}
-	HIDUsagePageMonitorEnum        = []byte{0x05, 0x81}
-	HIDUsagePageVESA               = []byte{0x05, 0x82}
-	HIDUsagePagePower              = []byte{0x05, 0x84}
-	HIDUsagePageBatterySystem      = []byte{0x05, 0x85}
-	HIDUsagePageBarcodeScanner     = []byte{0x05, 0x8C}
-	HIDUsagePageScales             = []byte{0x05, 0x8D}
-	HIDUsagePageMagneticStripe     = []byte{0x05, 0x8E}
-	HIDUsagePageCameraControl      = []byte{0x05, 0x90}
-	HIDUsagePageArcade             = []byte{0x05, 0x91}
-	HIDUsagePageGaming             = []byte{0x05, 0x92}
+import (
+	"encoding/binary"
+)
+
+const (
+	hidUsagePage       = 0x05
+	hidUsage           = 0x09
+	hidLogicalMinimum  = 0x15
+	hidLogicalMaximum  = 0x25
+	hidUsageMinimum    = 0x19
+	hidUsageMaximum    = 0x29
+	hidPhysicalMinimum = 0x35
+	hidPhysicalMaximum = 0x46
+	hidUnitExponent    = 0x55
+	hidUnit            = 0x65
+	hidCollection      = 0xa1
+	hidInput           = 0x81
+	hidReportSize      = 0x75
+	hidReportCount     = 0x95
+	hidReportID        = 0x85
 )
 
 var (
-	HIDUsageDesktopPointer         = []byte{0x09, 0x01}
-	HIDUsageDesktopMouse           = []byte{0x09, 0x02}
-	HIDUsageDesktopJoystick        = []byte{0x09, 0x04}
-	HIDUsageDesktopGamepad         = []byte{0x09, 0x05}
-	HIDUsageDesktopKeyboard        = []byte{0x09, 0x06}
-	HIDUsageDesktopKeypad          = []byte{0x09, 0x07}
-	HIDUsageDesktopMultiaxis       = []byte{0x09, 0x08}
-	HIDUsageDesktopTablet          = []byte{0x09, 0x09}
-	HIDUsageDesktopWaterCooling    = []byte{0x09, 0x0A}
-	HIDUsageDesktopChassis         = []byte{0x09, 0x0B}
-	HIDUsageDesktopWireless        = []byte{0x09, 0x0C}
-	HIDUsageDesktopPortable        = []byte{0x09, 0x0D}
-	HIDUsageDesktopSystemMultiaxis = []byte{0x09, 0x0E}
-	HIDUsageDesktopSpatial         = []byte{0x09, 0x0F}
-	HIDUsageDesktopAssistive       = []byte{0x09, 0x10}
-	HIDUsageDesktopDock            = []byte{0x09, 0x11}
-	HIDUsageDesktopDockable        = []byte{0x09, 0x12}
-	HIDUsageDesktopCallState       = []byte{0x09, 0x13}
-	HIDUsageDesktopX               = []byte{0x09, 0x30}
-	HIDUsageDesktopY               = []byte{0x09, 0x31}
-	HIDUsageDesktopZ               = []byte{0x09, 0x32}
-	HIDUsageDesktopRx              = []byte{0x09, 0x33}
-	HIDUsageDesktopRy              = []byte{0x09, 0x34}
-	HIDUsageDesktopRz              = []byte{0x09, 0x35}
-	HIDUsageDesktopSlider          = []byte{0x09, 0x36}
-	HIDUsageDesktopDial            = []byte{0x09, 0x37}
-	HIDUsageDesktopWheel           = []byte{0x09, 0x38}
-	HIDUsageDesktopHatSwitch       = []byte{0x09, 0x39}
-	HIDUsageDesktopCountedBuffer   = []byte{0x09, 0x3A}
+	HIDUsagePageGenericDesktop     = []byte{hidUsagePage, 0x01}
+	HIDUsagePageSimulationControls = []byte{hidUsagePage, 0x02}
+	HIDUsagePageVRControls         = []byte{hidUsagePage, 0x03}
+	HIDUsagePageSportControls      = []byte{hidUsagePage, 0x04}
+	HIDUsagePageGameControls       = []byte{hidUsagePage, 0x05}
+	HIDUsagePageGenericControls    = []byte{hidUsagePage, 0x06}
+	HIDUsagePageKeyboard           = []byte{hidUsagePage, 0x07}
+	HIDUsagePageLED                = []byte{hidUsagePage, 0x08}
+	HIDUsagePageButton             = []byte{hidUsagePage, 0x09}
+	HIDUsagePageOrdinal            = []byte{hidUsagePage, 0x0A}
+	HIDUsagePageTelephony          = []byte{hidUsagePage, 0x0B}
+	HIDUsagePageConsumer           = []byte{hidUsagePage, 0x0C}
+	HIDUsagePageDigitizers         = []byte{hidUsagePage, 0x0D}
+	HIDUsagePageHaptics            = []byte{hidUsagePage, 0x0E}
+	HIDUsagePagePhysicalInput      = []byte{hidUsagePage, 0x0F}
+	HIDUsagePageUnicode            = []byte{hidUsagePage, 0x10}
+	HIDUsagePageSoC                = []byte{hidUsagePage, 0x11}
+	HIDUsagePageEyeHeadTrackers    = []byte{hidUsagePage, 0x12}
+	HIDUsagePageAuxDisplay         = []byte{hidUsagePage, 0x14}
+	HIDUsagePageSensors            = []byte{hidUsagePage, 0x20}
+	HIDUsagePageMedicalInstrument  = []byte{hidUsagePage, 0x40}
+	HIDUsagePageBrailleDisplay     = []byte{hidUsagePage, 0x41}
+	HIDUsagePageLighting           = []byte{hidUsagePage, 0x59}
+	HIDUsagePageMonitor            = []byte{hidUsagePage, 0x80}
+	HIDUsagePageMonitorEnum        = []byte{hidUsagePage, 0x81}
+	HIDUsagePageVESA               = []byte{hidUsagePage, 0x82}
+	HIDUsagePagePower              = []byte{hidUsagePage, 0x84}
+	HIDUsagePageBatterySystem      = []byte{hidUsagePage, 0x85}
+	HIDUsagePageBarcodeScanner     = []byte{hidUsagePage, 0x8C}
+	HIDUsagePageScales             = []byte{hidUsagePage, 0x8D}
+	HIDUsagePageMagneticStripe     = []byte{hidUsagePage, 0x8E}
+	HIDUsagePageCameraControl      = []byte{hidUsagePage, 0x90}
+	HIDUsagePageArcade             = []byte{hidUsagePage, 0x91}
+	HIDUsagePageGaming             = []byte{hidUsagePage, 0x92}
 )
 
 var (
-	HIDUsageConsumerControl             = []byte{0x09, 0x01}
-	HIDUsageConsumerNumericKeypad       = []byte{0x09, 0x02}
-	HIDUsageConsumerProgrammableButtons = []byte{0x09, 0x03}
-	HIDUsageConsumerMicrophone          = []byte{0x09, 0x04}
-	HIDUsageConsumerHeadphone           = []byte{0x09, 0x05}
-	HIDUsageConsumerGraphicEqualizer    = []byte{0x09, 0x06}
+	HIDUsageDesktopPointer         = []byte{hidUsage, 0x01}
+	HIDUsageDesktopMouse           = []byte{hidUsage, 0x02}
+	HIDUsageDesktopJoystick        = []byte{hidUsage, 0x04}
+	HIDUsageDesktopGamepad         = []byte{hidUsage, 0x05}
+	HIDUsageDesktopKeyboard        = []byte{hidUsage, 0x06}
+	HIDUsageDesktopKeypad          = []byte{hidUsage, 0x07}
+	HIDUsageDesktopMultiaxis       = []byte{hidUsage, 0x08}
+	HIDUsageDesktopTablet          = []byte{hidUsage, 0x09}
+	HIDUsageDesktopWaterCooling    = []byte{hidUsage, 0x0A}
+	HIDUsageDesktopChassis         = []byte{hidUsage, 0x0B}
+	HIDUsageDesktopWireless        = []byte{hidUsage, 0x0C}
+	HIDUsageDesktopPortable        = []byte{hidUsage, 0x0D}
+	HIDUsageDesktopSystemMultiaxis = []byte{hidUsage, 0x0E}
+	HIDUsageDesktopSpatial         = []byte{hidUsage, 0x0F}
+	HIDUsageDesktopAssistive       = []byte{hidUsage, 0x10}
+	HIDUsageDesktopDock            = []byte{hidUsage, 0x11}
+	HIDUsageDesktopDockable        = []byte{hidUsage, 0x12}
+	HIDUsageDesktopCallState       = []byte{hidUsage, 0x13}
+	HIDUsageDesktopX               = []byte{hidUsage, 0x30}
+	HIDUsageDesktopY               = []byte{hidUsage, 0x31}
+	HIDUsageDesktopZ               = []byte{hidUsage, 0x32}
+	HIDUsageDesktopRx              = []byte{hidUsage, 0x33}
+	HIDUsageDesktopRy              = []byte{hidUsage, 0x34}
+	HIDUsageDesktopRz              = []byte{hidUsage, 0x35}
+	HIDUsageDesktopSlider          = []byte{hidUsage, 0x36}
+	HIDUsageDesktopDial            = []byte{hidUsage, 0x37}
+	HIDUsageDesktopWheel           = []byte{hidUsage, 0x38}
+	HIDUsageDesktopHatSwitch       = []byte{hidUsage, 0x39}
+	HIDUsageDesktopCountedBuffer   = []byte{hidUsage, 0x3A}
 )
 
 var (
-	HIDCollectionPhysical    = []byte{0xa1, 0x00}
-	HIDCollectionApplication = []byte{0xa1, 0x01}
+	HIDUsageConsumerControl             = []byte{hidUsage, 0x01}
+	HIDUsageConsumerNumericKeypad       = []byte{hidUsage, 0x02}
+	HIDUsageConsumerProgrammableButtons = []byte{hidUsage, 0x03}
+	HIDUsageConsumerMicrophone          = []byte{hidUsage, 0x04}
+	HIDUsageConsumerHeadphone           = []byte{hidUsage, 0x05}
+	HIDUsageConsumerGraphicEqualizer    = []byte{hidUsage, 0x06}
 )
 
 var (
-	HIDEndCollection = []byte{0xc0}
+	HIDCollectionPhysical    = []byte{hidCollection, 0x00}
+	HIDCollectionApplication = []byte{hidCollection, 0x01}
+	HIDCollectionEnd         = []byte{0xc0}
 )
 
 var (
 	// Input (Data,Ary,Abs), Key arrays (6 bytes)
-	HIDInputDataAryAbs = []byte{0x81, 0x00}
+	HIDInputDataAryAbs = []byte{hidInput, 0x00}
 
 	// Input (Data, Variable, Absolute), Modifier byte
-	HIDInputDataVarAbs = []byte{0x81, 0x02}
+	HIDInputDataVarAbs = []byte{hidInput, 0x02}
 
 	// Input (Const,Var,Abs), Modifier byte
-	HIDInputConstVarAbs = []byte{0x81, 0x03}
+	HIDInputConstVarAbs = []byte{hidInput, 0x03}
 
 	// Input (Data, Variable, Relative), 2 position bytes (X & Y)
-	HIDInputDataVarRel = []byte{0x81, 0x06}
+	HIDInputDataVarRel = []byte{hidInput, 0x06}
 )
 
 func HIDReportSize(size int) []byte {
-	return []byte{0x75, byte(size)}
+	return []byte{hidReportSize, byte(size)}
 }
 
 func HIDReportCount(count int) []byte {
-	return []byte{0x95, byte(count)}
+	return []byte{hidReportCount, byte(count)}
 }
 
 func HIDReportID(id int) []byte {
-	return []byte{0x85, byte(id)}
+	return []byte{hidReportID, byte(id)}
 }
 
 func HIDLogicalMinimum(min int) []byte {
-	return []byte{0x15, byte(min)}
+	if min < -255 {
+		result := []byte{hidLogicalMinimum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(min))
+		return result
+	}
+
+	return []byte{hidLogicalMinimum, byte(min)}
 }
 
 func HIDLogicalMaximum(max int) []byte {
-	return []byte{0x25, byte(max)}
+	if max > 255 {
+		result := []byte{hidLogicalMaximum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(max))
+		return result
+	}
+
+	return []byte{hidLogicalMaximum, byte(max)}
 }
 
 func HIDUsageMinimum(min int) []byte {
-	return []byte{0x19, byte(min)}
+	if min < -255 {
+		result := []byte{hidUsageMinimum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(min))
+		return result
+	}
+
+	return []byte{hidUsageMinimum, byte(min)}
 }
 
 func HIDUsageMaximum(max int) []byte {
-	return []byte{0x29, byte(max)}
+	if max > 255 {
+		result := []byte{hidUsageMaximum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(max))
+		return result
+	}
+
+	return []byte{hidUsageMaximum, byte(max)}
+}
+
+func HIDPhysicalMinimum(min int) []byte {
+	if min < -255 {
+		result := []byte{hidPhysicalMinimum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(min))
+		return result
+	}
+
+	return []byte{hidPhysicalMinimum, byte(min)}
+}
+
+func HIDPhysicalMaximum(max int) []byte {
+	if max > 255 {
+		result := []byte{hidPhysicalMaximum, 0x0, 0x0}
+		binary.LittleEndian.PutUint16(result[1:3], uint16(max))
+		return result
+	}
+
+	return []byte{hidPhysicalMaximum, byte(max)}
+}
+
+func HIDUnitExponent(exp int) []byte {
+	return []byte{hidUnitExponent, byte(exp)}
+}
+
+func HIDUnit(unit int) []byte {
+	return []byte{hidUnit, byte(unit)}
 }

--- a/src/machine/usb/descriptor/hidreport.go
+++ b/src/machine/usb/descriptor/hidreport.go
@@ -1,0 +1,130 @@
+package descriptor
+
+var (
+	HIDUsagePageGenericDesktop     = []byte{0x05, 0x01}
+	HIDUsagePageSimulationControls = []byte{0x05, 0x02}
+	HIDUsagePageVRControls         = []byte{0x05, 0x03}
+	HIDUsagePageSportControls      = []byte{0x05, 0x04}
+	HIDUsagePageGameControls       = []byte{0x05, 0x05}
+	HIDUsagePageGenericControls    = []byte{0x05, 0x06}
+	HIDUsagePageKeyboard           = []byte{0x05, 0x07}
+	HIDUsagePageLED                = []byte{0x05, 0x08}
+	HIDUsagePageButton             = []byte{0x05, 0x09}
+	HIDUsagePageOrdinal            = []byte{0x05, 0x0A}
+	HIDUsagePageTelephony          = []byte{0x05, 0x0B}
+	HIDUsagePageConsumer           = []byte{0x05, 0x0C}
+	HIDUsagePageDigitizers         = []byte{0x05, 0x0D}
+	HIDUsagePageHaptics            = []byte{0x05, 0x0E}
+	HIDUsagePagePhysicalInput      = []byte{0x05, 0x0F}
+	HIDUsagePageUnicode            = []byte{0x05, 0x10}
+	HIDUsagePageSoC                = []byte{0x05, 0x11}
+	HIDUsagePageEyeHeadTrackers    = []byte{0x05, 0x12}
+	HIDUsagePageAuxDisplay         = []byte{0x05, 0x14}
+	HIDUsagePageSensors            = []byte{0x05, 0x20}
+	HIDUsagePageMedicalInstrument  = []byte{0x05, 0x40}
+	HIDUsagePageBrailleDisplay     = []byte{0x05, 0x41}
+	HIDUsagePageLighting           = []byte{0x05, 0x59}
+	HIDUsagePageMonitor            = []byte{0x05, 0x80}
+	HIDUsagePageMonitorEnum        = []byte{0x05, 0x81}
+	HIDUsagePageVESA               = []byte{0x05, 0x82}
+	HIDUsagePagePower              = []byte{0x05, 0x84}
+	HIDUsagePageBatterySystem      = []byte{0x05, 0x85}
+	HIDUsagePageBarcodeScanner     = []byte{0x05, 0x8C}
+	HIDUsagePageScales             = []byte{0x05, 0x8D}
+	HIDUsagePageMagneticStripe     = []byte{0x05, 0x8E}
+	HIDUsagePageCameraControl      = []byte{0x05, 0x90}
+	HIDUsagePageArcade             = []byte{0x05, 0x91}
+	HIDUsagePageGaming             = []byte{0x05, 0x92}
+)
+
+var (
+	HIDUsageDesktopPointer         = []byte{0x09, 0x01}
+	HIDUsageDesktopMouse           = []byte{0x09, 0x02}
+	HIDUsageDesktopJoystick        = []byte{0x09, 0x04}
+	HIDUsageDesktopGamepad         = []byte{0x09, 0x05}
+	HIDUsageDesktopKeyboard        = []byte{0x09, 0x06}
+	HIDUsageDesktopKeypad          = []byte{0x09, 0x07}
+	HIDUsageDesktopMultiaxis       = []byte{0x09, 0x08}
+	HIDUsageDesktopTablet          = []byte{0x09, 0x09}
+	HIDUsageDesktopWaterCooling    = []byte{0x09, 0x0A}
+	HIDUsageDesktopChassis         = []byte{0x09, 0x0B}
+	HIDUsageDesktopWireless        = []byte{0x09, 0x0C}
+	HIDUsageDesktopPortable        = []byte{0x09, 0x0D}
+	HIDUsageDesktopSystemMultiaxis = []byte{0x09, 0x0E}
+	HIDUsageDesktopSpatial         = []byte{0x09, 0x0F}
+	HIDUsageDesktopAssistive       = []byte{0x09, 0x10}
+	HIDUsageDesktopDock            = []byte{0x09, 0x11}
+	HIDUsageDesktopDockable        = []byte{0x09, 0x12}
+	HIDUsageDesktopCallState       = []byte{0x09, 0x13}
+	HIDUsageDesktopX               = []byte{0x09, 0x30}
+	HIDUsageDesktopY               = []byte{0x09, 0x31}
+	HIDUsageDesktopZ               = []byte{0x09, 0x32}
+	HIDUsageDesktopRx              = []byte{0x09, 0x33}
+	HIDUsageDesktopRy              = []byte{0x09, 0x34}
+	HIDUsageDesktopRz              = []byte{0x09, 0x35}
+	HIDUsageDesktopSlider          = []byte{0x09, 0x36}
+	HIDUsageDesktopDial            = []byte{0x09, 0x37}
+	HIDUsageDesktopWheel           = []byte{0x09, 0x38}
+	HIDUsageDesktopHatSwitch       = []byte{0x09, 0x39}
+	HIDUsageDesktopCountedBuffer   = []byte{0x09, 0x3A}
+)
+
+var (
+	HIDUsageConsumerControl             = []byte{0x09, 0x01}
+	HIDUsageConsumerNumericKeypad       = []byte{0x09, 0x02}
+	HIDUsageConsumerProgrammableButtons = []byte{0x09, 0x03}
+	HIDUsageConsumerMicrophone          = []byte{0x09, 0x04}
+	HIDUsageConsumerHeadphone           = []byte{0x09, 0x05}
+	HIDUsageConsumerGraphicEqualizer    = []byte{0x09, 0x06}
+)
+
+var (
+	HIDCollectionPhysical    = []byte{0xa1, 0x00}
+	HIDCollectionApplication = []byte{0xa1, 0x01}
+)
+
+var (
+	HIDEndCollection = []byte{0xc0}
+)
+
+var (
+	// Input (Data,Ary,Abs), Key arrays (6 bytes)
+	HIDInputDataAryAbs = []byte{0x81, 0x00}
+
+	// Input (Data, Variable, Absolute), Modifier byte
+	HIDInputDataVarAbs = []byte{0x81, 0x02}
+
+	// Input (Const,Var,Abs), Modifier byte
+	HIDInputConstVarAbs = []byte{0x81, 0x03}
+
+	// Input (Data, Variable, Relative), 2 position bytes (X & Y)
+	HIDInputDataVarRel = []byte{0x81, 0x06}
+)
+
+func HIDReportSize(size int) []byte {
+	return []byte{0x75, byte(size)}
+}
+
+func HIDReportCount(count int) []byte {
+	return []byte{0x95, byte(count)}
+}
+
+func HIDReportID(id int) []byte {
+	return []byte{0x85, byte(id)}
+}
+
+func HIDLogicalMinimum(min int) []byte {
+	return []byte{0x15, byte(min)}
+}
+
+func HIDLogicalMaximum(max int) []byte {
+	return []byte{0x25, byte(max)}
+}
+
+func HIDUsageMinimum(min int) []byte {
+	return []byte{0x19, byte(min)}
+}
+
+func HIDUsageMaximum(max int) []byte {
+	return []byte{0x29, byte(max)}
+}

--- a/src/machine/usb/descriptor/joystick.go
+++ b/src/machine/usb/descriptor/joystick.go
@@ -83,40 +83,32 @@ var JoystickDefaultHIDReport = Append([][]byte{
 	HIDInputDataVarAbs,
 	HIDReportCount(1),
 	HIDReportSize(3),
-	[]byte{
-		0x55, 0x00, // Unit Exponent (-16)
-		0x65, 0x00, // Unit (0x00)
-	},
+	HIDUnitExponent(-16),
+	HIDUnit(0),
 	HIDInputDataVarAbs,
 
 	HIDUsagePageGenericDesktop,
 	HIDUsageDesktopHatSwitch,
 	HIDLogicalMinimum(0),
 	HIDLogicalMaximum(7),
-	[]byte{
-		0x35, 0x00, // PHYSICAL_MINIMUM (0)
-		0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
-		0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
-	},
+	HIDPhysicalMinimum(0),
+	HIDPhysicalMaximum(315),
+	HIDUnit(0x14),
 	HIDReportCount(1),
 	HIDReportSize(4),
 	HIDInputDataVarAbs,
 	HIDUsageDesktopHatSwitch,
 	HIDLogicalMinimum(0),
 	HIDLogicalMaximum(7),
-	[]byte{
-		0x35, 0x00, // PHYSICAL_MINIMUM (0)
-		0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
-		0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
-	},
+	HIDPhysicalMinimum(0),
+	HIDPhysicalMaximum(315),
+	HIDUnit(0x14),
 	HIDReportCount(1),
 	HIDReportSize(4),
 	HIDInputDataVarAbs,
 	HIDUsageDesktopPointer,
-	[]byte{
-		0x16, 0x01, 0x80, // LOGICAL_MINIMUM (-32767)
-		0x26, 0xff, 0x7f, // LOGICAL_MAXIMUM (32767)
-	},
+	HIDLogicalMinimum(-32767),
+	HIDLogicalMaximum(32767),
 	HIDReportCount(6),
 	HIDReportSize(16),
 	HIDCollectionPhysical,
@@ -127,8 +119,8 @@ var JoystickDefaultHIDReport = Append([][]byte{
 	HIDUsageDesktopRy,
 	HIDUsageDesktopRz,
 	HIDInputDataVarAbs,
-	HIDEndCollection,
-	HIDEndCollection,
+	HIDCollectionEnd,
+	HIDCollectionEnd,
 })
 
 // CDCJoystick requires that you append the JoystickDescriptor

--- a/src/machine/usb/descriptor/joystick.go
+++ b/src/machine/usb/descriptor/joystick.go
@@ -68,7 +68,7 @@ var ClassHIDJoystick = ClassHIDType{
 	data: classHIDJoystick[:],
 }
 
-var JoystickDefaultHIDReport = appendSlices([][]byte{
+var JoystickDefaultHIDReport = Append([][]byte{
 	HIDUsagePageGenericDesktop,
 	HIDUsageDesktopJoystick,
 	HIDCollectionApplication,
@@ -136,7 +136,7 @@ var JoystickDefaultHIDReport = appendSlices([][]byte{
 // custom configurations.
 var CDCJoystick = Descriptor{
 	Device: DeviceJoystick.Bytes(),
-	Configuration: appendSlices([][]byte{
+	Configuration: Append([][]byte{
 		ConfigurationCDCJoystick.Bytes(),
 		InterfaceAssociationCDC.Bytes(),
 		InterfaceCDCControl.Bytes(),

--- a/src/machine/usb/descriptor/joystick.go
+++ b/src/machine/usb/descriptor/joystick.go
@@ -68,56 +68,68 @@ var ClassHIDJoystick = ClassHIDType{
 	data: classHIDJoystick[:],
 }
 
-var JoystickDefaultHIDReport = []byte{
-	0x05, 0x01, // Usage page
-	0x09, 0x04, // Joystick
-	0xa1, 0x01, // COLLECTION (Application)
-	0x85, 0x01, // REPORT_ID (1)
-	0x05, 0x09, // USAGE_PAGE (Button)
-	0x19, 0x01, // USAGE_MINIMUM (Button 1)
-	0x29, 0x10, // USAGE_MAXIMUM (Button 16)
-	0x15, 0x00, // LOGICAL_MINIMUM (0)
-	0x25, 0x01, // LOGICAL_MAXIMUM (1)
-	0x75, 0x01, // REPORT_SIZE (1)
-	0x95, 0x10, // REPORT_COUNT (16)
-	0x55, 0x00, // Unit Exponent (-16)
-	0x65, 0x00, // Unit (0x00)
-	0x81, 0x02, // INPUT (Data/Var/Abs)
-	0x05, 0x01, // USAGE_PAGE (Generic Desktop Controls)
-	0x09, 0x39, // USAGE(Hat Switch)
-	0x15, 0x00, // LOGICAL_MINIMUM (0)
-	0x25, 0x07, // LOGICAL_MAXIMUM (7)
-	0x35, 0x00, // PHYSICAL_MINIMUM (0)
-	0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
-	0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
-	0x75, 0x04, // REPORT_SIZE (4)
-	0x95, 0x01, // REPORT_COUNT (1)
-	0x81, 0x02, // INPUT (Data/Var/Abs)
-	0x09, 0x39, // USAGE(Hat Switch)
-	0x15, 0x00, // LOGICAL_MINIMUM (0)
-	0x25, 0x07, // LOGICAL_MAXIMUM (7)
-	0x35, 0x00, // PHYSICAL_MINIMUM (0)
-	0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
-	0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
-	0x75, 0x04, // REPORT_SIZE (4)
-	0x95, 0x01, // REPORT_COUNT (1)
-	0x81, 0x02, // INPUT (Data/Var/Abs)
-	0x09, 0x01, // USAGE (Pointer)
-	0x16, 0x01, 0x80, // LOGICAL_MINIMUM (-32767)
-	0x26, 0xff, 0x7f, // LOGICAL_MAXIMUM (32767)
-	0x75, 0x10, // REPORT_SIZE (16bits)
-	0x95, 0x06, // REPORT_COUNT (6)
-	0xa1, 0x00, // COLLECTION (Physical)
-	0x09, 0x30, // USAGE(X)
-	0x09, 0x31, // USAGE(Y)
-	0x09, 0x32, // USAGE(Z)
-	0x09, 0x33, // USAGE(RX)
-	0x09, 0x34, // USAGE(RY)
-	0x09, 0x35, // USAGE(RZ)
-	0x81, 0x02, // INPUT (Data/Var/Abs)
-	0xc0, // END_COLLECTION
-	0xc0, // END_COLLECTION
-}
+var JoystickDefaultHIDReport = appendSlices([][]byte{
+	HIDUsagePageGenericDesktop,
+	HIDUsageDesktopJoystick,
+	HIDCollectionApplication,
+	HIDReportID(1),
+	HIDUsagePageButton,
+	HIDUsageMinimum(1),
+	HIDUsageMaximum(16),
+	HIDLogicalMinimum(0),
+	HIDLogicalMaximum(1),
+	HIDReportSize(1),
+	HIDReportCount(16),
+	HIDInputDataVarAbs,
+	HIDReportCount(1),
+	HIDReportSize(3),
+	[]byte{
+		0x55, 0x00, // Unit Exponent (-16)
+		0x65, 0x00, // Unit (0x00)
+	},
+	HIDInputDataVarAbs,
+
+	HIDUsagePageGenericDesktop,
+	HIDUsageDesktopHatSwitch,
+	HIDLogicalMinimum(0),
+	HIDLogicalMaximum(7),
+	[]byte{
+		0x35, 0x00, // PHYSICAL_MINIMUM (0)
+		0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
+		0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
+	},
+	HIDReportCount(1),
+	HIDReportSize(4),
+	HIDInputDataVarAbs,
+	HIDUsageDesktopHatSwitch,
+	HIDLogicalMinimum(0),
+	HIDLogicalMaximum(7),
+	[]byte{
+		0x35, 0x00, // PHYSICAL_MINIMUM (0)
+		0x46, 0x3b, 0x01, // PHYSICAL_MAXIMUM(315)
+		0x65, 0x14, // UNIT (Eng Rot:Angular Pos)
+	},
+	HIDReportCount(1),
+	HIDReportSize(4),
+	HIDInputDataVarAbs,
+	HIDUsageDesktopPointer,
+	[]byte{
+		0x16, 0x01, 0x80, // LOGICAL_MINIMUM (-32767)
+		0x26, 0xff, 0x7f, // LOGICAL_MAXIMUM (32767)
+	},
+	HIDReportCount(6),
+	HIDReportSize(16),
+	HIDCollectionPhysical,
+	HIDUsageDesktopX,
+	HIDUsageDesktopY,
+	HIDUsageDesktopZ,
+	HIDUsageDesktopRx,
+	HIDUsageDesktopRy,
+	HIDUsageDesktopRz,
+	HIDInputDataVarAbs,
+	HIDEndCollection,
+	HIDEndCollection,
+})
 
 // CDCJoystick requires that you append the JoystickDescriptor
 // to the Configuration before using. This is in order to support

--- a/src/machine/usb/descriptor/midi.go
+++ b/src/machine/usb/descriptor/midi.go
@@ -220,7 +220,7 @@ var ConfigurationCDCMIDI = ConfigurationType{
 
 var CDCMIDI = Descriptor{
 	Device: DeviceCDC.Bytes(),
-	Configuration: appendSlices([][]byte{
+	Configuration: Append([][]byte{
 		ConfigurationCDCMIDI.Bytes(),
 		InterfaceAssociationCDC.Bytes(),
 		InterfaceCDCControl.Bytes(),


### PR DESCRIPTION
This PR refactors the HID report descriptor creation in machine/usb/descriptor to make it a lot easier.

Note that this PR depends on https://github.com/tinygo-org/tinygo/pull/3692 which needs to be merged first and then this one rebased.