### PR TITLE
example: simplify pininterrupt

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,7 +43,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4612, 280, 0, 2252},
 		{"microbit", "examples/serial", 2724, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6159, 1485, 116, 6816},
+		{"wioterminal", "examples/pininterrupt", 6039, 1485, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/examples/pininterrupt/pininterrupt.go
+++ b/src/examples/pininterrupt/pininterrupt.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"machine"
-	"runtime/volatile"
 	"time"
 )
 
@@ -18,8 +17,6 @@ const (
 )
 
 func main() {
-	var lightLed volatile.Register8
-	lightLed.Set(0)
 
 	// Configure the LED, defaulting to on (usually setting the pin to low will
 	// turn the LED on).
@@ -33,13 +30,7 @@ func main() {
 
 	// Set an interrupt on this pin.
 	err := button.SetInterrupt(buttonPinChange, func(machine.Pin) {
-		if lightLed.Get() != 0 {
-			lightLed.Set(0)
-			led.Low()
-		} else {
-			lightLed.Set(1)
-			led.High()
-		}
+		led.Set(!led.Get())
 	})
 	if err != nil {
 		println("could not configure pin interrupt:", err.Error())


### PR DESCRIPTION
`volatile.Register8` workaround no longer needed since the state of the output pin can be read directly now.