### PR TITLE
all: release 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+0.30.0
+---
+
+* **general**
+  - add LLVM 16 support, use it by default
+* **compiler**
+  - `build`: work around a race condition by building Go SSA serially
+  - `compiler`: fix a crash by not using the LLVM global context types
+  - `interp`: don't copy unknown values in `runtime.sliceCopy` to fix miscompile
+  - `interp`: fix crash in error report by not returning raw LLVM values
+* **standard library**
+  - `machine/usb/adc/midi`: various improvements and API changes
+  - `reflect`: add support for `[...]T` → `[]T` in reflect
+* **targets**
+  - `atsamd21`, `atsamd51`: add support for USB INTERRUPT OUT
+  - `rp2040`: always use the USB device enumeration fix, even in chips that supposedly have the HW fix
+  - `wasm`: increase default stack size to 32k for wasi/wasm
+* **boards**
+  - `gobadge`: add GoBadge target as alias for PyBadge :)
+  - `gemma-m0`: add support for the Adafruit Gemma M0
+
+
 0.29.0
 ---
 

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -9,7 +9,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const Version = "0.30.0-dev"
+const Version = "0.30.0"
 
 var (
 	// This variable is set at build time using -ldflags parameters.


### PR DESCRIPTION
This is a small release just in time for GopherCon US.

Some of the bigger changes of this release are:

  - switch to LLVM 16
  - fixes for two separate hard-to-reproduce compiler crashes
  - added support for the Adafruit Gemma M0