### PR TITLE
machine/rp2040: wait for 1000 us after flash reset to avoid issues with busy USB bus

### DIFF
--- a/src/machine/machine_rp2040_usb_fix_usb_device_enumeration.go
+++ b/src/machine/machine_rp2040_usb_fix_usb_device_enumeration.go
@@ -3,6 +3,7 @@
 package machine
 
 import (
+	"device/arm"
 	"device/rp"
 )
 
@@ -87,6 +88,7 @@ func hw_enumeration_fix_force_ls_j() {
 	rp.USBCTRL_REGS.USB_MUXING.Set(rp.USBCTRL_REGS_USB_MUXING_TO_DIGITAL_PAD | rp.USBCTRL_REGS_USB_MUXING_SOFTCON)
 
 	// LS_J is now forced but while loop here just to check
+	waitCycles(125000)
 
 	// if timer pool disabled, or no timer available, have to busy wait.
 	hw_enumeration_fix_finish()
@@ -108,4 +110,11 @@ func hw_enumeration_fix_finish() {
 	ioBank0.io[dp].ctrl.Set(gpioCtrlPrev)
 	// Restore the pad ctrl value
 	padsBank0.io[dp].Set(padCtrlPrev)
+}
+
+func waitCycles(n int) {
+	for n > 0 {
+		arm.Asm("nop")
+		n--
+	}
 }


### PR DESCRIPTION
This PR modifies the machine/rp2040 USB reset to wait for 1000 microseconds after flash reset to avoid issues with busy USB bus.

See https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c#L130