### PR TITLE
WIP: add initial support for ESP32-S3

### DIFF
--- a/src/device/esp/esp32s3.S
+++ b/src/device/esp/esp32s3.S
@@ -2,7 +2,7 @@
 // The following definitions were copied from:
 // esp-idf/components/xtensa/include/xtensa/corebits.h
 #define PS_WOE_MASK                0x00040000
-#define PS_OWB_MASK                0x00000F00
+#define PS_OWB_MASK                0x00000F01
 #define PS_CALLINC_MASK            0x00030000
 #define PS_WOE                     PS_WOE_MASK
 

--- a/src/device/esp/esp32s3.S
+++ b/src/device/esp/esp32s3.S
@@ -1,0 +1,57 @@
+
+// The following definitions were copied from:
+// esp-idf/components/xtensa/include/xtensa/corebits.h
+#define PS_WOE_MASK                0x00040000
+#define PS_OWB_MASK                0x00000F00
+#define PS_CALLINC_MASK            0x00030000
+#define PS_WOE                     PS_WOE_MASK
+
+// Only calling it call_start_cpu0 for consistency with ESP-IDF.
+.section .text.call_start_cpu0
+1:
+    .long _stack_top
+.global call_start_cpu0
+call_start_cpu0:
+    // We need to set the stack pointer to a different value. This is somewhat
+    // complicated in the Xtensa architecture. The code below is a modified
+    // version of the following code:
+    // https://github.com/espressif/esp-idf/blob/c77c4ccf/components/xtensa/include/xt_instr_macros.h#L47
+
+    // Disable WOE.
+    rsr.ps a2
+    movi a3, ~(PS_WOE_MASK)
+    and a2, a2, a3
+    wsr.ps a2
+    rsync
+
+    // Set WINDOWSTART to 1 << WINDOWBASE.
+    rsr.windowbase  a2
+    ssl  a2
+    movi a2, 1
+    sll  a2, a2
+    wsr.windowstart a2
+    rsync
+
+    // Load new stack pointer.
+    l32r sp, 1b
+
+    // Re-enable WOE.
+    rsr.ps a2
+    movi a3, PS_WOE
+    or a2, a2, a3
+    wsr.ps a2
+    rsync
+
+    // Enable the FPU (coprocessor 0 so the lowest bit).
+    movi a2, 1
+    wsr.cpenable a2
+    rsync
+
+    // Jump to the runtime start function written in Go.
+    call4 main
+
+.section .text.tinygo_scanCurrentStack
+.global tinygo_scanCurrentStack
+tinygo_scanCurrentStack:
+    // TODO: save callee saved registers on the stack
+    j tinygo_scanstack

--- a/src/internal/task/task_stack_esp32.go
+++ b/src/internal/task/task_stack_esp32.go
@@ -1,4 +1,4 @@
-//go:build scheduler.tasks && esp32
+//go:build scheduler.tasks && (esp32 || esp32s3)
 
 package task
 

