### PR TITLE
all: switch to LLVM 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - llvm-source-14-v3
+            - llvm-source-16-v3
       - run:
           name: "Fetch LLVM source"
           command: make llvm-source
       - save_cache:
-          key: llvm-source-14-v3
+          key: llvm-source-16-v3
           paths:
             - llvm-project/clang/lib/Headers
             - llvm-project/clang/include

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-macos-v3
+          key: llvm-source-16-macos-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-macos-v4
+          key: llvm-build-16-macos-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -120,7 +120,7 @@ jobs:
       - name: Install LLVM
         shell: bash
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm@15
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm@16
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-contexts: tinygo-llvm-build=docker-image://tinygo/llvm-15
+          build-contexts: tinygo-llvm-build=docker-image://tinygo/llvm-16
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Trigger Drivers repo build on Github Actions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-alpine-v3
+          key: llvm-source-16-linux-alpine-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-alpine-v4
+          key: llvm-build-16-linux-alpine-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -194,7 +194,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-asserts-v3
+          key: llvm-source-16-linux-asserts-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -219,7 +219,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-asserts-v4
+          key: llvm-build-16-linux-asserts-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -297,7 +297,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v3
+          key: llvm-source-16-linux-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm-v4
+          key: llvm-build-16-linux-arm-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -414,7 +414,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-linux-v3
+          key: llvm-source-16-linux-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -439,7 +439,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-linux-arm64-v4
+          key: llvm-build-16-linux-arm64-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -35,8 +35,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            tinygo/llvm-15
-            ghcr.io/${{ github.repository_owner }}/llvm-15
+            tinygo/llvm-16
+            ghcr.io/${{ github.repository_owner }}/llvm-16
           tags: |
             type=sha,format=long
             type=raw,value=latest

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -24,19 +24,19 @@ jobs:
           submodules: true
       - name: Install apt dependencies
         run: |
-          echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+          echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-              llvm-15-dev \
-              clang-15 \
-              libclang-15-dev \
-              lld-15
+              llvm-16-dev \
+              clang-16 \
+              libclang-16-dev \
+              lld-16
       - name: Restore LLVM source cache
         uses: actions/cache@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-sizediff-v1
+          key: llvm-source-16-sizediff-v1
           path: |
             llvm-project/compiler-rt
       - name: Download LLVM source

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-15-windows-v4
+          key: llvm-source-16-windows-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-15-windows-v6
+          key: llvm-build-16-windows-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
 # Try to autodetect LLVM build tools.
 # Versions are listed here in descending priority order.
-LLVM_VERSIONS = 15 14 13 12 11
+LLVM_VERSIONS = 16 15 14 13 12 11
 errifempty = $(if $(1),$(1),$(error $(2)))
 detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
 toolSearchPathsVersion = $(1)-$(2)
@@ -113,7 +113,7 @@ endif
 
 .PHONY: all tinygo test $(LLVM_BUILDDIR) llvm-source clean fmt gen-device gen-device-nrf gen-device-nxp gen-device-avr gen-device-rp
 
-LLVM_COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core coroutines coverage debuginfodwarf debuginfopdb executionengine frontendopenmp instrumentation interpreter ipo irreader libdriver linker lto mc mcjit objcarcopts option profiledata scalaropts support target windowsdriver windowsmanifest
+LLVM_COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core coroutines coverage debuginfodwarf debuginfopdb executionengine frontendhlsl frontendopenmp instrumentation interpreter ipo irreader libdriver linker lto mc mcjit objcarcopts option profiledata scalaropts support target windowsdriver windowsmanifest
 
 ifeq ($(OS),Windows_NT)
     EXE = .exe
@@ -154,7 +154,7 @@ LLD_LIB_NAMES = lldCOFF lldCommon lldELF lldMachO lldMinGW lldWasm
 LLD_LIBS = $(START_GROUP) $(addprefix -l,$(LLD_LIB_NAMES)) $(END_GROUP)
 
 # Other libraries that are needed to link TinyGo.
