### PR TITLE
Stub udp support

### DIFF
--- a/src/net/net.go
+++ b/src/net/net.go
@@ -141,6 +141,13 @@ type OpError struct {
 	Err error
 }
 
+// Timeout implements OpError.Timeout
+// The supporting infra does not exist yet,
+// so it always returns false.
+func (e *OpError) Timeout() bool {
+	return false
+}
+
 func (e *OpError) Unwrap() error { return e.Err }
 
 func (e *OpError) Error() string {

--- a/src/net/udpconn.go
+++ b/src/net/udpconn.go
@@ -1,0 +1,85 @@
+package net
+
+import (
+	"syscall"
+	"time"
+)
+
+// UDPConn implements UDPConn by always failing.
+type UDPConn struct {
+}
+
+func ListenUDP(_ string, _ *UDPAddr) (*UDPConn, error) {
+	return nil, ErrNotImplemented
+}
+
+func ResolveUDPAddr(network, address string) (*UDPAddr, error) {
+	return nil, ErrNotImplemented
+}
+
+// Read implements the Conn Read method
+func (c *UDPConn) Read(b []byte) (n int, err error) {
+	return 0, ErrNotImplemented
+}
+
+// Write implements the Conn Write method
+func (c *UDPConn) Write(b []byte) (n int, err error) {
+	return 0, ErrNotImplemented
+}
+
+// Close implements the Conn Close method
+func (c *UDPConn) Close() error {
+	return ErrNotImplemented
+}
+
+// LocalAddr implements the Conn LocalAddr method
+func (c *UDPConn) LocalAddr() Addr {
+	return nil
+}
+
+// RemoteAddr implements the Conn RemoteAddr method
+func (c *UDPConn) RemoteAddr() Addr {
+	return nil
+}
+
+// SetReadDeadline implements the Conn SetReadDeadline method
+func (c *UDPConn) SetReadDeadline(t time.Time) error {
+	return ErrNotImplemented
+}
+
+// SetWriteDeadline implements the Conn SetWriteDeadline method
+func (c *UDPConn) SetWriteDeadline(t time.Time) error {
+	return ErrNotImplemented
+}
+
+// SetDeadline implements the Conn SetDeadline method
+func (c *UDPConn) SetDeadline(t time.Time) error {
+	return ErrNotImplemented
+}
+
+// SetReadBuffer implements the Conn SetReadBuffer method
+func (c *UDPConn) SetReadBuffer(bytes int) {
+	return
+}
+
+// SetWriteBuffer implements the Conn SetWriteBuffer method
+func (c *UDPConn) SetWriteBuffer(bytes int) {
+	return
+}
+
+// SyscallConn implements the Conn SyscallConn method
+func (c *UDPConn) SyscallConn() (syscall.RawConn, error) {
+	return nil, ErrNotImplemented
+}
+
+func (c *UDPConn) WriteTo(b []byte, addr Addr) (n int, err error) {
+	return -1, ErrNotImplemented
+}
+
+func (c *UDPConn) ReadFrom(p []byte) (n int, addr Addr, err error) {
+	return -1, nil, ErrNotImplemented
+}
+
+func (c *UDPConn) ReadFromUDP(p []byte) (n int, addr *UDPAddr, err error) {
+	return -1, nil, ErrNotImplemented
+}


### PR DESCRIPTION
UDPConn is needed to get u-root commands such as wget to build. We still need OpError.Timeout():
```
rminnich@pop-os:~/go/src/github.com/u-root/u-root/cmds/core/wget$ tinygo build -tags purego
# pack.ag/tftp
../../../vendor/pack.ag/tftp/server.go:113:49: err.Timeout undefined (type *net.OpError has no field or method Timeout)
```

I'd be much happier to just get rid of all tftp usage, but that is not easy, too many people still use it.

Rather than a new file, should this code just be in udpsock.go?