### PR TITLE
doc: fix a typo in the rtcinterrupt example

### DIFF
--- a/src/examples/rtcinterrupt/rtcinterrupt.go
+++ b/src/examples/rtcinterrupt/rtcinterrupt.go
@@ -25,6 +25,8 @@ func main() {
 	// Schedule and enable recurring interrupt.
 	// The callback function is executed in the context of an interrupt handler,
 	// so regular restrictions for this sort of code apply: no blocking, no memory allocation, etc.
+	// Please check the online documentation for the details about interrupts:
+	// https://tinygo.org/docs/concepts/compiler-internals/interrupts/
 	delay := time.Minute + 12*time.Second
 	machine.RTC.SetInterrupt(uint32(delay.Seconds()), true, func() { println("Peekaboo!") })
 

--- a/src/examples/rtcinterrupt/rtcinterrupt.go
+++ b/src/examples/rtcinterrupt/rtcinterrupt.go
@@ -24,7 +24,7 @@ func main() {
 
 	// Schedule and enable recurring interrupt.
 	// The callback function is executed in the context of an interrupt handler,
-	// so regular restructions for this sort of code apply: no blocking, no memory allocation, etc.
+	// so regular restrictions for this sort of code apply: no blocking, no memory allocation, etc.
 	delay := time.Minute + 12*time.Second
 	machine.RTC.SetInterrupt(uint32(delay.Seconds()), true, func() { println("Peekaboo!") })
 


### PR DESCRIPTION
I came across this while glancing through the examples.

Maybe it also makes sense to link to the docs like this: https://tinygo.org/docs/concepts/compiler-internals/heap-allocation/ 
Is it worth adding the hint about blocking and memory to the interrupt documentation page https://tinygo.org/docs/concepts/compiler-internals/interrupts/ as well? This came to my mind when I was thinking if `fmt.Println()` is blocking or not I am pretty sure it does :-)