### PR TITLE
all: release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,140 @@
+0.28.0
+---
+
+* **general**
+  - fix parallelism in the compiler on Windows by building LLVM with thread support
+  - support qemu-user debugging
+  - make target JSON msd-volume-name an array
+  - print source location when a panic happens in -monitor
+  - `test`: don't print `ok` for a successful compile-only
+* **compiler**
+  - `builder`: remove non-ThinLTO build mode
+  - `builder`: fail earlier if Go is not available
+  - `builder`: improve `-size=full` in a number of ways
+  - `builder`: implement Nordic DFU file writer in Go
+  - `cgo`: allow `LDFLAGS: --export=...`
+  - `compiler`: support recursive slice types
+  - `compiler`: zero struct padding during map operations
+  - `compiler`: add llvm.ident metadata
+  - `compiler`: remove `unsafe.Pointer(uintptr(v) + idx)` optimization (use `unsafe.Add` instead)
+  - `compiler`: add debug info to `//go:embed` data structures for better `-size` output
+  - `compiler`: add debug info to string constants
+  - `compiler`: fix a minor race condition
+  - `compiler`: emit correct alignment in debug info for global variables
+  - `compiler`: correctly generate reflect data for local named types
+  - `compiler`: add alloc attributes to `runtime.alloc`, reducing flash usage slightly
+  - `compiler`: for interface maps, use the original named type if available
+  - `compiler`: implement most math/bits functions as LLVM intrinsics
+  - `compiler`: ensure all defers have been seen before creating rundefers
+* **standard library**
+  - `internal/task`: disallow blocking inside an interrupt
+  - `machine`: add `CPUReset`
+  - `machine/usb/hid`: add MediaKey support
+  - `machine/usb/hid/joystick`: move joystick under HID
+  - `machine/usb/hid/joystick`: allow joystick settings override
+  - `machine/usb/hid/joystick`: handle case where we cannot find the correct HID descriptor
+  - `machine/usb/hid/mouse`: add support for mouse back and forward
+  - `machine/usb`: add ability to override default VID, PID, manufacturer name, and product name
+  - `net`: added missing `TCPAddr` and `UDPAddr` implementations
+  - `os`: add IsTimeout function
+  - `os`: fix resource leak in `(*File).Close`
+  - `os`: add `(*File).Sync`
+  - `os`: implement `(*File).ReadDir` for wasi
+  - `os`: implement `(*File).WriteAt`
+  - `reflect`: make sure null bytes are supported in tags
+  - `reflect`: refactor this package to enable many new features
+  - `reflect`: add map type methods: `Elem` and `Key`
+  - `reflect`: add map methods: `MapIndex`, `MapRange`/`MapIter`, `SetMapIndex`, `MakeMap`, `MapKeys`
+  - `reflect`: add slice methods: `Append`, `MakeSlice`, `Slice`, `Slice3`, `Copy`, `Bytes`, `SetLen`
+  - `reflect`: add misc methods: `Zero`, `Addr`, `UnsafeAddr`, `OverflowFloat`, `OverflowInt`, `OverflowUint`, `SetBytes`, `Convert`, `CanInt`, `CanFloat`, `CanComplex`, `Comparable`
+  - `reflect`: add type methods: `String`, `PkgPath`, `FieldByName`, `FieldByIndex`, `NumMethod`
+  - `reflect`: add stubs for `Type.Method`, `CanConvert`, `ArrayOf`, `StructOf`, `MapOf`
+  - `reflect`: add stubs for channel select routines/types
+  - `reflect`: allow nil rawType to call Kind()
+  - `reflect`: ensure all ValueError panics have Kind fields
+  - `reflect`: add support for named types
+  - `reflect`: improve `Value.String()`
+  - `reflect`: set `Index` and `PkgPath` field in `Type.Field`
+  - `reflect`: `Type.AssignableTo`: you can assign anything to `interface{}`
+  - `reflect`: add type check to `Value.Field`
+  - `reflect`: let `TypeOf(nil)` return nil
+  - `reflect`: move `StructField.Anonymous` field to match upstream location
+  - `reflect`: add `UnsafePointer` for Func types
+  - `reflect`: `MapIter.Next` needs to allocate new keys/values every time
+  - `reflect`: fix `IsNil` for interfaces
+  - `reflect`: fix `Type.Name` to return an empty string for non-named types
+  - `reflect`: add `VisibleFields`
+  - `reflect`: properly handle embedded structs
+  - `reflect`: make sure `PointerTo` works for named types
+  - `reflect`: `Set`: convert non-interface to interface
+  - `reflect`: `Set`: fix direction of assignment check
+  - `reflect`: support channel directions
+  - `reflect`: print struct tags in Type.String()
+  - `reflect`: properly handle read-only values
+  - `runtime`: allow custom-gc SetFinalizer and clarify KeepAlive
+  - `runtime`: implement KeepAlive using inline assembly
+  - `runtime`: check for heap allocations inside interrupts
+  - `runtime`: properly turn pointer into empty interface when hashing
+  - `runtime`: improve map size hint usage
+  - `runtime`: zero map key/value on deletion to so GC doesn't see them
+  - `runtime`: print the address where a panic happened
+  - `runtime/debug`: stub `SetGCPercent`, `BuildInfo.Settings`
+  - `runtime/metrics`: add this package as a stub
+  - `syscall`: `Stat_t` timespec fields are Atimespec on darwin
+  - `syscall`: add `Timespec.Unix()` for wasi
+  - `syscall`: add fsync using libc
+  - `testing`: support -test.count
+  - `testing`: make test output unbuffered when verbose
+  - `testing`: add -test.skip
+  - `testing`: move runtime.GC() call to runN to match upstream
+  - `testing`: add -test.shuffle to order randomize test and benchmark order
+* **targets**
+  - `arm64`: fix register save/restore to include vector registers
+  - `attiny1616`: add support for this chip
+  - `cortexm`: refactor EnableInterrupts and DisableInterrupts to avoid `arm.AsmFull`
+  - `cortexm`: enable functions in RAM for go & cgo
+  - `cortexm`: convert SystemStack from `AsmFull` to C inline assembly
+  - `cortexm`: fix crash due to wrong stack size offset
+  - `nrf`: samd21, stm32: add flash API
+  - `nrf`: fix memory issue in ADC read
+  - `nrf`: new peripheral type for nrf528xx chips
+  - `nrf`: implement target mode
+  - `nrf`: improve ADC and add oversampling, longer sample time, and reference voltage
+  - `rp2040`: change calling order for device enumeration fix to do first
+  - `rp2040`: rtc delayed interrupt
+  - `rp2040`: provide better errors for invalid pins on I2C and SPI
+  - `rp2040`: change uart to allow for a single pin
+  - `rp2040`: implement Flash interface
+  - `rp2040`: remove SPI `DataBits` property
+  - `rp2040`: unify all linker scripts using LDFLAGS
+  - `rp2040`: remove SPI deadline for improved performance
+  - `rp2040`: use 4MHz as default frequency for SPI
+  - `rp2040`: implement target mode
+  - `rp2040`: use DMA for send-only SPI transfers
+  - `samd21`: rearrange switch case for get pin cfg
+  - `samd21`: fix issue with WS2812 driver by making pin accesses faster
+  - `samd51`: enable CMCC cache for greatly improved performance
+  - `samd51`: remove extra BK0RDY clear
+  - `samd51`: implement Flash interface
+  - `samd51`: use correct SPI frequency
+  - `samd51`: remove extra BK0RDY clear
+  - `samd51`: fix ADC multisampling
+  - `wasi`: allow users to set the `runtime_memhash_tsip` or `runtime_memhash_fnv` build tags
+  - `wasi`: set `WASMTIME_BACKTRACE_DETAILS` when running in wasmtime.
+  - `wasm`: implement the `//go:wasmimport` directive
+* **boards**
+  - `gameboy-advance`: switch to use register definitions in device/gba
+  - `gameboy-advance`: rename display and make pointer receivers
+  - `gopher-badge`: Added Gopher Badge support
+  - `lorae5`: add needed definition for UART2
+  - `lorae5`: correct mapping for I2C bus, add pin mapping to enable power
+  - `pinetime`: update the target file (rename from pinetime-devkit0)
+  - `qtpy`: fix bad pin assignment
+  - `wioterminal`: fix pin definition of BCM13
+  - `xiao`: Pins D4 & D5 are I2C1. Use pins D2 & D3 for I2C0.
+  - `xiao`: add DefaultUART
+
+
 0.27.0
 ---
 


### PR DESCRIPTION
These are some major or breaking changes:

 - Reflect support got improved a lot.
 - Interrupts became more strict: heap allocations an blocking operations, which have always been undefined behavior, now result in a panic.
 - `//go:wasmimport` was added
 - various new flags were added to `tinygo test`
 - the source location for panics is printed in the `-monitor` output