### PR TITLE
compileopts, targets, main: support Wasmtime v14

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.1/wasmtime-v14.0.1-x86_64-linux.tar.xz -o wasmtime-v14.0.1-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.1-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.1-x86_64-linux/*
+          curl https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.4/wasmtime-v14.0.4-x86_64-linux.tar.xz -o wasmtime-v14.0.4-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.4-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.4-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v3
@@ -187,8 +187,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.1/wasmtime-v14.0.1-x86_64-linux.tar.xz -o wasmtime-v14.0.1-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.1-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.1-x86_64-linux/*
+          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.4/wasmtime-v14.0.4-x86_64-linux.tar.xz -o wasmtime-v14.0.4-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.4-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.4-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz -o wasmtime-v13.0.0-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v13.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v13.0.0-x86_64-linux/*
+          curl https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.1/wasmtime-v14.0.1-x86_64-linux.tar.xz -o wasmtime-v14.0.1-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.1-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.1-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v3
@@ -187,8 +187,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz -o wasmtime-v13.0.0-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v13.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v13.0.0-x86_64-linux/*
+          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v14.0.1/wasmtime-v14.0.1-x86_64-linux.tar.xz -o wasmtime-v14.0.1-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v14.0.1-x86_64-linux.tar.xz --strip-components=1 wasmtime-v14.0.1-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          scoop install binaryen && scoop install wasmtime@13.0.0
+          scoop install binaryen && scoop install wasmtime@14.0.1
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
         run: make wasi-libc
       - name: Install wasmtime
         run: |
-          scoop install wasmtime@14.0.1
+          scoop install wasmtime@14.0.4
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo
@@ -203,7 +203,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          scoop install binaryen && scoop install wasmtime@14.0.1
+          scoop install binaryen && scoop install wasmtime@14.0.4
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
         run: make wasi-libc
       - name: Install wasmtime
         run: |
-          scoop install wasmtime@13.0.0
+          scoop install wasmtime@14.0.1
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -349,7 +349,7 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 			"--stack-first",
 			"--no-demangle",
 		)
-		spec.Emulator = "wasmtime --mapdir=/tmp::{tmpDir} {}"
+		spec.Emulator = "wasmtime --dir={tmpDir}::/tmp {}"
 		spec.ExtraFiles = append(spec.ExtraFiles,
 			"src/runtime/asm_tinygowasm.S",
 			"src/internal/task/task_asyncify_wasm.S",

--- a/main.go
+++ b/main.go
@@ -825,10 +825,9 @@ func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, c
 			emuArgs = append(emuArgs, "--env", v)
 		}
 		if len(cmdArgs) != 0 {
-			// Mark end of wasmtime arguments and start of program ones: --
-			// This should not be necessary as of Wasmtime v14:
+			// Use of '--' argument no longer necessary as of Wasmtime v14:
 			// https://github.com/bytecodealliance/wasmtime/pull/6946
-			args = append(args, "--")
+			// args = append(args, "--")
 			args = append(args, cmdArgs...)
 		}
 

--- a/main.go
+++ b/main.go
@@ -797,7 +797,7 @@ func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, c
 			needsEnvInVars = true
 		}
 	}
-	var args, env []string
+	var args, emuArgs, env []string
 	var extraCmdEnv []string
 	if needsEnvInVars {
 		runtimeGlobals := make(map[string]string)
@@ -820,12 +820,14 @@ func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, c
 	} else if config.EmulatorName() == "wasmtime" {
 		// Wasmtime needs some special flags to pass environment variables
 		// and allow reading from the current directory.
-		args = append(args, "--dir=.")
+		emuArgs = append(emuArgs, "--dir=.")
 		for _, v := range environmentVars {
-			args = append(args, "--env", v)
+			emuArgs = append(emuArgs, "--env", v)
 		}
 		if len(cmdArgs) != 0 {
-			// mark end of wasmtime arguments and start of program ones: --
+			// Mark end of wasmtime arguments and start of program ones: --
+			// This should not be necessary as of Wasmtime v14:
+			// https://github.com/bytecodealliance/wasmtime/pull/6946
 			args = append(args, "--")
 			args = append(args, cmdArgs...)
 		}
@@ -876,7 +878,7 @@ func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, c
 			return result, err
 		}
 		name = emulator[0]
-		emuArgs := append([]string(nil), emulator[1:]...)
+		emuArgs = append(emuArgs, emulator[1:]...)
 		args = append(emuArgs, args...)
 	}
 	var cmd *exec.Cmd

--- a/targets/wasi.json
+++ b/targets/wasi.json
@@ -22,5 +22,5 @@
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator":      "wasmtime --mapdir=/tmp::{tmpDir} {}"
+	"emulator":      "wasmtime --dir={tmpDir}::/tmp {}"
 }


### PR DESCRIPTION
This PR adds support for [Wasmtime v14](https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md#1400) (released 2023-10-20), reenabling support for:

`tinygo test -v -target=wasi ./...`

1. Changes `--mapdir=GUEST::HOST` to `--dir=HOST::GUEST`
2. Reorders CLI arguments to `wasmtime` so Wasmtime arguments are before the `.wasm` module argument, and arguments to the Go program (e.g. `-test.v`) are after. The `--` argument has no effect.

Note this PR does not attempt to detect the version of Wasmtime being run.

For additional context, see:

- https://github.com/bytecodealliance/wasmtime/pull/6925
- https://github.com/bytecodealliance/wasmtime/pull/6946
 
Fixes #3970.