### PR TITLE
machine/spi: use interface to ensure uniformity for all machine implementations

### DIFF
--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -57,8 +57,9 @@ type SPIConfig struct {
 	Mode      uint8
 }
 
-func (spi SPI) Configure(config SPIConfig) {
+func (spi SPI) Configure(config SPIConfig) error {
 	spiConfigure(spi.Bus, config.SCK, config.SDO, config.SDI)
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/machine_mimxrt1062_spi.go
+++ b/src/machine/machine_mimxrt1062_spi.go
@@ -68,7 +68,7 @@ var (
 )
 
 // Configure is intended to setup an SPI interface for transmit/receive.
-func (spi *SPI) Configure(config SPIConfig) {
+func (spi *SPI) Configure(config SPIConfig) error {
 
 	const defaultSpiFreq = 4000000 // 4 MHz
 
@@ -132,6 +132,8 @@ func (spi *SPI) Configure(config SPIConfig) {
 	spi.Bus.CR.Set(nxp.LPSPI_CR_MEN)
 
 	spi.configured = true
+
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -49,7 +49,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) {
+func (spi SPI) Configure(config SPIConfig) error {
 	// Disable bus to configure it
 	spi.Bus.ENABLE.Set(nrf.SPI_ENABLE_ENABLE_Disabled)
 
@@ -117,6 +117,8 @@ func (spi SPI) Configure(config SPIConfig) {
 
 	// Re-enable bus now that it is configured.
 	spi.Bus.ENABLE.Set(nrf.SPI_ENABLE_ENABLE_Enabled)
+
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -197,7 +197,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) {
+func (spi SPI) Configure(config SPIConfig) error {
 	// Disable bus to configure it
 	spi.Bus.ENABLE.Set(nrf.SPIM_ENABLE_ENABLE_Disabled)
 
@@ -265,6 +265,8 @@ func (spi SPI) Configure(config SPIConfig) {
 
 	// Re-enable bus now that it is configured.
 	spi.Bus.ENABLE.Set(nrf.SPIM_ENABLE_ENABLE_Enabled)
+
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/machine_stm32_spi.go
+++ b/src/machine/machine_stm32_spi.go
@@ -21,7 +21,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the STM32 SPI1 interface.
-func (spi SPI) Configure(config SPIConfig) {
+func (spi SPI) Configure(config SPIConfig) error {
 
 	// -- CONFIGURING THE SPI IN MASTER MODE --
 	//
@@ -93,6 +93,8 @@ func (spi SPI) Configure(config SPIConfig) {
 
 	// enable SPI
 	spi.Bus.CR1.SetBits(stm32.SPI_CR1_SPE)
+
+	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -16,3 +16,14 @@ var (
 	ErrTxInvalidSliceSize      = errors.New("SPI write and read slices must be same size")
 	errSPIInvalidMachineConfig = errors.New("SPI port was not configured properly by the machine")
 )
+
+// If you are getting a compile error on this line please check to see you've
+// correctly implemented the methods on the SPI type. They must match
+// the interface method signatures type to type perfectly.
+// If not implementing the SPI type please remove your target from the build tags
+// at the top of this file.
+var _ interface { // 2
+	Configure(config SPIConfig) error
+	Tx(w, r []byte) error
+	Transfer(w byte) (byte, error)
+} = (*SPI)(nil)


### PR DESCRIPTION
This PR does the same for `machine/spi` as #3406 did for `i2c`, which is to use an interface check to ensure uniformity for all machine implementations.