### PR TITLE
docker: update clang to version 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.20 AS tinygo-llvm
 
 RUN apt-get update && \
-    apt-get install -y apt-utils make cmake clang-11 ninja-build
+    apt-get install -y apt-utils make cmake clang-15 ninja-build
 
 COPY ./Makefile /tinygo/Makefile
 


### PR DESCRIPTION
When I try to build the docker image, it fails with this error `Unable to locate package clang-11`.
This commit updates the clang version to match the current one, which is 15.