### PR TITLE
machine: add DefaultUART to xiao

### DIFF
--- a/src/machine/board_xiao.go
+++ b/src/machine/board_xiao.go
@@ -96,3 +96,7 @@ var (
 	usb_VID uint16 = 0x2886
 	usb_PID uint16 = 0x802F
 )
+
+var (
+	DefaultUART = UART1
+)


### PR DESCRIPTION
Activate the -serial option for tinygo.

This is the xiao version of #2626 