### PR TITLE
build: explicitly pass the github token to GH action

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -91,5 +91,6 @@ jobs:
       - name: Add comment
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           filePath: comment.txt
           comment_tag: sizediff


### PR DESCRIPTION
This PR is yet another attempt to address the permissions issue with the https://github.com/thollander/actions-comment-pull-request plugin.