### PR TITLE
loader: merge go.env file which is now required starting in Go 1.21

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -207,6 +207,11 @@ func listGorootMergeLinks(goroot, tinygoroot string, overrides map[string]bool) 
 		merges[dir] = filepath.Join(goroot, dir)
 	}
 
+	// Required starting in Go 1.21 due to https://github.com/golang/go/issues/61928
+	if _, err := os.Stat(filepath.Join(goroot, "go.env")); err == nil {
+		merges["go.env"] = filepath.Join(goroot, "go.env")
+	}
+
 	return merges, nil
 }
 


### PR DESCRIPTION
This PR modifies the loader to merge the `go.env` file which is now required starting in Go 1.21 to correctly get required packages when building.

Solves https://github.com/tinygo-org/tinygo/issues/3865