### PR TITLE
m5stamp-c3: change settings to explicitly use UART

### DIFF
--- a/targets/m5stamp-c3.json
+++ b/targets/m5stamp-c3.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["esp32c3"],
 	"build-tags": ["m5stamp_c3"],
+	"serial": "uart",
 	"serial-port": ["1a86:55d4"]
 }
 


### PR DESCRIPTION
Due to #4011, the default has been changed to USB, so I made the necessary corrections.
I have verified the operation on m5stamp.