### PR TITLE
reflect: use .key() instead of a type assert

### DIFF
--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -913,7 +913,7 @@ func (v Value) MapKeys() []Value {
 	k := New(v.typecode.Key())
 	e := New(v.typecode.Elem())
 
-	keyType := v.typecode.Key().(*rawType)
+	keyType := v.typecode.key()
 	isKeyStoredAsInterface := keyType.Kind() != String && !keyType.isBinary()
 
 	for hashmapNext(v.pointer(), it, k.value, e.value) {


### PR DESCRIPTION
This should be ever so slightly more efficient.

This is basically the same change as https://github.com/tinygo-org/tinygo/pull/3591/commits/507d76a64abf5e974fb01357aed7bff3dc8ee872.