-EXTRA_LIB_NAMES = LLVMInterpreter LLVMMCA LLVMX86TargetMCA
+EXTRA_LIB_NAMES = LLVMInterpreter LLVMMCA LLVMRISCVTargetMCA LLVMX86TargetMCA
 
 # All libraries to be built and linked with the tinygo binary (lib/lib*.a).
 LIB_NAMES = clang $(CLANG_LIB_NAMES) $(LLD_LIB_NAMES) $(EXTRA_LIB_NAMES)
@@ -170,7 +170,7 @@ NINJA_BUILD_TARGETS = clang llvm-config llvm-ar llvm-nm $(addprefix lib/lib,$(ad
 # For static linking.
 ifneq ("$(wildcard $(LLVM_BUILDDIR)/bin/llvm-config*)","")
     CGO_CPPFLAGS+=$(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --cppflags) -I$(abspath $(LLVM_BUILDDIR))/tools/clang/include -I$(abspath $(CLANG_SRC))/include -I$(abspath $(LLD_SRC))/include
-    CGO_CXXFLAGS=-std=c++14
+    CGO_CXXFLAGS=-std=c++17
     CGO_LDFLAGS+=-L$(abspath $(LLVM_BUILDDIR)/lib) -lclang $(CLANG_LIBS) $(LLD_LIBS) $(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --ldflags --libs --system-libs $(LLVM_COMPONENTS)) -lstdc++ $(CGO_LDFLAGS_EXTRA)
 endif
 
@@ -238,7 +238,7 @@ gen-device-renesas: build/gen-device-svd
 
 # Get LLVM sources.
 $(LLVM_PROJECTDIR)/llvm:
-	git clone -b xtensa_release_15.x --depth=1 https://github.com/espressif/llvm-project $(LLVM_PROJECTDIR)
+	git clone -b xtensa_release_16.x --depth=1 https://github.com/espressif/llvm-project $(LLVM_PROJECTDIR)
 llvm-source: $(LLVM_PROJECTDIR)/llvm
 
 # Configure LLVM.

--- a/builder/cc1as.cpp
+++ b/builder/cc1as.cpp
@@ -56,6 +56,7 @@
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
+#include <optional>
 #include <system_error>
 using namespace clang;
 using namespace clang::driver;
@@ -103,6 +104,14 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
   Opts.Triple = llvm::Triple::normalize(Args.getLastArgValue(OPT_triple));
   if (Arg *A = Args.getLastArg(options::OPT_darwin_target_variant_triple))
     Opts.DarwinTargetVariantTriple = llvm::Triple(A->getValue());
+  if (Arg *A = Args.getLastArg(OPT_darwin_target_variant_sdk_version_EQ)) {
+    VersionTuple Version;
+    if (Version.tryParse(A->getValue()))
+      Diags.Report(diag::err_drv_invalid_value)
+          << A->getAsString(Args) << A->getValue();
+    else
+      Opts.DarwinTargetVariantSDKVersion = Version;
+  }
 
   Opts.CPU = std::string(Args.getLastArgValue(OPT_target_cpu));
   Opts.Features = Args.getAllArgValues(OPT_target_feature);
@@ -122,11 +131,12 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
     Opts.CompressDebugSections =
         llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
             .Case("none", llvm::DebugCompressionType::None)
-            .Case("zlib", llvm::DebugCompressionType::Z)
+            .Case("zlib", llvm::DebugCompressionType::Zlib)
+            .Case("zstd", llvm::DebugCompressionType::Zstd)
             .Default(llvm::DebugCompressionType::None);
   }
 
-  Opts.RelaxELFRelocations = Args.hasArg(OPT_mrelax_relocations);
+  Opts.RelaxELFRelocations = !Args.hasArg(OPT_mrelax_relocations_no);
   if (auto *DwarfFormatArg = Args.getLastArg(OPT_gdwarf64, OPT_gdwarf32))
     Opts.Dwarf64 = DwarfFormatArg->getOption().matches(OPT_gdwarf64);
   Opts.DwarfVersion = getLastArgIntValue(Args, OPT_dwarf_version_EQ, 2, Diags);
@@ -189,6 +199,7 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
   Opts.NoExecStack = Args.hasArg(OPT_mno_exec_stack);
   Opts.FatalWarnings = Args.hasArg(OPT_massembler_fatal_warnings);
   Opts.NoWarn = Args.hasArg(OPT_massembler_no_warn);
+  Opts.NoTypeCheck = Args.hasArg(OPT_mno_type_check);
   Opts.RelocationModel =
       std::string(Args.getLastArgValue(OPT_mrelocation_model, "pic"));
   Opts.TargetABI = std::string(Args.getLastArgValue(OPT_target_abi));
@@ -213,6 +224,8 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
             .Case("no-compact-unwind", EmitDwarfUnwindType::NoCompactUnwind)
             .Case("default", EmitDwarfUnwindType::Default);
   }
