### PR TITLE
Implement watchdog support on RP2040, SAMD51, NRF528xx, STM32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,6 +490,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-rp2040      examples/i2c-target
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-rp2040      examples/watchdog
+	@$(MD5SUM) test.hex
 	# test simulated boards on play.tinygo.org
 ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1

--- a/src/examples/watchdog/main.go
+++ b/src/examples/watchdog/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"machine"
+	"time"
+)
+
+func main() {
+	//sleep for 2 secs for console
+	time.Sleep(2 * time.Second)
+
+	config := machine.WatchdogConfig{
+		TimeoutMillis: 1000,
+	}
+
+	println("configuring watchdog for max 1 second updates")
+	machine.Watchdog.Configure(config)
+
+	// From this point the watchdog is running and Update must be
+	// called periodically, per the config
+	machine.Watchdog.Start()
+
+	// This loop should complete because watchdog update is called
+	// every 100ms.
+	start := time.Now()
+	println("updating watchdog for 3 seconds")
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		machine.Watchdog.Update()
+		fmt.Printf("alive @ %v\n", time.Now().Sub(start))
+	}
+
+	// This loop should cause a watchdog reset after 1s since
+	// there is no update call.
+	start = time.Now()
+	println("entering tight loop")
+	for {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Printf("alive @ %v\n", time.Now().Sub(start))
+	}
+}

