### PR TITLE
os: implement os.(*File).Sync

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -247,6 +247,18 @@ func (f *File) Fd() uintptr {
 	return ^uintptr(0)
 }
 
+// Sync commits the current contents of the file to stable storage.
+// Typically, this means flushing the file system's in-memory copy of recently
+// written data to disk.
+func (f *File) Sync() (err error) {
+	if f.handle == nil {
+		err = ErrClosed
+	} else {
+		err = f.handle.Sync()
+	}
+	return
+}
+
 // Truncate is a stub, not yet implemented
 func (f *File) Truncate(size int64) (err error) {
 	if f.handle == nil {

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -140,6 +140,9 @@ var closeTests = map[string]func(*File) error{
 		_, err := f.Seek(0, 0)
 		return err
 	},
+	"Sync": func(f *File) error {
+		return f.Sync()
+	},
 	"SyscallConn": func(f *File) error {
 		_, err := f.SyscallConn()
 		return err

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -91,6 +91,10 @@ func (f stdioFileHandle) Seek(offset int64, whence int) (int64, error) {
 	return -1, ErrUnsupported
 }
 
+func (f stdioFileHandle) Sync() error {
+	return ErrUnsupported
+}
+
 func (f stdioFileHandle) Fd() uintptr {
 	return uintptr(f)
 }

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -130,6 +130,11 @@ func (f unixFileHandle) Seek(offset int64, whence int) (int64, error) {
 	return newoffset, handleSyscallError(err)
 }
 
+func (f unixFileHandle) Sync() error {
+	err := syscall.Fsync(syscallFd(f))
+	return handleSyscallError(err)
+}
+
 type unixDirent struct {
 	parent string
 	name   string

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -90,6 +90,10 @@ func (f unixFileHandle) Seek(offset int64, whence int) (int64, error) {
 	return newoffset, handleSyscallError(err)
 }
 
+func (f unixFileHandle) Sync() error {
+	return ErrNotImplemented
+}
+
 // isWindowsNulName reports whether name is os.DevNull ('NUL') on Windows.
 // True is returned if name is 'NUL' whatever the case.
 func isWindowsNulName(name string) bool {

--- a/src/os/filesystem.go
+++ b/src/os/filesystem.go
@@ -52,6 +52,9 @@ type FileHandle interface {
 	// Seek resets the file pointer relative to start, current position, or end
 	Seek(offset int64, whence int) (newoffset int64, err error)
 
+	// Sync blocks until buffered writes have been written to persistent storage
+	Sync() (err error)
+
 	// Write writes up to len(b) bytes to the file.
 	Write(b []byte) (n int, err error)
 

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -6,11 +6,6 @@
 
 package os
 
-// Sync is a stub, not yet implemented
-func (f *File) Sync() error {
-	return ErrNotImplemented
-}
-
 // Stat is a stub, not yet implemented
 func (f *File) Stat() (FileInfo, error) {
 	return nil, ErrNotImplemented

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -10,11 +10,6 @@ import (
 	"syscall"
 )
 
-// Sync is a stub, not yet implemented
-func (f *File) Sync() error {
-	return ErrNotImplemented
-}
-
 // Stat returns the FileInfo structure describing file.
 // If there is an error, it will be of type *PathError.
 func (f *File) Stat() (FileInfo, error) {

--- a/src/os/stat_windows.go
+++ b/src/os/stat_windows.go
@@ -10,11 +10,6 @@ import (
 	"unsafe"
 )
 
-// Sync is a stub, not yet implemented
-func (f *File) Sync() error {
-	return ErrNotImplemented
-}
-
 // Stat returns the FileInfo structure describing file.
 // If there is an error, it will be of type *PathError.
 func (file *File) Stat() (FileInfo, error) {

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -71,6 +71,13 @@ func Open(path string, flag int, mode uint32) (fd int, err error) {
 	return
 }
 
+func Fsync(fd int) (err error) {
+	if libc_fsync(int32(fd)) < 0 {
+		err = getErrno()
+	}
+	return
+}
+
 func Readlink(path string, p []byte) (n int, err error) {
 	data := cstring(path)
 	buf, count := splitSlice(p)
@@ -403,6 +410,11 @@ func libc_rename(from, to *byte) int32
 //
 //export symlink
 func libc_symlink(from, to *byte) int32
+
+// int fsync(int fd);
+//
+//export fsync
+func libc_fsync(fd int32) int32
 
 // ssize_t readlink(const char *path, void *buf, size_t count);
 //


### PR DESCRIPTION
This PR implements `os.(*File).Sync`. The use case I am targeting is WASI but the implementation also touches Darwin and other targets using libc.
