### PR TITLE
machine/stm32: implement DeviceID() with unique ID per processor

### DIFF
--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -15,6 +15,8 @@ func CPUFrequency() uint32 {
 	return 72000000
 }
 
+var deviceIDAddr = []uintptr{0x1FFFF7E8, 0x1FFFF7EC, 0x1FFFF7F0}
+
 // Internal use: configured speed of the APB1 and APB2 timers, this should be kept
 // in sync with any changes to runtime package which configures the oscillators
 // and clock frequencies

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -14,6 +14,8 @@ import (
 	"unsafe"
 )
 
+var deviceIDAddr = []uintptr{0x1FFF7A10, 0x1FFF7A14, 0x1FFF7A18}
+
 const (
 	PA0  = portA + 0
 	PA1  = portA + 1

--- a/src/machine/machine_stm32f7.go
+++ b/src/machine/machine_stm32f7.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+var deviceIDAddr = []uintptr{0x1FF0F420, 0x1FF0F424, 0x1FF0F428}
+
 // Alternative peripheral pin functions
 const (
 	AF0_SYSTEM                               = 0

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -13,6 +13,8 @@ func CPUFrequency() uint32 {
 	return 32000000
 }
 
+var deviceIDAddr = []uintptr{0x1FF80050, 0x1FF80054, 0x1FF80058}
+
 // Internal use: configured speed of the APB1 and APB2 timers, this should be kept
 // in sync with any changes to runtime package which configures the oscillators
 // and clock frequencies

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -13,6 +13,8 @@ import (
 
 // Peripheral abstraction layer for the stm32l4
 
+var deviceIDAddr = []uintptr{0x1FFF7590, 0x1FFF7594, 0x1FFF7598}
+
 const (
 	AF0_SYSTEM             = 0
 	AF1_TIM1_2_LPTIM1      = 1

--- a/src/machine/machine_stm32l5.go
+++ b/src/machine/machine_stm32l5.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+var deviceIDAddr = []uintptr{0x0BFA0590, 0x0BFA0594, 0x0BFA0598}
+
 const (
 	AF0_SYSTEM                                = 0
 	AF1_TIM1_2_5_8_LPTIM1                     = 1

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -14,6 +14,8 @@ import (
 	"unsafe"
 )
 
+var deviceIDAddr = []uintptr{0x1FFF7590, 0x1FFF7594, 0x1FFF7598}
+
 const (
 	AF0_SYSTEM             = 0
 	AF1_TIM1_2_LPTIM1      = 1


### PR DESCRIPTION
THis PR implements the `machine.DeviceID()` function for STM32 to match the implementations from https://github.com/tinygo-org/tinygo/pull/3968