### PR TITLE
machine/usb: allow USB Endpoint settings to be changed externally

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -266,18 +266,18 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 	ConfigureUSBEndpoint(usbDescriptor,
 		[]usb.EndpointConfig{
 			{
-				No:   usb.CDC_ENDPOINT_ACM,
-				IsIn: true,
-				Type: usb.ENDPOINT_TYPE_INTERRUPT,
+				Index: usb.CDC_ENDPOINT_ACM,
+				IsIn:  true,
+				Type:  usb.ENDPOINT_TYPE_INTERRUPT,
 			},
 			{
-				No:        usb.CDC_ENDPOINT_OUT,
+				Index:     usb.CDC_ENDPOINT_OUT,
 				IsIn:      false,
 				Type:      usb.ENDPOINT_TYPE_BULK,
 				RxHandler: rxHandler,
 			},
 			{
-				No:        usb.CDC_ENDPOINT_IN,
+				Index:     usb.CDC_ENDPOINT_IN,
 				IsIn:      true,
 				Type:      usb.ENDPOINT_TYPE_BULK,
 				TxHandler: txHandler,
@@ -285,7 +285,7 @@ func EnableCDC(txHandler func(), rxHandler func([]byte), setupHandler func(usb.S
 		},
 		[]usb.SetupConfig{
 			{
-				No:      usb.CDC_ACM_INTERFACE,
+				Index:   usb.CDC_ACM_INTERFACE,
 				Handler: setupHandler,
 			},
 		})
@@ -296,19 +296,19 @@ func ConfigureUSBEndpoint(desc descriptor.Descriptor, epSettings []usb.EndpointC
 
 	for _, ep := range epSettings {
 		if ep.IsIn {
-			endPoints[ep.No] = uint32(ep.Type | usb.EndpointIn)
+			endPoints[ep.Index] = uint32(ep.Type | usb.EndpointIn)
 			if ep.TxHandler != nil {
-				usbTxHandler[ep.No] = ep.TxHandler
+				usbTxHandler[ep.Index] = ep.TxHandler
 			}
 		} else {
-			endPoints[ep.No] = uint32(ep.Type | usb.EndpointOut)
+			endPoints[ep.Index] = uint32(ep.Type | usb.EndpointOut)
 			if ep.RxHandler != nil {
-				usbRxHandler[ep.No] = ep.RxHandler
+				usbRxHandler[ep.Index] = ep.RxHandler
 			}
 		}
 	}
 
 	for _, s := range setup {
-		usbSetupHandler[s.No] = s.Handler
+		usbSetupHandler[s.Index] = s.Handler
 	}
 }

--- a/src/machine/usb/adc/midi/midi.go
+++ b/src/machine/usb/adc/midi/midi.go
@@ -3,6 +3,7 @@ package midi
 import (
 	"machine"
 	"machine/usb"
+	"machine/usb/descriptor"
 )
 
 const (
@@ -40,7 +41,23 @@ func newMidi() *midi {
 	m := &midi{
 		buf: NewRingBuffer(),
 	}
-	machine.EnableMIDI(m.Handler, m.RxHandler, nil)
+	machine.ConfigureUSBEndpoint(descriptor.CDCMIDI,
+		[]usb.EndpointConfig{
+			{
+				No:        usb.MIDI_ENDPOINT_OUT,
+				IsIn:      false,
+				Type:      usb.ENDPOINT_TYPE_BULK,
+				RxHandler: m.RxHandler,
+			},
+			{
+				No:        usb.MIDI_ENDPOINT_IN,
+				IsIn:      true,
+				Type:      usb.ENDPOINT_TYPE_BULK,
+				TxHandler: m.Handler,
+			},
+		},
+		[]usb.SetupConfig{},
+	)
 	return m
 }
 

--- a/src/machine/usb/adc/midi/midi.go
+++ b/src/machine/usb/adc/midi/midi.go
@@ -44,13 +44,13 @@ func newMidi() *midi {
 	machine.ConfigureUSBEndpoint(descriptor.CDCMIDI,
 		[]usb.EndpointConfig{
 			{
-				No:        usb.MIDI_ENDPOINT_OUT,
+				Index:     usb.MIDI_ENDPOINT_OUT,
 				IsIn:      false,
 				Type:      usb.ENDPOINT_TYPE_BULK,
 				RxHandler: m.RxHandler,
 			},
 			{
-				No:        usb.MIDI_ENDPOINT_IN,
+				Index:     usb.MIDI_ENDPOINT_IN,
 				IsIn:      true,
 				Type:      usb.ENDPOINT_TYPE_BULK,
 				TxHandler: m.Handler,

--- a/src/machine/usb/config.go
+++ b/src/machine/usb/config.go
@@ -1,7 +1,7 @@
 package usb
 
 type EndpointConfig struct {
-	No        uint8
+	Index     uint8
 	IsIn      bool
 	TxHandler func()
 	RxHandler func([]byte)
@@ -9,6 +9,6 @@ type EndpointConfig struct {
 }
 
 type SetupConfig struct {
-	No      uint8
+	Index   uint8
 	Handler func(Setup) bool
 }

--- a/src/machine/usb/config.go
+++ b/src/machine/usb/config.go
@@ -1,0 +1,14 @@
+package usb
+
+type EndpointConfig struct {
+	No        uint8
+	IsIn      bool
+	TxHandler func()
+	RxHandler func([]byte)
+	Type      uint8
+}
+
+type SetupConfig struct {
+	No      uint8
+	Handler func(Setup) bool
+}

--- a/src/machine/usb/hid/hid.go
+++ b/src/machine/usb/hid/hid.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"machine"
 	"machine/usb"
+	"machine/usb/descriptor"
 )
 
 // from usb-hid.go
@@ -32,7 +33,21 @@ var size int
 // calls machine.EnableHID for USB configuration
 func SetHandler(d hidDevicer) {
 	if size == 0 {
-		machine.EnableHID(handler, nil, setupHandler)
+		machine.ConfigureUSBEndpoint(descriptor.CDCHID,
+			[]usb.EndpointConfig{
+				{
+					No:        usb.HID_ENDPOINT_IN,
+					IsIn:      true,
+					Type:      usb.ENDPOINT_TYPE_INTERRUPT,
+					TxHandler: handler,
+				},
+			},
+			[]usb.SetupConfig{
+				{
+					No:      usb.HID_INTERFACE,
+					Handler: setupHandler,
+				},
+			})
 	}
 
 	devices[size] = d

--- a/src/machine/usb/hid/hid.go
+++ b/src/machine/usb/hid/hid.go
@@ -36,7 +36,7 @@ func SetHandler(d hidDevicer) {
 		machine.ConfigureUSBEndpoint(descriptor.CDCHID,
 			[]usb.EndpointConfig{
 				{
-					No:        usb.HID_ENDPOINT_IN,
+					Index:     usb.HID_ENDPOINT_IN,
 					IsIn:      true,
 					Type:      usb.ENDPOINT_TYPE_INTERRUPT,
 					TxHandler: handler,
@@ -44,7 +44,7 @@ func SetHandler(d hidDevicer) {
 			},
 			[]usb.SetupConfig{
 				{
-					No:      usb.HID_INTERFACE,
+					Index:   usb.HID_INTERFACE,
 					Handler: setupHandler,
 				},
 			})

--- a/src/machine/usb/hid/joystick/joystick.go
+++ b/src/machine/usb/hid/joystick/joystick.go
@@ -51,13 +51,13 @@ func UseSettings(def Definitions, rxHandlerFunc func(b []byte), setupFunc func(s
 	machine.ConfigureUSBEndpoint(descriptor.CDCJoystick,
 		[]usb.EndpointConfig{
 			{
-				No:        usb.HID_ENDPOINT_OUT,
+				Index:     usb.HID_ENDPOINT_OUT,
 				IsIn:      false,
 				Type:      usb.ENDPOINT_TYPE_INTERRUPT,
 				RxHandler: rxHandlerFunc,
 			},
 			{
-				No:        usb.HID_ENDPOINT_IN,
+				Index:     usb.HID_ENDPOINT_IN,
 				IsIn:      true,
 				Type:      usb.ENDPOINT_TYPE_INTERRUPT,
 				TxHandler: js.handler,
@@ -65,7 +65,7 @@ func UseSettings(def Definitions, rxHandlerFunc func(b []byte), setupFunc func(s
 		},
 		[]usb.SetupConfig{
 			{
-				No:      usb.HID_INTERFACE,
+				Index:   usb.HID_INTERFACE,
 				Handler: setupFunc,
 			},
 		},


### PR DESCRIPTION
This PR is configured from machine/usb/xxx instead of machine using the changes in #3849.
This PR needs to be merged after #3849.