### PR TITLE
build: switch GH actions builds to use Go 1.21 final release

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3
@@ -126,7 +126,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Build TinyGo
         run: go install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21rc4-alpine
+      image: golang:1.21-alpine
     steps:
       - name: Install apk dependencies
         # tar: needed for actions/cache@v3
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Install wasmtime
         run: |
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -290,7 +290,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3
@@ -407,7 +407,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v3
@@ -143,7 +143,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v2
@@ -173,7 +173,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v2
@@ -209,7 +209,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This PR switches the GH actions builds to use Go 1.21 final release.

Fixes #3830