### PR TITLE
wasi: allow zero inodes when reading directories

### DIFF
--- a/src/os/dir_wasi.go
+++ b/src/os/dir_wasi.go
@@ -53,9 +53,6 @@ func (f *File) readdir(n int, mode readdirMode) (names []string, dirents []DirEn
 		if dirent == nil { // EOF
 			break
 		}
-		if dirent.Ino == 0 {
-			continue
-		}
 		name := dirent.Name()
 		// Check for useless names before allocating a string.
 		if string(name) == "." || string(name) == ".." {


### PR DESCRIPTION
When I submitted https://github.com/tinygo-org/tinygo/pull/3696, I ported the behavior from [Go](https://github.com/golang/go/blob/master/src/os/dir_unix.go#L92-L94) without clear reflection on the reasons why this check existed in the first place.

After further discussion with @codefromthecrypt, it appeared that this check causes more problems than it solves, especially when targeting WASI, due to the guest not knowing the type of underlying file system the host runtime is exposing.

I submitted https://go-review.googlesource.com/c/go/+/507915 to Go to address the issue, and Wazero also recorded more details about it in its [RATIONALE.md](https://github.com/tetratelabs/wazero/blob/008bcdc75ea69d853b3979555758deb7b73dd329/RATIONALE.md#why-dont-we-require-inodes-to-be-non-zero).

This PR addresses the issue for TinyGo by allowing zero inodes when building for the `wasi` target.