### PR TITLE
ci: redo LLVM build on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-16-windows-v1
+          key: llvm-build-16-windows-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
MinGW got updated, so it looks like we need to do a new LLVM build.