+
+  Opts.AsSecureLogFile = Args.getLastArgValue(OPT_as_secure_log_file);
 
   return Success;
 }
@@ -265,6 +278,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
 
   MCTargetOptions MCOptions;
   MCOptions.EmitDwarfUnwind = Opts.EmitDwarfUnwind;
+  MCOptions.AsSecureLogFile = Opts.AsSecureLogFile;
 
   std::unique_ptr<MCAsmInfo> MAI(
       TheTarget->createMCAsmInfo(*MRI, Opts.Triple, MCOptions));
@@ -314,6 +328,8 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
       TheTarget->createMCObjectFileInfo(Ctx, PIC));
   if (Opts.DarwinTargetVariantTriple)
     MOFI->setDarwinTargetVariantTriple(*Opts.DarwinTargetVariantTriple);
+  if (!Opts.DarwinTargetVariantSDKVersion.empty())
+    MOFI->setDarwinTargetVariantSDKVersion(Opts.DarwinTargetVariantSDKVersion);
   Ctx.setObjectFileInfo(MOFI.get());
 
   if (Opts.SaveTemporaryLabels)
@@ -353,6 +369,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
 
   MCOptions.MCNoWarn = Opts.NoWarn;
   MCOptions.MCFatalWarnings = Opts.FatalWarnings;
+  MCOptions.MCNoTypeCheck = Opts.NoTypeCheck;
   MCOptions.ABIName = Opts.TargetABI;
 
   // FIXME: There is a bit of code duplication with addPassesToEmitFile.

