### PR TITLE
device: add support for Renesas family of MCU

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/macos-minimal-sdk"]
 	path = lib/macos-minimal-sdk
 	url = https://github.com/aykevl/macos-minimal-sdk.git
+[submodule "lib/renesas-svd"]
+	path = lib/renesas-svd
+	url = git@github.com:tinygo-org/renesas-svd.git

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ gen-device-rp: build/gen-device-svd
 	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/RaspberryPi lib/cmsis-svd/data/RaspberryPi/ src/device/rp/
 	GO111MODULE=off $(GO) fmt ./src/device/rp
 
+gen-device-renesas: build/gen-device-svd
+	./build/gen-device-svd -source=https://github.com/tinygo-org/renesas-svd lib/renesas-svd/ src/device/renesas/
+	GO111MODULE=off $(GO) fmt ./src/device/renesas
+
 # Get LLVM sources.
 $(LLVM_PROJECTDIR)/llvm:
 	git clone -b xtensa_release_15.x --depth=1 https://github.com/espressif/llvm-project $(LLVM_PROJECTDIR)


### PR DESCRIPTION
This PR is work in progress to add device support for the Renesas R7FA family of MCUs in preparation to add machine package support for some boards based on these processors.