### PR TITLE
reflect: implement Value.Grow

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -790,6 +790,8 @@ func TestFunctionValue(t *testing.T) {
 	assert(t, v.Type().String(), "func()")
 }
 
+*/
+
 func TestGrow(t *testing.T) {
 	v := ValueOf([]int(nil))
 	shouldPanic("reflect.Value.Grow using unaddressable value", func() { v.Grow(0) })
@@ -856,8 +858,6 @@ func TestGrow(t *testing.T) {
 		}
 	})
 }
-
-*/
 
 var appendTests = []struct {
 	orig, extra []int


### PR DESCRIPTION
This was added in Go 1.20 and becomes necessary for encoding/json in Go 1.21.