### PR TITLE
build: pin wasmtime version used for testing to v13.0.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.0/wasmtime-v5.0.0-x86_64-linux.tar.xz -o wasmtime-v5.0.0-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v5.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v5.0.0-x86_64-linux/*
+          curl https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz -o wasmtime-v13.0.0-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v13.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v13.0.0-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Download release artifact
         uses: actions/download-artifact@v3
@@ -187,8 +187,8 @@ jobs:
       - name: Install wasmtime
         run: |
           mkdir -p $HOME/.wasmtime $HOME/.wasmtime/bin
-          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v5.0.0/wasmtime-v5.0.0-x86_64-linux.tar.xz -o wasmtime-v5.0.0-x86_64-linux.tar.xz -SfL
-          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v5.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v5.0.0-x86_64-linux/*
+          curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v13.0.0/wasmtime-v13.0.0-x86_64-linux.tar.xz -o wasmtime-v13.0.0-x86_64-linux.tar.xz -SfL
+          tar -C $HOME/.wasmtime/bin --wildcards -xf wasmtime-v13.0.0-x86_64-linux.tar.xz --strip-components=1 wasmtime-v13.0.0-x86_64-linux/*
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
         run: make wasi-libc
       - name: Install wasmtime
         run: |
-          scoop install wasmtime
+          scoop install wasmtime@13.0.0
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo
@@ -203,7 +203,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          scoop install binaryen wasmtime
+          scoop install binaryen && scoop install wasmtime@13.0.0
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Go


### PR DESCRIPTION
This PR modifies the build to use wasmtime version v13.0.0 for testing, in order to address https://github.com/tinygo-org/tinygo/issues/3970