### PR TITLE
machine: modify UART and USB CDC ACM Read() to be blocking 

### DIFF
--- a/src/machine/board_ae_rp2040.go
+++ b/src/machine/board_ae_rp2040.go
@@ -81,14 +81,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_arduino_mega2560.go
+++ b/src/machine/board_arduino_mega2560.go
@@ -125,7 +125,7 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
+		UARTCommon: NewUARTCommon(),
 
 		dataReg:    avr.UDR1,
 		baudRegH:   avr.UBRR1H,
@@ -136,7 +136,7 @@ var (
 	}
 	UART2  = &_UART2
 	_UART2 = UART{
-		Buffer: NewRingBuffer(),
+		UARTCommon: NewUARTCommon(),
 
 		dataReg:    avr.UDR2,
 		baudRegH:   avr.UBRR2H,
@@ -147,7 +147,7 @@ var (
 	}
 	UART3  = &_UART3
 	_UART3 = UART{
-		Buffer: NewRingBuffer(),
+		UARTCommon: NewUARTCommon(),
 
 		dataReg:    avr.UDR3,
 		baudRegH:   avr.UBRR3H,

--- a/src/machine/board_badger2040.go
+++ b/src/machine/board_badger2040.go
@@ -96,8 +96,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/board_bluepill.go
+++ b/src/machine/board_bluepill.go
@@ -81,13 +81,13 @@ var (
 	// USART1 is the first hardware serial port on the STM32.
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    stm32.USART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        stm32.USART1,
 	}
 	UART2  = &_UART2
 	_UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    stm32.USART2,
+		UARTCommon: NewUARTCommon(),
+		Bus:        stm32.USART2,
 	}
 )
 

--- a/src/machine/board_challenger_rp2040.go
+++ b/src/machine/board_challenger_rp2040.go
@@ -88,14 +88,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -122,21 +122,21 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,
 	}
 	UART2  = &_UART2
 	_UART2 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART6,
 		TxAltFuncSelector: AF8_USART4_5_6,
 		RxAltFuncSelector: AF8_USART4_5_6,
 	}
 	UART3  = &_UART3
 	_UART3 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -77,14 +77,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_gnse.go
