### PR TITLE
avr: pin change interrupt

### DIFF
--- a/src/examples/pininterrupt/arduino.go
+++ b/src/examples/pininterrupt/arduino.go
@@ -1,11 +1,11 @@
-//go:build pca10040
+//go:build arduino
 
 package main
 
 import "machine"
 
 const (
-	button          = machine.BUTTON
+	button          = machine.D2
 	buttonMode      = machine.PinInputPullup
 	buttonPinChange = machine.PinRising
 )

--- a/src/examples/pininterrupt/circuitplay-express.go
+++ b/src/examples/pininterrupt/circuitplay-express.go
@@ -5,6 +5,7 @@ package main
 import "machine"
 
 const (
+	button          = machine.BUTTON
 	buttonMode      = machine.PinInputPulldown
 	buttonPinChange = machine.PinFalling
 )

--- a/src/examples/pininterrupt/pininterrupt.go
+++ b/src/examples/pininterrupt/pininterrupt.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	button = machine.BUTTON
-	led    = machine.LED
+	led = machine.LED
 )
 
 func main() {

--- a/src/examples/pininterrupt/stm32.go
+++ b/src/examples/pininterrupt/stm32.go
@@ -5,6 +5,7 @@ package main
 import "machine"
 
 const (
+	button          = machine.BUTTON
 	buttonMode      = machine.PinInputPulldown
 	buttonPinChange = machine.PinRising | machine.PinFalling
 )

--- a/src/examples/pininterrupt/wioterminal.go
+++ b/src/examples/pininterrupt/wioterminal.go
@@ -5,6 +5,7 @@ package main
 import "machine"
 
 const (
+	button          = machine.BUTTON
 	buttonMode      = machine.PinInput
 	buttonPinChange = machine.PinFalling
 )


### PR DESCRIPTION
This adds support for pin change interrupts on AVR, atmega328p chip used by Arduino UNO and Nano boards.
Fixes #3145

This PR is based on work done by @mrbell321 in #3139 (that PR apparently stalled).

Implemented in addition to original PR:
- Support for de-registering of callbacks (passing `nil`)
- Support for `PinRising` and `PinFalling`
- PinInterrupt example for "arduino" target

Verified on Arduino UNO by shorting D2 and GND pins: LED changes on breaking the contact (as expected).