### PR TITLE
expose UART4 on wioterminal board

### DIFF
--- a/src/machine/board_wioterminal.go
+++ b/src/machine/board_wioterminal.go
@@ -353,6 +353,9 @@ var (
 
 	// RTL8720D (tx: PB24, rx: PC24)
 	UART3 = &sercomUSART0
+
+	// Right-hand grove port (tx: D0, rx: D1)
+	UART4 = &sercomUSART4
 )
 
 // I2C pins


### PR DESCRIPTION
The right-hand grove port on the wioterminal can be used as UART, using D0/D1 pins.  The pins D0/D1 are tied to SERCOM4, so this patch exposes a UART4 for sercom4 access.

  RX = A0/D0 = PB08/SERCOM4.0 (port 4 pad 0)
  TX = A1/D1 = PB09/SERCOM4.1 (port 4 pad 1)

Tested with Lora E5 UART.

  uart : = machine.UART4
  tx := machine.D0
  rx := machine.D1

Note: must also cross Tx/Rx wires in grove cable.  See https://www.lucadentella.it/en/2022/01/29/wio-terminal-porta-grove-di-destra-e-moduli-uart/