### PR TITLE
nrf52: improve ADC support

### DIFF
--- a/src/machine/adc.go
+++ b/src/machine/adc.go
@@ -9,4 +9,5 @@ type ADCConfig struct {
 	Reference  uint32 // analog reference voltage (AREF) in millivolts
 	Resolution uint32 // number of bits for a single conversion (e.g., 8, 10, 12)
 	Samples    uint32 // number of samples for a single conversion (e.g., 4, 8, 16, 32)
+	SampleTime uint32 // sample time, in microseconds (µs)
 }

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -30,7 +30,6 @@ func (a ADC) Configure(config ADCConfig) {
 	var configVal uint32 = nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESP_Pos |
 		nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESN_Pos |
 		nrf.SAADC_CH_CONFIG_REFSEL_Internal<<nrf.SAADC_CH_CONFIG_REFSEL_Pos |
-		nrf.SAADC_CH_CONFIG_TACQ_3us<<nrf.SAADC_CH_CONFIG_TACQ_Pos |
 		nrf.SAADC_CH_CONFIG_MODE_SE<<nrf.SAADC_CH_CONFIG_MODE_Pos
 
 	switch config.Reference {
@@ -52,6 +51,22 @@ func (a ADC) Configure(config ADCConfig) {
 		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_6 << nrf.SAADC_CH_CONFIG_GAIN_Pos
 	default:
 		// TODO: return an error
+	}
+
+	// Source resistance, according to table 89 on page 364 of the nrf52832 datasheet.
+	// https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf
+	if config.SampleTime <= 3 { // <= 10kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_3us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	} else if config.SampleTime <= 5 { // <= 40kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_5us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	} else if config.SampleTime <= 10 { // <= 100kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_10us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	} else if config.SampleTime <= 15 { // <= 200kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_15us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	} else if config.SampleTime <= 20 { // <= 400kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_20us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	} else { // <= 800kΩ
+		configVal |= nrf.SAADC_CH_CONFIG_TACQ_40us << nrf.SAADC_CH_CONFIG_TACQ_Pos
 	}
 
 	// Configure channel 0, which is the only channel we use.

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -24,7 +24,8 @@ func (a ADC) Configure(config ADCConfig) {
 	// enabled.
 	nrf.SAADC.ENABLE.Set(nrf.SAADC_ENABLE_ENABLE_Enabled << nrf.SAADC_ENABLE_ENABLE_Pos)
 
-	// Configure ADC.
+	// Use fixed resolution of 12 bits.
+	// TODO: is it useful for users to change this?
 	nrf.SAADC.RESOLUTION.Set(nrf.SAADC_RESOLUTION_VAL_12bit)
 
 	var configVal uint32 = nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESP_Pos |
@@ -67,6 +68,34 @@ func (a ADC) Configure(config ADCConfig) {
 		configVal |= nrf.SAADC_CH_CONFIG_TACQ_20us << nrf.SAADC_CH_CONFIG_TACQ_Pos
 	} else { // <= 800kΩ
 		configVal |= nrf.SAADC_CH_CONFIG_TACQ_40us << nrf.SAADC_CH_CONFIG_TACQ_Pos
+	}
+
+	// Oversampling configuration.
+	burst := true
+	switch config.Samples {
+	default: // no oversampling
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Bypass)
+		burst = false
+	case 2:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over2x)
+	case 4:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over4x)
+	case 8:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over8x)
+	case 16:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over16x)
+	case 32:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over32x)
+	case 64:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over64x)
+	case 128:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over128x)
+	case 256:
+		nrf.SAADC.OVERSAMPLE.Set(nrf.SAADC_OVERSAMPLE_OVERSAMPLE_Over256x)
+	}
+	if burst {
+		// BURST=1 is needed when oversampling
+		configVal |= nrf.SAADC_CH_CONFIG_BURST
 	}
 
 	// Configure channel 0, which is the only channel we use.

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -18,7 +18,7 @@ func InitADC() {
 }
 
 // Configure configures an ADC pin to be able to read analog data.
-func (a ADC) Configure(ADCConfig) {
+func (a ADC) Configure(config ADCConfig) {
 	// Enable ADC.
 	// The ADC does not consume a noticeable amount of current simply by being
 	// enabled.
@@ -27,13 +27,35 @@ func (a ADC) Configure(ADCConfig) {
 	// Configure ADC.
 	nrf.SAADC.RESOLUTION.Set(nrf.SAADC_RESOLUTION_VAL_12bit)
 
-	// Configure channel 0, which is the only channel we use.
-	nrf.SAADC.CH[0].CONFIG.Set(nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESP_Pos |
+	var configVal uint32 = nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESP_Pos |
 		nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESN_Pos |
-		nrf.SAADC_CH_CONFIG_GAIN_Gain1_5<<nrf.SAADC_CH_CONFIG_GAIN_Pos |
 		nrf.SAADC_CH_CONFIG_REFSEL_Internal<<nrf.SAADC_CH_CONFIG_REFSEL_Pos |
 		nrf.SAADC_CH_CONFIG_TACQ_3us<<nrf.SAADC_CH_CONFIG_TACQ_Pos |
-		nrf.SAADC_CH_CONFIG_MODE_SE<<nrf.SAADC_CH_CONFIG_MODE_Pos)
+		nrf.SAADC_CH_CONFIG_MODE_SE<<nrf.SAADC_CH_CONFIG_MODE_Pos
+
+	switch config.Reference {
+	case 150: // 0.15V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain4 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 300: // 0.3V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain2 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 600: // 0.6V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 1200: // 1.2V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_2 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 1800: // 1.8V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_3 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 2400: // 2.4V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_4 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 3000, 0: // 3.0V (default)
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_5 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	case 3600: // 3.6V
+		configVal |= nrf.SAADC_CH_CONFIG_GAIN_Gain1_6 << nrf.SAADC_CH_CONFIG_GAIN_Pos
+	default:
+		// TODO: return an error
+	}
+
+	// Configure channel 0, which is the only channel we use.
+	nrf.SAADC.CH[0].CONFIG.Set(configVal)
 }
 
 // Get returns the current value of a ADC pin in the range 0..0xffff.


### PR DESCRIPTION
There are various settings that weren't used, and that can be quite useful.
I'm using these new settings to correctly read the battery voltage on the PineTime.