### PR TITLE
Fix race in `tinygo test`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -878,7 +878,7 @@ deb:
 	@mkdir -p build/release-deb/usr/local/lib
 	cp -ar build/release/tinygo build/release-deb/usr/local/lib/tinygo
 	ln -sf ../lib/tinygo/bin/tinygo build/release-deb/usr/local/bin/tinygo
-	fpm -f -s dir -t deb -n tinygo -a $(DEB_ARCH) -v $(shell grep "const Version = " goenv/version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb
+	fpm -f -s dir -t deb -n tinygo -a $(DEB_ARCH) -v $(shell grep "const version = " goenv/version.go | awk '{print $$NF}') -m '@tinygo-org' --description='TinyGo is a Go compiler for small places.' --license='BSD 3-Clause' --url=https://tinygo.org/ --deb-changelog CHANGELOG.md -p build/release.deb -C ./build/release-deb
 
 ifneq ($(RELEASEONLY), 1)
 release: build/release

--- a/builder/build.go
+++ b/builder/build.go
@@ -168,7 +168,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		CodeModel:       config.CodeModel(),
 		RelocationModel: config.RelocationModel(),
 		SizeLevel:       sizeLevel,
-		TinyGoVersion:   goenv.Version,
+		TinyGoVersion:   goenv.Version(),
 
 		Scheduler:          config.Scheduler(),
 		AutomaticStackSize: config.AutomaticStackSize(),
@@ -220,14 +220,10 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		config.Options.GlobalValues = make(map[string]map[string]string)
 	}
 	if config.Options.GlobalValues["runtime"]["buildVersion"] == "" {
-		version := goenv.Version
-		if strings.HasSuffix(goenv.Version, "-dev") && goenv.GitSha1 != "" {
-			version += "-" + goenv.GitSha1
-		}
 		if config.Options.GlobalValues["runtime"] == nil {
 			config.Options.GlobalValues["runtime"] = make(map[string]string)
 		}
-		config.Options.GlobalValues["runtime"]["buildVersion"] = version
+		config.Options.GlobalValues["runtime"]["buildVersion"] = goenv.Version()
 	}
 	if config.TestConfig.CompileTestBinary {
 		// The testing.testBinary is set to "1" when in a test.

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -9,13 +9,23 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const Version = "0.30.0"
+const version = "0.30.0"
 
 var (
 	// This variable is set at build time using -ldflags parameters.
 	// See: https://stackoverflow.com/a/11355611
 	GitSha1 string
 )
+
+// Return TinyGo version, either in the form 0.30.0 or as a development version
+// (like 0.30.0-dev-abcd012).
+func Version() string {
+	v := version
+	if strings.HasSuffix(version, "-dev") && GitSha1 != "" {
+		v += "-" + GitSha1
+	}
+	return v
+}
 
 // GetGorootVersion returns the major and minor version for a given GOROOT path.
 // If the goroot cannot be determined, (0, 0) is returned.

--- a/main.go
+++ b/main.go
@@ -1212,15 +1212,10 @@ func getBMPPorts() (gdbPort, uartPort string, err error) {
 }
 
 func usage(command string) {
-	version := goenv.Version
-	if strings.HasSuffix(version, "-dev") && goenv.GitSha1 != "" {
-		version += "-" + goenv.GitSha1
-	}
-
 	switch command {
 	default:
 		fmt.Fprintln(os.Stderr, "TinyGo is a Go compiler for small places.")
-		fmt.Fprintln(os.Stderr, "version:", version)
+		fmt.Fprintln(os.Stderr, "version:", goenv.Version())
 		fmt.Fprintf(os.Stderr, "usage: %s <command> [arguments]\n", os.Args[0])
 		fmt.Fprintln(os.Stderr, "\ncommands:")
 		fmt.Fprintln(os.Stderr, "  build:   compile packages and dependencies")
@@ -1874,11 +1869,7 @@ func main() {
 		if s, err := goenv.GorootVersionString(); err == nil {
 			goversion = s
 		}
-		version := goenv.Version
-		if strings.HasSuffix(goenv.Version, "-dev") && goenv.GitSha1 != "" {
-			version += "-" + goenv.GitSha1
-		}
-		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", version, runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
+		fmt.Printf("tinygo version %s %s/%s (using go version %s and LLVM version %s)\n", goenv.Version(), runtime.GOOS, runtime.GOARCH, goversion, llvm.Version)
 	case "env":
 		if flag.NArg() == 0 {
 			// Show all environment variables.

--- a/src/runtime/extern.go
+++ b/src/runtime/extern.go
@@ -10,8 +10,7 @@ func Callers(skip int, pc []uintptr) int {
 var buildVersion string
 
 // Version returns the Tinygo tree's version string.
-// It is the same as goenv.Version, or in case of a development build,
-// it will be the concatenation of goenv.Version and the git commit hash.
+// It is the same as goenv.Version().
 func Version() string {
 	return buildVersion
 }


### PR DESCRIPTION
This happens with `tinygo test` for example when testing multiple packages at the same time. I found this because the compiler crashed in `make tinygo-test-fast`:

    fatal error: concurrent map writes
    fatal error: concurrent map read and map write

    goroutine 15 [running]:
    github.com/tinygo-org/tinygo/builder.Build({0x40002d0be0, 0xa}, {0x0, 0x0}, {0x4000398048, 0x14}, 0x40003b0000)
            /home/ayke/src/tinygo/tinygo/builder/build.go:131 +0x388
    main.buildAndRun({0x40002d0be0, 0xa}, 0x40003b0000, {0x8bc178, 0x40003a4090}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...)
            /home/ayke/src/tinygo/tinygo/main.go:856 +0x45c
    main.Test({0x40002d0be0, 0xa}, {0x8bc118, 0x40000b3a08}, {0x0?, 0x0?}, 0x40001e6000, {0x0, 0x0})
            /home/ayke/src/tinygo/tinygo/main.go:270 +0x758
    main.main.func3()
            /home/ayke/src/tinygo/tinygo/main.go:1718 +0xe4
    created by main.main in goroutine 1
            /home/ayke/src/tinygo/tinygo/main.go:1712 +0x34ec

My solution is essentially to copy the map over instead of modifying it directly.

I've also moved the code up a little, because I think that's a more sensible place (out of the way of the whole package compile logic).

---

The first commit refactors the `goenv.Version` logic, which I found while fixing this issue and is a conflicting change (hence why it's in the same PR).