### PR TITLE
builds: free space before doing docker build job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,14 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/graalvm
+          sudo rm -rf /usr/local/share/boost
       - name: Check out the repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR is to free space before doing the docker build job on GH actions.