### PR TITLE
refactor: rm io/ioutil funcs

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -157,7 +156,7 @@ func listGorootMergeLinks(goroot, tinygoroot string, overrides map[string]bool) 
 
 		// Add files from TinyGo.
 		tinygoDir := filepath.Join(tinygoSrc, dir)
-		tinygoEntries, err := ioutil.ReadDir(tinygoDir)
+		tinygoEntries, err := os.ReadDir(tinygoDir)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +176,7 @@ func listGorootMergeLinks(goroot, tinygoroot string, overrides map[string]bool) 
 		// Add all directories from $GOROOT that are not part of the TinyGo
 		// overrides.
 		goDir := filepath.Join(goSrc, dir)
-		goEntries, err := ioutil.ReadDir(goDir)
+		goEntries, err := os.ReadDir(goDir)
 		if err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"go/scanner"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -1736,14 +1735,20 @@ func main() {
 		handleCompilerError(err)
 	case "targets":
 		dir := filepath.Join(goenv.Get("TINYGOROOT"), "targets")
-		entries, err := ioutil.ReadDir(dir)
+		entries, err := os.ReadDir(dir)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "could not list targets:", err)
 			os.Exit(1)
 			return
 		}
 		for _, entry := range entries {
-			if !entry.Mode().IsRegular() || !strings.HasSuffix(entry.Name(), ".json") {
+			entryInfo, err := entry.Info()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "could not get entry info:", err)
+				os.Exit(1)
+				return
+			}
+			if !entryInfo.Mode().IsRegular() || !strings.HasSuffix(entry.Name(), ".json") {
 				// Only inspect JSON files.
 				continue
 			}


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16
https://pkg.go.dev/io/ioutil