### PR TITLE
board: add AKIZUKI DENSHI AE-RP2040

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -648,6 +648,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=gopher-badge      examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=ae-rp2040           examples/echo
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/src/machine/board_ae_rp2040.go
+++ b/src/machine/board_ae_rp2040.go
@@ -1,0 +1,111 @@
+//go:build ae_rp2040
+
+package machine
+
+import (
+	"device/rp"
+	"runtime/interrupt"
+)
+
+// GPIO pins
+const (
+	GP0  Pin = GPIO0
+	GP1  Pin = GPIO1
+	GP2  Pin = GPIO2
+	GP3  Pin = GPIO3
+	GP4  Pin = GPIO4
+	GP5  Pin = GPIO5
+	GP6  Pin = GPIO6
+	GP7  Pin = GPIO7
+	GP8  Pin = GPIO8
+	GP9  Pin = GPIO9
+	GP10 Pin = GPIO10
+	GP11 Pin = GPIO11
+	GP12 Pin = GPIO12
+	GP13 Pin = GPIO13
+	GP14 Pin = GPIO14
+	GP15 Pin = GPIO15
+	GP16 Pin = GPIO16
+	GP17 Pin = GPIO17
+	GP18 Pin = GPIO18
+	GP19 Pin = GPIO19
+	GP20 Pin = GPIO20
+	GP21 Pin = GPIO21
+	GP22 Pin = GPIO22
+	GP26 Pin = GPIO26
+	GP27 Pin = GPIO27
+	GP28 Pin = GPIO28
+	GP29 Pin = GPIO29
+
+	// Onboard crystal oscillator frequency, in MHz.
+	xoscFreq = 12 // MHz
+)
+
+// I2C Default pins on Raspberry Pico.
+const (
+	I2C0_SDA_PIN = GP4
+	I2C0_SCL_PIN = GP5
+
+	I2C1_SDA_PIN = GP2
+	I2C1_SCL_PIN = GP3
+)
+
+// SPI default pins
+const (
+	// Default Serial Clock Bus 0 for SPI communications
+	SPI0_SCK_PIN = GPIO18
+	// Default Serial Out Bus 0 for SPI communications
+	SPI0_SDO_PIN = GPIO19 // Tx
+	// Default Serial In Bus 0 for SPI communications
+	SPI0_SDI_PIN = GPIO16 // Rx
+
+	// Default Serial Clock Bus 1 for SPI communications
+	SPI1_SCK_PIN = GPIO10
+	// Default Serial Out Bus 1 for SPI communications
+	SPI1_SDO_PIN = GPIO11 // Tx
+	// Default Serial In Bus 1 for SPI communications
+	SPI1_SDI_PIN = GPIO12 // Rx
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART1_TX_PIN = GPIO8
+	UART1_RX_PIN = GPIO9
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+// UART on the RP2040
+var (
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART0,
+	}
+
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
+)
+
+var DefaultUART = UART0
+
+func init() {
+	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
+}
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "AE-RP2040"
+	usb_STRING_MANUFACTURER = "AKIZUKI DENSHI"
+)
+
+var (
+	usb_VID uint16 = 0x2E8A
+	usb_PID uint16 = 0x000A
+)

--- a/targets/ae-rp2040.json
+++ b/targets/ae-rp2040.json
@@ -1,0 +1,14 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "build-tags": ["ae_rp2040"],
+    "serial-port": ["2e8a:000A"],
+    "ldflags": [
+        "--defsym=__flash_size=2048K"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}
+


### PR DESCRIPTION
This PR adds AE-RP2040 board support for [AKIZUKI DENSHI](https://akizukidenshi.com/) .

This board is almost identical to pico, but instead of having no LEDs, all pins are pulled out.
It is also characterized by being slightly smaller than pico.
AKIZUKI DENSHI is very well known in Japan, so adding this board would do little good.

![image](https://github.com/tinygo-org/tinygo/assets/9251039/cb80eb5e-c41b-44a9-a56c-aea20e33af40)

https://akizukidenshi.com/catalog/g/gK-17542/