--- a/src/machine/machine_rp2040_clocks.go
+++ b/src/machine/machine_rp2040_clocks.go
@@ -182,7 +182,7 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 // Must be called before any other clock function.
 func (clks *clocksType) init() {
 	// Start the watchdog tick
-	watchdog.startTick(xoscFreq)
+	Watchdog.startTick(xoscFreq)
 
 	// Disable resus that may be enabled from previous software
 	clks.resus.ctrl.Set(0)

--- a/src/machine/machine_rp2040_watchdog.go
+++ b/src/machine/machine_rp2040_watchdog.go
@@ -4,24 +4,67 @@ package machine
 
 import (
 	"device/rp"
-	"runtime/volatile"
-	"unsafe"
 )
 
-type watchdogType struct {
-	ctrl    volatile.Register32
-	load    volatile.Register32
-	reason  volatile.Register32
-	scratch [8]volatile.Register32
-	tick    volatile.Register32
+// Watchdog provides access to the hardware watchdog available
+// in the RP2040.
+var Watchdog = &watchdogImpl{}
+
+const (
+	// WatchdogMaxTimeout in milliseconds (approx 8.3s).
+	//
+	// Nominal 1us per watchdog tick, 24-bit counter,
+	// but due to errata two ticks consumed per 1us.
+	// See: Errata RP2040-E1
+	WatchdogMaxTimeout = (rp.WATCHDOG_LOAD_LOAD_Msk / 1000) / 2
+)
+
+type watchdogImpl struct {
+	// The value to reset the counter to on each Update
+	loadValue uint32
 }
 
-var watchdog = (*watchdogType)(unsafe.Pointer(rp.WATCHDOG))
+// Configure the watchdog.
+//
+// This method should not be called after the watchdog is started and on
+// some platforms attempting to reconfigure after starting the watchdog
+// is explicitly forbidden / will not work.
+func (wd *watchdogImpl) Configure(config WatchdogConfig) error {
+	// x2 due to errata RP2040-E1
+	wd.loadValue = config.TimeoutMillis * 1000 * 2
+	if wd.loadValue > rp.WATCHDOG_LOAD_LOAD_Msk {
+		wd.loadValue = rp.WATCHDOG_LOAD_LOAD_Msk
+	}
+
+	rp.WATCHDOG.CTRL.ClearBits(rp.WATCHDOG_CTRL_ENABLE)
+
+	// Reset everything apart from ROSC and XOSC
+	rp.PSM.WDSEL.Set(0x0001ffff &^ (rp.PSM_WDSEL_ROSC | rp.PSM_WDSEL_XOSC))
+
+	// Pause watchdog during debug
+	rp.WATCHDOG.CTRL.SetBits(rp.WATCHDOG_CTRL_PAUSE_DBG0 | rp.WATCHDOG_CTRL_PAUSE_DBG1 | rp.WATCHDOG_CTRL_PAUSE_JTAG)
+
+	// Load initial counter
+	rp.WATCHDOG.LOAD.Set(wd.loadValue)
+
+	return nil
+}
+
+// Starts the watchdog.
+func (wd *watchdogImpl) Start() error {
+	rp.WATCHDOG.CTRL.SetBits(rp.WATCHDOG_CTRL_ENABLE)
+	return nil
+}
+
+// Update the watchdog, indicating that the app is healthy.
+func (wd *watchdogImpl) Update() {
+	rp.WATCHDOG.LOAD.Set(wd.loadValue)
+}
 
 // startTick starts the watchdog tick.
 // cycles needs to be a divider that when applied to the xosc input,
 // produces a 1MHz clock. So if the xosc frequency is 12MHz,
 // this will need to be 12.
-func (wd *watchdogType) startTick(cycles uint32) {
-	wd.tick.Set(cycles | rp.WATCHDOG_TICK_ENABLE)
+func (wd *watchdogImpl) startTick(cycles uint32) {
+	rp.WATCHDOG.TICK.Set(cycles | rp.WATCHDOG_TICK_ENABLE)
 }

--- a/src/machine/machine_stm32_iwdg.go
+++ b/src/machine/machine_stm32_iwdg.go
@@ -1,0 +1,66 @@
+//go:build stm32
+
+package machine
+
+import "device/stm32"
+
+var (
+	Watchdog = &watchdogImpl{}
+)
+
+const (
+	// WatchdogMaxTimeout in milliseconds (32.768s)
+	//
+	// Timeout is based on 12-bit counter with /256 divider on
+	// 32.768kHz clock.  See 21.3.3 of RM0090 for table.
+	WatchdogMaxTimeout = ((0xfff + 1) * 256 * 1024) / 32768
+)
+
+const (
+	// Enable access to PR, RLR and WINR registers (0x5555)
+	iwdgKeyEnable = 0x5555
+	// Reset the watchdog value (0xAAAA)
+	iwdgKeyReset = 0xaaaa
+	// Start the watchdog (0xCCCC)
+	iwdgKeyStart = 0xcccc
+	// Divide by 256
+	iwdgDiv256 = 6
+)
+
+type watchdogImpl struct {
+}
+
+// Configure the watchdog.
+//
+// This method should not be called after the watchdog is started and on
+// some platforms attempting to reconfigure after starting the watchdog
+// is explicitly forbidden / will not work.
+func (wd *watchdogImpl) Configure(config WatchdogConfig) error {
+
+	// Enable configuration of IWDG
+	stm32.IWDG.KR.Set(iwdgKeyEnable)
+
+	// Unconditionally divide by /256 since we don't really need accuracy
+	// less than 8ms
+	stm32.IWDG.PR.Set(iwdgDiv256)
+
+	timeout := config.TimeoutMillis
+	if timeout > WatchdogMaxTimeout {
+		timeout = WatchdogMaxTimeout
+	}
+
+	// Set reload value based on /256 divider
+	stm32.IWDG.RLR.Set(((config.TimeoutMillis*32768 + (256 * 1024) - 1) / (256 * 1024)) - 1)
+	return nil
+}
+
+// Starts the watchdog.
+func (wd *watchdogImpl) Start() error {
+	stm32.IWDG.KR.Set(iwdgKeyStart)
+	return nil
+}
+
+// Update the watchdog, indicating that `source` is healthy.
+func (wd *watchdogImpl) Update() {
+	stm32.IWDG.KR.Set(iwdgKeyReset)
+}

--- a/src/machine/watchdog.go
+++ b/src/machine/watchdog.go
@@ -1,0 +1,34 @@
+//go:build nrf52840 || nrf52833 || rp2040 || atsamd51 || atsame5x || stm32
+
+package machine
+
+// WatchdogConfig holds configuration for the watchdog timer.
+type WatchdogConfig struct {
+	// The timeout (in milliseconds) before the watchdog fires.
+	//
+	// If the requested timeout exceeds `MaxTimeout` it will be rounded
+	// down.
+	TimeoutMillis uint32
+}
+
+// watchdog must be implemented by any platform supporting watchdog functionality
+type watchdog interface {
+	// Configure the watchdog.
+	//
+	// This method should not be called after the watchdog is started and on
+	// some platforms attempting to reconfigure after starting the watchdog
+	// is explicitly forbidden / will not work.
+	Configure(config WatchdogConfig) error
+
+	// Starts the watchdog.
+	Start() error
+
+	// Update the watchdog, indicating that the app is healthy.
+	Update()
+}
+
+// Ensure required public symbols var exists and meets interface spec
+var _ = watchdog(Watchdog)
+
+// Ensure required public constants exist
+const _ = WatchdogMaxTimeout


### PR DESCRIPTION
The watchdog hardware is quite different, but the basics seem consistent enough for a common abstraction.

In my case, I need watchdog because I've got some code that is crashing after an 'indeterminate amount of time' on a tinygo based sensor that i don't have good access to.  A quick restart is beneficial while I track down the bug...

In general watchdog is useful for production use where things 'need to just work'