### PR TITLE
compiler: don't use types in the global context

### DIFF
--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -147,7 +147,7 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 				c.addError(token.NoPos, fmt.Sprintf("too many levels of pointers for typecode: %s", typstr))
 			}
 			return llvm.ConstGEP(c.ctx.Int8Type(), ptr, []llvm.Value{
-				llvm.ConstInt(llvm.Int32Type(), 1, false),
+				llvm.ConstInt(c.ctx.Int32Type(), 1, false),
 			})
 		}
 	}
@@ -452,8 +452,8 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 		offset = 1
 	}
 	return llvm.ConstGEP(global.GlobalValueType(), global, []llvm.Value{
-		llvm.ConstInt(llvm.Int32Type(), 0, false),
-		llvm.ConstInt(llvm.Int32Type(), offset, false),
+		llvm.ConstInt(c.ctx.Int32Type(), 0, false),
+		llvm.ConstInt(c.ctx.Int32Type(), offset, false),
 	})
 }
 


### PR DESCRIPTION
This usually works by chance, but leads to crashes. So we should never ever do this.

I'm pretty sure this is the crash behind this issue: https://github.com/tinygo-org/tinygo/issues/3894

It may also have caused this crash: https://github.com/tinygo-org/tinygo/issues/3874

I have a suspicion this is also behind the rather crash-prone CircleCI jobs, that we haven't been able to find the source of. But we'll find out soon enough once this fix is merged.

To avoid hitting this issue again in the future, I've created a PR to remove these dangerous functions altogether from the go-llvm API: https://github.com/tinygo-org/go-llvm/pull/54