### PR TITLE
wasm: add support for GOOS=wasip1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -153,6 +153,7 @@ jobs:
           tar -C ~/lib -xf tinygo.linux-amd64.tar.gz
           ln -s ~/lib/tinygo/bin/tinygo ~/go/bin/tinygo
       - run: make tinygo-test-wasi-fast
+      - run: make tinygo-test-wasip1-fast
       - run: make smoketest
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch

--- a/Makefile
+++ b/Makefile
@@ -417,8 +417,12 @@ tinygo-bench-fast:
 # Same thing, except for wasi rather than the current platform.
 tinygo-test-wasi:
 	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW) ./tests/runtime_wasi
+tinygo-test-wasip1:
+	GOOS=wasip1 GOARCH=wasm $(TINYGO) test $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW) ./tests/runtime_wasi
 tinygo-test-wasi-fast:
 	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
+tinygo-test-wasip1-fast:
+	GOOS=wasip1 GOARCH=wasm $(TINYGO) test $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-bench-wasi:
 	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW)
 tinygo-bench-wasi-fast:

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -60,6 +60,7 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "darwin", GOARCH: "arm64"},
 		{GOOS: "windows", GOARCH: "amd64"},
 		{GOOS: "windows", GOARCH: "arm64"},
+		{GOOS: "wasip1", GOARCH: "wasm"},
 	} {
 		name := "GOOS=" + options.GOOS + ",GOARCH=" + options.GOARCH
 		if options.GOARCH == "arm" {

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasi
+//go:build linux && !baremetal && !wasi && !wasip1
 
 package os
 

--- a/src/os/dir_wasi.go
+++ b/src/os/dir_wasi.go
@@ -6,7 +6,7 @@
 // fairly similar: we use fdopendir, fdclosedir, and readdir from wasi-libc in
 // a similar way that the darwin code uses functions from libc.
 
-//go:build wasi
+//go:build wasi || wasip1
 
 package os
 

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux
+//go:build darwin || linux || wasip1
 
 package os_test
 

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || windows
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || wasip1 || windows
 
 package os
 

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || (wasm && !wasi && !wasip1)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal) || wasip1
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/getpagesize_test.go
+++ b/src/os/getpagesize_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal) || wasip1
 
 package os_test
 

--- a/src/os/is_wasi_no_test.go
+++ b/src/os/is_wasi_no_test.go
@@ -1,4 +1,4 @@
-//go:build !wasi
+//go:build !wasi && !wasip1
 
 package os_test
 

--- a/src/os/is_wasi_test.go
+++ b/src/os/is_wasi_test.go
@@ -1,4 +1,4 @@
-//go:build wasi
+//go:build wasi || wasip1
 
 package os_test
 

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal) || wasip1
 
 package os_test
 
@@ -23,7 +23,6 @@ var dot = []string{
 	"os_test.go",
 	"types.go",
 	"stat_darwin.go",
-	"stat_linux.go",
 }
 
 func randomName() string {

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !baremetal && !js && !wasi
+//go:build !windows && !baremetal && !js && !wasi && !wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/read_test.go
+++ b/src/os/read_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !wasip1
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi
+//go:build baremetal || js || wasi || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_linuxlike.go
+++ b/src/os/stat_linuxlike.go
@@ -1,8 +1,12 @@
-//go:build linux && !baremetal
+//go:build (linux && !baremetal) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// Note: this file is used for both Linux and WASI.
+// Eventually it might be better to spit it up, and make the syscall constants
+// match the typical WASI constants instead of the Linux-equivalents used here.
 
 package os
 

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || (wasm && !wasi && !wasip1)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal) || wasip1
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/tempfile_test.go
+++ b/src/os/tempfile_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !wasip1
 
 package os_test
 

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/env.go
+++ b/src/runtime/env.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin || windows
+//go:build linux || darwin || windows || wasip1
 
 package runtime
 

--- a/src/runtime/env_unix.go
+++ b/src/runtime/env_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || wasip1
 
 package runtime
 

--- a/src/runtime/os_wasip1.go
+++ b/src/runtime/os_wasip1.go
@@ -1,0 +1,10 @@
+//go:build wasip1
+
+package runtime
+
+// The actual GOOS=wasip1, as newly added in the Go 1.21 toolchain.
+// Previously we supported -target=wasi, but that was essentially faked by using
+// linux/arm instead because that was the closest thing that was already
+// supported in the Go standard library.
+
+const GOOS = "wasip1"

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi
+//go:build wasm && !wasi && !wasip1
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !scheduler.none
+//go:build wasm && !wasi && !scheduler.none && !wasip1
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && wasi
+//go:build tinygo.wasm && (wasi || wasip1)
 
 package runtime
 

--- a/src/syscall/errno_other.go
+++ b/src/syscall/errno_other.go
@@ -1,4 +1,4 @@
-//go:build !wasi && !darwin
+//go:build !wasi && !wasip1 && !darwin
 
 package syscall
 

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasm
+//go:build baremetal || (wasm && !wasip1)
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasm
+//go:build !(baremetal || (wasm && !wasip1))
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasi || wasm
+//go:build baremetal || tinygo.wasm
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasi && !wasm
+//go:build !baremetal && !tinygo.wasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -1,4 +1,4 @@
-//go:build darwin || nintendoswitch || wasi
+//go:build darwin || nintendoswitch || wasi || wasip1
 
 package syscall
 

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -1,4 +1,4 @@
-//go:build wasi
+//go:build wasi || wasip1
 
 package syscall
 

--- a/src/testing/is_wasi_no_test.go
+++ b/src/testing/is_wasi_no_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //
-//go:build !wasi
+//go:build !wasi && !wasip1
 
 package testing_test
 

--- a/src/testing/is_wasi_test.go
+++ b/src/testing/is_wasi_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //
-//go:build wasi
+//go:build wasi || wasip1
 
 package testing_test
 


### PR DESCRIPTION
This is WIP, a preview of what we might want to add (see https://github.com/tinygo-org/tinygo/issues/3685).

This is bigger than you might expect, for two reasons:

1. This uses GOOS=wasip1 support in the Go standard library (added in Go 1.21) instead of using our old support for WASM that basically just pretended to be linux/arm as a workaround for lack of native support.
2. Support is entirely built into the compiler (instead of in a target JSON file), similar to other operating systems (linux, darwin, windows) but unlike our existing js/wasm and wasi/wasm support. I'm not entirely sure this is a good idea, although it does make sense if we expose this feature only using environment variables and not using the `-target` flag.

It's not fully working, I'll need to continue working on it later. But a basic "hello world" already compiles.