### PR TITLE
machine/rp2040: flash write and erase corrections

### DIFF
--- a/src/machine/machine_rp2040_rom.go
+++ b/src/machine/machine_rp2040_rom.go
@@ -195,7 +195,7 @@ func (f flashBlockDevice) Size() int64 {
 	return int64(FlashDataEnd() - FlashDataStart())
 }
 
-const writeBlockSize = 4
+const writeBlockSize = 1 << 8
 
 // WriteBlockSize returns the block size in which data can be written to
 // memory. It can be used by a client to optimize writes, non-aligned writes

--- a/src/machine/machine_rp2040_rom.go
+++ b/src/machine/machine_rp2040_rom.go
@@ -229,7 +229,7 @@ func (f flashBlockDevice) EraseBlocks(start, length int64) error {
 	state := interrupt.Disable()
 	defer interrupt.Restore(state)
 
-	C.flash_erase_blocks(C.uint32_t(address), C.ulong(length))
+	C.flash_erase_blocks(C.uint32_t(address), C.ulong(length*f.EraseBlockSize()))
 
 	return nil
 }


### PR DESCRIPTION
This PR includes 2 commits for errors I found in the code for writing and erasing the onboard flash on the RP2040.

The first corrects the size passed to the onboard ROM flash erase command to bytes, not blocks.

See https://github.com/raspberrypi/pico-sdk/blob/f396d05f8252d4670d4ea05c8b7ac938ef0cd381/src/rp2_common/hardware_flash/flash.c#L63

The second corrects the write page size from 4 to 256 bytes.

See https://github.com/raspberrypi/pico-sdk/blob/f396d05f8252d4670d4ea05c8b7ac938ef0cd381/src/rp2_common/hardware_flash/include/hardware/flash.h#L42

Note that this PR requires https://github.com/tinygo-org/tinygo/pull/3710 be merged first, and then this PR rebased. 