### PR TITLE
build: add issues write permission to sizediff job

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
+      issues: write
     steps:
       # Prepare, install tools
       - name: Add GOBIN to $PATH


### PR DESCRIPTION
The `sizediff` job appears to run successfully when the PR is submitted by TinyGo org team member, but is still failing when PRs are submitted by other contributors.

This PR tries (yet again) to address the `Error: Resource not accessible by integration` error.

Perhaps it is the issues that require this permission?

https://github.com/thollander/actions-comment-pull-request/blob/main/src/main.ts#L114
