### PR TITLE
reflect: add SetZero

### DIFF
--- a/src/reflect/all_test.go
+++ b/src/reflect/all_test.go
@@ -1559,8 +1559,6 @@ func TestIsZero(t *testing.T) {
 			t.Errorf("%d: IsZero(Zero(TypeOf((%s)(%+v)))) is false", i, x.Kind(), tt.x)
 		}
 
-		/* // TODO(tinygo): missing SetZero support
-
 		p := New(x.Type()).Elem()
 		p.Set(x)
 		p.SetZero()
@@ -1568,7 +1566,6 @@ func TestIsZero(t *testing.T) {
 			t.Errorf("%d: IsZero((%s)(%+v)) is true after SetZero", i, p.Kind(), tt.x)
 
 		}
-		*/
 
 	}
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -1068,6 +1068,13 @@ func (v Value) Set(x Value) {
 	memcpy(v.value, xptr, size)
 }
 
+func (v Value) SetZero() {
+	v.checkAddressable()
+	v.checkRO()
+	size := v.typecode.Size()
+	memzero(v.value, size)
+}
+
 func (v Value) SetBool(x bool) {
 	v.checkAddressable()
 	v.checkRO()
@@ -1568,6 +1575,9 @@ func (e *ValueError) Error() string {
 
 //go:linkname memcpy runtime.memcpy
 func memcpy(dst, src unsafe.Pointer, size uintptr)
+
+//go:linkname memzero runtime.memzero
+func memzero(ptr unsafe.Pointer, size uintptr)
 
 //go:linkname alloc runtime.alloc
 func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer


### PR DESCRIPTION
This was added in Go 1.20 and is required by encoding/json starting with Go 1.21. See: #3824.