### PR TITLE
machine: add SPI DMA support for the rp2040 and samd51

### DIFF
--- a/src/machine/machine_atsamd51g19.go
+++ b/src/machine/machine_atsamd51g19.go
@@ -62,6 +62,27 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has three TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsamd51j19.go
+++ b/src/machine/machine_atsamd51j19.go
@@ -62,6 +62,27 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0B
+	case sam.SERCOM4_SPIM:
+		return 0x0D
+	case sam.SERCOM5_SPIM:
+		return 0x0F
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsamd51j20.go
+++ b/src/machine/machine_atsamd51j20.go
@@ -62,6 +62,27 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsamd51p19.go
+++ b/src/machine/machine_atsamd51p19.go
@@ -76,6 +76,31 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	case sam.SERCOM6_SPIM:
+		return 0x10
+	case sam.SERCOM7_SPIM:
+		return 0x12
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsamd51p20.go
+++ b/src/machine/machine_atsamd51p20.go
@@ -76,6 +76,31 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	case sam.SERCOM6_SPIM:
+		return 0x10
+	case sam.SERCOM7_SPIM:
+		return 0x12
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsame51j19.go
+++ b/src/machine/machine_atsame51j19.go
@@ -62,6 +62,27 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/machine_atsame54p20.go
+++ b/src/machine/machine_atsame54p20.go
@@ -76,6 +76,31 @@ func setSERCOMClockGenerator(sercom uint8, gclk uint32) {
 	}
 }
 
+// DMA trigger source
+func (spi SPI) triggerSource() (tx uint32) {
+	// See TRIGSRC field of CHCTRLA register for description of these constants.
+	switch spi.Bus {
+	case sam.SERCOM0_SPIM:
+		return 0x05
+	case sam.SERCOM1_SPIM:
+		return 0x07
+	case sam.SERCOM2_SPIM:
+		return 0x09
+	case sam.SERCOM3_SPIM:
+		return 0x0A
+	case sam.SERCOM4_SPIM:
+		return 0x0C
+	case sam.SERCOM5_SPIM:
+		return 0x0E
+	case sam.SERCOM6_SPIM:
+		return 0x10
+	case sam.SERCOM7_SPIM:
+		return 0x12
+	default:
+		return 0 // should be unreachable
+	}
+}
+
 // This chip has five TCC peripherals, which have PWM as one feature.
 var (
 	TCC0 = (*TCC)(sam.TCC0)

--- a/src/machine/spi-dummy-async.go
+++ b/src/machine/spi-dummy-async.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || atsamd21 || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 package machine
 

--- a/src/machine/spi-dummy-async.go
+++ b/src/machine/spi-dummy-async.go
@@ -1,0 +1,29 @@
+//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+
+package machine
+
+// This is a non-async implementation of the async SPI calls.
+// It is useful for devices that don't support DMA on SPI, or for which it
+// hasn't been implemented yet.
+
+// IsAsync returns whether the SPI supports async operation (usually DMA).
+//
+// This SPI does not support async operations.
+func (s SPI) IsAsync() bool {
+	return false
+}
+
+// Start a transfer in the background.
+//
+// Because this SPI implementation doesn't support async operation, it is an
+// alias for Tx.
+func (s SPI) StartTx(tx, rx []byte) error {
+	return s.Tx(tx, rx)
+}
+
+// Wait until all active transactions (started by StartTx) have finished.
+//
+// This is a no-op on this SPI implementation.
+func (s SPI) Wait() error {
+	return nil
+}

--- a/src/machine/spi-dummy-async.go
+++ b/src/machine/spi-dummy-async.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 package machine
 

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -26,4 +26,7 @@ var _ interface { // 2
 	Configure(config SPIConfig) error
 	Tx(w, r []byte) error
 	Transfer(w byte) (byte, error)
+	IsAsync() bool
+	StartTx(tx, rx []byte) error
+	Wait() error
 } = (*SPI)(nil)


### PR DESCRIPTION
This adds SPI DMA support for the rp2040, and a fallback for all the other devices.

For more details, see: https://github.com/tinygo-org/tinygo-site/pull/342

Draft, until:
 - [x] I've added samd51 support
 - [ ] https://github.com/tinygo-org/tinygo-site/pull/342 has been resolved