### PR TITLE
gc: findHead scan optimization

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,10 +41,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-
-		{"hifive1b", "examples/echo", 4720, 280, 0, 2252},
-		{"microbit", "examples/serial", 2820, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6091, 1485, 116, 6816},
+		{"hifive1b", "examples/echo", 4688, 280, 0, 2268},
+		{"microbit", "examples/serial", 2952, 388, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 6148, 1484, 116, 6832},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,7 +41,7 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 4688, 280, 0, 2268},
+		{"hifive1b", "examples/echo", 4692, 280, 0, 2268},
 		{"microbit", "examples/serial", 2952, 388, 8, 2272},
 		{"wioterminal", "examples/pininterrupt", 6148, 1484, 116, 6832},
 

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,9 +41,16 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
+<<<<<<< HEAD
 		{"hifive1b", "examples/echo", 4568, 280, 0, 2268},
 		{"microbit", "examples/serial", 2868, 388, 8, 2272},
 		{"wioterminal", "examples/pininterrupt", 6104, 1484, 116, 6832},
+=======
+
+		{"hifive1b", "examples/echo", 4720, 280, 0, 2252},
+		{"microbit", "examples/serial", 2820, 388, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 6091, 1485, 116, 6816},
+>>>>>>> 3214fcb5 (changed expected size so all tests can run)
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,16 +41,10 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-<<<<<<< HEAD
-		{"hifive1b", "examples/echo", 4568, 280, 0, 2268},
-		{"microbit", "examples/serial", 2868, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 6104, 1484, 116, 6832},
-=======
 
 		{"hifive1b", "examples/echo", 4720, 280, 0, 2252},
 		{"microbit", "examples/serial", 2820, 388, 8, 2256},
 		{"wioterminal", "examples/pininterrupt", 6091, 1485, 116, 6816},
->>>>>>> 3214fcb5 (changed expected size so all tests can run)
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -125,6 +125,9 @@ func (b gcBlock) address() uintptr {
 	return addr
 }
 
+// findHead returns the head (first block) of an object, assuming the block
+// points to an allocated object. It returns the same block if this block
+// already points to the head.
 func (b gcBlock) findHead() gcBlock {
 	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 

--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -125,35 +125,25 @@ func (b gcBlock) address() uintptr {
 	return addr
 }
 
-// findHead returns the head (first block) of an object, assuming the block
-// points to an allocated object. It returns the same block if this block
-// already points to the head.
 func (b gcBlock) findHead() gcBlock {
 	stateBytePtr := (*uint8)(unsafe.Add(metadataStart, b/blocksPerStateByte))
 
-	// XOR the stateByte with byte containing all tails to turn tail bits to 0
-	// and shift out the bits that are not part of the object
-	stateByte := ((*stateBytePtr) ^ blockStateByteAllTails) << ((blocksPerStateByte - (b%blocksPerStateByte + 1)) * stateBits)
-	// if stateByte is 0 that means all blocks are tails so we loop trough subsequent states,
-	// byte at a time to find the first byte that is not all tails
-	if stateByte == 0 {
-		// subtract the number of object blocks that were in the first byte
-		b -= (b%blocksPerStateByte + 1)
-		// skip to next byte
+	// XOR the stateByte with byte containing all tails to turn tail bits to 0 and
+	// mask out the bits that are not part of the object
+	otherObjectBlocks := int(blocksPerStateByte - (b%blocksPerStateByte + 1))
+	stateByte := ((*stateBytePtr) ^ blockStateByteAllTails) & (uint8(1<<(8-(otherObjectBlocks*stateBits))) - 1)
+
+	// loop until state byte is not all tails
+	for stateByte == 0 {
 		stateBytePtr = (*uint8)(unsafe.Add(unsafe.Pointer(stateBytePtr), -1))
-		// loop until state byte is not all tails
-		for (*stateBytePtr)^blockStateByteAllTails == 0 {
-			stateBytePtr = (*uint8)(unsafe.Add(unsafe.Pointer(stateBytePtr), -1))
-			b -= blocksPerStateByte
-		}
-		// set stateByte variable to the first byte that is not all tails and turn all tail bits to zeroes
 		stateByte = (*stateBytePtr) ^ blockStateByteAllTails
+		b -= blocksPerStateByte
 	}
 
-	// at this point stateByte is set to the first state byte of the object that we encountered which is not all tails
-	// and all tail bits in it are turned to zero. We count number of bytes that are 0 (tail) using LeadingZeros8
-	// and divide it by stateBits to get the number of tail blocks in state bits.
-	b -= gcBlock(bits.LeadingZeros8(stateByte) / stateBits)
+	// in the first state byte which is not all tails, count the number of leading bits that are 0 and
+	// divide it by stateBits to get the number of tail blocks. Subtract otherObjectBlocks to exclude
+	// blocks that are not part of the object
+	b -= gcBlock((bits.LeadingZeros8(stateByte) / stateBits) - otherObjectBlocks)
 
 	if gcAsserts {
 		if b.state() != blockStateHead && b.state() != blockStateMark {


### PR DESCRIPTION
Draft PR to continue discussion with @dgryski and @aykevl about optimizing findHead algorithm in case of large object allocation.
The idea is to scan the block state byte at the time. State byte is first XOR-ed with all tails byte which turns all tails in state byte to 0 and then bits.LeadingZeros8 is used to get how many tails are in the byte. Also, if XOR-ed byte is 0 that means it is all tails so we can skip to the next. For the first byte we first shift out the bits that are not part of current object.