### PR TITLE
build: only make comment on sizediff job when run from the main repo

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Comment contents
         run: cat comment.txt
       - name: Add comment
-        if: github.repository == 'tinygo-org/tinygo'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         uses: thollander/actions-comment-pull-request@v2.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR should implement correctly the repo name check to skip trying to make a GH actions comment when that pull request comes from a fork.

https://github.com/orgs/community/discussions/26829#discussioncomment-3253575