### PR TITLE
all: use the new LLVM pass manager

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,9 +41,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 4568, 280, 0, 2252},
-		{"microbit", "examples/serial", 2728, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 5996, 1484, 116, 6816},
+		{"hifive1b", "examples/echo", 4484, 280, 0, 2252},
+		{"microbit", "examples/serial", 2724, 388, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 6000, 1484, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -145,18 +145,18 @@ func (c *Config) Serial() string {
 
 // OptLevels returns the optimization level (0-2), size level (0-2), and inliner
 // threshold as used in the LLVM optimization pipeline.
-func (c *Config) OptLevels() (optLevel, sizeLevel int, inlinerThreshold uint) {
+func (c *Config) OptLevel() (level string, speedLevel, sizeLevel int) {
 	switch c.Options.Opt {
 	case "none", "0":
-		return 0, 0, 0 // -O0
+		return "O0", 0, 0
 	case "1":
-		return 1, 0, 0 // -O1
+		return "O1", 1, 0
 	case "2":
-		return 2, 0, 225 // -O2
+		return "O2", 2, 0
 	case "s":
-		return 2, 1, 225 // -Os
+		return "Os", 2, 1
 	case "z":
-		return 2, 2, 5 // -Oz, default
+		return "Oz", 2, 2 // default
 	default:
 		// This is not shown to the user: valid choices are already checked as
 		// part of Options.Verify(). It is here as a sanity check.

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -91,14 +91,12 @@ func TestCompiler(t *testing.T) {
 			}
 
 			// Optimize IR a little.
-			funcPasses := llvm.NewFunctionPassManagerForModule(mod)
-			defer funcPasses.Dispose()
-			funcPasses.AddInstructionCombiningPass()
-			funcPasses.InitializeFunc()
-			for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
-				funcPasses.RunFunc(fn)
+			passOptions := llvm.NewPassBuilderOptions()
+			defer passOptions.Dispose()
+			err = mod.RunPasses("instcombine", llvm.TargetMachine{}, passOptions)
+			if err != nil {
+				t.Error(err)
 			}
-			funcPasses.FinalizeFunc()
 
 			outFilePrefix := tc.file[:len(tc.file)-3]
 			if tc.target != "" {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -77,12 +77,9 @@ func runTest(t *testing.T, pathPrefix string) {
 	}
 
 	// Run some cleanup passes to get easy-to-read outputs.
-	pm := llvm.NewPassManager()
-	defer pm.Dispose()
-	pm.AddGlobalOptimizerPass()
-	pm.AddDeadStoreEliminationPass()
-	pm.AddAggressiveDCEPass()
-	pm.Run(mod)
+	to := llvm.NewPassBuilderOptions()
+	defer to.Dispose()
+	mod.RunPasses("globalopt,dse,adce", llvm.TargetMachine{}, to)
 
 	// Read the expected output IR.
 	out, err := os.ReadFile(pathPrefix + ".out.ll")

--- a/transform/allocs_test.go
+++ b/transform/allocs_test.go
@@ -38,11 +38,12 @@ func TestAllocs2(t *testing.T) {
 	mod := compileGoFileForTesting(t, "./testdata/allocs2.go")
 
 	// Run functionattrs pass, which is necessary for escape analysis.
-	pm := llvm.NewPassManager()
-	defer pm.Dispose()
-	pm.AddInstructionCombiningPass()
-	pm.AddFunctionAttrsPass()
-	pm.Run(mod)
+	po := llvm.NewPassBuilderOptions()
+	defer po.Dispose()
+	err := mod.RunPasses("function(instcombine),function-attrs", llvm.TargetMachine{}, po)
+	if err != nil {
+		t.Error("failed to run passes:", err)
+	}
 
 	// Run heap to stack transform.
 	var testOutputs []allocsTestOutput

--- a/transform/interface-lowering_test.go
+++ b/transform/interface-lowering_test.go
@@ -15,9 +15,11 @@ func TestInterfaceLowering(t *testing.T) {
 			t.Error(err)
 		}
 
-		pm := llvm.NewPassManager()
-		defer pm.Dispose()
-		pm.AddGlobalDCEPass()
-		pm.Run(mod)
+		po := llvm.NewPassBuilderOptions()
+		defer po.Dispose()
+		err = mod.RunPasses("globaldce", llvm.TargetMachine{}, po)
+		if err != nil {
+			t.Error("failed to run passes:", err)
+		}
 	})
 }

--- a/transform/maps_test.go
+++ b/transform/maps_test.go
@@ -15,10 +15,11 @@ func TestOptimizeMaps(t *testing.T) {
 
 		// Run an optimization pass, to clean up the result.
 		// This shows that all code related to the map is really eliminated.
-		pm := llvm.NewPassManager()
-		defer pm.Dispose()
-		pm.AddDeadStoreEliminationPass()
-		pm.AddAggressiveDCEPass()
-		pm.Run(mod)
+		po := llvm.NewPassBuilderOptions()
+		defer po.Dispose()
+		err := mod.RunPasses("dse,adce", llvm.TargetMachine{}, po)
+		if err != nil {
+			t.Error("failed to run passes:", err)
+		}
 	})
 }

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -22,7 +22,7 @@ import (
 // the -opt= compiler flag.
 func AddStandardAttributes(fn llvm.Value, config *compileopts.Config) {
 	ctx := fn.Type().Context()
-	_, sizeLevel, _ := config.OptLevels()
+	_, _, sizeLevel := config.OptLevel()
 	if sizeLevel >= 1 {
 		fn.AddFunctionAttr(ctx.CreateEnumAttribute(llvm.AttributeKindID("optsize"), 0))
 	}


### PR DESCRIPTION
The old LLVM pass manager is deprecated and should not be used anymore. Moreover, the pass manager builder (which we used to set up a pass pipeline) is actually removed from LLVM entirely in LLVM 17:
https://reviews.llvm.org/D145387
https://reviews.llvm.org/D145835

The new pass manager does change the binary size in many cases: both growing and shrinking it. However, on average the binary size remains more or less the same.

This is needed as a preparation for LLVM 17.

~WIP because this needs https://github.com/tinygo-org/go-llvm/pull/50.~