### PR TITLE
machine.UART refactor

### DIFF
--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -97,7 +97,7 @@ func (i2c *I2C) stop() {
 }
 
 // writeByte writes a single byte to the I2C bus.
-func (i2c *I2C) writeByte(data byte) {
+func (i2c *I2C) writeByte(data byte) error {
 	// Write data to register.
 	avr.TWDR.Set(data)
 
@@ -107,6 +107,7 @@ func (i2c *I2C) writeByte(data byte) {
 	// Wait till data is transmitted.
 	for !avr.TWCR.HasBits(avr.TWCR_TWINT) {
 	}
+	return nil
 }
 
 // readByte reads a single byte from the I2C bus.

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -190,7 +190,7 @@ func (uart *UART) handleInterrupt(intr interrupt.Interrupt) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	// Wait until UART buffer is not busy.
 	for !uart.statusRegA.HasBits(avr.UCSR0A_UDRE0) {
 	}

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -198,6 +198,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 // SPIConfig is used to store config info for SPI.
 type SPIConfig struct {
 	Frequency uint32

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -634,6 +634,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 // handleInterrupt should be called from the appropriate interrupt handler for
 // this UART instance.
 func (uart *UART) handleInterrupt(interrupt.Interrupt) {

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -626,7 +626,7 @@ func (uart *UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	// wait until ready to receive
 	for !uart.Bus.INTFLAG.HasBits(sam.SERCOM_USART_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1122,6 +1122,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	// should reset IRQ
 	uart.Receive(byte((uart.Bus.DATA.Get() & 0xFF)))

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1114,7 +1114,7 @@ func (uart *UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	// wait until ready to receive
 	for !uart.Bus.INTFLAG.HasBits(sam.SERCOM_USART_INT_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -314,7 +314,7 @@ func (uart *UART) Configure(config UARTConfig) {
 	uart.Bus.CLKDIV.Set(peripheralClock / config.BaudRate)
 }
 
-func (uart *UART) WriteByte(b byte) error {
+func (uart *UART) writeByte(b byte) error {
 	for (uart.Bus.STATUS.Get()>>16)&0xff >= 128 {
 		// Read UART_TXFIFO_CNT from the status register, which indicates how
 		// many bytes there are in the transmit buffer. Wait until there are

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -324,6 +324,8 @@ func (uart *UART) WriteByte(b byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 // Serial Peripheral Interface on the ESP32.
 type SPI struct {
 	Bus *esp.SPI_Type

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -502,3 +502,5 @@ func (uart *UART) WriteByte(b byte) error {
 	uart.Bus.FIFO.Set(uint32(b))
 	return nil
 }
+
+func (uart *UART) flush() {}

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -493,7 +493,7 @@ func (uart *UART) enableReceiver() {
 	uart.Bus.SetINT_ENA_RXFIFO_OVF_INT_ENA(1)
 }
 
-func (uart *UART) WriteByte(b byte) error {
+func (uart *UART) writeByte(b byte) error {
 	for (uart.Bus.STATUS.Get()&esp.UART_STATUS_TXFIFO_CNT_Msk)>>esp.UART_STATUS_TXFIFO_CNT_Pos >= 128 {
 		// Read UART_TXFIFO_CNT from the status register, which indicates how
 		// many bytes there are in the transmit buffer. Wait until there are

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -181,9 +181,9 @@ func (uart *UART) Configure(config UARTConfig) {
 	esp.UART0.UART_CLKDIV.Set(CPUFrequency() / config.BaudRate)
 }
 
-// WriteByte writes a single byte to the output buffer. Note that the hardware
+// writeByte writes a single byte to the output buffer. Note that the hardware
 // includes a buffer of 128 bytes which will be used first.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	for (esp.UART0.UART_STATUS.Get()>>16)&0xff >= 128 {
 		// Wait until the TX buffer has room.
 	}

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -190,3 +190,5 @@ func (uart *UART) WriteByte(c byte) error {
 	esp.UART0.UART_FIFO.Set(uint32(c))
 	return nil
 }
+
+func (uart *UART) flush() {}

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -111,7 +111,7 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart *UART) WriteByte(c byte) {
+func (uart *UART) writeByte(c byte) {
 	for sifive.UART0.TXDATA.Get()&sifive.UART_TXDATA_FULL != 0 {
 	}
 

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -119,6 +119,8 @@ func (uart *UART) writeByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 // SPI on the FE310. The normal SPI0 is actually a quad-SPI meant for flash, so it is best
 // to use SPI1 or SPI2 port for most applications.
 type SPI struct {

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -111,11 +111,12 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart *UART) writeByte(c byte) {
+func (uart *UART) writeByte(c byte) error {
 	for sifive.UART0.TXDATA.Get()&sifive.UART_TXDATA_FULL != 0 {
 	}
 
 	sifive.UART0.TXDATA.Set(uint32(c))
+	return nil
 }
 
 // SPI on the FE310. The normal SPI0 is actually a quad-SPI meant for flash, so it is best

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -392,7 +392,7 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart *UART) WriteByte(c byte) {
+func (uart *UART) writeByte(c byte) {
 	for uart.Bus.TXDATA.Get()&kendryte.UARTHS_TXDATA_FULL != 0 {
 	}
 

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -399,6 +399,8 @@ func (uart *UART) WriteByte(c byte) {
 	uart.Bus.TXDATA.Set(uint32(c))
 }
 
+func (uart *UART) flush() {}
+
 type SPI struct {
 	Bus *kendryte.SPI_Type
 }

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -392,11 +392,12 @@ func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	uart.Receive(c)
 }
 
-func (uart *UART) writeByte(c byte) {
+func (uart *UART) writeByte(c byte) error {
 	for uart.Bus.TXDATA.Get()&kendryte.UARTHS_TXDATA_FULL != 0 {
 	}
 
 	uart.Bus.TXDATA.Set(uint32(c))
+	return nil
 }
 
 func (uart *UART) flush() {}

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -173,7 +173,7 @@ func (uart *UART) Sync() error {
 }
 
 // WriteByte writes a single byte of data to the UART interface.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	uart.startTransmitting()
 	for !uart.txBuffer.Put(c) {
 	}

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -181,6 +181,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 // getBaudRateDivisor finds the greatest over-sampling factor (4..32) and
 // corresponding baud rate divisor (1..8191) that best partition a given baud
 // rate into equal intervals.

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -186,7 +186,7 @@ func (uart *UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	nrf.UART0.EVENTS_TXDRDY.Set(0)
 	nrf.UART0.TXD.Set(uint32(c))
 	for nrf.UART0.EVENTS_TXDRDY.Get() == 0 {

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -194,6 +194,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
+func (uart *UART) flush() {}
+
 func (uart *UART) handleInterrupt(interrupt.Interrupt) {
 	if nrf.UART0.EVENTS_RXDRDY.Get() != 0 {
 		uart.Receive(byte(nrf.UART0.RXD.Get()))

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -292,7 +292,7 @@ func (u *UART) handleStatusInterrupt(interrupt.Interrupt) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (u *UART) WriteByte(c byte) error {
+func (u *UART) writeByte(c byte) error {
 	if !u.Configured {
 		return ErrNotConfigured
 	}

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -305,3 +305,5 @@ func (u *UART) WriteByte(c byte) error {
 	u.C2.Set(uartC2TXActive)
 	return nil
 }
+
+func (uart *UART) flush() {}

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -94,12 +94,13 @@ func (uart *UART) WriteByte(c byte) error {
 
 	// write data
 	uart.Bus.UARTDR.Set(uint32(c))
+	return nil
+}
 
-	// wait until done transmitting.
+func (uart *UART) flush() {
 	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_BUSY) {
 		gosched()
 	}
-	return nil
 }
 
 // SetFormat for number of data bits, stop bits, and parity for the UART.

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -86,7 +86,7 @@ func (uart *UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	// wait until buffer is not full
 	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_TXFF) {
 		gosched()

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -89,10 +89,16 @@ func (uart *UART) SetBaudRate(br uint32) {
 func (uart *UART) WriteByte(c byte) error {
 	// wait until buffer is not full
 	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_TXFF) {
+		gosched()
 	}
 
 	// write data
 	uart.Bus.UARTDR.Set(uint32(c))
+
+	// wait until done transmitting.
+	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_BUSY) {
+		gosched()
+	}
 	return nil
 }
 

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -74,7 +74,7 @@ func (uart *UART) SetBaudRate(br uint32) {
 }
 
 // WriteByte writes a byte of data to the UART.
-func (uart *UART) WriteByte(c byte) error {
+func (uart *UART) writeByte(c byte) error {
 	uart.txReg.Set(uint32(c))
 
 	for !uart.statusReg.HasBits(uart.txEmptyFlag) {

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -81,3 +81,5 @@ func (uart *UART) WriteByte(c byte) error {
 	}
 	return nil
 }
+
+func (uart *UART) flush() {}

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -73,8 +73,11 @@ func (uart *UART) WriteByte(c byte) error {
 // Write data over the UART's Tx.
 // This function blocks until the data is finished being sent.
 func (uart *UART) Write(data []byte) (n int, err error) {
-	for _, v := range data {
-		uart.writeByte(v)
+	for i, v := range data {
+		err = uart.writeByte(v)
+		if err != nil {
+			return i, err
+		}
 	}
 	uart.flush() // flush() blocks until all data has been transmitted.
 	return len(data), nil

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -59,10 +59,20 @@ func (uart *UART) Read(data []byte) (n int, err error) {
 	return size, nil
 }
 
+// WriteByte writes a byte of data to the UART.
+func (uart *UART) WriteByte(c byte) error {
+	err := uart.writeByte(c)
+	if err != nil {
+		return err
+	}
+	uart.flush() // flush() blocks until all data has been transmitted.
+	return nil
+}
+
 // Write data to the UART.
 func (uart *UART) Write(data []byte) (n int, err error) {
 	for _, v := range data {
-		uart.WriteByte(v)
+		uart.writeByte(v)
 	}
 	uart.flush() // flush() blocks until all data has been transmitted.
 	return len(data), nil

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -64,6 +64,7 @@ func (uart *UART) Write(data []byte) (n int, err error) {
 	for _, v := range data {
 		uart.WriteByte(v)
 	}
+	uart.flush()
 	return len(data), nil
 }
 

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -64,7 +64,7 @@ func (uart *UART) Write(data []byte) (n int, err error) {
 	for _, v := range data {
 		uart.WriteByte(v)
 	}
-	uart.flush()
+	uart.flush() // flush() blocks until all data has been transmitted.
 	return len(data), nil
 }
 

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -59,7 +59,8 @@ func (uart *UART) Read(data []byte) (n int, err error) {
 	return size, nil
 }
 
-// WriteByte writes a byte of data to the UART.
+// WriteByte writes a byte of data over the UART's Tx.
+// This function blocks until the data is finished being sent.
 func (uart *UART) WriteByte(c byte) error {
 	err := uart.writeByte(c)
 	if err != nil {
@@ -69,7 +70,8 @@ func (uart *UART) WriteByte(c byte) error {
 	return nil
 }
 
-// Write data to the UART.
+// Write data over the UART's Tx.
+// This function blocks until the data is finished being sent.
 func (uart *UART) Write(data []byte) (n int, err error) {
 	for _, v := range data {
 		uart.writeByte(v)


### PR DESCRIPTION
Resolves #3537, closes #3538.

Adds:
- `UART.flush`: method implemented by UARTs that blocks until all data has finished being transmitted
- `uart.writeByte`: method implemented by UARTs that writes over the UART pin without blocking.
- Comments to WriteBytes shared by all implementations.

Semantic changes:
- `UART.WriteByte` and `UART.Write`: Methods now expected to block until all data has been finished being transmitted over wire.