--- a/src/machine/machine_esp32s3.go
+++ b/src/machine/machine_esp32s3.go
@@ -1,0 +1,204 @@
+//go:build esp32s3
+
+package machine
+
+import (
+	"device/esp"
+	"errors"
+	"runtime/volatile"
+	"unsafe"
+)
+
+const deviceName = esp.Device
+
+const peripheralClock = 80000000 // 80MHz
+
+// CPUFrequency returns the current CPU frequency of the chip.
+// Currently it is a fixed frequency but it may allow changing in the future.
+func CPUFrequency() uint32 {
+	return 160e6 // 160MHz
+}
+
+var (
+	ErrInvalidSPIBus = errors.New("machine: invalid SPI bus")
+)
+
+const (
+	PinOutput PinMode = iota
+	PinInput
+	PinInputPullup
+	PinInputPulldown
+)
+
+// Hardware pin numbers
+const (
+	GPIO0  Pin = 0
+	GPIO1  Pin = 1
+	GPIO2  Pin = 2
+	GPIO3  Pin = 3
+	GPIO4  Pin = 4
+	GPIO5  Pin = 5
+	GPIO6  Pin = 6
+	GPIO7  Pin = 7
+	GPIO8  Pin = 8
+	GPIO9  Pin = 9
+	GPIO10 Pin = 10
+	GPIO11 Pin = 11
+	GPIO12 Pin = 12
+	GPIO13 Pin = 13
+	GPIO14 Pin = 14
+	GPIO15 Pin = 15
+	GPIO16 Pin = 16
+	GPIO17 Pin = 17
+	GPIO18 Pin = 18
+	GPIO19 Pin = 19
+	GPIO21 Pin = 21
+	GPIO22 Pin = 22
+	GPIO23 Pin = 23
+	GPIO25 Pin = 25
+	GPIO26 Pin = 26
+	GPIO27 Pin = 27
+	GPIO32 Pin = 32
+	GPIO33 Pin = 33
+	GPIO34 Pin = 34
+	GPIO35 Pin = 35
+	GPIO36 Pin = 36
+	GPIO37 Pin = 37
+	GPIO38 Pin = 38
+	GPIO39 Pin = 39
+	GPIO40 Pin = 40
+	GPIO41 Pin = 41
+	GPIO42 Pin = 42
+	GPIO43 Pin = 43
+	GPIO44 Pin = 44
+)
+
+// Configure this pin with the given configuration.
+func (p Pin) Configure(config PinConfig) {
+	// Output function 256 is a special value reserved for use as a regular GPIO
+	// pin. Peripherals (SPI etc) can set a custom output function by calling
+	// lowercase configure() instead with a signal name.
+	p.configure(config, 256)
+}
+
+// configure is the same as Configure, but allows for setting a specific input
+// or output signal.
+// Signals are always routed through the GPIO matrix for simplicity. Output
+// signals are configured in FUNCx_OUT_SEL_CFG which selects a particular signal
+// to output on a given pin. Input signals are configured in FUNCy_IN_SEL_CFG,
+// which sets the pin to use for a particular input signal.
+func (p Pin) configure(config PinConfig, signal uint32) {
+	if p == NoPin {
+		// This simplifies pin configuration in peripherals such as SPI.
+		return
+	}
+
+	// TODO: Mux config
+}
+
+// outFunc returns the FUNCx_OUT_SEL_CFG register used for configuring the
+// output function selection.
+func (p Pin) outFunc() *volatile.Register32 {
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_OUT_SEL_CFG), uintptr(p)*4))
+}
+
+// inFunc returns the FUNCy_IN_SEL_CFG register used for configuring the input
+// function selection.
+func inFunc(signal uint32) *volatile.Register32 {
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&esp.GPIO.FUNC0_IN_SEL_CFG), uintptr(signal)*4))
+}
+
+// Set the pin to high or low.
+// Warning: only use this on an output pin!
+func (p Pin) Set(value bool) {
+	if value {
+		reg, mask := p.portMaskSet()
+		reg.Set(mask)
+	} else {
+		reg, mask := p.portMaskClear()
+		reg.Set(mask)
+	}
+}
+
+// Return the register and mask to enable a given GPIO pin. This can be used to
+// implement bit-banged drivers.
+//
+// Warning: only use this on an output pin!
+func (p Pin) PortMaskSet() (*uint32, uint32) {
+	reg, mask := p.portMaskSet()
+	return &reg.Reg, mask
+}
+
+// Return the register and mask to disable a given GPIO pin. This can be used to
+// implement bit-banged drivers.
+//
+// Warning: only use this on an output pin!
+func (p Pin) PortMaskClear() (*uint32, uint32) {
+	reg, mask := p.portMaskClear()
+	return &reg.Reg, mask
+}
+
+func (p Pin) portMaskSet() (*volatile.Register32, uint32) {
+	if p < 32 {
+		return &esp.GPIO.OUT_W1TS, 1 << p
+	} else {
+		return &esp.GPIO.OUT1_W1TS, 1 << (p - 32)
+	}
+}
+
+func (p Pin) portMaskClear() (*volatile.Register32, uint32) {
+	if p < 32 {
+		return &esp.GPIO.OUT_W1TC, 1 << p
+	} else {
+		return &esp.GPIO.OUT1_W1TC, 1 << (p - 32)
+	}
+}
+
+// Get returns the current value of a GPIO pin when the pin is configured as an
+// input or as an output.
+func (p Pin) Get() bool {
+	if p < 32 {
+		return esp.GPIO.IN.Get()&(1<<p) != 0
+	} else {
+		return esp.GPIO.IN1.Get()&(1<<(p-32)) != 0
+	}
+}
+
+// TODO: Mux
+
+var DefaultUART = UART0
+
+var (
+	UART0  = &_UART0
+	_UART0 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	UART1  = &_UART1
+	_UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	UART2  = &_UART2
+	_UART2 = UART{Bus: esp.UART2, Buffer: NewRingBuffer()}
+)
+
+type UART struct {
+	Bus    *esp.UART_Type
+	Buffer *RingBuffer
+}
+
+func (uart *UART) Configure(config UARTConfig) {
+	if config.BaudRate == 0 {
+		config.BaudRate = 115200
+	}
+	uart.Bus.CLKDIV.Set(peripheralClock / config.BaudRate)
+}
+
+func (uart *UART) writeByte(b byte) error {
+	for (uart.Bus.STATUS.Get()>>16)&0xff >= 128 {
+		// Read UART_TXFIFO_CNT from the status register, which indicates how
+		// many bytes there are in the transmit buffer. Wait until there are
+		// less than 128 bytes in this buffer (the default buffer size).
+	}
+	uart.Bus.FIFO.Set(uint32(b))
+	return nil
+}
+
+func (uart *UART) flush() {}
+
+// TODO: SPI

