### PR TITLE
build: update GH actions-comment-pull-request to v2.3.1

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Comment contents
         run: cat comment.txt
       - name: Add comment
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v2.3.1
         with:
           filePath: comment.txt
           comment_tag: sizediff


### PR DESCRIPTION
This PR updates the GH actions-comment-pull-request to v2.3.1 to pickup whatever permissions code changes occurred from v2 to v2.3.1