### PR TITLE
pinetime: update the target file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=particle-xenon      examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=pinetime-devkit0    examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=pinetime            examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=x9pro               examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/machine/board_pinetime.go
+++ b/src/machine/board_pinetime.go
@@ -1,4 +1,4 @@
-//go:build pinetime_devkit0
+//go:build pinetime
 
 package machine
 
@@ -17,13 +17,10 @@ const (
 	LED  = LED1
 )
 
-var DefaultUART = UART0
-
-// UART pins for PineTime. Note that RX is set to NoPin as RXD is not listed in
-// the PineTime schematic 1.0:
-// http://files.pine64.org/doc/PineTime/PineTime%20Port%20Assignment%20rev1.0.pdf
+// The PineTime doesn't have a UART output.
+// Additionally, leaving the UART on results in a pretty big current drain.
 const (
-	UART_TX_PIN Pin = 11 // TP29 (TXD)
+	UART_TX_PIN Pin = NoPin
 	UART_RX_PIN Pin = NoPin
 )
 

--- a/targets/pinetime.json
+++ b/targets/pinetime.json
@@ -1,7 +1,7 @@
 {
 	"inherits": ["nrf52"],
-	"build-tags": ["pinetime_devkit0"],
-	"serial": "uart",
+	"build-tags": ["pinetime"],
+	"serial": "none",
 	"flash-method": "openocd",
 	"flash-command": "nrfjprog -f nrf52 --sectorerase --program {hex} --reset",
 	"openocd-interface": "jlink",


### PR DESCRIPTION
  * Rename pinetime-devkit0 to pinetime because the production device is almost the same hardware (the only noticeable difference is a different accelerometer, which isn't part of the board file).
  * Remove the UART and set serial to none. The UART uses a lot of current by default, so it seems better to disable it.

This is a breaking change, but honestly I think I'm the only one who has ever actually used TinyGo for the PineTime and I'm fine with this change :slightly_smiling_face: 