### PR TITLE
machine/usb/hid,joystick: fix hidreport (3)

### DIFF
--- a/src/machine/usb/descriptor/hidreport.go
+++ b/src/machine/usb/descriptor/hidreport.go
@@ -129,48 +129,66 @@ func HIDReportID(id int) []byte {
 }
 
 func HIDLogicalMinimum(min int) []byte {
-	if min > 255 {
-		return []byte{hidLogicalMinimum + 1, uint8(min), uint8(min >> 8)}
+	m := uint32(min)
+	if 65535 < m {
+		return []byte{hidLogicalMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 32)}
+	} else if 255 < m {
+		return []byte{hidLogicalMinimum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidLogicalMinimum, byte(min)}
 }
 
 func HIDLogicalMaximum(max int) []byte {
-	if max > 255 {
-		return []byte{hidLogicalMaximum + 1, uint8(max), uint8(max >> 8)}
+	m := uint32(max)
+	if 65535 < m {
+		return []byte{hidLogicalMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
+	} else if 255 < m {
+		return []byte{hidLogicalMaximum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidLogicalMaximum, byte(max)}
 }
 
 func HIDUsageMinimum(min int) []byte {
-	if min > 255 {
-		return []byte{hidUsageMinimum + 1, uint8(min), uint8(min >> 8)}
+	m := uint32(min)
+	if 65535 < m {
+		return []byte{hidUsageMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
+	} else if 255 < m {
+		return []byte{hidUsageMinimum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidUsageMinimum, byte(min)}
 }
 
 func HIDUsageMaximum(max int) []byte {
-	if max > 255 {
-		return []byte{hidUsageMaximum + 1, uint8(max), uint8(max >> 8)}
+	m := uint32(max)
+	if 65535 < m {
+		return []byte{hidUsageMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
+	} else if 255 < m {
+		return []byte{hidUsageMaximum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidUsageMaximum, byte(max)}
 }
 
 func HIDPhysicalMinimum(min int) []byte {
-	if min > 255 {
-		return []byte{hidPhysicalMinimum + 1, uint8(min), uint8(min >> 8)}
+	m := uint32(min)
+	if 65535 < m {
+		return []byte{hidPhysicalMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
+	} else if 255 < m {
+		return []byte{hidPhysicalMinimum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidPhysicalMinimum, byte(min)}
 }
 
 func HIDPhysicalMaximum(max int) []byte {
-	if max > 255 {
-		return []byte{hidPhysicalMaximum + 1, uint8(max), uint8(max >> 8)}
+	m := uint32(max)
+	if 65535 < m {
+		return []byte{hidPhysicalMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
+	} else if 255 < m {
+		return []byte{hidPhysicalMaximum + 1, uint8(m), uint8(m >> 8)}
 	}
 
 	return []byte{hidPhysicalMaximum, byte(max)}

--- a/src/machine/usb/descriptor/hidreport.go
+++ b/src/machine/usb/descriptor/hidreport.go
@@ -3,12 +3,12 @@ package descriptor
 const (
 	hidUsagePage       = 0x05
 	hidUsage           = 0x09
-	hidLogicalMinimum  = 0x15
-	hidLogicalMaximum  = 0x25
-	hidUsageMinimum    = 0x19
-	hidUsageMaximum    = 0x29
-	hidPhysicalMinimum = 0x35
-	hidPhysicalMaximum = 0x46
+	hidLogicalMinimum  = 0x14
+	hidLogicalMaximum  = 0x24
+	hidUsageMinimum    = 0x18
+	hidUsageMaximum    = 0x28
+	hidPhysicalMinimum = 0x34
+	hidPhysicalMaximum = 0x44
 	hidUnitExponent    = 0x55
 	hidUnit            = 0x65
 	hidCollection      = 0xa1
@@ -16,6 +16,13 @@ const (
 	hidReportSize      = 0x75
 	hidReportCount     = 0x95
 	hidReportID        = 0x85
+)
+
+const (
+	hidSizeValue0 = 0x00
+	hidSizeValue1 = 0x01
+	hidSizeValue2 = 0x02
+	hidSizeValue4 = 0x03
 )
 
 var (
@@ -129,69 +136,63 @@ func HIDReportID(id int) []byte {
 }
 
 func HIDLogicalMinimum(min int) []byte {
-	m := uint32(min)
-	if 65535 < m {
-		return []byte{hidLogicalMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 32)}
-	} else if 255 < m {
-		return []byte{hidLogicalMinimum + 1, uint8(m), uint8(m >> 8)}
+	if min < -32767 || 65535 < min {
+		return []byte{hidLogicalMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
+	} else if min < -127 || 255 < min {
+		return []byte{hidLogicalMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
 	}
 
-	return []byte{hidLogicalMinimum, byte(min)}
+	return []byte{hidLogicalMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDLogicalMaximum(max int) []byte {
-	m := uint32(max)
-	if 65535 < m {
-		return []byte{hidLogicalMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
-	} else if 255 < m {
-		return []byte{hidLogicalMaximum + 1, uint8(m), uint8(m >> 8)}
+	if max < -32767 || 65535 < max {
+		return []byte{hidLogicalMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
+	} else if max < -127 || 255 < max {
+		return []byte{hidLogicalMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
 	}
 
-	return []byte{hidLogicalMaximum, byte(max)}
+	return []byte{hidLogicalMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDUsageMinimum(min int) []byte {
-	m := uint32(min)
-	if 65535 < m {
-		return []byte{hidUsageMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
-	} else if 255 < m {
-		return []byte{hidUsageMinimum + 1, uint8(m), uint8(m >> 8)}
+	if min < -32767 || 65535 < min {
+		return []byte{hidUsageMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
+	} else if min < -127 || 255 < min {
+		return []byte{hidUsageMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
 	}
 
-	return []byte{hidUsageMinimum, byte(min)}
+	return []byte{hidUsageMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDUsageMaximum(max int) []byte {
-	m := uint32(max)
-	if 65535 < m {
-		return []byte{hidUsageMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
-	} else if 255 < m {
-		return []byte{hidUsageMaximum + 1, uint8(m), uint8(m >> 8)}
+	if max < -32767 || 65535 < max {
+		return []byte{hidUsageMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
+	} else if max < -127 || 255 < max {
+		return []byte{hidUsageMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
 	}
 
-	return []byte{hidUsageMaximum, byte(max)}
+	return []byte{hidUsageMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDPhysicalMinimum(min int) []byte {
-	m := uint32(min)
-	if 65535 < m {
-		return []byte{hidPhysicalMinimum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
-	} else if 255 < m {
-		return []byte{hidPhysicalMinimum + 1, uint8(m), uint8(m >> 8)}
+	if min < -32767 || 65535 < min {
+		return []byte{hidPhysicalMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
+	} else if min < -127 || 255 < min {
+		return []byte{hidPhysicalMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
 	}
 
-	return []byte{hidPhysicalMinimum, byte(min)}
+	return []byte{hidPhysicalMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDPhysicalMaximum(max int) []byte {
-	m := uint32(max)
-	if 65535 < m {
-		return []byte{hidPhysicalMaximum + 2, uint8(m), uint8(m >> 8), uint8(m >> 16), uint8(m >> 24)}
-	} else if 255 < m {
-		return []byte{hidPhysicalMaximum + 1, uint8(m), uint8(m >> 8)}
+	if max < -32767 || 65535 < max {
+		return []byte{hidPhysicalMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
+	} else if max < -127 || 255 < max {
+		return []byte{hidPhysicalMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
 	}
 
-	return []byte{hidPhysicalMaximum, byte(max)}
+	return []byte{hidPhysicalMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDUnitExponent(exp int) []byte {

--- a/src/machine/usb/descriptor/hidreport.go
+++ b/src/machine/usb/descriptor/hidreport.go
@@ -136,63 +136,69 @@ func HIDReportID(id int) []byte {
 }
 
 func HIDLogicalMinimum(min int) []byte {
-	if min < -32767 || 65535 < min {
+	switch {
+	case min < -32767 || 65535 < min:
 		return []byte{hidLogicalMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
-	} else if min < -127 || 255 < min {
+	case min < -127 || 255 < min:
 		return []byte{hidLogicalMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
+	default:
+		return []byte{hidLogicalMinimum + hidSizeValue1, byte(min)}
 	}
-
-	return []byte{hidLogicalMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDLogicalMaximum(max int) []byte {
-	if max < -32767 || 65535 < max {
+	switch {
+	case max < -32767 || 65535 < max:
 		return []byte{hidLogicalMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
-	} else if max < -127 || 255 < max {
+	case max < -127 || 255 < max:
 		return []byte{hidLogicalMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
+	default:
+		return []byte{hidLogicalMaximum + hidSizeValue1, byte(max)}
 	}
-
-	return []byte{hidLogicalMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDUsageMinimum(min int) []byte {
-	if min < -32767 || 65535 < min {
+	switch {
+	case min < -32767 || 65535 < min:
 		return []byte{hidUsageMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
-	} else if min < -127 || 255 < min {
+	case min < -127 || 255 < min:
 		return []byte{hidUsageMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
+	default:
+		return []byte{hidUsageMinimum + hidSizeValue1, byte(min)}
 	}
-
-	return []byte{hidUsageMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDUsageMaximum(max int) []byte {
-	if max < -32767 || 65535 < max {
+	switch {
+	case max < -32767 || 65535 < max:
 		return []byte{hidUsageMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
-	} else if max < -127 || 255 < max {
+	case max < -127 || 255 < max:
 		return []byte{hidUsageMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
+	default:
+		return []byte{hidUsageMaximum + hidSizeValue1, byte(max)}
 	}
-
-	return []byte{hidUsageMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDPhysicalMinimum(min int) []byte {
-	if min < -32767 || 65535 < min {
+	switch {
+	case min < -32767 || 65535 < min:
 		return []byte{hidPhysicalMinimum + hidSizeValue4, uint8(min), uint8(min >> 8), uint8(min >> 16), uint8(min >> 24)}
-	} else if min < -127 || 255 < min {
+	case min < -127 || 255 < min:
 		return []byte{hidPhysicalMinimum + hidSizeValue2, uint8(min), uint8(min >> 8)}
+	default:
+		return []byte{hidPhysicalMinimum + hidSizeValue1, byte(min)}
 	}
-
-	return []byte{hidPhysicalMinimum + hidSizeValue1, byte(min)}
 }
 
 func HIDPhysicalMaximum(max int) []byte {
-	if max < -32767 || 65535 < max {
+	switch {
+	case max < -32767 || 65535 < max:
 		return []byte{hidPhysicalMaximum + hidSizeValue4, uint8(max), uint8(max >> 8), uint8(max >> 16), uint8(max >> 24)}
-	} else if max < -127 || 255 < max {
+	case max < -127 || 255 < max:
 		return []byte{hidPhysicalMaximum + hidSizeValue2, uint8(max), uint8(max >> 8)}
+	default:
+		return []byte{hidPhysicalMaximum + hidSizeValue1, byte(max)}
 	}
-
-	return []byte{hidPhysicalMaximum + hidSizeValue1, byte(max)}
 }
 
 func HIDUnitExponent(exp int) []byte {

--- a/src/machine/usb/descriptor/joystick.go
+++ b/src/machine/usb/descriptor/joystick.go
@@ -80,10 +80,7 @@ var JoystickDefaultHIDReport = Append([][]byte{
 	HIDLogicalMaximum(1),
 	HIDReportSize(1),
 	HIDReportCount(16),
-	HIDInputDataVarAbs,
-	HIDReportCount(1),
-	HIDReportSize(3),
-	HIDUnitExponent(-16),
+	HIDUnitExponent(0),
 	HIDUnit(0),
 	HIDInputDataVarAbs,
 


### PR DESCRIPTION
This PR makes corrections to the hidreport.

This fixes a problem with examples/hid-joystick not working properly.
This problem occurs in tinygo-0.28.0.
More precisely, it occurs in #3693.

https://github.com/tinygo-org/tinygo/pull/3636#issuecomment-1596234114

Changes to descriptor/joytsick.go will change it back to the report as of e4da35486bc56c84c3869cd1e3ad79e332228ffb
Changes to descriptor/hidreport.go fix length handling.

| Item |	Range 0-255	| Range 256 and above| Range 65536 and above |
| --- | -- | -- | -- |
|Logical Minimum|	0x15|	0x16|  0x17 |
|Logical Maximum	|0x25	|0x26| 0x27 |
|Physical Minimum	|0x35	|0x36| 0x37 |
|Physical Maximum	|0x45	|0x46| 0x47 |
|Usage Minimum	|0x19	|0x1A| 0x1B |
|Usage Maximum	|0x29	|0x2A| 0x2B |


