### PR TITLE
adding new uf2 target for PCA10056

### DIFF
--- a/targets/pca10056-s140v6-uf2.json
+++ b/targets/pca10056-s140v6-uf2.json
@@ -1,5 +1,5 @@
 {
-	"inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
+    "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
     "build-tags": ["pca10056"],
     "serial-port": ["239a:0x0029"],
     "msd-volume-name": ["NRF52BOOT"]

--- a/targets/pca10056-s140v6-uf2.json
+++ b/targets/pca10056-s140v6-uf2.json
@@ -1,0 +1,6 @@
+{
+	"inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
+    "build-tags": ["pca10056"],
+    "serial-port": ["239a:0x0029"],
+    "msd-volume-name": ["NRF52BOOT"]
+}


### PR DESCRIPTION
Tested on actual hardware with blink1 and blink2 examples.
Unlike flashing with the "vanilla" pca10056 target, this new target uses the secondary USB port (not the JLINK one) to flash and keeps the bootloader and softdevice on the device.