### PR TITLE
ci: rename release-double-zipped to something more useful

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -108,7 +108,7 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v2
         with:
-          name: release-double-zipped
+          name: darwin-amd64-double-zipped
           path: build/tinygo.darwin-amd64.tar.gz
       - name: Smoke tests
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,7 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v3
         with:
-          name: release-double-zipped
+          name: windows-amd64-double-zipped
           path: build/release/release.zip
 
   smoke-test-windows:
@@ -148,7 +148,7 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v2
         with:
-          name: release-double-zipped
+          name: windows-amd64-double-zipped
           path: build/
       - name: Unzip TinyGo build
         shell: bash
@@ -178,7 +178,7 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v2
         with:
-          name: release-double-zipped
+          name: windows-amd64-double-zipped
           path: build/
       - name: Unzip TinyGo build
         shell: bash
@@ -214,7 +214,7 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v2
         with:
-          name: release-double-zipped
+          name: windows-amd64-double-zipped
           path: build/
       - name: Unzip TinyGo build
         shell: bash


### PR DESCRIPTION
The Linux artifacts have clear names (linux-amd64-double-zipped etc), but the MacOS and Windows ones didn't. This patch renames these artifact names to be more readable, especially when downloading the artifacts.