### PR TITLE
Add Settings to debug.BuildInfo

### DIFF
--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -33,9 +33,17 @@ func ReadBuildInfo() (info *BuildInfo, ok bool) {
 // BuildInfo represents the build information read from
 // the running binary.
 type BuildInfo struct {
-	Path string    // The main package path
-	Main Module    // The module containing the main package
-	Deps []*Module // Module dependencies
+	Path     string    // The main package path
+	Main     Module    // The module containing the main package
+	Deps     []*Module // Module dependencies
+	Settings []BuildSetting
+}
+
+type BuildSetting struct {
+	// Key and Value describe the build setting.
+	// Key must not contain an equals sign, space, tab, or newline.
+	// Value must not contain newlines ('\n').
+	Key, Value string
 }
 
 // Module represents a module.


### PR DESCRIPTION
While using `tinygo` to compile one of my projects, I ran into a problem because, in `tinygo`, `debug.BuildInfo` does not have the `Settings []BuildSetting` field like in `golang` [here](https://github.com/golang/go/blob/aeb0644bd33e67f24e2411a651ac9ff72ddc96b4/src/runtime/debug/mod.go#L41).

I made this change locally, compiled `tinygo` and then I was able to compile my project successfully. 

Kindly let me know if this makes sense or if I need to make other changes to fix it.

(also when running the `make test` locally (on M2 laptop), I ran into some llvm problem, so submitting the PR to see if I can validate this using CI here).

Many thanks