### PR TITLE
Add bluemicro840 board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,6 +528,10 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10059            examples/blinky2
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=bluemicro840        examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=bluemicro840        examples/blinky2
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-m0          examples/blinky1

--- a/Makefile
+++ b/Makefile
@@ -528,8 +528,6 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10059            examples/blinky2
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=bluemicro840        examples/blinky1
-	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=bluemicro840        examples/blinky2
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/blinky1

--- a/src/machine/board_bluemicro840.go
+++ b/src/machine/board_bluemicro840.go
@@ -1,0 +1,80 @@
+//go:build bluemicro840
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+// GPIO Pins
+const (
+	D006 = P0_06
+	D008 = P0_08
+	D015 = P0_15
+	D017 = P0_17
+	D020 = P0_20
+	D013 = P0_13
+	D024 = P0_24
+	D009 = P0_09
+	D010 = P0_10
+	D106 = P1_06
+
+	D031 = P0_31 // AIN7; P0.31 (AIN7) is used to read the voltage of the battery via ADC. It can’t be used for any other function.
+	D012 = P0_12 // VCC 3.3V; P0.12 on VCC shuts off the power to VCC when you set it to high; This saves on battery immensely for LEDs of all kinds that eat power even when off
+
+	D030 = P0_30
+	D026 = P0_26
+	D029 = P0_29
+	D002 = P0_02
+	D113 = P1_13
+	D003 = P0_03
+	D028 = P0_28
+	D111 = P1_11
+)
+
+// Analog Pins
+const (
+	AIN0 = P0_02
+	AIN1 = P0_03
+	AIN2 = P0_04 // Not Connected
+	AIN3 = P0_05 // Not Connected
+	AIN4 = P0_28
+	AIN5 = P0_29
+	AIN6 = P0_30
+	AIN7 = P0_31 // Battery
+)
+
+const (
+	LED1 Pin = P1_04 // Red LED
+	LED2 Pin = P1_10 // Blue LED
+	LED  Pin = LED1
+)
+
+// UART0 pins (logical UART1) - Maps to same location as Pro Micro
+const (
+	UART_RX_PIN = P0_08
+	UART_TX_PIN = P0_06
+)
+
+// I2C pins
+const (
+	SDA_PIN = P0_15 // I2C0 external
+	SCL_PIN = P0_17 // I2C0 external
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN = P1_13 // SCK
+	SPI0_SDI_PIN = P0_03 // SDI
+	SPI0_SDO_PIN = P0_28 // SDO
+
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "bluemicro840"
+	usb_STRING_MANUFACTURER = "BlueMicro"
+)
+
+var (
+	usb_VID uint16 = 0x1d50
+	usb_PID uint16 = 0x6161
+)

--- a/targets/bluemicro840.json
+++ b/targets/bluemicro840.json
@@ -1,0 +1,5 @@
+{
+    "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
+    "build-tags": ["bluemicro840"],
+    "msd-volume-name": ["BLUEMICRO"]
+}

--- a/targets/bluemicro840.json
+++ b/targets/bluemicro840.json
@@ -1,5 +1,6 @@
 {
     "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["bluemicro840"],
+    "serial-port": ["1d50:6161"],
     "msd-volume-name": ["BLUEMICRO"]
 }


### PR DESCRIPTION
Takes care of the BlueMicro840 of issue #3746 

Schematic is located [here](https://nrf52.jpconstantineau.com/docs/bluemicro840_v1)
USB Vendor ID/Product ID were assigned for firmware on this device by [openmoko](https://github.com/openmoko/openmoko-usb-oui/blob/master/usb_product_ids.psv)

Tested on actual hardware.