### PR TITLE
interp: add 'max depth' parameter to limit cost

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -446,7 +446,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				if pkgInit.IsNil() {
 					panic("init not found for " + pkg.Pkg.Path())
 				}
-				err := interp.RunFunc(pkgInit, config.Options.InterpTimeout, config.DumpSSA())
+				err := interp.RunFunc(pkgInit, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.DumpSSA())
 				if err != nil {
 					return err
 				}
@@ -1043,7 +1043,7 @@ func createEmbedObjectFile(data, hexSum, sourceFile, sourceDir, tmpdir string, c
 // needed to convert a program to its final form. Some transformations are not
 // optional and must be run as the compiler expects them to run.
 func optimizeProgram(mod llvm.Module, config *compileopts.Config) error {
-	err := interp.Run(mod, config.Options.InterpTimeout, config.DumpSSA())
+	err := interp.Run(mod, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.DumpSSA())
 	if err != nil {
 		return err
 	}

--- a/builder/build.go
+++ b/builder/build.go
@@ -446,7 +446,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				if pkgInit.IsNil() {
 					panic("init not found for " + pkg.Pkg.Path())
 				}
-				err := interp.RunFunc(pkgInit, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.DumpSSA())
+				err := interp.RunFunc(pkgInit, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.Options.InterpMaxInstr, config.DumpSSA())
 				if err != nil {
 					return err
 				}
@@ -1043,7 +1043,7 @@ func createEmbedObjectFile(data, hexSum, sourceFile, sourceDir, tmpdir string, c
 // needed to convert a program to its final form. Some transformations are not
 // optional and must be run as the compiler expects them to run.
 func optimizeProgram(mod llvm.Module, config *compileopts.Config) error {
-	err := interp.Run(mod, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.DumpSSA())
+	err := interp.Run(mod, config.Options.InterpTimeout, config.Options.InterpMaxDepth, config.Options.InterpMaxInstr, config.DumpSSA())
 	if err != nil {
 		return err
 	}

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	Work            bool // -work flag to print temporary build directory
 	InterpTimeout   time.Duration
 	InterpMaxDepth  int
+	InterpMaxInstr  int
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	Serial          string
 	Work            bool // -work flag to print temporary build directory
 	InterpTimeout   time.Duration
+	InterpMaxDepth  int
 	PrintIR         bool
 	DumpSSA         bool
 	VerifyIR        bool

--- a/interp/errors.go
+++ b/interp/errors.go
@@ -19,6 +19,7 @@ var (
 	errUnsupportedRuntimeInst = errors.New("interp: unsupported instruction (to be emitted at runtime)")
 	errMapAlreadyCreated      = errors.New("interp: map already created")
 	errLoopUnrolled           = errors.New("interp: loop unrolled")
+	errDepthExceeded          = errors.New("interp: depth exceeded")
 )
 
 // This is one of the errors that can be returned from toLLVMValue when the
@@ -29,7 +30,7 @@ var errInvalidPtrToIntSize = errors.New("interp: ptrtoint integer size does not 
 func isRecoverableError(err error) bool {
 	return err == errIntegerAsPointer || err == errUnsupportedInst ||
 		err == errUnsupportedRuntimeInst || err == errMapAlreadyCreated ||
-		err == errLoopUnrolled
+		err == errLoopUnrolled || err == errDepthExceeded
 }
 
 // ErrorLine is one line in a traceback. The position may be missing.

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -53,7 +53,7 @@ func runTest(t *testing.T, pathPrefix string) {
 	defer mod.Dispose()
 
 	// Perform the transform.
-	err = Run(mod, 10*time.Minute, false)
+	err = Run(mod, 10*time.Minute, 10, false)
 	if err != nil {
 		if err, match := err.(*Error); match {
 			println(err.Error())

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -53,7 +53,7 @@ func runTest(t *testing.T, pathPrefix string) {
 	defer mod.Dispose()
 
 	// Perform the transform.
-	err = Run(mod, 10*time.Minute, 10, false)
+	err = Run(mod, 10*time.Minute, 10, 0, false)
 	if err != nil {
 		if err, match := err.(*Error); match {
 			println(err.Error())

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -33,7 +33,14 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, depth 
 	lastBB := -1 // last basic block is undefined, only defined after a branch
 	var operands []value
 	startRTInsts := len(mem.instructions)
+	instCount := 0
 	for instIndex := 0; instIndex < len(bb.instructions); instIndex++ {
+		instCount++
+		if r.maxInstr > 0 && instCount > r.maxInstr {
+			fmt.Printf("interp: excess instructions evaluated in %v\n", fn.name)
+			return nil, mem, r.errorAt(fn.blocks[0].instructions[0], errDepthExceeded)
+		}
+
 		if instIndex == 0 {
 			if r.maxDepth > 0 && depth >= r.maxDepth {
 				fmt.Printf("interp: depth exceeded in %v\n", fn.name)

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -12,7 +12,7 @@ import (
 	"tinygo.org/x/go-llvm"
 )
 
-func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent string) (value, memoryView, *Error) {
+func (r *runner) run(fn *function, params []value, parentMem *memoryView, depth int, indent string) (value, memoryView, *Error) {
 	mem := memoryView{r: r, parent: parentMem}
 	locals := make([]value, len(fn.locals))
 	r.callsExecuted++
@@ -35,6 +35,11 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 	startRTInsts := len(mem.instructions)
 	for instIndex := 0; instIndex < len(bb.instructions); instIndex++ {
 		if instIndex == 0 {
+			if r.maxDepth > 0 && depth >= r.maxDepth {
+				fmt.Printf("interp: depth exceeded in %v\n", fn.name)
+				return nil, mem, r.errorAt(fn.blocks[0].instructions[0], errDepthExceeded)
+			}
+
 			// This is the start of a new basic block.
 			if len(mem.instructions) != startRTInsts {
 				if _, ok := runtimeBlocks[lastBB]; ok {
@@ -523,7 +528,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 					}
 					fmt.Fprintln(os.Stderr, indent+"call:", callFn.name+"("+strings.Join(argStrings, ", ")+")")
 				}
-				retval, callMem, callErr := r.run(callFn, operands[1:], &mem, indent+"    ")
+				retval, callMem, callErr := r.run(callFn, operands[1:], &mem, depth+1, indent+"    ")
 				if callErr != nil {
 					if isRecoverableError(callErr.Err) {
 						// This error can be recovered by doing the call at

--- a/main.go
+++ b/main.go
@@ -1419,6 +1419,7 @@ func main() {
 	work := flag.Bool("work", false, "print the name of the temporary build directory and do not delete this directory on exit")
 	interpTimeout := flag.Duration("interp-timeout", 180*time.Second, "interp optimization pass timeout")
 	interpMaxDepth := flag.Int("interp-maxdepth", 0, "interp optimization max depth (default 0=disabled)")
+	interpMaxInstr := flag.Int("interp-maxinstr", 100_000, "limit interp optimization max instructions (0=disabled)")
 	var tags buildutil.TagsFlag
 	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
@@ -1530,6 +1531,7 @@ func main() {
 		Work:            *work,
 		InterpTimeout:   *interpTimeout,
 		InterpMaxDepth:  *interpMaxDepth,
+		InterpMaxInstr:  *interpMaxInstr,
 		PrintIR:         *printIR,
 		DumpSSA:         *dumpSSA,
 		VerifyIR:        *verifyIR,

--- a/main.go
+++ b/main.go
@@ -1418,6 +1418,7 @@ func main() {
 	serial := flag.String("serial", "", "which serial output to use (none, uart, usb)")
 	work := flag.Bool("work", false, "print the name of the temporary build directory and do not delete this directory on exit")
 	interpTimeout := flag.Duration("interp-timeout", 180*time.Second, "interp optimization pass timeout")
+	interpMaxDepth := flag.Int("interp-maxdepth", 0, "interp optimization max depth (default 0=disabled)")
 	var tags buildutil.TagsFlag
 	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
@@ -1528,6 +1529,7 @@ func main() {
 		Serial:          *serial,
 		Work:            *work,
 		InterpTimeout:   *interpTimeout,
+		InterpMaxDepth:  *interpMaxDepth,
 		PrintIR:         *printIR,
 		DumpSSA:         *dumpSSA,
 		VerifyIR:        *verifyIR,

--- a/main_test.go
+++ b/main_test.go
@@ -290,15 +290,16 @@ func emuCheck(t *testing.T, options compileopts.Options) {
 func optionsFromTarget(target string, sema chan struct{}) compileopts.Options {
 	return compileopts.Options{
 		// GOOS/GOARCH are only used if target == ""
-		GOOS:          goenv.Get("GOOS"),
-		GOARCH:        goenv.Get("GOARCH"),
-		GOARM:         goenv.Get("GOARM"),
-		Target:        target,
-		Semaphore:     sema,
-		InterpTimeout: 180 * time.Second,
-		Debug:         true,
-		VerifyIR:      true,
-		Opt:           "z",
+		GOOS:           goenv.Get("GOOS"),
+		GOARCH:         goenv.Get("GOARCH"),
+		GOARM:          goenv.Get("GOARM"),
+		Target:         target,
+		Semaphore:      sema,
+		InterpTimeout:  180 * time.Second,
+		InterpMaxDepth: 10,
+		Debug:          true,
+		VerifyIR:       true,
+		Opt:            "z",
 	}
 }
 
@@ -308,13 +309,14 @@ func optionsFromTarget(target string, sema chan struct{}) compileopts.Options {
 func optionsFromOSARCH(osarch string, sema chan struct{}) compileopts.Options {
 	parts := strings.Split(osarch, "/")
 	options := compileopts.Options{
-		GOOS:          parts[0],
-		GOARCH:        parts[1],
-		Semaphore:     sema,
-		InterpTimeout: 180 * time.Second,
-		Debug:         true,
-		VerifyIR:      true,
-		Opt:           "z",
+		GOOS:           parts[0],
+		GOARCH:         parts[1],
+		Semaphore:      sema,
+		InterpTimeout:  180 * time.Second,
+		InterpMaxDepth: 10,
+		Debug:          true,
+		VerifyIR:       true,
+		Opt:            "z",
 	}
 	if options.GOARCH == "arm" {
 		options.GOARM = parts[2]

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -22,11 +22,12 @@ func TestTraceback(t *testing.T) {
 	// Build a small binary that only panics.
 	tmpdir := t.TempDir()
 	config, err := builder.NewConfig(&compileopts.Options{
-		GOOS:          runtime.GOOS,
-		GOARCH:        runtime.GOARCH,
-		Opt:           "z",
-		InterpTimeout: time.Minute,
-		Debug:         true,
+		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
+		Opt:            "z",
+		InterpTimeout:  time.Minute,
+		InterpMaxDepth: 10,
+		Debug:          true,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Prototype of limiting max depth for interp evaluation (number of functions) as a way of keeping it's cost-to-execute down.

This should still have reproducible builds since the code structure (function call chains) is fixed for any given code being compiled.