### PR TITLE
Add dummy package for `runtime/metrics`

### DIFF
--- a/src/runtime/metrics/metrics.go
+++ b/src/runtime/metrics/metrics.go
@@ -1,0 +1,32 @@
+// Package metrics is a dummy package that is not yet implemented.
+
+package metrics
+
+type Description struct{}
+
+func All() []Description {
+	return nil
+}
+
+type Float64Histogram struct{}
+
+type Sample struct{}
+
+func Read(m []Sample) {}
+
+type Value struct{}
+
+func (v Value) Float64() float64 {
+	return 0
+}
+func (v Value) Float64Histogram() *Float64Histogram {
+	return nil
+}
+func (v Value) Kind() ValueKind {
+	return ValueKind{}
+}
+func (v Value) Uint64() uint64 {
+	return 0
+}
+
+type ValueKind struct{}


### PR DESCRIPTION
Add dummy package for `runtime/metrics` so that modules that depend upon it (e.g. [Prometheus Go client library](https://github.com/prometheus/client_golang/blob/main/prometheus/internal/go_runtime_metrics.go)) will compile.

Avoids:
```console
package runtime/metrics is not in GOROOT
```

Fixes #3705