### PR TITLE
Update golang.org/x/tools to v0.12.0

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -3005,6 +3005,11 @@ func (c *compilerContext) createConst(expr *ssa.Const, pos token.Pos) llvm.Value
 			panic("expected nil pointer constant")
 		}
 		return llvm.ConstPointerNull(c.getLLVMType(typ))
+	case *types.Array:
+		if expr.Value != nil {
+			panic("expected nil array constant")
+		}
+		return llvm.ConstNull(c.getLLVMType(expr.Type()))
 	case *types.Slice:
 		if expr.Value != nil {
 			panic("expected nil slice constant")
@@ -3018,6 +3023,11 @@ func (c *compilerContext) createConst(expr *ssa.Const, pos token.Pos) llvm.Value
 			llvmLen, // cap
 		}, false)
 		return slice
+	case *types.Struct:
+		if expr.Value != nil {
+			panic("expected nil struct constant")
+		}
+		return llvm.ConstNull(c.getLLVMType(expr.Type()))
 	case *types.Map:
 		if !expr.IsNil() {
 			// I believe this is not allowed by the Go spec.

--- a/compiler/testdata/basic.ll
+++ b/compiler/testdata/basic.ll
@@ -196,10 +196,6 @@ entry:
 ; Function Attrs: nounwind
 define hidden void @main.foo(ptr %context) unnamed_addr #2 {
 entry:
-  %complit = alloca %main.kv.0, align 8
-  %stackalloc = alloca i8, align 1
-  store %main.kv.0 zeroinitializer, ptr %complit, align 8
-  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #3
   call void @"main.foo$1"(%main.kv.0 zeroinitializer, ptr undef)
   ret void
 }
@@ -207,11 +203,6 @@ entry:
 ; Function Attrs: nounwind
 define internal void @"main.foo$1"(%main.kv.0 %b, ptr %context) unnamed_addr #2 {
 entry:
-  %b1 = alloca %main.kv.0, align 8
-  %stackalloc = alloca i8, align 1
-  store %main.kv.0 zeroinitializer, ptr %b1, align 8
-  call void @runtime.trackPointer(ptr nonnull %b1, ptr nonnull %stackalloc, ptr undef) #3
-  store %main.kv.0 %b, ptr %b1, align 8
   ret void
 }
 

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -57,10 +57,7 @@ declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(32), ptr, ptr dereferen
 ; Function Attrs: nounwind
 define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  %complit = alloca {}, align 8
   %chan.blockedList = alloca %runtime.channelBlockedList, align 8
-  %stackalloc = alloca i8, align 1
-  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #4
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
   call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)

