### PR TITLE
lib/cmsis-svd: change to new repo location for the SVD files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/avr-rust/avr-mcu.git
 [submodule "lib/cmsis-svd"]
 	path = lib/cmsis-svd
-	url = https://github.com/cmsis-svd/cmsis-svd.git
+	url = https://github.com/cmsis-svd/cmsis-svd-data.git
 	branch = main
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc


### PR DESCRIPTION
The location for the repo with the SVD files has now changed to https://github.com/cmsis-svd/cmsis-svd-data