### PR TITLE
Internal flags

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -175,7 +175,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		AutomaticStackSize: config.AutomaticStackSize(),
 		DefaultStackSize:   config.StackSize(),
 		NeedsStackObjects:  config.NeedsStackObjects(),
-		Debug:              true,
+		Debug:              !config.Options.SkipDWARF, // emit DWARF except when -internal-nodwarf is passed
 	}
 
 	// Load the target machine, which is the LLVM object that contains all

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool
+	SkipDWARF       bool
 	PrintCommands   func(cmd string, args ...string) `json:"-"`
 	Semaphore       chan struct{}                    `json:"-"` // -p flag controls cap
 	Debug           bool

--- a/main.go
+++ b/main.go
@@ -1431,6 +1431,12 @@ func main() {
 	printIR := flag.Bool("internal-printir", false, "print LLVM IR")
 	dumpSSA := flag.Bool("internal-dumpssa", false, "dump internal Go SSA")
 	verifyIR := flag.Bool("internal-verifyir", false, "run extra verification steps on LLVM IR")
+	// Don't generate debug information in the IR, to make IR more readable.
+	// You generally want debug information in IR for various features, like
+	// stack size calculation and features like -size=short, -print-allocs=,
+	// etc. The -no-debug flag is used to strip it at link time. But for TinyGo
+	// development it can be useful to not emit debug information at all.
+	skipDwarf := flag.Bool("internal-nodwarf", false, "internal flag, use -no-debug instead")
 
 	var flagJSON, flagDeps, flagTest bool
 	if command == "help" || command == "list" || command == "info" || command == "build" {
@@ -1508,6 +1514,7 @@ func main() {
 		PrintIR:         *printIR,
 		DumpSSA:         *dumpSSA,
 		VerifyIR:        *verifyIR,
+		SkipDWARF:       *skipDwarf,
 		Semaphore:       make(chan struct{}, *parallelism),
 		Debug:           !*nodebug,
 		PrintSizes:      *printSize,

--- a/main.go
+++ b/main.go
@@ -1401,9 +1401,6 @@ func main() {
 	serial := flag.String("serial", "", "which serial output to use (none, uart, usb)")
 	work := flag.Bool("work", false, "print the name of the temporary build directory and do not delete this directory on exit")
 	interpTimeout := flag.Duration("interp-timeout", 180*time.Second, "interp optimization pass timeout")
-	printIR := flag.Bool("printir", false, "print LLVM IR")
-	dumpSSA := flag.Bool("dumpssa", false, "dump internal Go SSA")
-	verifyIR := flag.Bool("verifyir", false, "run extra verification steps on LLVM IR")
 	var tags buildutil.TagsFlag
 	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
@@ -1429,6 +1426,11 @@ func main() {
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
 	baudrate := flag.Int("baudrate", 115200, "baudrate of serial monitor")
+
+	// Internal flags, that are only intended for TinyGo development.
+	printIR := flag.Bool("internal-printir", false, "print LLVM IR")
+	dumpSSA := flag.Bool("internal-dumpssa", false, "dump internal Go SSA")
+	verifyIR := flag.Bool("internal-verifyir", false, "run extra verification steps on LLVM IR")
 
 	var flagJSON, flagDeps, flagTest bool
 	if command == "help" || command == "list" || command == "info" || command == "build" {


### PR DESCRIPTION
Two small changes:

1. Rename a few flags that are only intended for TinyGo developers.
2. Add a `-internal-nodwarf` flag to avoid debug information generation. This can be useful during development.