### PR TITLE
lib/cmsis-svd: change to new shared location and update version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
 	url = https://github.com/avr-rust/avr-mcu.git
 [submodule "lib/cmsis-svd"]
 	path = lib/cmsis-svd
-	url = https://github.com/tinygo-org/cmsis-svd
+	url = https://github.com/cmsis-svd/cmsis-svd.git
+	branch = main
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc
 	url = https://github.com/WebAssembly/wasi-libc

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -200,8 +200,8 @@ build/gen-device-svd: ./tools/gen-device-svd/*.go
 	$(GO) build -o $@ ./tools/gen-device-svd/
 
 gen-device-esp: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif-Community -interrupts=software lib/cmsis-svd/data/Espressif-Community/ src/device/esp/
 	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif -interrupts=software lib/cmsis-svd/data/Espressif/ src/device/esp/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif-Community -interrupts=software lib/cmsis-svd/data/Espressif-Community/ src/device/esp/
 	GO111MODULE=off $(GO) fmt ./src/device/esp
 
 gen-device-nrf: build/gen-device-svd


### PR DESCRIPTION
This PR modifies the submodule `lib/cmsis-svd` to change to new shared location and updates to the latest version.

As a result, a small change to the makefile was needed to avoid overwriting the `esp32` implementation in the community version that we are currently using  with an official one that is now part of `cmsis-svd`.

At some point, switching to the use the official implementation would possibly be a good idea. I have not looked too deeply into that part.