### PR TITLE
machine/usb: add support for ISERIAL descriptor

### DIFF
--- a/src/examples/hid-keyboard/main.go
+++ b/src/examples/hid-keyboard/main.go
@@ -1,6 +1,6 @@
 // to override the USB Manufacturer or Product names:
 //
-// tinygo flash -target circuitplay-express -ldflags="-X main.usbManufacturer='TinyGopher Labs' -X main.usbProduct='GopherKeyboard'" examples/hid-keyboard
+// tinygo flash -target circuitplay-express -ldflags="-X main.usbManufacturer='TinyGopher Labs' -X main.usbProduct='GopherKeyboard' -X main.usbSerial='XXXXX'" examples/hid-keyboard
 //
 // you can also override the VID/PID. however, only set this if you know what you are doing,
 // since changing it can make it difficult to reflash some devices.
@@ -15,7 +15,7 @@ import (
 )
 
 var usbVID, usbPID string
-var usbManufacturer, usbProduct string
+var usbManufacturer, usbProduct, usbSerial string
 
 func main() {
 	button := machine.BUTTON
@@ -48,5 +48,9 @@ func init() {
 
 	if usbProduct != "" {
 		usb.Product = usbProduct
+	}
+
+	if usbSerial != "" {
+		usb.Serial = usbSerial
 	}
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -63,6 +63,13 @@ func usbProduct() string {
 	return usb_STRING_PRODUCT
 }
 
+func usbSerial() string {
+	if usb.Serial != "" {
+		return usb.Serial
+	}
+	return ""
+}
+
 // strToUTF16LEDescriptor converts a utf8 string into a string descriptor
 // note: the following code only converts ascii characters to UTF16LE. In order
 // to do a "proper" conversion, we would need to pull in the 'unicode/utf16'
@@ -160,8 +167,14 @@ func sendDescriptor(setup usb.Setup) {
 			sendUSBPacket(0, b, setup.WLength)
 
 		case usb.ISERIAL:
-			// TODO: allow returning a product serial number
-			SendZlp()
+			sz := len(usbSerial())
+			if sz == 0 {
+				SendZlp()
+			} else {
+				b := usb_trans_buffer[:(sz<<1)+2]
+				strToUTF16LEDescriptor(usbSerial(), b)
+				sendUSBPacket(0, b, setup.WLength)
+			}
 		}
 		return
 	case descriptor.TypeHIDReport:

--- a/src/machine/usb/usb.go
+++ b/src/machine/usb/usb.go
@@ -134,4 +134,8 @@ var (
 
 	// Product is the product name displayed for this USB device.
 	Product string
+
+	// Serial is the serial value displayed for this USB device. Assign a value to
+	// transmit the serial to the host when requested.
+	Serial string
 )


### PR DESCRIPTION
`ISERIAL` is sent only if usb.Serial is not an empty string.

The implementation of ISERIAL was necessary for compatibility with vial-gui in [sago35/tinygo-keyboard](https://github.com/sago35/tinygo-keyboard).