### PR TITLE
build: #3893 do not return LLVM structs from Build

### DIFF
--- a/interp/compiler.go
+++ b/interp/compiler.go
@@ -49,7 +49,10 @@ func (inst *instruction) String() string {
 		operands[i] = op.String()
 	}
 
-	name := instructionNameMap[inst.opcode]
+	name := ""
+	if int(inst.opcode) < len(instructionNameMap) {
+		name = instructionNameMap[inst.opcode]
+	}
 	if name == "" {
 		name = "<unknown op>"
 	}

--- a/interp/errors.go
+++ b/interp/errors.go
@@ -35,14 +35,14 @@ func isRecoverableError(err error) bool {
 // ErrorLine is one line in a traceback. The position may be missing.
 type ErrorLine struct {
 	Pos  token.Position
-	Inst llvm.Value
+	Inst string
 }
 
 // Error encapsulates compile-time interpretation errors with an associated
 // import path. The errors may not have a precise location attached.
 type Error struct {
 	ImportPath string
-	Inst       llvm.Value
+	Inst       string
 	Pos        token.Position
 	Err        error
 	Traceback  []ErrorLine
@@ -60,10 +60,10 @@ func (r *runner) errorAt(inst instruction, err error) *Error {
 	pos := getPosition(inst.llvmInst)
 	return &Error{
 		ImportPath: r.pkgName,
-		Inst:       inst.llvmInst,
+		Inst:       inst.String(),
 		Pos:        pos,
 		Err:        err,
-		Traceback:  []ErrorLine{{pos, inst.llvmInst}},
+		Traceback:  []ErrorLine{{pos, inst.String()}},
 	}
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -57,16 +57,14 @@ func runTest(t *testing.T, pathPrefix string) {
 	if err != nil {
 		if err, match := err.(*Error); match {
 			println(err.Error())
-			if !err.Inst.IsNil() {
-				err.Inst.Dump()
-				println()
+			if len(err.Inst) != 0 {
+				println(err.Inst)
 			}
 			if len(err.Traceback) > 0 {
 				println("\ntraceback:")
 				for _, line := range err.Traceback {
 					println(line.Pos.String() + ":")
-					line.Inst.Dump()
-					println()
+					println(line.Inst)
 				}
 			}
 		}

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -543,7 +543,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 					// how this function got called.
 					callErr.Traceback = append(callErr.Traceback, ErrorLine{
 						Pos:  getPosition(inst.llvmInst),
-						Inst: inst.llvmInst,
+						Inst: inst.String(),
 					})
 					return nil, mem, callErr
 				}

--- a/main.go
+++ b/main.go
@@ -1289,16 +1289,14 @@ func printCompilerError(logln func(...interface{}), err error) {
 	case *interp.Error:
 		logln("#", err.ImportPath)
 		logln(err.Error())
-		if !err.Inst.IsNil() {
-			err.Inst.Dump()
-			logln()
+		if len(err.Inst) != 0 {
+			logln(err.Inst)
 		}
 		if len(err.Traceback) > 0 {
 			logln("\ntraceback:")
 			for _, line := range err.Traceback {
 				logln(line.Pos.String() + ":")
-				line.Inst.Dump()
-				logln()
+				logln(line.Inst)
 			}
 		}
 	case loader.Errors:


### PR DESCRIPTION
This looses a bit of info about the instruction causing the failure - but since Dump can't be used after builder.Build is finished, this is probably the best available for now?

Maybe there's a way to enhance go-llvm to provide more detail in the `String` function?