### PR TITLE
machine/flash: improvements and fixes to FlashBuffer Write() and Seek()

### DIFF
--- a/src/examples/flash/main.go
+++ b/src/examples/flash/main.go
@@ -7,7 +7,10 @@ import (
 
 var (
 	err     error
-	message = "1234567887654321123456788765432112345678876543211234567887654321"
+	message = "1234567887654321123456788765432112345678876543211234567887654321" +
+		"1234567887654321123456788765432112345678876543211234567887654321" +
+		"1234567887654321123456788765432112345678876543211234567887654321" +
+		"1234567887654321123456788765432112345678876543211234567887654321"
 )
 
 func main() {
@@ -26,25 +29,46 @@ func main() {
 	saved := make([]byte, len(message))
 
 	// Read flash contents on start (data shall survive power off)
-	print("Reading data from flash: ")
-	_, err = flash.Read(original)
-	checkError(err)
-	println(string(original))
+	println("Reading data from flash: ")
+	for i := 0; i < 10; i++ {
+		_, err = flash.Read(original)
+		checkError(err)
+		println(string(original))
+	}
 
 	// Write the message to flash
-	print("Writing data to flash: ")
+	println("Writing data to flash: ")
 	flash.Seek(0, 0) // rewind back to beginning
-	_, err = flash.Write([]byte(message))
-	checkError(err)
-	println(string(message))
+	for i := 0; i < 10; i++ {
+		_, err = flash.Write([]byte(message))
+		checkError(err)
+		println(string(message))
+	}
 
 	// Read back flash contents after write (verify data is the same as written)
-	print("Reading data back from flash: ")
+	println("Reading data back from flash: ")
 	flash.Seek(0, 0) // rewind back to beginning
-	_, err = flash.Read(saved)
-	checkError(err)
-	println(string(saved))
-	println()
+	for i := 0; i < 10; i++ {
+		_, err = flash.Read(saved)
+		checkError(err)
+		if !equal(saved, []byte(message)) {
+			println("data verify error")
+		}
+		println(string(saved))
+	}
+	println("Done.")
+}
+
+func equal(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func checkError(err error) {


### PR DESCRIPTION
This PR has improvements and fixes to the `FlashBuffer` `Write()` and `Seek()` functions.

It also updates the example to show that you can perform multiple `Write()` operations, as long as the data is a multiple of the write block size.