--- a/builder/cc1as.h
+++ b/builder/cc1as.h
@@ -82,6 +82,7 @@ struct AssemblerInvocation {
   unsigned NoExecStack : 1;
   unsigned FatalWarnings : 1;
   unsigned NoWarn : 1;
+  unsigned NoTypeCheck : 1;
   unsigned IncrementalLinkerCompatible : 1;
   unsigned EmbedBitcode : 1;
 
@@ -97,7 +98,14 @@ struct AssemblerInvocation {
 
   /// Darwin target variant triple, the variant of the deployment target
   /// for which the code is being compiled.
-  llvm::Optional<llvm::Triple> DarwinTargetVariantTriple;
+  std::optional<llvm::Triple> DarwinTargetVariantTriple;
+
+  /// The version of the darwin target variant SDK which was used during the
+  /// compilation
+  llvm::VersionTuple DarwinTargetVariantSDKVersion;
+
+  /// The name of a file to use with \c .secure_log_unique directives.
+  std::string AsSecureLogFile;
   /// @}
 
 public:
@@ -114,6 +122,7 @@ public:
     NoExecStack = 0;
     FatalWarnings = 0;
     NoWarn = 0;
+    NoTypeCheck = 0;
     IncrementalLinkerCompatible = 0;
     Dwarf64 = 0;
     DwarfVersion = 0;

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,9 +41,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 4612, 280, 0, 2252},
-		{"microbit", "examples/serial", 2724, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6063, 1485, 116, 6816},
+		{"hifive1b", "examples/echo", 4568, 280, 0, 2252},
+		{"microbit", "examples/serial", 2728, 388, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 5996, 1484, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/cgo/libclang_config_llvm15.go
+++ b/cgo/libclang_config_llvm15.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && !llvm14
+//go:build !byollvm && llvm15
 
 package cgo
 

--- a/cgo/libclang_config_llvm16.go
+++ b/cgo/libclang_config_llvm16.go
@@ -1,0 +1,21 @@
+//go:build !byollvm && !llvm14 && !llvm15
+
+package cgo
+
+// As of 2023-05-05, there is a packaging issue on Debian:
+// https://github.com/llvm/llvm-project/issues/62199
+// A workaround is to fix this locally, using something like this:
+//
+//   ln -sf ../../x86_64-linux-gnu/libclang-16.so.1 /usr/lib/llvm-16/lib/libclang.so
+
+/*
+#cgo linux        CFLAGS:  -I/usr/lib/llvm-16/include
+#cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@16/include
+#cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@16/include
+#cgo freebsd      CFLAGS:  -I/usr/local/llvm16/include
+#cgo linux        LDFLAGS: -L/usr/lib/llvm-16/lib -lclang
+#cgo darwin,amd64 LDFLAGS: -L/usr/local/opt/llvm@16/lib -lclang -lffi
+#cgo darwin,arm64 LDFLAGS: -L/opt/homebrew/opt/llvm@16/lib -lclang -lffi
+#cgo freebsd      LDFLAGS: -L/usr/local/llvm16/lib -lclang
+*/
+import "C"

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -77,6 +77,10 @@ CXType tinygo_clang_getEnumDeclIntegerType(CXCursor c) {
 	return clang_getEnumDeclIntegerType(c);
 }
 
+unsigned tinygo_clang_Cursor_isAnonymous(CXCursor c) {
+	return clang_Cursor_isAnonymous(c);
+}
+
 unsigned tinygo_clang_Cursor_isBitField(CXCursor c) {
 	return clang_Cursor_isBitField(c);
 }

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -51,10 +51,10 @@ type (
 	C.longlong  int64
 	C.ulonglong uint64
 )
-type C._Ctype_struct___0 struct {
+type C.struct_point_t struct {
 	x C.int
 	y C.int
 }
-type C.point_t = C._Ctype_struct___0
+type C.point_t = C.struct_point_t
 
 const C.SOME_CONST_3 = 1234

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -38,11 +38,11 @@ type (
 	C.ulonglong uint64
 )
 type C.myint = C.int
-type C._Ctype_struct___0 struct {
+type C.struct_point2d_t struct {
 	x C.int
 	y C.int
 }
-type C.point2d_t = C._Ctype_struct___0
+type C.point2d_t = C.struct_point2d_t
 type C.struct_point3d struct {
 	x C.int
 	y C.int
@@ -55,21 +55,19 @@ type C.struct_type1 struct {
 	___type C.int
 }
 type C.struct_type2 struct{ _type C.int }
-type C._Ctype_union___1 struct{ i C.int }
-type C.union1_t = C._Ctype_union___1
-type C._Ctype_union___2 struct{ $union uint64 }
+type C.union_union1_t struct{ i C.int }
+type C.union1_t = C.union_union1_t
+type C.union_union3_t struct{ $union uint64 }
 
-func (union *C._Ctype_union___2) unionfield_i() *C.int {
-	return (*C.int)(unsafe.Pointer(&union.$union))
-}
-func (union *C._Ctype_union___2) unionfield_d() *float64 {
+func (union *C.union_union3_t) unionfield_i() *C.int { return (*C.int)(unsafe.Pointer(&union.$union)) }
+func (union *C.union_union3_t) unionfield_d() *float64 {
 	return (*float64)(unsafe.Pointer(&union.$union))
 }
-func (union *C._Ctype_union___2) unionfield_s() *C.short {
+func (union *C.union_union3_t) unionfield_s() *C.short {
 	return (*C.short)(unsafe.Pointer(&union.$union))
 }
 
-type C.union3_t = C._Ctype_union___2
+type C.union3_t = C.union_union3_t
 type C.union_union2d struct{ $union [2]uint64 }
 
 func (union *C.union_union2d) unionfield_i() *C.int { return (*C.int)(unsafe.Pointer(&union.$union)) }
@@ -78,50 +76,50 @@ func (union *C.union_union2d) unionfield_d() *[2]float64 {
 }
 
 type C.union2d_t = C.union_union2d
-type C._Ctype_union___3 struct{ arr [10]C.uchar }
-type C.unionarray_t = C._Ctype_union___3
-type C._Ctype_union___5 struct{ $union [3]uint32 }
+type C.union_unionarray_t struct{ arr [10]C.uchar }
+type C.unionarray_t = C.union_unionarray_t
+type C._Ctype_union___0 struct{ $union [3]uint32 }
 
-func (union *C._Ctype_union___5) unionfield_area() *C.point2d_t {
+func (union *C._Ctype_union___0) unionfield_area() *C.point2d_t {
 	return (*C.point2d_t)(unsafe.Pointer(&union.$union))
 }
-func (union *C._Ctype_union___5) unionfield_solid() *C.point3d_t {
+func (union *C._Ctype_union___0) unionfield_solid() *C.point3d_t {
 	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
 }
 
-type C._Ctype_struct___4 struct {
+type C.struct_struct_nested_t struct {
 	begin C.point2d_t
 	end   C.point2d_t
 	tag   C.int
 
-	coord C._Ctype_union___5
+	coord C._Ctype_union___0
 }
-type C.struct_nested_t = C._Ctype_struct___4
-type C._Ctype_union___6 struct{ $union [2]uint64 }
+type C.struct_nested_t = C.struct_struct_nested_t
+type C.union_union_nested_t struct{ $union [2]uint64 }
 
-func (union *C._Ctype_union___6) unionfield_point() *C.point3d_t {
+func (union *C.union_union_nested_t) unionfield_point() *C.point3d_t {
 	return (*C.point3d_t)(unsafe.Pointer(&union.$union))
 }
-func (union *C._Ctype_union___6) unionfield_array() *C.unionarray_t {
+func (union *C.union_union_nested_t) unionfield_array() *C.unionarray_t {
 	return (*C.unionarray_t)(unsafe.Pointer(&union.$union))
 }
-func (union *C._Ctype_union___6) unionfield_thing() *C.union3_t {
+func (union *C.union_union_nested_t) unionfield_thing() *C.union3_t {
 	return (*C.union3_t)(unsafe.Pointer(&union.$union))
 }
 
-type C.union_nested_t = C._Ctype_union___6
+type C.union_nested_t = C.union_union_nested_t
 type C.enum_option = C.int
 type C.option_t = C.enum_option
-type C._Ctype_enum___7 = C.uint
-type C.option2_t = C._Ctype_enum___7
-type C._Ctype_struct___8 struct {
+type C.enum_option2_t = C.uint
+type C.option2_t = C.enum_option2_t
+type C.struct_types_t struct {
 	f   float32
 	d   float64
 	ptr *C.int
 }
-type C.types_t = C._Ctype_struct___8
+type C.types_t = C.struct_types_t
 type C.myIntArray = [10]C.int
-type C._Ctype_struct___9 struct {
+type C.struct_bitfield_t struct {
 	start        C.uchar
 	__bitfield_1 C.uchar
 
@@ -129,21 +127,21 @@ type C._Ctype_struct___9 struct {
 	e C.uchar
 }
 
-func (s *C._Ctype_struct___9) bitfield_a() C.uchar { return s.__bitfield_1 & 0x1f }
-func (s *C._Ctype_struct___9) set_bitfield_a(value C.uchar) {
+func (s *C.struct_bitfield_t) bitfield_a() C.uchar { return s.__bitfield_1 & 0x1f }
+func (s *C.struct_bitfield_t) set_bitfield_a(value C.uchar) {
 	s.__bitfield_1 = s.__bitfield_1&^0x1f | value&0x1f<<0
 }
-func (s *C._Ctype_struct___9) bitfield_b() C.uchar {
+func (s *C.struct_bitfield_t) bitfield_b() C.uchar {
 	return s.__bitfield_1 >> 5 & 0x1
 }
-func (s *C._Ctype_struct___9) set_bitfield_b(value C.uchar) {
+func (s *C.struct_bitfield_t) set_bitfield_b(value C.uchar) {
 	s.__bitfield_1 = s.__bitfield_1&^0x20 | value&0x1<<5
 }
-func (s *C._Ctype_struct___9) bitfield_c() C.uchar {
+func (s *C.struct_bitfield_t) bitfield_c() C.uchar {
 	return s.__bitfield_1 >> 6
 }
-func (s *C._Ctype_struct___9) set_bitfield_c(value C.uchar,
+func (s *C.struct_bitfield_t) set_bitfield_c(value C.uchar,
 
 ) { s.__bitfield_1 = s.__bitfield_1&0x3f | value<<6 }
 
-type C.bitfield_t = C._Ctype_struct___9
+type C.bitfield_t = C.struct_bitfield_t

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -281,10 +281,14 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 		}
 	case "arm64":
 		spec.CPU = "generic"
-		spec.Features = "+neon"
+		if goos == "darwin" {
+			spec.Features = "+neon"
+		} else { // windows, linux
+			spec.Features = "+neon,-fmv"
+		}
 	case "wasm":
 		spec.CPU = "generic"
-		spec.Features = "+bulk-memory,+nontrapping-fptoint,+sign-ext"
+		spec.Features = "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext"
 		spec.BuildTags = append(spec.BuildTags, "tinygo.wasm")
 		spec.CFlags = append(spec.CFlags,
 			"-mbulk-memory",

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -180,7 +180,7 @@ func (c *compilerContext) getFunction(fn *ssa.Function) (llvm.Type, llvm.Value) 
 		if strings.Split(c.Triple, "-")[0] == "avr" {
 			// These functions are compiler-rt/libgcc functions that are
 			// currently implemented in Go. Assembly versions should appear in
-			// LLVM 16 hopefully. Until then, they need to be made available to
+			// LLVM 17 hopefully. Until then, they need to be made available to
 			// the linker and the best way to do that is llvm.compiler.used.
 			// I considered adding a pragma for this, but the LLVM language
 			// reference explicitly says that this feature should not be exposed

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -206,7 +206,7 @@ entry:
   ret void
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -31,12 +31,12 @@ entry:
   ret void
 }
 
-; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3
 
 declare void @runtime.chanSend(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #1
 
-; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3
 
 ; Function Attrs: nounwind
@@ -107,8 +107,8 @@ select.body:                                      ; preds = %select.next
 
 declare { i32, i1 } @runtime.tryChanSelect(ptr, ptr, i32, i32, ptr) #1
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { argmemonly nocallback nofree nosync nounwind willreturn }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #4 = { nounwind }

--- a/compiler/testdata/float.ll
+++ b/compiler/testdata/float.ll
@@ -93,6 +93,6 @@ entry:
   ret i8 %0
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }

--- a/compiler/testdata/func.ll
+++ b/compiler/testdata/func.ll
@@ -44,7 +44,7 @@ entry:
   ret void
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -135,7 +135,7 @@ entry:
   ret %runtime._interface %1
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/go1.20.ll
+++ b/compiler/testdata/go1.20.ll
@@ -57,7 +57,7 @@ entry:
   ret ptr %s.data
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/go1.21.ll
+++ b/compiler/testdata/go1.21.ll
@@ -138,7 +138,7 @@ entry:
   ret void
 }
 
-; Function Attrs: argmemonly nocallback nofree nounwind willreturn writeonly
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i32(ptr nocapture writeonly, i8, i32, i1 immarg) #3
 
 ; Function Attrs: nounwind
@@ -156,24 +156,24 @@ entry:
 
 declare void @runtime.hashmapClear(ptr dereferenceable_or_null(40), ptr) #1
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.smin.i32(i32, i32) #4
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i8 @llvm.umin.i8(i8, i8) #4
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.umin.i32(i32, i32) #4
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.smax.i32(i32, i32) #4
 
-; Function Attrs: nocallback nofree nosync nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare i32 @llvm.umax.i32(i32, i32) #4
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { argmemonly nocallback nofree nounwind willreturn writeonly }
-attributes #4 = { nocallback nofree nosync nounwind readnone speculatable willreturn }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #5 = { nounwind }

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -188,13 +188,13 @@ entry:
   unreachable
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.regularFunction" }
-attributes #4 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
-attributes #5 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
-attributes #6 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper" }
-attributes #7 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
-attributes #8 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.regularFunction" }
+attributes #4 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.inlineFunctionGoroutine$1" }
+attributes #5 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="main.closureFunctionGoroutine$1" }
+attributes #6 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper" }
+attributes #7 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Print(string)" "tinygo-methods"="reflect/methods.Print(string)" }
+attributes #8 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-gowrapper"="interface:{Print:func:{basic:string}{}}.Print$invoke" }
 attributes #9 = { nounwind }

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -130,11 +130,11 @@ entry:
 
 declare %runtime._string @"interface:{Error:func:{}{basic:string}}.Error$invoke"(ptr, ptr, ptr) #6
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.Error() string" }
-attributes #4 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.String() string" }
-attributes #5 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
-attributes #6 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.Error() string" }
+attributes #4 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-methods"="reflect/methods.String() string" }
+attributes #5 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="main.$methods.foo(int) uint8" "tinygo-methods"="reflect/methods.String() string; main.$methods.foo(int) uint8" }
+attributes #6 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "tinygo-invoke"="reflect/methods.Error() string" "tinygo-methods"="reflect/methods.Error() string" }
 attributes #7 = { nounwind }

--- a/compiler/testdata/pointer.ll
+++ b/compiler/testdata/pointer.ll
@@ -44,7 +44,7 @@ entry:
   ret ptr %x
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -72,13 +72,13 @@ entry:
 
 declare void @main.undefinedFunctionNotInSection(ptr) #1
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" }
-attributes #4 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" }
-attributes #7 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="modulename" "wasm-import-name"="import1" }
-attributes #8 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="foobar" "wasm-import-name"="imported" }
-attributes #9 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exported" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" }
+attributes #4 = { inlinehint nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" }
+attributes #7 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="modulename" "wasm-import-name"="import1" }
+attributes #8 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="foobar" "wasm-import-name"="imported" }
+attributes #9 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exported" }

--- a/compiler/testdata/slice.ll
+++ b/compiler/testdata/slice.ll
@@ -322,7 +322,7 @@ unsafe.Slice.throw:                               ; preds = %entry
   unreachable
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/string.ll
+++ b/compiler/testdata/string.ll
@@ -97,7 +97,7 @@ lookup.throw:                                     ; preds = %entry
   unreachable
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #3 = { nounwind }

--- a/compiler/testdata/zeromap.ll
+++ b/compiler/testdata/zeromap.ll
@@ -38,14 +38,14 @@ entry:
   ret i32 %6
 }
 
-; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #4
 
 declare void @runtime.memzero(ptr, i32, ptr) #1
 
 declare i1 @runtime.hashmapBinaryGet(ptr dereferenceable_or_null(40), ptr, ptr, i32, ptr) #1
 
-; Function Attrs: argmemonly nocallback nofree nosync nounwind willreturn
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #4
 
 ; Function Attrs: noinline nounwind
@@ -132,9 +132,9 @@ entry:
   ret void
 }
 
-attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #4 = { argmemonly nocallback nofree nosync nounwind willreturn }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #3 = { noinline nounwind "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
+attributes #4 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #5 = { nounwind }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/sys v0.11.0
 	golang.org/x/tools v0.12.0
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32
+	tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/sys v0.11.0
 	golang.org/x/tools v0.12.0
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581
+	tinygo.org/x/go-llvm v0.0.0-20230918183930-9edb6403d0bc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -65,5 +65,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581 h1:z/i3eLbAyNru8QaYyccJ4nBvdmtvjI7BmmP80QJr7rY=
-tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20230918183930-9edb6403d0bc h1:IVX1dqCX3c88P7iEMBtz1xCAM4UIqCMgbqHdSefBaWE=
+tinygo.org/x/go-llvm v0.0.0-20230918183930-9edb6403d0bc/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/go.sum
+++ b/go.sum
@@ -65,5 +65,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32 h1:LvdmoXncO43m2cws1chRB2hkLBAxfN6CbSjDI7+gk4Y=
-tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581 h1:z/i3eLbAyNru8QaYyccJ4nBvdmtvjI7BmmP80QJr7rY=
+tinygo.org/x/go-llvm v0.0.0-20230522123337-073e98d0d581/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
-	"features": "+c,+m,-relax,-save-restore",
+	"features": "+32bit,+c,+m,-64bit,-a,-d,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-f,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["esp32c3", "esp"],
 	"serial": "uart",
 	"rtlib": "compiler-rt",

--- a/targets/fe310.json
+++ b/targets/fe310.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
 	"cpu": "sifive-e31",
-	"features": "+a,+c,+m,-64bit,-relax,-save-restore",
+	"features": "+32bit,+a,+c,+m,-64bit,-d,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-f,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["fe310", "sifive"]
 }

--- a/targets/k210.json
+++ b/targets/k210.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv64"],
-	"features": "+64bit,+a,+c,+d,+f,+m,-relax,-save-restore",
+	"features": "+64bit,+a,+c,+d,+f,+m,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["k210", "kendryte"],
 	"code-model": "medium"
 }

--- a/targets/nintendoswitch.json
+++ b/targets/nintendoswitch.json
@@ -1,7 +1,7 @@
 {
   "llvm-target": "aarch64",
   "cpu": "cortex-a57",
-  "features": "+aes,+crc,+crypto,+fp-armv8,+neon,+sha2,+v8a",
+  "features": "+aes,+crc,+crypto,+fp-armv8,+neon,+sha2,+v8a,-fmv",
   "build-tags": ["nintendoswitch", "arm64"],
   "scheduler": "tasks",
   "goos": "linux",

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -1,6 +1,6 @@
 {
 	"inherits": ["riscv32"],
-	"features": "+a,+c,+m,-relax,-save-restore",
+	"features": "+32bit,+a,+c,+m,-64bit,-d,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-f,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["virt", "qemu"],
 	"default-stack-size": 4096,
 	"linkerscript": "targets/riscv-qemu.ld",

--- a/targets/riscv32.json
+++ b/targets/riscv32.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["riscv"],
 	"llvm-target": "riscv32-unknown-none",
+	"cpu": "generic-rv32",
 	"target-abi": "ilp32",
 	"build-tags": ["tinygo.riscv32"],
 	"scheduler": "tasks",

--- a/targets/riscv64.json
+++ b/targets/riscv64.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["riscv"],
 	"llvm-target": "riscv64-unknown-none",
+	"cpu": "generic-rv64",
 	"target-abi": "lp64",
 	"build-tags": ["tinygo.riscv64"],
 	"cflags": [

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target":   "wasm32-unknown-wasi",
 	"cpu":           "generic",
-	"features":      "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features":      "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext",
 	"build-tags":    ["tinygo.wasm", "wasi"],
 	"goos":          "linux",
 	"goarch":        "arm",

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target":   "wasm32-unknown-wasi",
 	"cpu":           "generic",
-	"features":      "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features":      "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext",
 	"build-tags":    ["tinygo.wasm"],
 	"goos":          "js",
 	"goarch":        "wasm",


### PR DESCRIPTION
This commit adds support for LLVM 16 and switches to it by default. That means three LLVM versions are supported at the same time: LLVM 14, 15, and 16.

Part of this work was based on a PR by QuLogic: https://github.com/tinygo-org/tinygo/pull/3649
But I also had parts of this already implemented in an old branch I already made for LLVM 16.

Here are some differences:
  * It switches to LLVM 16 by default.
  * It updates some things to also make it work with a self-built LLVM.
  * It fixes the CGo bug in a slightly different way, and also fixes another one not included in the original PR.
  * It does not keep compiler tests passing on older LLVM versions. I have found this to be quite burdensome and therefore don't generally do this - the smoke tests should hopefully catch most regressions.