### PR TITLE
build: add write permission to sizediff GH actions job to be able to comment

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -10,6 +10,8 @@ concurrency:
 jobs:
   sizediff:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       # Prepare, install tools
       - name: Add GOBIN to $PATH


### PR DESCRIPTION
This PR adds write permission to the `sizediff` GH actions job to always be able to add comments.

See https://github.com/thollander/actions-comment-pull-request#permissions