### PR TITLE
docker: remove lists after update to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
         /var/tmp/* \
         /tmp/*
 
-COPY ./Makefile /tinygo/Makefile
+COPY ./GNUmakefile /tinygo/GNUmakefile
 
 RUN cd /tinygo/ && \
     make llvm-source

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@
 FROM golang:1.21 AS tinygo-llvm
 
 RUN apt-get update && \
-    apt-get install -y apt-utils make cmake clang-15 ninja-build
+    apt-get install -y apt-utils make cmake clang-15 ninja-build && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/tmp/* \
+        /tmp/*
 
 COPY ./Makefile /tinygo/Makefile
 


### PR DESCRIPTION
This PR modifies the Dockerfile to remove lists after update to reduce image size.