--- a/src/machine/machine_esp32s3.go
+++ b/src/machine/machine_esp32s3.go
@@ -11,12 +11,12 @@ import (
 
 const deviceName = esp.Device
 
-const peripheralClock = 80000000 // 80MHz
+const peripheralClock = 40_000000 // 80MHz
 
 // CPUFrequency returns the current CPU frequency of the chip.
 // Currently it is a fixed frequency but it may allow changing in the future.
 func CPUFrequency() uint32 {
-	return 160e6 // 160MHz
+	return 160e6 // 80 MHz
 }
 
 var (
@@ -71,6 +71,8 @@ const (
 	GPIO42 Pin = 42
 	GPIO43 Pin = 43
 	GPIO44 Pin = 44
+	GPIO45 Pin = 45
+	GPIO46 Pin = 46
 )
 
 // Configure this pin with the given configuration.
@@ -170,7 +172,7 @@ var DefaultUART = UART0
 
 var (
 	UART0  = &_UART0
-	_UART0 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	_UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
 	UART1  = &_UART1
 	_UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
 	UART2  = &_UART2

--- a/src/runtime/runtime_esp32s3.go
+++ b/src/runtime/runtime_esp32s3.go
@@ -3,146 +3,57 @@
 package runtime
 
 import (
-	"device"
 	"device/esp"
-	"machine"
-	"unsafe"
 )
 
-type timeUnit int64
-
-func putchar(c byte) {
-	machine.Serial.WriteByte(c)
-}
-
-func getchar() byte {
-	for machine.Serial.Buffered() == 0 {
-		Gosched()
-	}
-	v, _ := machine.Serial.ReadByte()
-	return v
-}
-
-func buffered() int {
-	return machine.Serial.Buffered()
-}
-
-// Initialize .bss: zero-initialized global variables.
-// The .data section has already been loaded by the ROM bootloader.
-func clearbss() {
-	ptr := unsafe.Pointer(&_sbss)
-	for ptr != unsafe.Pointer(&_ebss) {
-		*(*uint32)(ptr) = 0
-		ptr = unsafe.Add(ptr, 4)
-	}
-}
-
-func initTimer() {
-	// Configure timer 0 in timer group 0, for timekeeping.
-	//   EN:       Enable the timer.
-	//   INCREASE: Count up every tick (as opposed to counting down).
-	//   DIVIDER:  16-bit prescaler, set to 2 for dividing the APB clock by two
-	//             (40MHz).
-	// esp.TIMG0.T0CONFIG.Set(0 << esp.TIMG_T0CONFIG_T0_EN_Pos)
-	// TODO: Add support for esp32s3
-	// esp.TIMG0.T0CONFIG.Set(esp.TIMG_T0CONFIG_T0_EN | esp.TIMG_T0CONFIG_T0_INCREASE | 2<<esp.TIMG_T0CONFIG_T0_DIVIDER_Pos)
-
-	// esp.TIMG0.T0CONFIG.Set(1 << esp.TIMG_T0CONFIG_T0_DIVCNT_RST_Pos)
-	// esp.TIMG0.T0CONFIG.Set(esp.TIMG_T0CONFIG_T0_EN)
-
-	// Set the timer counter value to 0.
-	esp.TIMG0.T0LOADLO.Set(0)
-	esp.TIMG0.T0LOADHI.Set(0)
-	esp.TIMG0.T0LOAD.Set(0) // value doesn't matter.
-}
-
-func ticks() timeUnit {
-	// First, update the LO and HI register pair by writing any value to the
-	// register. This allows reading the pair atomically.
-	esp.TIMG0.T0UPDATE.Set(0)
-	// Then read the two 32-bit parts of the timer.
-	return timeUnit(uint64(esp.TIMG0.T0LO.Get()) | uint64(esp.TIMG0.T0HI.Get())<<32)
-}
-
-func nanosecondsToTicks(ns int64) timeUnit {
-	// Calculate the number of ticks from the number of nanoseconds. At a 80MHz
-	// APB clock, that's 25 nanoseconds per tick with a timer prescaler of 2:
-	// 25 = 1e9 / (80MHz / 2)
-	return timeUnit(ns / 25)
-}
-
-func ticksToNanoseconds(ticks timeUnit) int64 {
-	// See nanosecondsToTicks.
-	return int64(ticks) * 25
-}
-
-// sleepTicks busy-waits until the given number of ticks have passed.
-func sleepTicks(d timeUnit) {
-	sleepUntil := ticks() + d
-	for ticks() < sleepUntil {
-		// TODO: suspend the CPU to not burn power here unnecessarily.
-	}
-}
-
-func exit(code int) {
-	abort()
-}
-
-//go:extern _sbss
-var _sbss [0]byte
-
-//go:extern _ebss
-var _ebss [0]byte
-
-func abort() {
-	for {
-		device.Asm("waiti 0")
-	}
-}
-
-// This is the function called on startup right after the stack pointer has been
-// set.
+// This is the function called on startup after the flash (IROM/DROM) is
+// initialized and the stack pointer has been set.
 //
 //export main
 func main() {
-	// Disable the protection on the watchdog timer (needed when started from
-	// the bootloader).
-	esp.RTC_CNTL.RTC_WDTWPROTECT.Set(0x050D83AA1)
+	// This initialization configures the following things:
+	// * It disables all watchdog timers. They might be useful at some point in
+	//   the future, but will need integration into the scheduler. For now,
+	//   they're all disabled.
+	// * It sets the CPU frequency to 160MHz, which is the maximum speed allowed
+	//   for this CPU. Lower frequencies might be possible in the future, but
+	//   running fast and sleeping quickly is often also a good strategy to save
+	//   power.
+	// TODO: protect certain memory regions, especially the area below the stack
+	// to protect against stack overflows. See
+	// esp_cpu_configure_region_protection in ESP-IDF.
 
-	// Disable both watchdog timers that are enabled by default on startup.
-	// Note that these watchdogs can be protected, but the ROM bootloader
-	// doesn't seem to protect them.
+	// Disable RTC watchdog.
+	esp.RTC_CNTL.RTC_WDTWPROTECT.Set(0x50D83AA1)
 	esp.RTC_CNTL.RTC_WDTCONFIG0.Set(0)
-	esp.TIMG0.WDTCONFIG0.Set(0)
+	esp.RTC_CNTL.RTC_WDTWPROTECT.Set(0x0) // Re-enable write protect
 
-	// Switch SoC clock source to PLL (instead of the default which is XTAL).
-	// This switches the CPU (and APB) clock from 40MHz to 80MHz.
-	// Options:
-	//   RTC_CNTL_CLK_CONF_SOC_CLK_SEL:       PLL    (default XTAL)
-	//   RTC_CNTL_CLK_CONF_CK8M_DIV_SEL:      2      (default)
-	//   RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN: Enable (default)
-	//   RTC_CNTL_CLK_CONF_CK8M_DIV:          DIV256 (default)
-	// The only real change made here is modifying RTC_CNTL_CLK_CONF_SOC_CLK_SEL,
-	// but setting a fixed value produces smaller code.
+	// Disable Timer 0 watchdog.
+	esp.TIMG1.WDTWPROTECT.Set(0x50D83AA1) // write protect
+	esp.TIMG1.WDTCONFIG0.Set(0)           // disable TG0 WDT
+	esp.TIMG1.WDTWPROTECT.Set(0x0)        // Re-enable write protect
 
-	// TODO: Implement this for esp32s3
-	//esp.RTC_CNTL.RTC_CLK_CONF.Set((esp.RTC_CNTL_CLK_CONF_SOC_CLK_SEL_PLL << esp.RTC_CNTL_CLK_CONF_SOC_CLK_SEL_Pos) |
-	//	(2 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_SEL_Pos) |
-	//	(esp.RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN_Enable << esp.RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN_Pos) |
-	//	(esp.RTC_CNTL_CLK_CONF_CK8M_DIV_DIV256 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_Pos))
+	esp.TIMG0.WDTWPROTECT.Set(0x50D83AA1) // write protect
+	esp.TIMG0.WDTCONFIG0.Set(0)           // disable TG0 WDT
+	esp.TIMG0.WDTWPROTECT.Set(0x0)        // Re-enable write protect
 
-	// Switch CPU from 80MHz to 160MHz. This doesn't affect the APB clock,
-	// which is still running at 80MHz.
-	// TODO: Implement this for esp32s3
-	// esp.DPORT.CPU_PER_CONF.Set(esp.DPORT_CPU_PER_CONF_CPUPERIOD_SEL_SEL_160)
+	// Disable super watchdog.
+	esp.RTC_CNTL.RTC_SWD_WPROTECT.Set(0x8F1D312A)
+	esp.RTC_CNTL.RTC_SWD_CONF.Set(esp.RTC_CNTL_RTC_SWD_CONF_SWD_DISABLE)
+	esp.RTC_CNTL.RTC_SWD_WPROTECT.Set(0x0) // Re-enable write protect
 
-	// Clear .bss section. .data has already been loaded by the ROM bootloader.
-	// Do this after increasing the CPU clock to possibly make startup slightly
-	// faster.
+	// // Change CPU frequency from 20MHz to 80MHz, by switching from the XTAL to
+	// // the PLL clock source (see table "CPU Clock Frequency" in the reference
+	// // manual).
+	// esp.SYSTEM.SYSCLK_CONF.Set(1 << esp.SYSTEM_SYSCLK_CONF_SOC_CLK_SEL_Pos)
+
+	// // Change CPU frequency from 80MHz to 160MHz by setting SYSTEM_CPUPERIOD_SEL
+	// // to 1 (see table "CPU Clock Frequency" in the reference manual).
+	// // Note: we might not want to set SYSTEM_CPU_WAIT_MODE_FORCE_ON to save
+	// // power. It is set here to keep the default on reset.
+	// esp.SYSTEM.CPU_PER_CONF.Set(esp.SYSTEM_CPU_PER_CONF_CPU_WAIT_MODE_FORCE_ON | esp.SYSTEM_CPU_PER_CONF_PLL_FREQ_SEL | 1<<esp.SYSTEM_CPU_PER_CONF_CPUPERIOD_SEL_Pos)
+
 	clearbss()
-
-	// Initialize UART.
-	machine.InitSerial()
 
 	// Initialize main system timer used for time.Now.
 	initTimer()
@@ -153,3 +64,17 @@ func main() {
 	// Fallback: if main ever returns, hang the CPU.
 	exit(0)
 }
+
+func abort() {
+	// lock up forever
+	print("abort called\n")
+}
+
+//go:extern _vector_table
+var _vector_table [0]uintptr
+
+//go:extern _sbss
+var _sbss [0]byte
+
+//go:extern _ebss
+var _ebss [0]byte

--- a/src/runtime/runtime_esp32s3.go
+++ b/src/runtime/runtime_esp32s3.go
@@ -1,0 +1,155 @@
+//go:build esp32s3
+
+package runtime
+
+import (
+	"device"
+	"device/esp"
+	"machine"
+	"unsafe"
+)
+
+type timeUnit int64
+
+func putchar(c byte) {
+	machine.Serial.WriteByte(c)
+}
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
+// Initialize .bss: zero-initialized global variables.
+// The .data section has already been loaded by the ROM bootloader.
+func clearbss() {
+	ptr := unsafe.Pointer(&_sbss)
+	for ptr != unsafe.Pointer(&_ebss) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Add(ptr, 4)
+	}
+}
+
+func initTimer() {
+	// Configure timer 0 in timer group 0, for timekeeping.
+	//   EN:       Enable the timer.
+	//   INCREASE: Count up every tick (as opposed to counting down).
+	//   DIVIDER:  16-bit prescaler, set to 2 for dividing the APB clock by two
+	//             (40MHz).
+	// esp.TIMG0.T0CONFIG.Set(0 << esp.TIMG_T0CONFIG_T0_EN_Pos)
+	// TODO: Add support for esp32s3
+	// esp.TIMG0.T0CONFIG.Set(esp.TIMG_T0CONFIG_T0_EN | esp.TIMG_T0CONFIG_T0_INCREASE | 2<<esp.TIMG_T0CONFIG_T0_DIVIDER_Pos)
+
+	// esp.TIMG0.T0CONFIG.Set(1 << esp.TIMG_T0CONFIG_T0_DIVCNT_RST_Pos)
+	// esp.TIMG0.T0CONFIG.Set(esp.TIMG_T0CONFIG_T0_EN)
+
+	// Set the timer counter value to 0.
+	esp.TIMG0.T0LOADLO.Set(0)
+	esp.TIMG0.T0LOADHI.Set(0)
+	esp.TIMG0.T0LOAD.Set(0) // value doesn't matter.
+}
+
+func ticks() timeUnit {
+	// First, update the LO and HI register pair by writing any value to the
+	// register. This allows reading the pair atomically.
+	esp.TIMG0.T0UPDATE.Set(0)
+	// Then read the two 32-bit parts of the timer.
+	return timeUnit(uint64(esp.TIMG0.T0LO.Get()) | uint64(esp.TIMG0.T0HI.Get())<<32)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	// Calculate the number of ticks from the number of nanoseconds. At a 80MHz
+	// APB clock, that's 25 nanoseconds per tick with a timer prescaler of 2:
+	// 25 = 1e9 / (80MHz / 2)
+	return timeUnit(ns / 25)
+}
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	// See nanosecondsToTicks.
+	return int64(ticks) * 25
+}
+
+// sleepTicks busy-waits until the given number of ticks have passed.
+func sleepTicks(d timeUnit) {
+	sleepUntil := ticks() + d
+	for ticks() < sleepUntil {
+		// TODO: suspend the CPU to not burn power here unnecessarily.
+	}
+}
+
+func exit(code int) {
+	abort()
+}
+
+//go:extern _sbss
+var _sbss [0]byte
+
+//go:extern _ebss
+var _ebss [0]byte
+
+func abort() {
+	for {
+		device.Asm("waiti 0")
+	}
+}
+
+// This is the function called on startup right after the stack pointer has been
+// set.
+//
+//export main
+func main() {
+	// Disable the protection on the watchdog timer (needed when started from
+	// the bootloader).
+	esp.RTC_CNTL.RTC_WDTWPROTECT.Set(0x050D83AA1)
+
+	// Disable both watchdog timers that are enabled by default on startup.
+	// Note that these watchdogs can be protected, but the ROM bootloader
+	// doesn't seem to protect them.
+	esp.RTC_CNTL.RTC_WDTCONFIG0.Set(0)
+	esp.TIMG0.WDTCONFIG0.Set(0)
+
+	// Switch SoC clock source to PLL (instead of the default which is XTAL).
+	// This switches the CPU (and APB) clock from 40MHz to 80MHz.
+	// Options:
+	//   RTC_CNTL_CLK_CONF_SOC_CLK_SEL:       PLL    (default XTAL)
+	//   RTC_CNTL_CLK_CONF_CK8M_DIV_SEL:      2      (default)
+	//   RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN: Enable (default)
+	//   RTC_CNTL_CLK_CONF_CK8M_DIV:          DIV256 (default)
+	// The only real change made here is modifying RTC_CNTL_CLK_CONF_SOC_CLK_SEL,
+	// but setting a fixed value produces smaller code.
+
+	// TODO: Implement this for esp32s3
+	//esp.RTC_CNTL.RTC_CLK_CONF.Set((esp.RTC_CNTL_CLK_CONF_SOC_CLK_SEL_PLL << esp.RTC_CNTL_CLK_CONF_SOC_CLK_SEL_Pos) |
+	//	(2 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_SEL_Pos) |
+	//	(esp.RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN_Enable << esp.RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN_Pos) |
+	//	(esp.RTC_CNTL_CLK_CONF_CK8M_DIV_DIV256 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_Pos))
+
+	// Switch CPU from 80MHz to 160MHz. This doesn't affect the APB clock,
+	// which is still running at 80MHz.
+	// TODO: Implement this for esp32s3
+	// esp.DPORT.CPU_PER_CONF.Set(esp.DPORT_CPU_PER_CONF_CPUPERIOD_SEL_SEL_160)
+
+	// Clear .bss section. .data has already been loaded by the ROM bootloader.
+	// Do this after increasing the CPU clock to possibly make startup slightly
+	// faster.
+	clearbss()
+
+	// Initialize UART.
+	machine.InitSerial()
+
+	// Initialize main system timer used for time.Now.
+	initTimer()
+
+	// Initialize the heap, call main.main, etc.
+	run()
+
+	// Fallback: if main ever returns, hang the CPU.
+	exit(0)
+}

--- a/src/runtime/runtime_esp32sx.go
+++ b/src/runtime/runtime_esp32sx.go
@@ -1,0 +1,86 @@
+//go:build esp32s3
+
+package runtime
+
+import (
+	"device/esp"
+	"machine"
+	"unsafe"
+)
+
+type timeUnit int64
+
+func putchar(c byte) {
+	machine.Serial.WriteByte(c)
+}
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
+}
+
+// Initialize .bss: zero-initialized global variables.
+// The .data section has already been loaded by the ROM bootloader.
+func clearbss() {
+	ptr := unsafe.Pointer(&_sbss)
+	for ptr != unsafe.Pointer(&_ebss) {
+		*(*uint32)(ptr) = 0
+		ptr = unsafe.Add(ptr, 4)
+	}
+}
+
+func initTimer() {
+	// Configure timer 0 in timer group 0, for timekeeping.
+	//   EN:       Enable the timer.
+	//   INCREASE: Count up every tick (as opposed to counting down).
+	//   DIVIDER:  16-bit prescaler, set to 2 for dividing the APB clock by two
+	//             (40MHz).
+	// esp.TIMG0.T0CONFIG.Set(0 << esp.TIMG_T0CONFIG_T0_EN_Pos)
+	esp.TIMG0.T0CONFIG.Set(esp.TIMG_TCONFIG_T0_EN | esp.TIMG_TCONFIG_T0_INCREASE | 2<<esp.TIMG_TCONFIG_T0_DIVIDER_Pos)
+	// esp.TIMG0.T0CONFIG.Set(1 << esp.TIMG_T0CONFIG_T0_DIVCNT_RST_Pos)
+	// esp.TIMG0.T0CONFIG.Set(esp.TIMG_T0CONFIG_T0_EN)
+
+	// Set the timer counter value to 0.
+	esp.TIMG0.T0LOADLO.Set(0)
+	esp.TIMG0.T0LOADHI.Set(0)
+	esp.TIMG0.T0LOAD.Set(0) // value doesn't matter.
+}
+
+func ticks() timeUnit {
+	// First, update the LO and HI register pair by writing any value to the
+	// register. This allows reading the pair atomically.
+	esp.TIMG0.T0UPDATE.Set(0)
+	// Then read the two 32-bit parts of the timer.
+	return timeUnit(uint64(esp.TIMG0.T0LO.Get()) | uint64(esp.TIMG0.T0HI.Get())<<32)
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	// Calculate the number of ticks from the number of nanoseconds. At a 80MHz
+	// APB clock, that's 25 nanoseconds per tick with a timer prescaler of 2:
+	// 25 = 1e9 / (80MHz / 2)
+	return timeUnit(ns / 25)
+}
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	// See nanosecondsToTicks.
+	return int64(ticks) * 25
+}
+
+// sleepTicks busy-waits until the given number of ticks have passed.
+func sleepTicks(d timeUnit) {
+	sleepUntil := ticks() + d
+	for ticks() < sleepUntil {
+		// TODO: suspend the CPU to not burn power here unnecessarily.
+	}
+}
+
+func exit(code int) {
+	abort()
+}