+++ b/src/machine/board_gnse.go
@@ -57,7 +57,7 @@ var (
 	// STM32 UART2 is connected to the embedded STLINKV3 Virtual Com Port
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 7,

--- a/src/machine/board_gopher-badge.go
+++ b/src/machine/board_gopher-badge.go
@@ -96,8 +96,8 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_kb2040.go
+++ b/src/machine/board_kb2040.go
@@ -79,14 +79,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -61,7 +61,7 @@ var (
 	// Console UART (LPUSART1)
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.LPUART1,
 		TxAltFuncSelector: 6,
 		RxAltFuncSelector: 6,
@@ -70,7 +70,7 @@ var (
 	// Gps UART
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: 0,
 		RxAltFuncSelector: 0,

--- a/src/machine/board_lorae5.go
+++ b/src/machine/board_lorae5.go
@@ -56,7 +56,7 @@ var (
 	// Console UART
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: AF7_USART1_2,
 		RxAltFuncSelector: AF7_USART1_2,
@@ -69,7 +69,7 @@ var (
 	// UART2
 	UART2  = &_UART2
 	_UART2 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: AF7_USART1_2,
 		RxAltFuncSelector: AF7_USART1_2,

--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -82,8 +82,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -120,8 +120,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/board_nucleof103rb.go
+++ b/src/machine/board_nucleof103rb.go
@@ -31,8 +31,8 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	UART2  = &_UART2
 	_UART2 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    stm32.USART2,
+		UARTCommon: NewUARTCommon(),
+		Bus:        stm32.USART2,
 	}
 	DefaultUART = UART2
 )

--- a/src/machine/board_nucleof722ze.go
+++ b/src/machine/board_nucleof722ze.go
@@ -33,7 +33,7 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -71,7 +71,7 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 4,
 		RxAltFuncSelector: 4,

--- a/src/machine/board_nucleol432kc.go
+++ b/src/machine/board_nucleol432kc.go
@@ -73,7 +73,7 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 3,

--- a/src/machine/board_nucleol552ze.go
+++ b/src/machine/board_nucleol552ze.go
@@ -33,7 +33,7 @@ var (
 	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.LPUART1,
 		TxAltFuncSelector: UART_ALT_FN,
 		RxAltFuncSelector: UART_ALT_FN,

--- a/src/machine/board_nucleowl55jc.go
+++ b/src/machine/board_nucleowl55jc.go
@@ -55,7 +55,7 @@ var (
 	// STM32 UART2 is connected to the embedded STLINKV3 Virtual Com Port
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 7,
@@ -64,7 +64,7 @@ var (
 	// UART1 is free
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 7,

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -83,14 +83,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_qtpy_rp2040.go
+++ b/src/machine/board_qtpy_rp2040.go
@@ -88,14 +88,14 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_stm32f469disco.go
+++ b/src/machine/board_stm32f469disco.go
@@ -33,7 +33,7 @@ const (
 var (
 	UART3  = &_UART3
 	_UART3 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART3,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -53,7 +53,7 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART2,
 		TxAltFuncSelector: AF7_USART1_2_3,
 		RxAltFuncSelector: AF7_USART1_2_3,

--- a/src/machine/board_swan.go
+++ b/src/machine/board_swan.go
@@ -35,7 +35,7 @@ var (
 	// USART1 is connected to the TX/RX pins
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer:            NewRingBuffer(),
+		UARTCommon:        NewUARTCommon(),
 		Bus:               stm32.USART1,
 		TxAltFuncSelector: 7,
 		RxAltFuncSelector: 7,

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -143,9 +143,9 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Bus:      nxp.LPUART6,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART6,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D0 (PA3 [AD_B0_03])
 			mux: nxp.IOMUXC_LPUART6_RX_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART6_RX_SELECT_INPUT,
@@ -157,9 +157,9 @@ var (
 	}
 	UART2  = &_UART2
 	_UART2 = UART{
-		Bus:      nxp.LPUART4,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART4,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D7 (PB17 [B1_01])
 			mux: nxp.IOMUXC_LPUART4_RX_SELECT_INPUT_DAISY_GPIO_B1_01_ALT2,
 			sel: &nxp.IOMUXC.LPUART4_RX_SELECT_INPUT,
@@ -171,9 +171,9 @@ var (
 	}
 	UART3  = &_UART3
 	_UART3 = UART{
-		Bus:      nxp.LPUART2,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART2,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D15 (PA19 [AD_B1_03])
 			mux: nxp.IOMUXC_LPUART2_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART2_RX_SELECT_INPUT,
@@ -185,9 +185,9 @@ var (
 	}
 	UART4  = &_UART4
 	_UART4 = UART{
-		Bus:      nxp.LPUART3,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART3,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D16 (PA23 [AD_B1_07])
 			mux: nxp.IOMUXC_LPUART3_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT2,
 			sel: &nxp.IOMUXC.LPUART3_RX_SELECT_INPUT,
@@ -199,9 +199,9 @@ var (
 	}
 	UART5  = &_UART5
 	_UART5 = UART{
-		Bus:      nxp.LPUART8,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART8,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D21 (PA27 [AD_B1_11])
 			mux: nxp.IOMUXC_LPUART8_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_11_ALT2,
 			sel: &nxp.IOMUXC.LPUART8_RX_SELECT_INPUT,
@@ -213,18 +213,18 @@ var (
 	}
 	UART6  = &_UART6
 	_UART6 = UART{
-		Bus:      nxp.LPUART1,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART1,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		// LPUART1 not connected via IOMUXC
 		//   RX: D24 (PA12 [AD_B0_12])
 		//   TX: D25 (PA13 [AD_B0_13])
 	}
 	UART7  = &_UART7
 	_UART7 = UART{
-		Bus:      nxp.LPUART7,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART7,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D28 (PC18 [EMC_32])
 			mux: nxp.IOMUXC_LPUART7_RX_SELECT_INPUT_DAISY_GPIO_EMC_32_ALT2,
 			sel: &nxp.IOMUXC.LPUART7_RX_SELECT_INPUT,

--- a/src/machine/board_teensy41.go
+++ b/src/machine/board_teensy41.go
@@ -167,9 +167,9 @@ const (
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Bus:      nxp.LPUART6,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART6,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D0 (PA3 [AD_B0_03])
 			mux: nxp.IOMUXC_LPUART6_RX_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART6_RX_SELECT_INPUT,
@@ -181,9 +181,9 @@ var (
 	}
 	UART2  = &_UART2
 	_UART2 = UART{
-		Bus:      nxp.LPUART4,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART4,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D7 (PB17 [B1_01])
 			mux: nxp.IOMUXC_LPUART4_RX_SELECT_INPUT_DAISY_GPIO_B1_01_ALT2,
 			sel: &nxp.IOMUXC.LPUART4_RX_SELECT_INPUT,
@@ -195,9 +195,9 @@ var (
 	}
 	UART3  = &_UART3
 	_UART3 = UART{
-		Bus:      nxp.LPUART2,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART2,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D15 (PA19 [AD_B1_03])
 			mux: nxp.IOMUXC_LPUART2_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_03_ALT2,
 			sel: &nxp.IOMUXC.LPUART2_RX_SELECT_INPUT,
@@ -209,9 +209,9 @@ var (
 	}
 	UART4  = &_UART4
 	_UART4 = UART{
-		Bus:      nxp.LPUART3,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART3,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D16 (PA23 [AD_B1_07])
 			mux: nxp.IOMUXC_LPUART3_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT2,
 			sel: &nxp.IOMUXC.LPUART3_RX_SELECT_INPUT,
@@ -223,9 +223,9 @@ var (
 	}
 	UART5  = &_UART5
 	_UART5 = UART{
-		Bus:      nxp.LPUART8,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART8,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D21 (PA27 [AD_B1_11])
 			mux: nxp.IOMUXC_LPUART8_RX_SELECT_INPUT_DAISY_GPIO_AD_B1_11_ALT2,
 			sel: &nxp.IOMUXC.LPUART8_RX_SELECT_INPUT,
@@ -237,18 +237,18 @@ var (
 	}
 	UART6  = &_UART6
 	_UART6 = UART{
-		Bus:      nxp.LPUART1,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART1,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		// LPUART1 not connected via IOMUXC
 		//   RX: D24 (PA12 [AD_B0_12])
 		//   TX: D25 (PA13 [AD_B0_13])
 	}
 	UART7  = &_UART7
 	_UART7 = UART{
-		Bus:      nxp.LPUART7,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART7,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D28 (PC18 [EMC_32])
 			mux: nxp.IOMUXC_LPUART7_RX_SELECT_INPUT_DAISY_GPIO_EMC_32_ALT2,
 			sel: &nxp.IOMUXC.LPUART7_RX_SELECT_INPUT,
@@ -260,9 +260,9 @@ var (
 	}
 	UART8  = &_UART8
 	_UART8 = UART{
-		Bus:      nxp.LPUART5,
-		Buffer:   NewRingBuffer(),
-		txBuffer: NewRingBuffer(),
+		Bus:        nxp.LPUART5,
+		UARTCommon: NewUARTCommon(),
+		txBuffer:   NewRingBuffer(),
 		muxRX: muxSelect{ // D34 (PB29 [B1_13])
 			mux: nxp.IOMUXC_LPUART5_RX_SELECT_INPUT_DAISY_GPIO_B1_13_ALT1,
 			sel: &nxp.IOMUXC.LPUART5_RX_SELECT_INPUT,

--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -94,8 +94,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/board_tufty2040.go
+++ b/src/machine/board_tufty2040.go
@@ -91,8 +91,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -98,13 +98,13 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART1,
 	}
 )
 

--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -85,8 +85,8 @@ const (
 var (
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
+		UARTCommon: NewUARTCommon(),
+		Bus:        rp.UART0,
 	}
 )
 

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -144,7 +144,7 @@ var (
 	// UART0 is the hardware serial port on the AVR.
 	UART0  = &_UART0
 	_UART0 = UART{
-		Buffer: NewRingBuffer(),
+		UARTCommon: NewUARTCommon(),
 
 		dataReg:    avr.UDR0,
 		baudRegH:   avr.UBRR0H,
@@ -162,7 +162,7 @@ func init() {
 
 // UART on the AVR.
 type UART struct {
-	Buffer *RingBuffer
+	UARTCommon
 
 	dataReg  *volatile.Register8
 	baudRegH *volatile.Register8

--- a/src/machine/machine_atmega328pb.go
+++ b/src/machine/machine_atmega328pb.go
@@ -14,7 +14,7 @@ const irq_USART1_RX = avr.IRQ_USART1_RX
 var (
 	UART1  = &_UART1
 	_UART1 = UART{
-		Buffer: NewRingBuffer(),
+		UARTCommon: NewUARTCommon(),
 
 		dataReg:    avr.UDR1,
 		baudRegH:   avr.UBRR1H,

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -504,7 +504,7 @@ func waitADCSync() {
 
 // UART on the SAMD21.
 type UART struct {
-	Buffer    *RingBuffer
+	UARTCommon
 	Bus       *sam.SERCOM_USART_Type
 	SERCOM    uint8
 	Interrupt interrupt.Interrupt

--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	sercomUSART0 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM0_USART, SERCOM: 0}
-	sercomUSART1 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM1_USART, SERCOM: 1}
-	sercomUSART2 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM2_USART, SERCOM: 2}
-	sercomUSART3 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM3_USART, SERCOM: 3}
+	sercomUSART0 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM0_USART, SERCOM: 0}
+	sercomUSART1 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM1_USART, SERCOM: 1}
+	sercomUSART2 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM2_USART, SERCOM: 2}
+	sercomUSART3 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM3_USART, SERCOM: 3}
 
 	sercomI2CM0 = &I2C{Bus: sam.SERCOM0_I2CM, SERCOM: 0}
 	sercomI2CM1 = &I2C{Bus: sam.SERCOM1_I2CM, SERCOM: 1}

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -12,12 +12,12 @@ import (
 )
 
 var (
-	sercomUSART0 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM0_USART, SERCOM: 0}
-	sercomUSART1 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM1_USART, SERCOM: 1}
-	sercomUSART2 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM2_USART, SERCOM: 2}
-	sercomUSART3 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM3_USART, SERCOM: 3}
-	sercomUSART4 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM4_USART, SERCOM: 4}
-	sercomUSART5 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM5_USART, SERCOM: 5}
+	sercomUSART0 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM0_USART, SERCOM: 0}
+	sercomUSART1 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM1_USART, SERCOM: 1}
+	sercomUSART2 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM2_USART, SERCOM: 2}
+	sercomUSART3 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM3_USART, SERCOM: 3}
+	sercomUSART4 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM4_USART, SERCOM: 4}
+	sercomUSART5 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM5_USART, SERCOM: 5}
 
 	sercomI2CM0 = &I2C{Bus: sam.SERCOM0_I2CM, SERCOM: 0}
 	sercomI2CM1 = &I2C{Bus: sam.SERCOM1_I2CM, SERCOM: 1}

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -967,19 +967,19 @@ func (a ADC) getADCChannel() uint8 {
 
 // UART on the SAMD51.
 type UART struct {
-	Buffer    *RingBuffer
+	UARTCommon
 	Bus       *sam.SERCOM_USART_INT_Type
 	SERCOM    uint8
 	Interrupt interrupt.Interrupt // RXC interrupt
 }
 
 var (
-	sercomUSART0 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM0_USART_INT, SERCOM: 0}
-	sercomUSART1 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM1_USART_INT, SERCOM: 1}
-	sercomUSART2 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM2_USART_INT, SERCOM: 2}
-	sercomUSART3 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM3_USART_INT, SERCOM: 3}
-	sercomUSART4 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM4_USART_INT, SERCOM: 4}
-	sercomUSART5 = UART{Buffer: NewRingBuffer(), Bus: sam.SERCOM5_USART_INT, SERCOM: 5}
+	sercomUSART0 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM0_USART_INT, SERCOM: 0}
+	sercomUSART1 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM1_USART_INT, SERCOM: 1}
+	sercomUSART2 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM2_USART_INT, SERCOM: 2}
+	sercomUSART3 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM3_USART_INT, SERCOM: 3}
+	sercomUSART4 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM4_USART_INT, SERCOM: 4}
+	sercomUSART5 = UART{UARTCommon: NewUARTCommon(), Bus: sam.SERCOM5_USART_INT, SERCOM: 5}
 )
 
 func init() {

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -295,16 +295,16 @@ var DefaultUART = UART0
 
 var (
 	UART0  = &_UART0
-	_UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
+	_UART0 = UART{Bus: esp.UART0, UARTCommon: NewUARTCommon()}
 	UART1  = &_UART1
-	_UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	_UART1 = UART{Bus: esp.UART1, UARTCommon: NewUARTCommon()}
 	UART2  = &_UART2
-	_UART2 = UART{Bus: esp.UART2, Buffer: NewRingBuffer()}
+	_UART2 = UART{Bus: esp.UART2, UARTCommon: NewUARTCommon()}
 )
 
 type UART struct {
-	Bus    *esp.UART_Type
-	Buffer *RingBuffer
+	Bus *esp.UART_Type
+	UARTCommon
 }
 
 func (uart *UART) Configure(config UARTConfig) {

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -241,9 +241,9 @@ var (
 	DefaultUART = UART0
 
 	UART0  = &_UART0
-	_UART0 = UART{Bus: esp.UART0, Buffer: NewRingBuffer()}
+	_UART0 = UART{Bus: esp.UART0, UARTCommon: NewUARTCommon()}
 	UART1  = &_UART1
-	_UART1 = UART{Bus: esp.UART1, Buffer: NewRingBuffer()}
+	_UART1 = UART{Bus: esp.UART1, UARTCommon: NewUARTCommon()}
 
 	onceUart            = sync.Once{}
 	errSamePins         = errors.New("UART: invalid pin combination")
@@ -253,8 +253,8 @@ var (
 )
 
 type UART struct {
-	Bus                  *esp.UART_Type
-	Buffer               *RingBuffer
+	Bus *esp.UART_Type
+	UARTCommon
 	ParityErrorDetected  bool // set when parity error detected
 	DataErrorDetected    bool // set when data corruption detected
 	DataOverflowDetected bool // set when data overflow detected in UART FIFO buffer or RingBuffer

--- a/src/machine/machine_esp8266.go
+++ b/src/machine/machine_esp8266.go
@@ -166,10 +166,10 @@ var DefaultUART = UART0
 
 // UART0 is a hardware UART that supports both TX and RX.
 var UART0 = &_UART0
-var _UART0 = UART{Buffer: NewRingBuffer()}
+var _UART0 = UART{UARTCommon: NewUARTCommon()}
 
 type UART struct {
-	Buffer *RingBuffer
+	UARTCommon
 }
 
 // Configure the UART baud rate. TX and RX pins are fixed by the hardware so

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -70,13 +70,13 @@ func (p Pin) PortMaskClear() (*uint32, uint32) {
 }
 
 type UART struct {
-	Bus    *sifive.UART_Type
-	Buffer *RingBuffer
+	Bus *sifive.UART_Type
+	UARTCommon
 }
 
 var (
 	UART0  = &_UART0
-	_UART0 = UART{Bus: sifive.UART0, Buffer: NewRingBuffer()}
+	_UART0 = UART{Bus: sifive.UART0, UARTCommon: NewUARTCommon()}
 )
 
 func (uart *UART) Configure(config UARTConfig) {

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -341,13 +341,13 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 }
 
 type UART struct {
-	Bus    *kendryte.UARTHS_Type
-	Buffer *RingBuffer
+	Bus *kendryte.UARTHS_Type
+	UARTCommon
 }
 
 var (
 	UART0  = &_UART0
-	_UART0 = UART{Bus: kendryte.UARTHS, Buffer: NewRingBuffer()}
+	_UART0 = UART{Bus: kendryte.UARTHS, UARTCommon: NewUARTCommon()}
 )
 
 func (uart *UART) Configure(config UARTConfig) {

--- a/src/machine/machine_mimxrt1062_uart.go
+++ b/src/machine/machine_mimxrt1062_uart.go
@@ -11,8 +11,8 @@ import (
 // UART peripheral abstraction layer for the MIMXRT1062
 
 type UART struct {
-	Bus       *nxp.LPUART_Type
-	Buffer    *RingBuffer
+	Bus *nxp.LPUART_Type
+	UARTCommon
 	Interrupt interrupt.Interrupt
 
 	// txBuffer should be allocated globally (such as when UART is created) to

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -160,13 +160,13 @@ func (p Pin) SetInterrupt(change PinChange, callback func(Pin)) error {
 
 // UART on the NRF.
 type UART struct {
-	Buffer *RingBuffer
+	UARTCommon
 }
 
 // UART
 var (
 	// UART0 is the hardware UART on the NRF SoC.
-	_UART0 = UART{Buffer: NewRingBuffer()}
+	_UART0 = UART{UARTCommon: NewUARTCommon()}
 	UART0  = &_UART0
 )
 

--- a/src/machine/machine_nxpmk66f18_uart.go
+++ b/src/machine/machine_nxpmk66f18_uart.go
@@ -91,7 +91,7 @@ type UART struct {
 	DefaultTX Pin
 
 	// state
-	Buffer       RingBuffer // RX Buffer
+	UARTCommon
 	TXBuffer     RingBuffer
 	Configured   bool
 	Transmitting volatile.Register8
@@ -104,11 +104,11 @@ var (
 	UART2  = &_UART2
 	UART3  = &_UART3
 	UART4  = &_UART4
-	_UART0 = UART{UART_Type: nxp.UART0, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART0, DefaultRX: defaultUART0RX, DefaultTX: defaultUART0TX}
-	_UART1 = UART{UART_Type: nxp.UART1, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART1, DefaultRX: defaultUART1RX, DefaultTX: defaultUART1TX}
-	_UART2 = UART{UART_Type: nxp.UART2, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART2, DefaultRX: defaultUART2RX, DefaultTX: defaultUART2TX}
-	_UART3 = UART{UART_Type: nxp.UART3, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART3, DefaultRX: defaultUART3RX, DefaultTX: defaultUART3TX}
-	_UART4 = UART{UART_Type: nxp.UART4, SCGC: &nxp.SIM.SCGC1, SCGCMask: nxp.SIM_SCGC1_UART4, DefaultRX: defaultUART4RX, DefaultTX: defaultUART4TX}
+	_UART0 = UART{UART_Type: nxp.UART0, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART0, DefaultRX: defaultUART0RX, DefaultTX: defaultUART0TX, UARTCommon: NewUARTCommon()}
+	_UART1 = UART{UART_Type: nxp.UART1, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART1, DefaultRX: defaultUART1RX, DefaultTX: defaultUART1TX, UARTCommon: NewUARTCommon()}
+	_UART2 = UART{UART_Type: nxp.UART2, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART2, DefaultRX: defaultUART2RX, DefaultTX: defaultUART2TX, UARTCommon: NewUARTCommon()}
+	_UART3 = UART{UART_Type: nxp.UART3, SCGC: &nxp.SIM.SCGC4, SCGCMask: nxp.SIM_SCGC4_UART3, DefaultRX: defaultUART3RX, DefaultTX: defaultUART3TX, UARTCommon: NewUARTCommon()}
+	_UART4 = UART{UART_Type: nxp.UART4, SCGC: &nxp.SIM.SCGC1, SCGCMask: nxp.SIM_SCGC1_UART4, DefaultRX: defaultUART4RX, DefaultTX: defaultUART4TX, UARTCommon: NewUARTCommon()}
 )
 
 func init() {

--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -9,7 +9,8 @@ import (
 
 // UART on the RP2040.
 type UART struct {
-	Buffer    *RingBuffer
+	UARTCommon
+
 	Bus       *rp.UART0_Type
 	Interrupt interrupt.Interrupt
 }

--- a/src/machine/machine_stm32_uart.go
+++ b/src/machine/machine_stm32_uart.go
@@ -13,7 +13,7 @@ import (
 
 // UART representation
 type UART struct {
-	Buffer            *RingBuffer
+	UARTCommon
 	Bus               *stm32.USART_Type
 	Interrupt         interrupt.Interrupt
 	TxAltFuncSelector uint8

--- a/src/machine/usb/cdc/cdc.go
+++ b/src/machine/usb/cdc/cdc.go
@@ -11,6 +11,7 @@ func New() *USBCDC {
 	if USB == nil {
 		USB = &USBCDC{
 			rxBuffer: NewRxRingBuffer(),
+			RXChan:   make(chan bool),
 			txBuffer: NewTxRingBuffer(),
 		}
 	}


### PR DESCRIPTION
Using a callback for receiving serial data eliminates the need for polling.

So far I've only modified the files for RP2040 as that's what I'm testing on. If this PR is in the right direction, I will modify `type UART struct` for the other boards as well.