### PR TITLE
cgo: allow LDFLAGS: --export=...

### DIFF
--- a/cgo/security.go
+++ b/cgo/security.go
@@ -142,6 +142,7 @@ var validLinkerFlags = []*regexp.Regexp{
 	re(`-L([^@\-].*)`),
 	re(`-O`),
 	re(`-O([^@\-].*)`),
+	re(`--export=([^@\-].*)`),
 	re(`-f(no-)?(pic|PIC|pie|PIE)`),
 	re(`-f(no-)?openmp(-simd)?`),
 	re(`-fsanitize=([^@\-].*)`),

--- a/cgo/security_test.go
+++ b/cgo/security_test.go
@@ -108,6 +108,7 @@ var goodLinkerFlags = [][]string{
 	{"-Fbar"},
 	{"-lbar"},
 	{"-Lbar"},
+	{"--export=my_symbol"},
 	{"-fpic"},
 	{"-fno-pic"},
 	{"-fPIC"},


### PR DESCRIPTION
As discussed in https://github.com/tetratelabs/wazero/pull/1429, add `--export` to the accepted LDFLAGS.
Manually tested on [greet.go](https://github.com/tetratelabs/wazero/blob/5380321eeab50d4b0aaffd59d66ffab2c2e8ba80/examples/allocation/tinygo/testdata/greet.go#L3) by adding the line:

```
// #cgo LDFLAGS: --export=malloc --export=free
```
