### PR TITLE
WIP: Ensure UART implements `machine.Serialer`

### DIFF
--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -171,7 +171,7 @@ var (
 )
 
 // Configure the UART.
-func (uart *UART) Configure(config UARTConfig) {
+func (uart *UART) Configure(config UARTConfig) error {
 	// Default baud rate to 115200.
 	if config.BaudRate == 0 {
 		config.BaudRate = 115200
@@ -196,6 +196,8 @@ func (uart *UART) Configure(config UARTConfig) {
 	intr := interrupt.New(nrf.IRQ_UART0, _UART0.handleInterrupt)
 	intr.SetPriority(0xc0) // low priority
 	intr.Enable()
+
+	return nil
 }
 
 // SetBaudRate sets the communication speed for the UART.

--- a/src/machine/serial.go
+++ b/src/machine/serial.go
@@ -44,3 +44,13 @@ func (ns NullSerial) Buffered() int {
 func (ns NullSerial) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
+
+type Serialer interface {
+	WriteByte(c byte) error
+	Write(data []byte) (n int, err error)
+	Configure(config UARTConfig) error
+	Buffered() int
+	ReadByte() (byte, error)
+	DTR() bool
+	RTS() bool
+}

--- a/src/machine/uart.go
+++ b/src/machine/uart.go
@@ -23,6 +23,8 @@ const (
 	ParityOdd
 )
 
+var _ Serialer = (*UART)(nil)
+
 // To implement the UART interface for a board, you must declare a concrete type as follows:
 //
 // 		type UART struct {
@@ -103,4 +105,14 @@ func (uart *UART) Buffered() int {
 // Usually called by the IRQ handler for a machine.
 func (uart *UART) Receive(data byte) {
 	uart.Buffer.Put(data)
+}
+
+func (uart *UART) DTR() bool {
+	// Not Implemented ... part of machine.Serialer interface
+	return false
+}
+
+func (uart *UART) RTS() bool {
+	// Not Implemented ... part of machine.Serialer interface
+	return false
 }

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -19,16 +19,6 @@ var (
 	USBCDC Serialer
 )
 
-type Serialer interface {
-	WriteByte(c byte) error
-	Write(data []byte) (n int, err error)
-	Configure(config UARTConfig) error
-	Buffered() int
-	ReadByte() (byte, error)
-	DTR() bool
-	RTS() bool
-}
-
 var usbDescriptor descriptor.Descriptor
 
 func usbVendorID() uint16 {


### PR DESCRIPTION
Updates to ensure that `machine.UART` implements `machine.Serialer`

Will resolve https://github.com/tinygo-org/tinygo/issues/3990