### PR TITLE
Bump default stack size for target pico to 8kb from 2kb

### DIFF
--- a/targets/pico.json
+++ b/targets/pico.json
@@ -4,6 +4,7 @@
     ],
     "build-tags": ["pico"],
     "serial-port": ["2e8a:000A"],
+    "default-stack-size": 8192,
     "ldflags": [
         "--defsym=__flash_size=2048K"
     ],


### PR DESCRIPTION
The pico-w wifi driver needs a minimum of 8kb stack size.  The default stack size for pico (and pico-w) is 2kb, so -stack-size=8kb is needed when working with wifi driver.  Unfortunately, developers working on the wifi driver forget to specify -stack-size=8kb when testing, resulting in the wifi driver lockup during initialization.  Hours (or days) pass before we realize our mistake, and then HAND smacks HEAD and we specify --stack-size=8kb.

This RP sets the default stack size to 8kb for pico (and pico-w).  This will help developers who forget -stack-size=8kb, and will help users once the pico-w wifi driver is available.