### PR TITLE
build: only run sizediff job on the main repo

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
-      issues: write
     steps:
       # Prepare, install tools
       - name: Add GOBIN to $PATH
@@ -89,6 +88,7 @@ jobs:
       - name: Comment contents
         run: cat comment.txt
       - name: Add comment
+        if: github.repository == 'tinygo-org/tinygo'
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR modifies the sizediff build job to only create the comment when the pull request is made on the main TinyGo repo, not on forks. This is due to forked repos not having write permissions on the main repo for security reasons.

> You can use the permissions key to add and remove read permissions for forked repositories, but typically you can't grant write access. 

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

It will still perform the size calculation in the test, it just cannot create the comment itself unless the PR is on the main repo.