### PR TITLE
machine/serial, rp2040: add support for hardware flow control

### DIFF
--- a/src/machine/machine_rp2040_uart.go
+++ b/src/machine/machine_rp2040_uart.go
@@ -36,9 +36,18 @@ func (uart *UART) Configure(config UARTConfig) error {
 	uart.SetFormat(8, 1, ParityNone)
 
 	// Enable the UART, both TX and RX
-	uart.Bus.UARTCR.SetBits(rp.UART0_UARTCR_UARTEN |
+	settings := uint32(rp.UART0_UARTCR_UARTEN |
 		rp.UART0_UARTCR_RXE |
 		rp.UART0_UARTCR_TXE)
+
+	if config.RTS != 0 {
+		settings |= rp.UART0_UARTCR_RTSEN
+	}
+	if config.CTS != 0 {
+		settings |= rp.UART0_UARTCR_CTSEN
+	}
+
+	uart.Bus.UARTCR.SetBits(settings)
 
 	// set GPIO mux to UART for the pins
 	if config.TX != NoPin {
@@ -46,6 +55,12 @@ func (uart *UART) Configure(config UARTConfig) error {
 	}
 	if config.RX != NoPin {
 		config.RX.Configure(PinConfig{Mode: PinUART})
+	}
+	if config.RTS != 0 {
+		config.RTS.Configure(PinConfig{Mode: PinOutput})
+	}
+	if config.CTS != 0 {
+		config.CTS.Configure(PinConfig{Mode: PinInput})
 	}
 
 	// Enable RX IRQ.

--- a/src/machine/serial.go
+++ b/src/machine/serial.go
@@ -11,6 +11,8 @@ type UARTConfig struct {
 	BaudRate uint32
 	TX       Pin
 	RX       Pin
+	RTS      Pin
+	CTS      Pin
 }
 
 // NullSerial is a serial version of /dev/null (or null router): it drops


### PR DESCRIPTION
This PR extends the `machine` package serial implementation for the rp2040 to add support for hardware flow control.