### PR TITLE
os: implement os.(*File).Truncate and os.Truncate

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -265,9 +265,12 @@ func (f *File) Truncate(size int64) (err error) {
 	if f.handle == nil {
 		err = ErrClosed
 	} else {
-		err = ErrNotImplemented
+		err = f.handle.Truncate(size)
 	}
-	return &PathError{Op: "truncate", Path: f.name, Err: err}
+	if err != nil {
+		err = &PathError{Op: "truncate", Path: f.name, Err: err}
+	}
+	return err
 }
 
 // LinkError records an error during a link or symlink or rename system call and

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -95,6 +95,10 @@ func (f stdioFileHandle) Sync() error {
 	return ErrUnsupported
 }
 
+func (f stdioFileHandle) Truncate(size int64) error {
+	return ErrUnsupported
+}
+
 func (f stdioFileHandle) Fd() uintptr {
 	return uintptr(f)
 }

--- a/src/os/file_posix.go
+++ b/src/os/file_posix.go
@@ -1,10 +1,24 @@
+//go:build !windows
+
 package os
 
 import (
+	"syscall"
 	"time"
 )
 
 // Chtimes is a stub, not yet implemented
 func Chtimes(name string, atime time.Time, mtime time.Time) error {
 	return ErrNotImplemented
+}
+
+// Truncate changes the size of the named file.
+// If the file is a symbolic link, it changes the size of the link's target.
+// If there is an error, it will be of type *PathError.
+func Truncate(path string, size int64) error {
+	err := syscall.Truncate(path, size)
+	if err != nil {
+		err = &PathError{Op: "truncate", Path: path, Err: err}
+	}
+	return err
 }

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -135,6 +135,11 @@ func (f unixFileHandle) Sync() error {
 	return handleSyscallError(err)
 }
 
+func (f unixFileHandle) Truncate(size int64) error {
+	err := syscall.Ftruncate(syscallFd(f), size)
+	return handleSyscallError(err)
+}
+
 type unixDirent struct {
 	parent string
 	name   string

--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -9,12 +9,35 @@ package os
 import (
 	"internal/syscall/windows"
 	"syscall"
+	"time"
 	"unicode/utf16"
 )
 
 const DevNull = "NUL"
 
 type syscallFd = syscall.Handle
+
+// Chtimes is a stub, not yet implemented.
+func Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return ErrNotImplemented
+}
+
+// Truncate changes the size of the named file.
+// If the file is a symbolic link, it changes the size of the link's target.
+// If there is an error, it will be of type *PathError.
+func Truncate(path string, size int64) error {
+	// Windows has syscall.Ftruncate but not syscall.Truncate, we need to open
+	// the file in order to truncate it.
+	f, err := OpenFile(path, O_WRONLY, 0)
+	if err != nil {
+		if e, _ := err.(*PathError); e != nil {
+			e.Op = "truncate"
+		}
+		return err
+	}
+	defer f.Close()
+	return f.Truncate(size)
+}
 
 // Symlink is a stub, it is not implemented.
 func Symlink(oldname, newname string) error {
@@ -91,6 +114,10 @@ func (f unixFileHandle) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (f unixFileHandle) Sync() error {
+	return ErrNotImplemented
+}
+
+func (f unixFileHandle) Truncate(size int64) (err error) {
 	return ErrNotImplemented
 }
 

--- a/src/os/filesystem.go
+++ b/src/os/filesystem.go
@@ -55,6 +55,9 @@ type FileHandle interface {
 	// Sync blocks until buffered writes have been written to persistent storage
 	Sync() (err error)
 
+	// Truncate adjusts the file to the given size
+	Truncate(size int64) (err error)
+
 	// Write writes up to len(b) bytes to the file.
 	Write(b []byte) (n int, err error)
 

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -144,6 +144,22 @@ func Unlink(path string) (err error) {
 	return
 }
 
+func Truncate(path string, size int64) (err error) {
+	data := cstring(path)
+	fail := libc_truncate(&data[0], size)
+	if fail < 0 {
+		err = getErrno()
+	}
+	return
+}
+
+func Ftruncate(fd int, size int64) (err error) {
+	if libc_ftruncate(int32(fd), size) < 0 {
+		err = getErrno()
+	}
+	return
+}
+
 func Faccessat(dirfd int, path string, mode uint32, flags int) (err error)
 
 func Kill(pid int, sig Signal) (err error) {
@@ -346,6 +362,16 @@ func libc_pread(fd int32, buf *byte, count uint, offset int64) int
 //
 //export lseek
 func libc_lseek(fd int32, offset int64, whence int) int64
+
+// int ftruncate(int fd, off_t length)
+//
+//export ftruncate
+func libc_ftruncate(fd int32, size int64) int32
+
+// int truncate(const char *path, off_t length)
+//
+//export truncate
+func libc_truncate(path *byte, size int64) int32
 
 // int close(int fd)
 //


### PR DESCRIPTION
This PR adds an implementation of `os.(*File).Truncate` and `os.Truncate`. The implementation is based on libc's `truncate` and `ftruncate` functions. I ported the tests from the Go standard library as well.