### PR TITLE
targets: add GoBadge target as alias for PyBadge

### DIFF
--- a/targets/gobadge.json
+++ b/targets/gobadge.json
@@ -1,0 +1,3 @@
+{
+	"inherits": ["pybadge"]
+}


### PR DESCRIPTION
This PR adds a new target `gobadge` as an alias for PyBadge to make life easier for hack session users.