### PR TITLE
tools: process SVD files in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ commands:
               # formatting of generated files.
               name: Check Go code formatting
               command: make fmt-check
-      - run: make gen-device -j4
+      - run: make gen-device
       - run: make smoketest XTENSA=0
       - save_cache:
           key: go-cache-v3-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -88,7 +88,7 @@ jobs:
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
         run: make wasi-libc
       - name: make gen-device
-        run: make -j3 gen-device
+        run: make gen-device
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-short"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
         run: make wasi-libc
-      - run: make gen-device -j4
+      - run: make gen-device
       - name: Test TinyGo
         run: make ASSERT=1 test
       - name: Build TinyGo

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -49,7 +49,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-      - run: make gen-device -j4
+      - run: make gen-device
       - name: Download drivers repo
         run: git clone https://github.com/tinygo-org/drivers.git
       - name: Save HEAD

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           scoop install wasmtime
       - name: make gen-device
-        run: make -j3 gen-device
+        run: make gen-device
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-short"


### PR DESCRIPTION
This speeds up the generation of SVD files, for example as part of a package build (where parallelism may not be desired, or tools should auto-detect the number of threads to use).

I have used the same pattern as in gen-device-avr, which was already parallelized.