### PR TITLE
machine/samd51: fix i2cTimeout was decreasing due to cache activation

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1162,7 +1162,7 @@ const (
 	wireCmdStop        = 3
 )
 
-const i2cTimeout = 1000
+const i2cTimeout = 28000 // about 210us
 
 // Configure is intended to setup the I2C interface.
 func (i2c *I2C) Configure(config I2CConfig) error {


### PR DESCRIPTION
#3820

Fix timeout time is decreasing due to cache activation (https://github.com/tinygo-org/tinygo/pull/3492) .