### PR TITLE
machine/esp32c3: add USB_SERIAL allowing USBCDC communication.

### DIFF
--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -88,8 +88,9 @@ func strToUTF16LEDescriptor(in string, out []byte) {
 const cdcLineInfoSize = 7
 
 var (
-	ErrUSBReadTimeout = errors.New("USB read timeout")
-	ErrUSBBytesRead   = errors.New("USB invalid number of bytes read")
+	ErrUSBReadTimeout  = errors.New("USB read timeout")
+	ErrUSBBytesRead    = errors.New("USB invalid number of bytes read")
+	ErrUSBBytesWritten = errors.New("USB invalid number of bytes written")
 )
 
 var (

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"device/esp"
 	"device/riscv"
+	"machine"
 	"runtime/volatile"
 	"unsafe"
 )
@@ -52,6 +53,10 @@ func main() {
 
 	// Configure interrupt handler
 	interruptInit()
+
+	// Initialize UART.
+	machine.USBCDC.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	// Initialize main system timer used for time.Now.
 	initTimer()

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -10,22 +10,6 @@ import (
 
 type timeUnit int64
 
-func putchar(c byte) {
-	machine.Serial.WriteByte(c)
-}
-
-func getchar() byte {
-	for machine.Serial.Buffered() == 0 {
-		Gosched()
-	}
-	v, _ := machine.Serial.ReadByte()
-	return v
-}
-
-func buffered() int {
-	return machine.Serial.Buffered()
-}
-
 // Initialize .bss: zero-initialized global variables.
 // The .data section has already been loaded by the ROM bootloader.
 func clearbss() {
@@ -83,4 +67,20 @@ func sleepTicks(d timeUnit) {
 
 func exit(code int) {
 	abort()
+}
+
+func putchar(c byte) {
+	machine.Serial.WriteByte(c)
+}
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
 }

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -2,7 +2,7 @@
 	"inherits": ["riscv32"],
 	"features": "+32bit,+c,+m,-64bit,-a,-d,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-f,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["esp32c3", "esp"],
-	"serial": "uart",
+	"serial": "usb",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"cflags": [


### PR DESCRIPTION
This PR adds to the `machine/esp32c3` the implementation for USB_SERIAL allowing USBCDC communication.

Addresses https://github.com/tinygo-org/tinygo/issues/3631