### PR TITLE
docker: use Go 1.21 for Docker dev container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.20 AS tinygo-llvm
+FROM golang:1.21 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-15 ninja-build


### PR DESCRIPTION
This PR switches to use Go 1.21 for Docker dev container build.