### PR TITLE
machine/flash: fix block number passed to EraseBlock

### DIFF
--- a/src/machine/flash.go
+++ b/src/machine/flash.go
@@ -101,8 +101,8 @@ func (fl *FlashBuffer) Write(p []byte) (n int, err error) {
 	// block 1 -> fl.start + pagesize
 	// block 2 -> fl.start + pagesize*2
 	// ...
-	currentPageBlock := (fl.start + fl.offset - FlashDataStart()) + (pagesize-1)/pagesize
-	lastPageBlockNeeded := (fl.start + fl.offset + uintptr(len(p)) - FlashDataStart()) + (pagesize-1)/pagesize
+	currentPageBlock := ((fl.start + fl.offset - FlashDataStart()) + (pagesize - 1)) / pagesize
+	lastPageBlockNeeded := ((fl.start + fl.offset + uintptr(len(p)) - FlashDataStart()) + (pagesize - 1)) / pagesize
 
 	// erase enough blocks to hold the data
 	if err := fl.b.EraseBlocks(int64(currentPageBlock), int64(lastPageBlockNeeded-currentPageBlock)); err != nil {


### PR DESCRIPTION
This PR fixes the block number to be passed to the EraseBlock.
You can check the fixes in the following program.

I checked with macropad-rp2040.
No other boards are currently available.


```go
package main

import (
	"machine"
	"time"
)

var (
	err     error
	message = "1234567887654321123456788765432112345678876543211234567887654321"
)

func main() {
	time.Sleep(3 * time.Second)
	offset := int64(0x00300000)
	//offset := int64(0)

	// Print out general information
	println("Flash data start:      ", machine.FlashDataStart())
	println("Flash data end:        ", machine.FlashDataEnd())
	println("Flash data size, bytes:", machine.Flash.Size())
	println("Flash write block size:", machine.Flash.WriteBlockSize())
	println("Flash erase block size:", machine.Flash.EraseBlockSize())
	println()

	flash := machine.OpenFlashBuffer(machine.Flash, machine.FlashDataStart())
	original := make([]byte, len(message))
	saved := make([]byte, len(message))

	// Read flash contents on start (data shall survive power off)
	print("Reading data from flash: ")
	flash.Seek(offset, 0) // rewind back to beginning
	_, err = flash.Read(original)
	checkError(err)
	println(string(original))

	// Write the message to flash
	print("Writing data to flash: ")
	flash.Seek(offset, 0) // rewind back to beginning
	_, err = flash.Write([]byte(message))
	checkError(err)
	println(string(message))

	// Read back flash contents after write (verify data is the same as written)
	print("Reading data back from flash: ")
	flash.Seek(offset, 0) // rewind back to beginning
	_, err = flash.Read(saved)
	checkError(err)
	println(string(saved))

	message = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKL"
	// Write the message to flash
	print("Writing data to flash: ")
	flash.Seek(offset, 0) // rewind back to beginning
	_, err = flash.Write([]byte(message))
	checkError(err)
	println(string(message))

	// Read back flash contents after write (verify data is the same as written)
	print("Reading data back from flash: ")
	flash.Seek(offset, 0) // rewind back to beginning
	_, err = flash.Read(saved)
	checkError(err)
	println(string(saved))
	println()
}

func checkError(err error) {
	if err != nil {
		for {
			println(err.Error())
			time.Sleep(time.Second)
		}
	}
}

```