### PR TITLE
machine/esp32c3: implement RNG

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -1,4 +1,4 @@
-//go:build nrf || stm32 || (sam && atsamd51) || (sam && atsame5x)
+//go:build nrf || stm32 || (sam && atsamd51) || (sam && atsame5x) || esp32c3
 
 package rand
 


### PR DESCRIPTION
This PR implements the RNG on the `esp32c3` chips.

Note that this PR depends on https://github.com/tinygo-org/tinygo/pull/4014 which needs to be merged first and then this PR rebased.