### PR TITLE
Binaryen116

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
     steps:
       - run:
           name: "Pull submodules"
-          command: git submodule update --init
+          command: git submodule update --init --recursive
   llvm-source-linux:
     steps:
       - restore_cache:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,13 +356,13 @@ jobs:
         uses: actions/cache@v3
         id: cache-binaryen
         with:
-          key: binaryen-linux-${{ matrix.goarch }}-v1
+          key: binaryen-linux-${{ matrix.goarch }}-v3
           path: build/wasm-opt
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: |
           sudo apt-get install --no-install-recommends ninja-build
-          git submodule update --init lib/binaryen
+          git submodule update --init --recursive lib/binaryen
           make CROSS=${{ matrix.toolchain }} binaryen
       - name: Install fpm
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,7 +85,7 @@ Now that we have a working static build, it's time to make a release tarball:
 
 If you did not clone the repository with the `--recursive` option, you will get errors until you initialize the project submodules:
 
-    git submodule update --init
+    git submodule update --init --recursive
 
 The release tarball is stored in build/release.tar.gz, and can be extracted with
 the following command (for example in ~/lib):

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -190,7 +190,7 @@ gen-device: gen-device-stm32
 endif
 
 gen-device-avr:
-	@if [ ! -e lib/avr/README.md ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
+	@if [ ! -e lib/avr/README.md ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init --recursive"; exit 1; fi
 	$(GO) build -o ./build/gen-device-avr ./tools/gen-device-avr/
 	./build/gen-device-avr lib/avr/packs/atmega src/device/avr/
 	./build/gen-device-avr lib/avr/packs/tiny src/device/avr/
@@ -264,7 +264,7 @@ endif
 .PHONY: wasi-libc
 wasi-libc: lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a
 lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
-	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
+	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init --recursive"; exit 1; fi
 	cd lib/wasi-libc && $(MAKE) -j4 EXTRA_CFLAGS="-O2 -g -DNDEBUG -mnontrapping-fptoint -msign-ext" MALLOC_IMPL=none CC="$(CLANG)" AR=$(LLVM_AR) NM=$(LLVM_NM)
 
 # Check for Node.js used during WASM tests.

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,10 @@
 #
 # But you'll need a bit more to make TinyGo actually able to compile code:
 #
-#   make llvm-source              # fetch compiler-rt
-#   git submodule update --init   # fetch lots of other libraries and SVD files
-#   make gen-device -j4           # build src/device/*/*.go files
-#   make wasi-libc                # build support for wasi/wasm
+#   make llvm-source                        # fetch compiler-rt
+#   git submodule update --init --recursive # fetch lots of other libraries and SVD files
+#   make gen-device -j4                     # build src/device/*/*.go files
+#   make wasi-libc                          # build support for wasi/wasm
 #
 # With this, you should have an environment that can compile anything - except
 # for the Xtensa architecture (ESP8266/ESP32) because support for that lives in

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Docker hub does a recursive clone, then checks the branch out,
 # so when a PR adds a submodule (or updates it), it fails.
-git submodule update --init
+git submodule update --init --recursive


### PR DESCRIPTION
This PR is based on https://github.com/tinygo-org/tinygo/pull/3882 which seems to be no longer active.
I've run into issue https://github.com/tinygo-org/tinygo/issues/3881 too, this is why I would like to see this fix merged.

I've rebased the original PR against latest `dev` branch, and applied the requests from [this comment](https://github.com/tinygo-org/tinygo/pull/3882#issuecomment-1714392816).

Moreover, I've updated to latest release of binaryen v116, instead of v114 of the original PR

I've searched for other places inside of the GitHub actions where the binaryen code is checkout out, but this seems to be specific to Linux. On Mac/Windows the binaryen binaries are installed via package managers (brew and scoop).

