### PR TITLE
compiler: add compiler-rt to wasm.json

### DIFF
--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -7,6 +7,7 @@
 	"goarch":        "wasm",
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
+	"rtlib":         "compiler-rt",
 	"scheduler":     "asyncify",
 	"default-stack-size": 16384,
 	"cflags": [


### PR DESCRIPTION
Following on from #3844, adding `compiler-rt` to wasm.json