### PR TITLE
cgo: add C._Bool type

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -88,6 +88,7 @@ var cgoAliases = map[string]string{
 	"C.uintptr_t": "uintptr",
 	"C.float":     "float32",
 	"C.double":    "float64",
+	"C._Bool":     "bool",
 }
 
 // builtinAliases are handled specially because they only exist on the Go side
@@ -311,10 +312,11 @@ func Process(files []*ast.File, dir, importPath string, fset *token.FileSet, cfl
 	// Process CGo imports for each file.
 	for i, f := range files {
 		cf := p.newCGoFile(f, i)
-		// Float and double are aliased, meaning that C.float is the same thing
-		// as float32 in Go.
+		// These types are aliased with the corresponding types in C. For
+		// example, float in C is always float32 in Go.
 		cf.names["float"] = clangCursor{}
 		cf.names["double"] = clangCursor{}
+		cf.names["_Bool"] = clangCursor{}
 		// Now read all the names (identifies) that C defines in the header
 		// snippet.
 		cf.readNames(p.cgoHeaders[i], cflagsForCGo, filepath.Base(fset.File(f.Pos()).Name()), func(names map[string]clangCursor) {

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -9,6 +9,7 @@ int mul(int, int);
 #include <string.h>
 #cgo CFLAGS: -DSOME_CONSTANT=17
 #define someDefine -5 + 2 * 7
+bool someBool;
 */
 import "C"
 
@@ -55,6 +56,9 @@ func main() {
 	// equivalent types
 	var goInt8 int8 = 5
 	var _ C.int8_t = goInt8
+
+	var _ bool = C.someBool
+	var _ C._Bool = C.someBool
 
 	// more globals
 	println("bool:", C.globalBool, C.globalBool2 == true)


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/tinygo/issues/3926.

While working on this I've found another bug: if C.bool is referenced from within Go, it isn't available anymore on the C side. This is an existing bug that also applies to float and double, but may be less likely to be triggered there.
This bug is something to be fixed at a later time (it has something to do with preprocessor defines).