### PR TITLE
wasm: fix functions exported through //export

### DIFF
--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -62,6 +62,19 @@ func exportedFunctionInSection() {
 //go:wasmimport modulename import1
 func declaredImport()
 
+// Legacy way of importing a function.
+//
+//go:wasm-module foobar
+//export imported
+func foobarImport()
+
+// The wasm-module pragma is not functional here, but it should be safe.
+//
+//go:wasm-module foobar
+//export exported
+func foobarExportModule() {
+}
+
 // This function should not: it's only a declaration and not a definition.
 //
 //go:section .special_function_section

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -6,7 +6,7 @@ target triple = "wasm32-unknown-wasi"
 @extern_global = external global [0 x i8], align 1
 @main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32
 @main.alignedGlobal16 = hidden global [4 x i32] zeroinitializer, align 16
-@llvm.used = appending global [2 x ptr] [ptr @extern_func, ptr @exportedFunctionInSection]
+@llvm.used = appending global [3 x ptr] [ptr @extern_func, ptr @exportedFunctionInSection, ptr @exported]
 @main.globalInSection = hidden global i32 0, section ".special_global_section", align 4
 @undefinedGlobalNotInSection = external global i32, align 4
 @main.multipleGlobalPragmas = hidden global i32 0, section ".global_section", align 1024
@@ -62,13 +62,23 @@ entry:
 
 declare void @main.declaredImport() #7
 
+declare void @imported() #8
+
+; Function Attrs: nounwind
+define void @exported() #9 {
+entry:
+  ret void
+}
+
 declare void @main.undefinedFunctionNotInSection(ptr) #1
 
 attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #1 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #2 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" "wasm-import-module"="env" "wasm-import-name"="extern_func" }
+attributes #3 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="extern_func" }
 attributes #4 = { inlinehint nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
 attributes #5 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" "wasm-import-module"="env" "wasm-import-name"="exportedFunctionInSection" }
+attributes #6 = { noinline nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exportedFunctionInSection" }
 attributes #7 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="modulename" "wasm-import-name"="import1" }
+attributes #8 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-import-module"="foobar" "wasm-import-name"="imported" }
+attributes #9 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" "wasm-export-name"="exported" }


### PR DESCRIPTION
When a function is exported using `//export`, but also had a `//go:wasm-module` pragma, the `//export` name was ignored. The `//go:wasm-module` doesn't actually do anything besides breaking the export (exported functions don't have a module name) so I've made sure to remove this check.

I've also refactored and clarified the code a bit to avoid unnecessary complexity.