### PR TITLE
windows: re-enable parallelism

### DIFF
--- a/main.go
+++ b/main.go
@@ -1547,15 +1547,6 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	// Limit the number of threads to one.
-	// This is an attempted workaround for the crashes we're seeing in CI on
-	// Windows. If this change helps, it indicates there is a concurrency issue.
-	// If it doesn't, then there is something else going on. Either way, this
-	// should be removed once the test is done.
-	if runtime.GOOS == "windows" {
-		runtime.GOMAXPROCS(1)
-	}
-
 	switch command {
 	case "build":
 		pkgName := "."


### PR DESCRIPTION
This reverts https://github.com/tinygo-org/tinygo/pull/3525, because that change didn't seem to stop the CI failures we have been seeing. Instead, I've added thread support in https://github.com/tinygo-org/tinygo/pull/3130 which IIRC fixed most of the CI crashes.

Re-enabling parallelism should improve the performance of TinyGo a bit on Windows.

(Not sure whether it's better to include this in the coming release to avoid a performance regression, or to push it to the next release to avoid potentially introducing a bug in the release).