### PR TITLE
cgo: refactor Go types a little bit

### DIFF
--- a/cgo/testdata/errors.go
+++ b/cgo/testdata/errors.go
@@ -22,8 +22,12 @@ import "C"
 // #warning another warning
 import "C"
 
+// #include <stdint.h>
+import "C"
+
 // Make sure that errors for the following lines won't change with future
 // additions to the CGo preamble.
+//
 //line errors.go:100
 var (
 	// constant too large
@@ -38,4 +42,8 @@ var (
 	_ byte = C.SOME_CONST_3
 
 	_ = C.SOME_CONST_4
+
+	// This must result in a type error. Previously, TinyGo would allow this
+	// code (which is not allowed by upstream Go).
+	_ int8 = C.int8_t(5)
 )

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -11,6 +11,7 @@
 //     testdata/errors.go:108: undefined: C.SOME_CONST_1
 //     testdata/errors.go:110: cannot use C.SOME_CONST_3 (untyped int constant 1234) as byte value in variable declaration (overflows)
 //     testdata/errors.go:112: undefined: C.SOME_CONST_4
+//     testdata/errors.go:116: cannot use C.int8_t(5) (constant 5 of type C.schar) as int8 value in variable declaration
 
 package main
 
@@ -58,3 +59,5 @@ type C.struct_point_t struct {
 type C.point_t = C.struct_point_t
 
 const C.SOME_CONST_3 = 1234
+
+type C.int8_t = C.schar

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -52,10 +52,6 @@ func main() {
 	println("static headerfunc:", C.headerfunc_static(5))
 	headerfunc_2()
 
-	// equivalent types
-	var goInt8 int8 = 5
-	var _ C.int8_t = goInt8
-
 	// more globals
 	println("bool:", C.globalBool, C.globalBool2 == true)
 	println("float:", C.globalFloat)


### PR DESCRIPTION
Code like this is not allowed by the upstream Go CGo implementation, but was allowed by TinyGo:

    var _ int8 = C.int8_t(5)

The reason it shouldn't be allowed is a little bit complicated. While it is true that C.int8_t is always the same underlying data type as Go int8 (signed 8-bit integer), the C type is actually a typedef of one of the base C types (usually unsigned char or signed char) which in turn do _not_ map cleanly to Go types: the 'char' type is ambiguous (it may be either signed or unsigned depending on the ABI) and types like 'int' vary in size by ABI as well.

To make code more portable, I think it's better to match the upstream implementation.

---

This is a backwards incompatible change, but I'd like to make it sometime in the future. I will send corresponding patches to tinygo.org/x/bluetooth and tinygo.org/x/drivers.