--- a/compiler/testdata/zeromap.ll
+++ b/compiler/testdata/zeromap.ll
@@ -21,14 +21,9 @@ define hidden i32 @main.testZeroGet(ptr dereferenceable_or_null(40) %m, i1 %s.b1
 entry:
   %hashmap.key = alloca %main.hasPadding, align 8
   %hashmap.value = alloca i32, align 4
-  %s = alloca %main.hasPadding, align 8
   %0 = insertvalue %main.hasPadding zeroinitializer, i1 %s.b1, 0
   %1 = insertvalue %main.hasPadding %0, i32 %s.i, 1
   %2 = insertvalue %main.hasPadding %1, i1 %s.b2, 2
-  %stackalloc = alloca i8, align 1
-  store %main.hasPadding zeroinitializer, ptr %s, align 8
-  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #5
-  store %main.hasPadding %2, ptr %s, align 8
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   call void @llvm.lifetime.start.p0(i64 12, ptr nonnull %hashmap.key)
   store %main.hasPadding %2, ptr %hashmap.key, align 8
@@ -58,14 +53,9 @@ define hidden void @main.testZeroSet(ptr dereferenceable_or_null(40) %m, i1 %s.b
 entry:
   %hashmap.key = alloca %main.hasPadding, align 8
   %hashmap.value = alloca i32, align 4
-  %s = alloca %main.hasPadding, align 8
   %0 = insertvalue %main.hasPadding zeroinitializer, i1 %s.b1, 0
   %1 = insertvalue %main.hasPadding %0, i32 %s.i, 1
   %2 = insertvalue %main.hasPadding %1, i1 %s.b2, 2
-  %stackalloc = alloca i8, align 1
-  store %main.hasPadding zeroinitializer, ptr %s, align 8
-  call void @runtime.trackPointer(ptr nonnull %s, ptr nonnull %stackalloc, ptr undef) #5
-  store %main.hasPadding %2, ptr %s, align 8
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   store i32 5, ptr %hashmap.value, align 4
   call void @llvm.lifetime.start.p0(i64 12, ptr nonnull %hashmap.key)
@@ -87,24 +77,13 @@ define hidden i32 @main.testZeroArrayGet(ptr dereferenceable_or_null(40) %m, [2 
 entry:
   %hashmap.key = alloca [2 x %main.hasPadding], align 8
   %hashmap.value = alloca i32, align 4
-  %s1 = alloca [2 x %main.hasPadding], align 8
-  %stackalloc = alloca i8, align 1
-  store %main.hasPadding zeroinitializer, ptr %s1, align 8
-  %s1.repack2 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
-  store %main.hasPadding zeroinitializer, ptr %s1.repack2, align 4
-  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #5
-  %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
-  store %main.hasPadding %s.elt, ptr %s1, align 8
-  %s1.repack3 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
-  %s.elt4 = extractvalue [2 x %main.hasPadding] %s, 1
-  store %main.hasPadding %s.elt4, ptr %s1.repack3, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %hashmap.key)
-  %s.elt7 = extractvalue [2 x %main.hasPadding] %s, 0
-  store %main.hasPadding %s.elt7, ptr %hashmap.key, align 8
-  %hashmap.key.repack8 = getelementptr inbounds [2 x %main.hasPadding], ptr %hashmap.key, i32 0, i32 1
-  %s.elt9 = extractvalue [2 x %main.hasPadding] %s, 1
-  store %main.hasPadding %s.elt9, ptr %hashmap.key.repack8, align 4
+  %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
+  store %main.hasPadding %s.elt, ptr %hashmap.key, align 8
+  %hashmap.key.repack1 = getelementptr inbounds [2 x %main.hasPadding], ptr %hashmap.key, i32 0, i32 1
+  %s.elt2 = extractvalue [2 x %main.hasPadding] %s, 1
+  store %main.hasPadding %s.elt2, ptr %hashmap.key.repack1, align 4
   %0 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
   call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #5
   %1 = getelementptr inbounds i8, ptr %hashmap.key, i32 9
@@ -125,25 +104,14 @@ define hidden void @main.testZeroArraySet(ptr dereferenceable_or_null(40) %m, [2
 entry:
   %hashmap.key = alloca [2 x %main.hasPadding], align 8
   %hashmap.value = alloca i32, align 4
-  %s1 = alloca [2 x %main.hasPadding], align 8
-  %stackalloc = alloca i8, align 1
-  store %main.hasPadding zeroinitializer, ptr %s1, align 8
-  %s1.repack2 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
-  store %main.hasPadding zeroinitializer, ptr %s1.repack2, align 4
-  call void @runtime.trackPointer(ptr nonnull %s1, ptr nonnull %stackalloc, ptr undef) #5
-  %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
-  store %main.hasPadding %s.elt, ptr %s1, align 8
-  %s1.repack3 = getelementptr inbounds [2 x %main.hasPadding], ptr %s1, i32 0, i32 1
-  %s.elt4 = extractvalue [2 x %main.hasPadding] %s, 1
-  store %main.hasPadding %s.elt4, ptr %s1.repack3, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %hashmap.value)
   store i32 5, ptr %hashmap.value, align 4
   call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %hashmap.key)
-  %s.elt7 = extractvalue [2 x %main.hasPadding] %s, 0
-  store %main.hasPadding %s.elt7, ptr %hashmap.key, align 8
-  %hashmap.key.repack8 = getelementptr inbounds [2 x %main.hasPadding], ptr %hashmap.key, i32 0, i32 1
-  %s.elt9 = extractvalue [2 x %main.hasPadding] %s, 1
-  store %main.hasPadding %s.elt9, ptr %hashmap.key.repack8, align 4
+  %s.elt = extractvalue [2 x %main.hasPadding] %s, 0
+  store %main.hasPadding %s.elt, ptr %hashmap.key, align 8
+  %hashmap.key.repack1 = getelementptr inbounds [2 x %main.hasPadding], ptr %hashmap.key, i32 0, i32 1
+  %s.elt2 = extractvalue [2 x %main.hasPadding] %s, 1
+  store %main.hasPadding %s.elt2, ptr %hashmap.key.repack1, align 4
   %0 = getelementptr inbounds i8, ptr %hashmap.key, i32 1
   call void @runtime.memzero(ptr nonnull %0, i32 3, ptr undef) #5
   %1 = getelementptr inbounds i8, ptr %hashmap.key, i32 9

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/mattn/go-tty v0.0.4
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
 	go.bug.st/serial v1.6.0
-	golang.org/x/sys v0.8.0
-	golang.org/x/tools v0.9.0
+	golang.org/x/sys v0.11.0
+	golang.org/x/tools v0.12.0
 	gopkg.in/yaml.v2 v2.4.0
 	tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32
 )

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/mattn/go-tty v0.0.4
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
 	go.bug.st/serial v1.6.0
-	golang.org/x/sys v0.4.0
-	golang.org/x/tools v0.5.1-0.20230114154351-e035d0c426c8
+	golang.org/x/sys v0.8.0
+	golang.org/x/tools v0.9.0
 	gopkg.in/yaml.v2 v2.4.0
 	tinygo.org/x/go-llvm v0.0.0-20221028183034-8341240c0b32
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moA
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/deadprogram/go-serial v0.0.0-20230717164825-4529b3232919 h1:Hi7G1bCG70NwlyqGswJKEHoIi4hJVN1SsmfwZ+DQHtw=
-github.com/deadprogram/go-serial v0.0.0-20230717164825-4529b3232919/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
@@ -50,7 +48,7 @@ github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 go.bug.st/serial v1.6.0 h1:mAbRGN4cKE2J5gMwsMHC2KQisdLRQssO9WSM+rbZJ8A=
 go.bug.st/serial v1.6.0/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -58,10 +56,10 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.5.1-0.20230114154351-e035d0c426c8 h1:LHoToPgySGSr2NcUHbjENAidHz38RkKaNmmntwn9TjI=
-golang.org/x/tools v0.5.1-0.20230114154351-e035d0c426c8/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.9.0 h1:CtBMYmb33qYal6XpayZzNXlyK/3FpZV8bDq4CZo57b8=
+golang.org/x/tools v0.9.0/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,7 @@ github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 go.bug.st/serial v1.6.0 h1:mAbRGN4cKE2J5gMwsMHC2KQisdLRQssO9WSM+rbZJ8A=
 go.bug.st/serial v1.6.0/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -56,10 +56,10 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.9.0 h1:CtBMYmb33qYal6XpayZzNXlyK/3FpZV8bDq4CZo57b8=
-golang.org/x/tools v0.9.0/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
+golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
This required handling array and struct zero constants, due to https://github.com/golang/tools/commit/71ea8f168c160da91116b4ddbd577a8fc95aa334. I implemented that the same way as channels, which I hope is correct. At least, it appears to work for tests that I am able to run, but we'll see how it is with the more extensive checks on CI.

This also triggers an update of `golang.org/x/sys`, but that is only used for a constant and should be fine.