### PR TITLE
nrf,sam,rp2040: add machine.DeviceID function

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -506,6 +506,8 @@ smoketest:
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-rp2040      examples/watchdog
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=feather-rp2040      examples/device-id
+	@$(MD5SUM) test.hex
 	# test simulated boards on play.tinygo.org
 ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1

--- a/src/examples/device-id/main.go
+++ b/src/examples/device-id/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/hex"
+	"machine"
+	"time"
+)
+
+func main() {
+	time.Sleep(2 * time.Second)
+
+	// For efficiency, it's best to get the device ID once and cache it
+	// (e.g. on RP2040 XIP flash and interrupts disabled for period of
+	// retrieving the hardware ID from ROM chip)
+	id := machine.DeviceID()
+
+	for {
+		println("Device ID:", hex.EncodeToString(id))
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/src/machine/deviceid.go
+++ b/src/machine/deviceid.go
@@ -1,0 +1,17 @@
+//go:build rp2040 || nrf || sam
+
+package machine
+
+// DeviceID returns an identifier that is unique within
+// a particular chipset.
+//
+// The identity is one burnt into the MCU itself, or the
+// flash chip at time of manufacture.
+//
+// It's possible that two different vendors may allocate
+// the same DeviceID, so callers should take this into
+// account if needing to generate a globally unique id.
+//
+// The length of the hardware ID is vendor-specific, but
+// 8 bytes (64 bits) and 16 bytes (128 bits) are common.
+var _ = (func() []byte)(DeviceID)

--- a/src/machine/machine_atsam.go
+++ b/src/machine/machine_atsam.go
@@ -1,0 +1,31 @@
+//go:build sam
+
+package machine
+
+import (
+	"runtime/volatile"
+	"unsafe"
+)
+
+var deviceID [16]byte
+
+// DeviceID returns an identifier that is unique within
+// a particular chipset.
+//
+// The identity is one burnt into the MCU itself, or the
+// flash chip at time of manufacture.
+//
+// It's possible that two different vendors may allocate
+// the same DeviceID, so callers should take this into
+// account if needing to generate a globally unique id.
+//
+// The length of the hardware ID is vendor-specific, but
+// 8 bytes (64 bits) and 16 bytes (128 bits) are common.
+func DeviceID() []byte {
+	for i := 0; i < len(deviceID); i++ {
+		word := (*volatile.Register32)(unsafe.Pointer(deviceIDAddr[i/4])).Get()
+		deviceID[i] = byte(word >> ((i % 4) * 8))
+	}
+
+	return deviceID[:]
+}

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -18,6 +18,9 @@ import (
 
 const deviceName = sam.Device
 
+// DS40001882F, Section 10.3.3: Serial Number
+var deviceIDAddr = []uintptr{0x0080A00C, 0x0080A040, 0x0080A044, 0x0080A048}
+
 const (
 	PinAnalog    PinMode = 1
 	PinSERCOM    PinMode = 2

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -18,6 +18,9 @@ import (
 
 const deviceName = sam.Device
 
+// DS60001507, Section 9.6: Serial Number
+var deviceIDAddr = []uintptr{0x008061FC, 0x00806010, 0x00806014, 0x00806018}
+
 func CPUFrequency() uint32 {
 	return 120000000
 }

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -12,6 +12,34 @@ import (
 
 const deviceName = nrf.Device
 
+var deviceID [8]byte
+
+// DeviceID returns an identifier that is unique within
+// a particular chipset.
+//
+// The identity is one burnt into the MCU itself, or the
+// flash chip at time of manufacture.
+//
+// It's possible that two different vendors may allocate
+// the same DeviceID, so callers should take this into
+// account if needing to generate a globally unique id.
+//
+// The length of the hardware ID is vendor-specific, but
+// 8 bytes (64 bits) is common.
+func DeviceID() []byte {
+	words := make([]uint32, 2)
+	words[0] = nrf.FICR.DEVICEID[0].Get()
+	words[1] = nrf.FICR.DEVICEID[1].Get()
+
+	for i := 0; i < 8; i++ {
+		shift := (i % 4) * 8
+		w := i / 4
+		deviceID[i] = byte(words[w] >> shift)
+	}
+
+	return deviceID[:]
+}
+
 const (
 	PinInput         PinMode = (nrf.GPIO_PIN_CNF_DIR_Input << nrf.GPIO_PIN_CNF_DIR_Pos) | (nrf.GPIO_PIN_CNF_INPUT_Connect << nrf.GPIO_PIN_CNF_INPUT_Pos)
 	PinInputPullup   PinMode = PinInput | (nrf.GPIO_PIN_CNF_PULL_Pullup << nrf.GPIO_PIN_CNF_PULL_Pos)

--- a/src/machine/machine_rp2040_flash.go
+++ b/src/machine/machine_rp2040_flash.go
@@ -13,6 +13,32 @@ func EnterBootloader() {
 	enterBootloader()
 }
 
+// 13 = 1 + FLASH_RUID_DUMMY_BYTES(4) + FLASH_RUID_DATA_BYTES(8)
+var deviceIDBuf [13]byte
+
+// DeviceID returns an identifier that is unique within
+// a particular chipset.
+//
+// The identity is one burnt into the MCU itself, or the
+// flash chip at time of manufacture.
+//
+// It's possible that two different vendors may allocate
+// the same DeviceID, so callers should take this into
+// account if needing to generate a globally unique id.
+//
+// The length of the hardware ID is vendor-specific, but
+// 8 bytes (64 bits) is common.
+func DeviceID() []byte {
+	deviceIDBuf[0] = 0x4b // FLASH_RUID_CMD
+
+	err := doFlashCommand(deviceIDBuf[:], deviceIDBuf[:])
+	if err != nil {
+		panic(err)
+	}
+
+	return deviceIDBuf[5:13]
+}
+
 // compile-time check for ensuring we fulfill BlockDevice interface
 var _ BlockDevice = flashBlockDevice{}
 


### PR DESCRIPTION
This seems like a common feature and is super useful in network/lora/mesh scenarios to separate devices without flash config.

I've implemented on 3 chipsets nrf,sam,rp2040 so I'm confident we can have a common API.