### PR TITLE
machine/macropad_rp2040: add machine.BUTTON

### DIFF
--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -16,6 +16,7 @@ const (
 
 const (
 	SWITCH = GPIO0
+	BUTTON = GPIO0
 
 	KEY1  = GPIO1
 	KEY2  = GPIO2


### PR DESCRIPTION
There are many cases in TinyGo examples where BUTTON is used.