--- a/targets/esp32s3.json
+++ b/targets/esp32s3.json
@@ -1,0 +1,21 @@
+{
+	"inherits": ["xtensa"],
+	"cpu": "esp32s3",
+	"features": "+atomctl,+bool,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed",
+	"build-tags": ["esp32s3", "esp"],
+	"scheduler": "tasks",
+	"serial": "uart",
+	"linker": "ld.lld",
+	"default-stack-size": 2048,
+	"rtlib": "compiler-rt",
+	"libc": "picolibc",
+	"linkerscript": "targets/esp32s3.ld",
+	"extra-files": [
+		"src/device/esp/esp32s3.S",
+		"src/internal/task/task_stack_esp32.S"
+	],
+	"binary-format": "esp32s3",
+	"flash-command": "esptool.py --chip=esp32s3 --port {port} write_flash 0x1000 {bin} -ff 80m -fm dout",
+	"emulator": "qemu-system-xtensa -machine esp32 -nographic -drive file={img},if=mtd,format=raw",
+	"gdb": ["xtensa-esp32-elf-gdb"]
+}

--- a/targets/esp32s3.json
+++ b/targets/esp32s3.json
@@ -15,7 +15,7 @@
 		"src/internal/task/task_stack_esp32.S"
 	],
 	"binary-format": "esp32s3",
