### PR TITLE
runtime: stub out Breakpoint() function

### DIFF
--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -18,3 +18,8 @@ func NumCgoCall() int {
 func NumGoroutine() int {
 	return 1
 }
+
+// Stub for Breakpoint, does not do anything.
+func Breakpoint() {
+	panic("Breakpoint not supported")
+}


### PR DESCRIPTION
This PR stubs out `runtime.Breakpoint()` just to help more code compile.