### PR TITLE
goenv: re-add support for Clang headers on darwin

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -366,6 +366,22 @@ func findSystemClangResources(TINYGOROOT string) string {
 		if err == nil {
 			return path
 		}
+	case "darwin":
+		// This assumes a Homebrew installation, like in builder/commands.go.
+		var prefix string
+		switch runtime.GOARCH {
+		case "amd64":
+			prefix = "/usr/local/opt/llvm@" + llvmMajor
+		case "arm64":
+			prefix = "/opt/homebrew/opt/llvm@" + llvmMajor
+		default:
+			return "" // very unlikely for now
+		}
+		path := fmt.Sprintf("%s/lib/clang/%s", prefix, llvmMajor)
+		_, err := os.Stat(path + "/include/stdint.h")
+		if err == nil {
+			return path
+		}
 	}
 
 	// Could not find it.


### PR DESCRIPTION
When TinyGo is installed using `go install` or `go build`, it uses the Clang resource directory from the host. This works for Linux, but doesn't work anymore on macOS with a recent change I made.

This re-adds support for Darwin in that case (with much, much simpler code than there used to be).

---

I should have checked this in #3948 but my macOS install was borked after a Sonoma upgrade. It is now fixed, so I've fixed it.

This can be tested as follows:

```
$ go install
$ tinygo clean
$ tinygo run ./testdata/cgo/
```

Without the fix in this PR, it fails as follows:

```
# github.com/tinygo-org/tinygo/testdata/cgo
testdata/cgo/main.h:1:10: fatal: 'stdbool.h' file not found
testdata/cgo/main.go:6:10: note: in file included from main.go!cgo.c:5:
```

(Note that `go install` doesn't work on Windows, so we don't need to implement that one).