### PR TITLE
machine/atsam*, nrf, rp2040, stm32: correct error in flashBlockDevice padding

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1910,12 +1910,12 @@ func (f flashBlockDevice) EraseBlocks(start, len int64) error {
 
 // pad data if needed so it is long enough for correct byte alignment on writes.
 func (f flashBlockDevice) pad(p []byte) []byte {
-	paddingNeeded := f.WriteBlockSize() - (int64(len(p)) % f.WriteBlockSize())
-	if paddingNeeded == 0 {
+	overflow := int64(len(p)) % f.WriteBlockSize()
+	if overflow == 0 {
 		return p
 	}
 
-	padding := bytes.Repeat([]byte{0xff}, int(paddingNeeded))
+	padding := bytes.Repeat([]byte{0xff}, int(f.WriteBlockSize()-overflow))
 	return append(p, padding...)
 }
 

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -2239,12 +2239,12 @@ func (f flashBlockDevice) EraseBlocks(start, len int64) error {
 
 // pad data if needed so it is long enough for correct byte alignment on writes.
 func (f flashBlockDevice) pad(p []byte) []byte {
-	paddingNeeded := f.WriteBlockSize() - (int64(len(p)) % f.WriteBlockSize())
-	if paddingNeeded == 0 {
+	overflow := int64(len(p)) % f.WriteBlockSize()
+	if overflow == 0 {
 		return p
 	}
 
-	padding := bytes.Repeat([]byte{0xff}, int(paddingNeeded))
+	padding := bytes.Repeat([]byte{0xff}, int(f.WriteBlockSize()-overflow))
 	return append(p, padding...)
 }
 

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -396,12 +396,12 @@ func (f flashBlockDevice) EraseBlocks(start, len int64) error {
 
 // pad data if needed so it is long enough for correct byte alignment on writes.
 func (f flashBlockDevice) pad(p []byte) []byte {
-	paddingNeeded := f.WriteBlockSize() - (int64(len(p)) % f.WriteBlockSize())
-	if paddingNeeded == 0 {
+	overflow := int64(len(p)) % f.WriteBlockSize()
+	if overflow == 0 {
 		return p
 	}
 
-	padding := bytes.Repeat([]byte{0xff}, int(paddingNeeded))
+	padding := bytes.Repeat([]byte{0xff}, int(f.WriteBlockSize()-overflow))
 	return append(p, padding...)
 }
 

--- a/src/machine/machine_rp2040_rom.go
+++ b/src/machine/machine_rp2040_rom.go
@@ -236,12 +236,12 @@ func (f flashBlockDevice) EraseBlocks(start, length int64) error {
 
 // pad data if needed so it is long enough for correct byte alignment on writes.
 func (f flashBlockDevice) pad(p []byte) []byte {
-	paddingNeeded := f.WriteBlockSize() - (int64(len(p)) % f.WriteBlockSize())
-	if paddingNeeded == 0 {
+	overflow := int64(len(p)) % f.WriteBlockSize()
+	if overflow == 0 {
 		return p
 	}
 
-	padding := bytes.Repeat([]byte{0xff}, int(paddingNeeded))
+	padding := bytes.Repeat([]byte{0xff}, int(f.WriteBlockSize()-overflow))
 	return append(p, padding...)
 }
 

--- a/src/machine/machine_stm32_flash.go
+++ b/src/machine/machine_stm32_flash.go
@@ -92,13 +92,13 @@ func (f flashBlockDevice) EraseBlocks(start, len int64) error {
 
 // pad data if needed so it is long enough for correct byte alignment on writes.
 func (f flashBlockDevice) pad(p []byte) []byte {
-	paddingNeeded := f.WriteBlockSize() - (int64(len(p)) % f.WriteBlockSize())
-	if paddingNeeded == 0 {
+	overflow := int64(len(p)) % f.WriteBlockSize()
+	if overflow == 0 {
 		return p
 	}
 
-	padded := bytes.Repeat([]byte{0xff}, int(paddingNeeded))
-	return append(p, padded...)
+	padding := bytes.Repeat([]byte{0xff}, int(f.WriteBlockSize()-overflow))
+	return append(p, padding...)
 }
 
 const memoryStart = 0x08000000


### PR DESCRIPTION
This PR corrects an error in the `flashBlockDevice` padding for the atsam*, nrf, rp2040, and stm32 boards. The code as it was added extra padding.