### PR TITLE
machine/nano-rp2040: add UART1 and correct mappings for NINA via UART.

### DIFF
--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -87,8 +87,10 @@ const (
 	NINA_GPIO0  Pin = GPIO2
 	NINA_RESETN Pin = GPIO3
 
-	NINA_TX Pin = GPIO9
-	NINA_RX Pin = GPIO8
+	NINA_TX  Pin = GPIO8
+	NINA_RX  Pin = GPIO9
+	NINA_CTS Pin = GPIO10
+	NINA_RTS Pin = GPIO11
 )
 
 // Onboard crystal oscillator frequency, in MHz.
@@ -123,10 +125,17 @@ var (
 		Buffer: NewRingBuffer(),
 		Bus:    rp.UART0,
 	}
+
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
 )
 
 var DefaultUART = UART0
 
 func init() {
 	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
 }


### PR DESCRIPTION
This PR adds ad corrects the `machine` package nano-rp2040 implementation to add UART1 and also correct mappings for controlling the NINA chip via UART.