### PR TITLE
goenv: Resolve symlinks when looking for TINYGOROOT

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -213,6 +213,10 @@ func sourceDir() string {
 		// Very unlikely. Bail out if it happens.
 		panic("could not get executable path: " + err.Error())
 	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		path = resolved
+	}
 	root = filepath.Dir(filepath.Dir(path))
 	if isSourceDir(root) {
 		return root


### PR DESCRIPTION
On darwin, os.Executable doesn't resolve symlinks by default AFAIK, and linux does, so this normalizes the behavior to always resolve symlinks, so I can download tinygo and symlink it somewhere else.

See: https://pkg.go.dev/os#Executable