### PR TITLE
targets: support comments in target json files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/sys v0.4.0
 	golang.org/x/tools v0.5.1-0.20230114154351-e035d0c426c8
 	gopkg.in/yaml.v2 v2.4.0
+	muzzammil.xyz/jsonc v1.0.0
 	tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32
 )
 

--- a/go.sum
+++ b/go.sum
@@ -65,5 +65,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+muzzammil.xyz/jsonc v1.0.0 h1:B6kaT3wHueZ87mPz3q1nFuM1BlL32IG0wcq0/uOsQ18=
+muzzammil.xyz/jsonc v1.0.0/go.mod h1:rFv8tUUKe+QLh7v02BhfxXEf4ZHhYD7unR93HL/1Uvo=
 tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32 h1:LvdmoXncO43m2cws1chRB2hkLBAxfN6CbSjDI7+gk4Y=
 tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/targets/arduino-nano-new.json
+++ b/targets/arduino-nano-new.json
@@ -1,3 +1,9 @@
+// Arduino Nano
+// https://store.arduino.cc/products/arduino-nano
+//
+// Since 2018, Arduino Nanos and clones are sold with a new bootloader, which
+// requires programming at 115200 baud instead of the 57600 baud.
+// Use this target to flash newer boards.
 {
 	"inherits": ["arduino-nano"],
 	"flash-command": "avrdude -c arduino -p atmega328p -b 115200 -P {port} -U flash:w:{hex}:i"

--- a/targets/arduino-nano.json
+++ b/targets/arduino-nano.json
@@ -1,3 +1,9 @@
+// Arduino Nano
+// https://store.arduino.cc/products/arduino-nano
+//
+// Since 2018, Arduino Nanos and clones are sold with a new bootloader, which
+// requires programming at 115200 baud instead of the 57600 baud.
+// Use this target to flash older boards.
 {
 	"inherits": ["atmega328p"],
 	"build-tags": ["arduino_nano"],

--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,3 +1,5 @@
+// Arduino Nano 33 IoT
+// https://store.arduino.cc/products/arduino-nano-33-iot
 {
     "inherits": ["atsamd21g18a"],
     "build-tags": ["arduino_nano33"],

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -1,3 +1,5 @@
+// Arduino UNO
+// https://store.arduino.cc/products/arduino-uno-rev3
 {
 	"inherits": ["atmega328p"],
 	"build-tags": ["arduino"],


### PR DESCRIPTION
**New dependency**
- [muzzammil.xyz/jsonc](https://github.com/muhammadmuzzammil1998/jsonc)
This JSONC library is most up-to-date and widely used, also does not bring any extra dependencies.

**Cleanup**
`load()` function was completely dropped, since it does not serve its purpose anymore, as its outdated comment hints upon. Target inheritance is handled by `resolveInherits()` function instead.

**Related**
This PR replaces #2222 