-	"flash-command": "esptool.py --chip=esp32s3 --port {port} write_flash 0x1000 {bin} -ff 80m -fm dout",
+	"flash-command": "esptool.py --chip=esp32s3 --port {port} write_flash 0x0000 {bin} -ff 80m -fm dout",
 	"emulator": "qemu-system-xtensa -machine esp32 -nographic -drive file={img},if=mtd,format=raw",
 	"gdb": ["xtensa-esp32-elf-gdb"]
 }

--- a/targets/esp32s3.ld
+++ b/targets/esp32s3.ld
@@ -1,17 +1,15 @@
-/* Linker script for the ESP32 */
+/* Linker script for the ESP32-S3 */
+
 
 MEMORY
 {
-    /* Data RAM. Allows byte access.
-     * There are various data RAM regions:
-     *   SRAM1: 0x3FC8_8000..0x3FCE_FFFF (416K)
-     *   SRAM2: 0x3FCF_0000..0x3FCF_FFFF (64K)
-     * This gives us 480k of contiguous RAM, which is the largest span possible.
-     */
-    DRAM  (rw) : ORIGIN = 0x3FC88000, LENGTH = 416K /* Internal SRAM 1 + 2 */
+    /* Note: DRAM and IRAM below are actually in the same 416K address space. */
+    DRAM (rw) : ORIGIN = 0x3FC88000, LENGTH = 416K /* Internal SRAM 1 (data bus) */
+    IRAM (x)  : ORIGIN = 0x40378000, LENGTH = 416K /* Internal SRAM 1 (instruction bus) */
 
-    /* Instruction RAM. */
-    IRAM  (x)  : ORIGIN = 0x40370000, LENGTH = 32K /* Internal SRAM 0 */
+    /* Note: DROM and IROM below are actually in the same 32M address space. */
+    DROM (r)  : ORIGIN = 0x3C000000, LENGTH = 32M /* Data bus (read-only) */
+    IROM (rx) : ORIGIN = 0x42000000, LENGTH = 32M /* Instruction bus */
 }
 
 /* The entry point. It is set in the image flashed to the chip, so must be

--- a/targets/esp32s3.ld
+++ b/targets/esp32s3.ld
@@ -1,0 +1,203 @@
+/* Linker script for the ESP32 */
+
+MEMORY
+{
+    /* Data RAM. Allows byte access.
+     * There are various data RAM regions:
+     *   SRAM1: 0x3FC8_8000..0x3FCE_FFFF (416K)
+     *   SRAM2: 0x3FCF_0000..0x3FCF_FFFF (64K)
+     * This gives us 480k of contiguous RAM, which is the largest span possible.
+     */
+    DRAM  (rw) : ORIGIN = 0x3FC88000, LENGTH = 416K /* Internal SRAM 1 + 2 */
+
+    /* Instruction RAM. */
+    IRAM  (x)  : ORIGIN = 0x40370000, LENGTH = 32K /* Internal SRAM 0 */
+}
+
+/* The entry point. It is set in the image flashed to the chip, so must be
+ * defined.
+ */
+ENTRY(call_start_cpu0)
+
+SECTIONS
+{
+    /* Constant literals and code. Loaded into IRAM for now. Eventually, most
+     * code should be executed directly from flash.
+     * Note that literals must be before code for the l32r instruction to work.
+     */
+    .text : ALIGN(4)
+    {
+        *(.literal.text.call_start_cpu0)
+        *(.text.call_start_cpu0)
+        *(.literal .text)
+        *(.literal.* .text.*)
+    } >IRAM
+
+    /* Put the stack at the bottom of DRAM, so that the application will
+     * crash on stack overflow instead of silently corrupting memory.
+     * See: http://blog.japaric.io/stack-overflow-protection/ */
+    .stack (NOLOAD) :
+    {
+        . = ALIGN(16);
+        . += _stack_size;
+        _stack_top = .;
+    } >DRAM
+
+    /* Constant global variables.
+     * They are loaded in DRAM for ease of use. Eventually they should be stored
+     * in flash and loaded directly from there but they're kept in RAM to make
+     * sure they can always be accessed (even in interrupts).
+     */
+    .rodata : ALIGN(4)
+    {
+        *(.rodata)
+        *(.rodata.*)
+    } >DRAM
+
+    /* Mutable global variables.
+     */
+    .data : ALIGN(4)
+    {
+        _sdata = ABSOLUTE(.);
+        *(.data)
+        *(.data.*)
+        _edata = ABSOLUTE(.);
+    } >DRAM
+
+    /* Check that the boot ROM stack (for the APP CPU) does not overlap with the
+     * data that is loaded by the boot ROM. There may be ways to avoid this
+     * issue if it occurs in practice.
+     * The magic value here is _stack_sentry in the boot ROM ELF file.
+     */
+    ASSERT(_edata < 0x3ffe1320, "the .data section overlaps with the stack used by the boot ROM, possibly causing corruption at startup")
+
+    /* Global variables that are mutable and zero-initialized.
+     * These must be zeroed at startup (unlike data, which is loaded by the
+     * bootloader).
+     */
+    .bss (NOLOAD) : ALIGN(4)
+    {
+        . = ALIGN (4);
+        _sbss = ABSOLUTE(.);
+        *(.bss)
+        *(.bss.*)
+        . = ALIGN (4);
+        _ebss = ABSOLUTE(.);
+    } >DRAM
+}
+
+/* For the garbage collector.
+ */
+_globals_start = _sdata;
+_globals_end = _ebss;
+_heap_start = _ebss;
+_heap_end = ORIGIN(DRAM) + LENGTH(DRAM);
+
+_stack_size = 4K;
+
+/* From ESP-IDF:
+ * components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld
+ * This is the subset that is sometimes used by LLVM during codegen, and thus
+ * must always be present.
+ */
+memset = 0x400011e8;
+memcpy = 0x400011f4;
+memmove = 0x40001200;
+memcmp = 0x4000120c;
+
+/* From ESP-IDF:
+ * components/esp_rom/esp32/ld/esp32.rom.libgcc.ld
+ * These are called from LLVM during codegen. The original license is Apache
+ * 2.0, but I believe that a list of function names and addresses can't really
+ * be copyrighted.
+ */
+__absvdi2 = 0x4000216c;
+__absvsi2 = 0x40002178;
+__adddf3 = 0x40002184;
+__addsf3 = 0x40002190;
+__addvdi3 = 0x4000219c;
+__addvsi3 = 0x400021a8;
+__ashldi3 = 0x400021b4;
+__ashrdi3 = 0x400021c0;
+__bswapdi2 = 0x400021cc;
+__bswapsi2 = 0x400021d8;
+__clear_cache = 0x400021e4;
+__clrsbdi2 = 0x400021f0;
+__clrsbsi2 = 0x400021fc;
+__clzdi2 = 0x40002208;
+__clzsi2 = 0x40002214;
+__cmpdi2 = 0x40002220;
+__ctzdi2 = 0x4000222c;
+__ctzsi2 = 0x40002238;
+__divdc3 = 0x40002244;
+__divdf3 = 0x40002250;
+__divdi3 = 0x4000225c;
+__divsc3 = 0x40002268;
+__divsf3 = 0x40002274;
+__divsi3 = 0x40002280;
+__eqdf2 = 0x4000228c;
+__eqsf2 = 0x40002298;
+__extendsfdf2 = 0x400022a4;
+__ffsdi2 = 0x400022b0;
+__ffssi2 = 0x400022bc;
+__fixdfdi = 0x400022c8;
+__fixdfsi = 0x400022d4;
+__fixsfdi = 0x400022e0;
+__fixsfsi = 0x400022ec;
+__fixunsdfsi = 0x400022f8;
+__fixunssfdi = 0x40002304;
+__fixunssfsi = 0x40002310;
+__floatdidf = 0x4000231c;
+__floatdisf = 0x40002328;
+__floatsidf = 0x40002334;
+__floatsisf = 0x40002340;
+__floatundidf = 0x4000234c;
+__floatundisf = 0x40002358;
+__floatunsidf = 0x40002364;
+__floatunsisf = 0x40002370;
+__gcc_bcmp = 0x4000237c;
+__gedf2 = 0x40002388;
+__gesf2 = 0x40002394;
+__gtdf2 = 0x400023a0;
+__gtsf2 = 0x400023ac;
+__ledf2 = 0x400023b8;
+__lesf2 = 0x400023c4;
+__lshrdi3 = 0x400023d0;
+__ltdf2 = 0x400023dc;
+__ltsf2 = 0x400023e8;
+__moddi3 = 0x400023f4;
+__modsi3 = 0x40002400;
+__muldc3 = 0x4000240c;
+__muldf3 = 0x40002418;
+__muldi3 = 0x40002424;
+__mulsc3 = 0x40002430;
+__mulsf3 = 0x4000243c;
+__mulsi3 = 0x40002448;
+__mulvdi3 = 0x40002454;
+__mulvsi3 = 0x40002460;
+__nedf2 = 0x4000246c;
+__negdf2 = 0x40002478;
+__negdi2 = 0x40002484;
+__negsf2 = 0x40002490;
+__negvdi2 = 0x4000249c;
+__negvsi2 = 0x400024a8;
+__nesf2 = 0x400024b4;
+__paritysi2 = 0x400024c0;
+__popcountdi2 = 0x400024cc;
+__popcountsi2 = 0x400024d8;
+__powidf2 = 0x400024e4;
+__powisf2 = 0x400024f0;
+__subdf3 = 0x400024fc;
+__subsf3 = 0x40002508;
+__subvdi3 = 0x40002514;
+__subvsi3 = 0x40002520;
+__truncdfsf2 = 0x4000252c;
+__ucmpdi2 = 0x40002538;
+__udivdi3 = 0x40002544;
+__udivmoddi4 = 0x40002550;
+__udivsi3 = 0x4000255c;
+__udiv_w_sdiv = 0x40002568;
+__umoddi3 = 0x40002574;
+__umodsi3 = 0x40002580;
+__unorddf2 = 0x4000258c;
+__unordsf2 = 0x40002598;


