### PR TITLE
Add -info option to tinygo monitor

### DIFF
--- a/main.go
+++ b/main.go
@@ -1743,7 +1743,7 @@ func main() {
 			handleCompilerError(err)
 		}
 	case "targets":
-		specs, err := GetTargetSpecs()
+		specs, err := compileopts.GetTargetSpecs()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "could not list targets:", err)
 			os.Exit(1)


### PR DESCRIPTION
The output of running `tinygo monitor --info` is as follows.
It displays information about the targets managed by tinygo, making it easier to understand what is connected where.

Even if it is not defined in tinygo's `targets/*.json`, some information is displayed.
ex) COM101

```
$ tinygo monitor --info
COM1
COM155 2886 8045 xiao-ble
COM32
COM33
COM76 239A 8022 feather-m4
COM101 2E8A F00A
```