### PR TITLE
main: add target JSON file in `tinygo info` output

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -23,45 +23,45 @@ import (
 // https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/spec/struct.TargetOptions.html
 // https://github.com/shepmaster/rust-arduino-blink-led-no-core-with-cargo/blob/master/blink/arduino.json
 type TargetSpec struct {
-	Inherits         []string `json:"inherits"`
-	Triple           string   `json:"llvm-target"`
-	CPU              string   `json:"cpu"`
-	ABI              string   `json:"target-abi"` // rougly equivalent to -mabi= flag
-	Features         string   `json:"features"`
-	GOOS             string   `json:"goos"`
-	GOARCH           string   `json:"goarch"`
-	BuildTags        []string `json:"build-tags"`
-	GC               string   `json:"gc"`
-	Scheduler        string   `json:"scheduler"`
-	Serial           string   `json:"serial"` // which serial output to use (uart, usb, none)
-	Linker           string   `json:"linker"`
-	RTLib            string   `json:"rtlib"` // compiler runtime library (libgcc, compiler-rt)
-	Libc             string   `json:"libc"`
-	AutoStackSize    *bool    `json:"automatic-stack-size"` // Determine stack size automatically at compile time.
-	DefaultStackSize uint64   `json:"default-stack-size"`   // Default stack size if the size couldn't be determined at compile time.
-	CFlags           []string `json:"cflags"`
-	LDFlags          []string `json:"ldflags"`
-	LinkerScript     string   `json:"linkerscript"`
-	ExtraFiles       []string `json:"extra-files"`
-	RP2040BootPatch  *bool    `json:"rp2040-boot-patch"` // Patch RP2040 2nd stage bootloader checksum
-	Emulator         string   `json:"emulator"`
-	FlashCommand     string   `json:"flash-command"`
-	GDB              []string `json:"gdb"`
-	PortReset        string   `json:"flash-1200-bps-reset"`
-	SerialPort       []string `json:"serial-port"` // serial port IDs in the form "vid:pid"
-	FlashMethod      string   `json:"flash-method"`
-	FlashVolume      []string `json:"msd-volume-name"`
-	FlashFilename    string   `json:"msd-firmware-name"`
-	UF2FamilyID      string   `json:"uf2-family-id"`
-	BinaryFormat     string   `json:"binary-format"`
-	OpenOCDInterface string   `json:"openocd-interface"`
-	OpenOCDTarget    string   `json:"openocd-target"`
-	OpenOCDTransport string   `json:"openocd-transport"`
-	OpenOCDCommands  []string `json:"openocd-commands"`
-	OpenOCDVerify    *bool    `json:"openocd-verify"` // enable verify when flashing with openocd
-	JLinkDevice      string   `json:"jlink-device"`
-	CodeModel        string   `json:"code-model"`
-	RelocationModel  string   `json:"relocation-model"`
+	Inherits         []string `json:"inherits,omitempty"`
+	Triple           string   `json:"llvm-target,omitempty"`
+	CPU              string   `json:"cpu,omitempty"`
+	ABI              string   `json:"target-abi,omitempty"` // rougly equivalent to -mabi= flag
+	Features         string   `json:"features,omitempty"`
+	GOOS             string   `json:"goos,omitempty"`
+	GOARCH           string   `json:"goarch,omitempty"`
+	BuildTags        []string `json:"build-tags,omitempty"`
+	GC               string   `json:"gc,omitempty"`
+	Scheduler        string   `json:"scheduler,omitempty"`
+	Serial           string   `json:"serial,omitempty"` // which serial output to use (uart, usb, none)
+	Linker           string   `json:"linker,omitempty"`
+	RTLib            string   `json:"rtlib,omitempty"` // compiler runtime library (libgcc, compiler-rt)
+	Libc             string   `json:"libc,omitempty"`
+	AutoStackSize    *bool    `json:"automatic-stack-size,omitempty"` // Determine stack size automatically at compile time.
+	DefaultStackSize uint64   `json:"default-stack-size,omitempty"`   // Default stack size if the size couldn't be determined at compile time.
+	CFlags           []string `json:"cflags,omitempty"`
+	LDFlags          []string `json:"ldflags,omitempty"`
+	LinkerScript     string   `json:"linkerscript,omitempty"`
+	ExtraFiles       []string `json:"extra-files,omitempty"`
+	RP2040BootPatch  *bool    `json:"rp2040-boot-patch,omitempty"` // Patch RP2040 2nd stage bootloader checksum
+	Emulator         string   `json:"emulator,omitempty"`
+	FlashCommand     string   `json:"flash-command,omitempty"`
+	GDB              []string `json:"gdb,omitempty"`
+	PortReset        string   `json:"flash-1200-bps-reset,omitempty"`
+	SerialPort       []string `json:"serial-port,omitempty"` // serial port IDs in the form "vid:pid"
+	FlashMethod      string   `json:"flash-method,omitempty"`
+	FlashVolume      []string `json:"msd-volume-name,omitempty"`
+	FlashFilename    string   `json:"msd-firmware-name,omitempty"`
+	UF2FamilyID      string   `json:"uf2-family-id,omitempty"`
+	BinaryFormat     string   `json:"binary-format,omitempty"`
+	OpenOCDInterface string   `json:"openocd-interface,omitempty"`
+	OpenOCDTarget    string   `json:"openocd-target,omitempty"`
+	OpenOCDTransport string   `json:"openocd-transport,omitempty"`
+	OpenOCDCommands  []string `json:"openocd-commands,omitempty"`
+	OpenOCDVerify    *bool    `json:"openocd-verify,omitempty"` // enable verify when flashing with openocd
+	JLinkDevice      string   `json:"jlink-device,omitempty"`
+	CodeModel        string   `json:"code-model,omitempty"`
+	RelocationModel  string   `json:"relocation-model,omitempty"`
 }
 
 // overrideProperties overrides all properties that are set in child into itself using reflection.

--- a/main.go
+++ b/main.go
@@ -1796,15 +1796,17 @@ func main() {
 		}
 		if flagJSON {
 			json, _ := json.MarshalIndent(struct {
-				GOROOT     string   `json:"goroot"`
-				GOOS       string   `json:"goos"`
-				GOARCH     string   `json:"goarch"`
-				GOARM      string   `json:"goarm"`
-				BuildTags  []string `json:"build_tags"`
-				GC         string   `json:"garbage_collector"`
-				Scheduler  string   `json:"scheduler"`
-				LLVMTriple string   `json:"llvm_triple"`
+				Target     *compileopts.TargetSpec `json:"target"`
+				GOROOT     string                  `json:"goroot"`
+				GOOS       string                  `json:"goos"`
+				GOARCH     string                  `json:"goarch"`
+				GOARM      string                  `json:"goarm"`
+				BuildTags  []string                `json:"build_tags"`
+				GC         string                  `json:"garbage_collector"`
+				Scheduler  string                  `json:"scheduler"`
+				LLVMTriple string                  `json:"llvm_triple"`
 			}{
+				Target:     config.Target,
 				GOROOT:     cachedGOROOT,
 				GOOS:       config.GOOS(),
 				GOARCH:     config.GOARCH(),


### PR DESCRIPTION
It looks like this on my system, for example:

```json
    {
      "target": {
        "llvm-target": "aarch64-unknown-linux",
        "cpu": "generic",
        "features": "+neon",
        "goos": "linux",
        "goarch": "arm64",
        "build-tags": [
          "linux",
          "arm64"
        ],
        "gc": "precise",
        "scheduler": "tasks",
        "linker": "ld.lld",
        "rtlib": "compiler-rt",
        "libc": "musl",
        "default-stack-size": 65536,
        "ldflags": [
          "--gc-sections"
        ],
        "extra-files": [
          "src/runtime/asm_arm64.S",
          "src/internal/task/task_stack_arm64.S"
        ],
        "gdb": [
          "gdb"
        ],
        "flash-1200-bps-reset": "false"
      },
      "goroot": "/home/ayke/.cache/tinygo/goroot-23c311bcaa05f188affa3c42310aba343acc82562d5e5f04dea9d5b79ac35f7e",
      "goos": "linux",
      "goarch": "arm64",
      "goarm": "6",
      ...
    }
```

This can be very useful while working on the automatically generated target object for example (in my case, GOOS=wasip1).