### PR TITLE
machine/atmega: bufferSize = 32

### DIFF
--- a/src/machine/buffer.go
+++ b/src/machine/buffer.go
@@ -4,8 +4,6 @@ import (
 	"runtime/volatile"
 )
 
-const bufferSize = 128
-
 // RingBuffer is ring buffer implementation inspired by post at
 // https://www.embeddedrelated.com/showthread/comp.arch.embedded/77084-1.php
 type RingBuffer struct {

--- a/src/machine/buffer_atmega.go
+++ b/src/machine/buffer_atmega.go
@@ -1,0 +1,5 @@
+//go:build atmega
+
+package machine
+
+const bufferSize = 32

--- a/src/machine/buffer_generic.go
+++ b/src/machine/buffer_generic.go
@@ -1,0 +1,5 @@
+//go:build !atmega
+
+package machine
+
+const bufferSize = 128


### PR DESCRIPTION
`RingBuffer` is used for many things inside `machine` package and has size `128` bytes, hardcoded for optimisation. However, `128` bytes is quite big chunk of memory on `2k` ram targets (~6%) that many atmel chips are.
Among other things, `UART` uses `RingBuffer`, so this is an instant tax that end users can't really avoid.
Would be nice to cut this tax for targets with low memory budget.

This PR conditionally sets `RingBuffer`'s size to `32` bytes on `atmega` tagged targets.
Of course, there can be other targets with small ram and some `atmega` chips have up to `16k` ram and `128` bytes may be fine for them.
So this is a first step, and we may want to adjust the sizes conditionally further, as a follow up.

~This also updates `sizediff` tool to show ram differences and cleans up unused code.~
Change in `sizediff` extracted to a separate PR #4023

```
./tools/sizediff original.txt modified.txt
 flash                          ram
 before   after   diff          before   after   diff
   4184    4184      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/blinky1
   4312    4312      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/adc
   4972    4972      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/blinkm
   4848    4848      0   0.00%    2268    2268      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/blinky2
   4196    4196      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/button
   4264    4264      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/button2
   4548    4548      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/echo
  74624   74624      0   0.00%    3880    3880      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/echo2
   7340    7340      0   0.00%    4716    4716      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-express examples/i2s
   5040    5040      0   0.00%    2272    2272      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/mcp3008
  24508   24508      0   0.00%    3016    3016      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/memstats
   3128    3128      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=microbit            examples/microbit-blink
   4628    4628      0   0.00%    2336    2336      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/pininterrupt
  70064   70064      0   0.00%    4804    4804      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nano-rp2040         examples/rtcinterrupt
   4188    4188      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/serial
   4716    4716      0   0.00%    2280    2280      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/systick
   9300    9300      0   0.00%    2400    2400      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/test
  71956   71956      0   0.00%    4340    4340      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040            examples/time-offset
   9424    9424      0   0.00%    8128    8128      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=wioterminal         examples/hid-mouse
   9992    9992      0   0.00%    8152    8152      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=wioterminal         examples/hid-keyboard
  11280   11280      0   0.00%    3584    3584      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-rp2040      examples/i2c-target
  61008   61008      0   0.00%    4720    4720      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-rp2040      examples/watchdog
   8360    8360      0   0.00%    3444    3444      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-rp2040      examples/device-id
   4216    4216      0   0.00%    4312    4312      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040-s132v6     examples/blinky1
   3484    3484      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=microbit            examples/echo
   3512    3512      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=microbit-s110v8     examples/echo
   3928    3928      0   0.00%    4312    4312      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=microbit-v2         examples/microbit-blink
   3960    3960      0   0.00%    6104    6104      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=microbit-v2-s113v7  examples/microbit-blink
   7864    7864      0   0.00%    6544    6544      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
   3128    3128      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10031            examples/blinky1
   7612    7612      0   0.00%    6672    6672      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=reelboard           examples/blinky1
   7804    7804      0   0.00%    6676    6676      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=reelboard           examples/blinky2
   7636    7636      0   0.00%    6672    6672      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10056            examples/blinky1
   7828    7828      0   0.00%    6676    6676      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10056            examples/blinky2
   7852    7852      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10059            examples/blinky1
   8044    8044      0   0.00%    4500    4500      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10059            examples/blinky2
   8132    8132      0   0.00%    4500    4500      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=bluemicro840        examples/blinky2
   6532    6532      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=itsybitsy-m0        examples/blinky1
   6528    6528      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-m0          examples/blinky1
   6488    6488      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=trinket-m0          examples/blinky1
   6488    6488      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=gemma-m0            examples/blinky1
   6536    6536      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-express examples/blinky1
   7964    7964      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-bluefruit examples/blinky1
   7340    7340      0   0.00%    4716    4716      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-express examples/i2s
   7936    7936      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=clue-alpha          examples/blinky1
   1044    1044      0   0.00%    3076    3076      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.gba -target=gameboy-advance     examples/gba-display
   7052    7052      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=grandcentral-m4     examples/blinky1
   7016    7016      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=itsybitsy-m4        examples/blinky1
   7016    7016      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-m4          examples/blinky1
   7024    7024      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=matrixportal-m4     examples/blinky1
   7016    7016      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pybadge             examples/blinky1
   7024    7024      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=metro-m4-airlift    examples/blinky1
   7016    7016      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pyportal            examples/blinky1
   7604    7604      0   0.00%    6672    6672      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=particle-argon      examples/blinky1
   7604    7604      0   0.00%    6672    6672      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=particle-boron      examples/blinky1
   7604    7604      0   0.00%    6672    6672      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=particle-xenon      examples/blinky1
   2716    2716      0   0.00%    2128    2128      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pinetime            examples/blinky1
   4176    4176      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=x9pro               examples/blinky1
   7672    7672      0   0.00%    8464    8464      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10056-s140v7     examples/blinky1
   7648    7648      0   0.00%    8464    8464      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=reelboard-s140v7    examples/blinky1
   7048    7048      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=wioterminal         examples/blinky1
   7016    7016      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pygamer             examples/blinky1
   6512    6512      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=xiao                examples/blinky1
   7400    7400      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-express examples/dac
   7760    7760      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pyportal            examples/dac
   7968    7968      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-nrf52840        examples/blinky1
   7968    7968      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-nrf52840-sense examples/blinky1
   7960    7960      0   0.00%    4496    4496      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=itsybitsy-nrf52840  examples/blinky1
   6480    6480      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=qtpy                examples/serial
  19224   19224      0   0.00%    4504    4504      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=teensy41            examples/blinky1
  19224   19224      0   0.00%    4504    4504      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=teensy40            examples/blinky1
   6880    6880      0   0.00%    2972    2972      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=teensy36            examples/blinky1
   6524    6524      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=p1am-100            examples/blinky1
   7028    7028      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=atsame54-xpro       examples/blinky1
  58388   58388      0   0.00%   13092   13092      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=atsame54-xpro       examples/can
   7028    7028      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-m4-can      examples/blinky1
  59940   59940      0   0.00%   14500   14500      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-m4-can      examples/caninterrupt
   6520    6520      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-nano33      examples/blinky1
   6520    6520      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-mkrwifi1010 examples/blinky1
   7980    7980      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pico                examples/blinky1
   7904    7904      0   0.00%    6544    6544      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nano-33-ble         examples/blinky1
   7992    7992      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nano-rp2040         examples/blinky1
   7988    7988      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-rp2040          examples/blinky1
   8276    8276      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=qtpy-rp2040         examples/echo
   8272    8272      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=kb2040              examples/echo
   7988    7988      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=macropad-rp2040         examples/blinky1
   7984    7984      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=badger2040          examples/blinky1
   7984    7984      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=tufty2040           examples/blinky1
   7992    7992      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=thingplus-rp2040    examples/blinky1
   7980    7980      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=xiao-rp2040         examples/blinky1
   8276    8276      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=waveshare-rp2040-zero examples/echo
   7992    7992      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=challenger-rp2040    examples/blinky1
  60104   60104      0   0.00%    4688    4688      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=trinkey-qt2040      examples/temp
   7984    7984      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=gopher-badge      examples/blinky1
   8280    8280      0   0.00%    3260    3260      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=ae-rp2040           examples/echo
   8316    8316      0   0.00%    4732    4732      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
   8064    8064      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=itsybitsy-m4        examples/pwm
   8064    8064      0   0.00%    6780    6780      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-m4          examples/pwm
  10708   10708      0   0.00%    5876    5876      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-nrf52840    examples/hid-keyboard
   9596    9596      0   0.00%    6104    6104      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=circuitplay-express examples/hid-keyboard
   9032    9032      0   0.00%    5156    5156      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-nrf52840    examples/usb-midi
   6348    6348      0   0.00%    3304    3304      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=bluepill            examples/blinky1
   7440    7440      0   0.00%    6132    6132      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=feather-stm32f405   examples/blinky1
   6584    6584      0   0.00%    3084    3084      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=lgt92               examples/blinky1
   6348    6348      0   0.00%    3304    3304      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-f103rb       examples/blinky1
   7580    7580      0   0.00%    6136    6136      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-f722ze       examples/blinky1
   6492    6492      0   0.00%    3016    3016      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-l031k6       examples/blinky1
   6668    6668      0   0.00%    5204    5204      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-l432kc       examples/blinky1
   7312    7312      0   0.00%    5784    5784      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-l552ze       examples/blinky1
   6628    6628      0   0.00%    4872    4872      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=nucleo-wl55jc       examples/blinky1
   7520    7520      0   0.00%    6136    6136      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=stm32f4disco        examples/blinky1
   7736    7736      0   0.00%    6140    6140      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=stm32f4disco        examples/blinky2
   7520    7520      0   0.00%    6136    6136      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=stm32f4disco-1      examples/blinky1
   8904    8904      0   0.00%    6144    6144      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=stm32f4disco-1      examples/pwm
   7528    7528      0   0.00%    6136    6136      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=stm32f469disco      examples/blinky1
   6508    6508      0   0.00%    4872    4872      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=lorae5              examples/blinky1
   6660    6660      0   0.00%    5204    5204      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=swan                examples/blinky1
   1020    1020      0   0.00%     652     556    -96 -14.72% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=atmega1284p         examples/serial
    832     832      0   0.00%     652     556    -96 -14.72% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino             examples/blinky1
    800     800      0   0.00%     522     522      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-leonardo    examples/blinky1
   4949    4949      0   0.00%     977     881    -96  -9.83% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino             examples/pwm
   4559    4559      0   0.00%     699     603    -96 -13.73% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino -scheduler=tasks  examples/blinky1
    960     960      0   0.00%     652     556    -96 -14.72% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-mega1280    examples/blinky1
   4129    4129      0   0.00%     652     556    -96 -14.72% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-mega1280    examples/pwm
    832     832      0   0.00%     652     556    -96 -14.72% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=arduino-nano        examples/blinky1
    506     506      0   0.00%       5       5      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=attiny1616          examples/empty
    624     624      0   0.00%     138     138      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=digispark           examples/blinky1
    528     528      0   0.00%     136     136      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=digispark -gc=leaking examples/blinky1
   5212    5212      0   0.00%    9618    9618      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.bin -target=esp32c3             examples/serial
   5212    5212      0   0.00%    9618    9618      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.bin -target=esp32c3-12f         examples/serial
   4626    4626      0   0.00%    9434    9434      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.bin -target=m5stamp-c3          examples/serial
   5212    5212      0   0.00%    9618    9618      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.bin -target=xiao-esp32c3        examples/serial
   4388    4388      0   0.00%    2252    2252      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=hifive1b            examples/blinky1
   1872    1872      0   0.00%     160     160      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=maixbit             examples/blinky1
   2320    2320      0   0.00%    2192    2192      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040 -gc=none -scheduler=none examples/blinky1
  11560   11560      0   0.00%    2264    2264      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040 -opt=1     examples/blinky1
   2692    2692      0   0.00%    2128    2128      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040 -serial=none examples/echo
 129260  129260      0   0.00%   23856   23856      0   0.00% /Users/yursol/go/bin/tinygo build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go
  32956   32956      0   0.00%    1732    1732      0   0.00% GOOS=linux GOARCH=arm /Users/yursol/go/bin/tinygo build -size short -o test.elf       ./testdata/cgo
  27411   27411      0   0.00%     512     512      0   0.00% GOOS=windows GOARCH=amd64 /Users/yursol/go/bin/tinygo build -size short -o test.exe   ./testdata/cgo
  25070   25070      0   0.00%    1024    1024      0   0.00% GOOS=windows GOARCH=arm64 /Users/yursol/go/bin/tinygo build -size short -o test.exe   ./testdata/cgo
  15815   15815      0   0.00%     257     257      0   0.00% GOOS=darwin GOARCH=amd64 /Users/yursol/go/bin/tinygo build  -size short -o test       ./testdata/cgo
  13362   13362      0   0.00%     248     248      0   0.00% GOOS=darwin GOARCH=arm64 /Users/yursol/go/bin/tinygo build  -size short -o test       ./testdata/cgo
1565551 1565551      0   0.00%  645854  645182   -672  -0.01%
```