### PR TITLE
ci: add MacOS arm64 runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -14,7 +14,15 @@ concurrency:
 jobs:
   build-macos:
     name: build-macos
-    runs-on: macos-11
+    strategy:
+      matrix:
+        host: [ macos-11, macos-13-xlarge ]
+        include:
+          - host: macos-11
+            goarch: amd64
+          - host: macos-13-xlarge
+            goarch: arm64
+    runs-on: ${{ matrix.host }}
     steps:
       - name: Install Dependencies
         shell: bash
@@ -58,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-16-macos-v1
+          key: llvm-build-16-${{ matrix.host }}-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -82,7 +90,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v4
+          key: wasi-libc-sysroot-${{ matrix.host }}-v1
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
@@ -98,7 +106,7 @@ jobs:
         run: make tinygo-test
       - name: Make release artifact
         shell: bash
-        run: cp -p build/release.tar.gz build/tinygo.darwin-amd64.tar.gz 
+        run: cp -p build/release.tar.gz build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
         # Note: this release artifact is double-zipped, see:
         # https://github.com/actions/upload-artifact/issues/39
@@ -108,14 +116,17 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v2
         with:
-          name: darwin-amd64-double-zipped
-          path: build/tinygo.darwin-amd64.tar.gz
+          name: darwin-${{ matrix.goarch }}-double-zipped
+          path: build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Smoke tests
         shell: bash
         run: make smoketest TINYGO=$(PWD)/build/tinygo
   test-macos-homebrew:
     name: homebrew-install
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        host: [ macos-latest, macos-13-xlarge ]
+    runs-on: ${{ matrix.host }}
     steps:
       - name: Install LLVM
         shell: bash


### PR DESCRIPTION
See this post:
https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

This is a work in progress.