### PR DESCRIPTION
These are the first steps towards fixing #3442.

At the moment, the following TinyGo program doesn't print anything to stdout, but at least it seems like the `main` is reached:

```go
package main

import "machine"

func main() {
	machine.InitSerial()

	for {
		machine.Serial.Write([]byte("Hello world :)\r\n"))
	}
}
```


Here is the full boot log:

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x9 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd0108,len:0x1710
load:0x403b6000,len:0x8c8
load:0x403ba000,len:0x2eb4
SHA-256 comparison failed:
Calculated: 94284163cda84609f6d502e80255fb42297565c0c3c1795798a0c2beda02fced
Expected: ab492d70a98095a7841c7bfbf1d6d0b6161e082227abfb2028c51ce7cbe6144a
Attempting to boot anyway...
entry 0x403b61c0
I (43) boot: ESP-IDF v4.4-dev-3540-g4e03a9c34c 2nd stage bootloader
I (43) boot: compile time 09:24:35
I (44) boot: chip revision: 0
I (47) boot.esp32s3: Boot SPI Speed : 80MHz
I (51) boot.esp32s3: SPI Mode       : DIO
I (56) boot.esp32s3: SPI Flash Size : 8MB
I (61) boot: Enabling RNG early entropy source...
W (66) bootloader_random: RNG for ESP32-S3 not currently supported
I (73) boot: Partition Table:
I (77) boot: ## Label            Usage          Type ST Offset   Length
I (84) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (91) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (99) boot:  2 factory          factory app      00 00 00010000 007f0000
I (106) boot: End of partition table
I (111) esp_image: segment 0: paddr=00010020 vaddr=3fc89000 size=00088h (   136) load
I (119) esp_image: segment 1: paddr=000100b0 vaddr=40370000 size=009dch (  2524) load
I (129) boot: Loaded app from partition at offset 0x10000
I (134) boot: Disabling RNG early entropy source...
W (139) bootloader_random: RNG for ESP32-S3 not currently supported
```

I have based my changes on v0.29.0, because I can't run Tinygo with Xtensa and LLVM 16. For whatever reason I get some errors while running `tinygo build` when the target is `esp32` (or like in my case `esp32s3`):

```
unknown tool: -o
failed to run tool: clang
```

Much of my work here is copy & paste from the ESP32 code base, with a few adaptations. Hopefully it's a good start for someone else to continue my work :)