### PR TITLE
compiler: add compiler-rt and wasm symbols to table

### DIFF
--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -7,6 +7,7 @@
 	"goarch":        "arm",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
+	"rtlib":         "compiler-rt",
 	"scheduler":     "asyncify",
 	"default-stack-size": 16384,
 	"cflags": [


### PR DESCRIPTION
This PR adds `compiler-rt` and updates the `makeArchive` function to read symbols from wasm binaries and add them to the symbol table.

Fixes https://github.com/tinygo-org/tinygo/issues/3501