### PR TITLE
machine/usb/hid: add RxHandler interface

### DIFF
--- a/src/machine/usb/hid/hid.go
+++ b/src/machine/usb/hid/hid.go
@@ -23,7 +23,7 @@ const (
 )
 
 type hidDevicer interface {
-	Handler() bool
+	TxHandler() bool
 	RxHandler([]byte) bool
 }
 
@@ -40,7 +40,7 @@ func SetHandler(d hidDevicer) {
 					Index:     usb.HID_ENDPOINT_IN,
 					IsIn:      true,
 					Type:      usb.ENDPOINT_TYPE_INTERRUPT,
-					TxHandler: handler,
+					TxHandler: txHandler,
 				},
 			},
 			[]usb.SetupConfig{
@@ -55,12 +55,12 @@ func SetHandler(d hidDevicer) {
 	size++
 }
 
-func handler() {
+func txHandler() {
 	for _, d := range devices {
 		if d == nil {
 			continue
 		}
-		if done := d.Handler(); done {
+		if done := d.TxHandler(); done {
 			return
 		}
 	}

--- a/src/machine/usb/hid/hid.go
+++ b/src/machine/usb/hid/hid.go
@@ -24,6 +24,7 @@ const (
 
 type hidDevicer interface {
 	Handler() bool
+	RxHandler([]byte) bool
 }
 
 var devices [5]hidDevicer
@@ -60,6 +61,17 @@ func handler() {
 			continue
 		}
 		if done := d.Handler(); done {
+			return
+		}
+	}
+}
+
+func rxHandler(b []byte) {
+	for _, d := range devices {
+		if d == nil {
+			continue
+		}
+		if done := d.RxHandler(b); done {
 			return
 		}
 	}

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -81,7 +81,7 @@ func newKeyboard() *keyboard {
 	}
 }
 
-func (kb *keyboard) Handler() bool {
+func (kb *keyboard) TxHandler() bool {
 	kb.waitTxc = false
 	if b, ok := kb.buf.Get(); ok {
 		kb.waitTxc = true

--- a/src/machine/usb/hid/keyboard/keyboard.go
+++ b/src/machine/usb/hid/keyboard/keyboard.go
@@ -91,6 +91,10 @@ func (kb *keyboard) Handler() bool {
 	return false
 }
 
+func (kb *keyboard) RxHandler(b []byte) bool {
+	return false
+}
+
 func (kb *keyboard) tx(b []byte) {
 	if machine.USBDev.InitEndpointComplete {
 		if kb.waitTxc {

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -47,7 +47,7 @@ func newMouse() *mouse {
 	}
 }
 
-func (m *mouse) Handler() bool {
+func (m *mouse) TxHandler() bool {
 	m.waitTxc = false
 	if b, ok := m.buf.Get(); ok {
 		m.waitTxc = true

--- a/src/machine/usb/hid/mouse/mouse.go
+++ b/src/machine/usb/hid/mouse/mouse.go
@@ -57,6 +57,10 @@ func (m *mouse) Handler() bool {
 	return false
 }
 
+func (m *mouse) RxHandler(b []byte) bool {
+	return false
+}
+
 func (m *mouse) tx(b []byte) {
 	if machine.USBDev.InitEndpointComplete {
 		if m.waitTxc {


### PR DESCRIPTION
This PR needs to be merged after #3850

This PR adds `RxHandler()` interface to usbhid.
RxHandler is used, for example, with HID serial. RxHandler is also used for NUMLOCK indicators.