### PR TITLE
atsamd21, atsamd51: add support for USB INTERRUPT OUT

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,7 +43,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4612, 280, 0, 2252},
 		{"microbit", "examples/serial", 2724, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6039, 1485, 116, 6816},
+		{"wioterminal", "examples/pininterrupt", 6063, 1485, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -228,7 +228,23 @@ func initEndpoint(ep, config uint32) {
 		setEPSTATUSCLR(ep, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
 
 	case usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointOut:
-		// TODO: not really anything, seems like...
+		// set packet size
+		usbEndpointDescriptors[ep].DeviceDescBank[0].PCKSIZE.SetBits(epPacketSize(64) << usb_DEVICE_PCKSIZE_SIZE_Pos)
+
+		// set data buffer address
+		usbEndpointDescriptors[ep].DeviceDescBank[0].ADDR.Set(uint32(uintptr(unsafe.Pointer(&udd_ep_out_cache_buffer[ep]))))
+
+		// set endpoint type
+		setEPCFG(ep, ((usb.ENDPOINT_TYPE_INTERRUPT + 1) << sam.USB_DEVICE_ENDPOINT_EPCFG_EPTYPE0_Pos))
+
+		// receive interrupts when current transfer complete
+		setEPINTENSET(ep, sam.USB_DEVICE_ENDPOINT_EPINTENSET_TRCPT0)
+
+		// set byte count to zero, we have not received anything yet
+		usbEndpointDescriptors[ep].DeviceDescBank[0].PCKSIZE.ClearBits(usb_DEVICE_PCKSIZE_BYTE_COUNT_Mask << usb_DEVICE_PCKSIZE_BYTE_COUNT_Pos)
+
+		// ready for next transfer
+		setEPSTATUSCLR(ep, sam.USB_DEVICE_ENDPOINT_EPSTATUSCLR_BK0RDY)
 
 	case usb.ENDPOINT_TYPE_BULK | usb.EndpointIn:
 		// set packet size


### PR DESCRIPTION
This PR adds `INTERRUPT OUT` support to the following microcontrollers

* atsamd21
* atsamd51

Setting of `INTERRUPT OUT` is almost the same as `BULK OUT`.
The only difference is the parameter at `setEPCFG()`.

Note that rp2040 and nrf52840 were already supported.