### PR TITLE
targets: add ninafw tag to nano-rp2040 for ninafw BLE support

### DIFF
--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -3,7 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2341:005e"],
-    "build-tags": ["nano_rp2040"],
+    "build-tags": ["nano_rp2040", "ninafw", "ninafw_reset_inverse"],
     "ldflags": [
         "--defsym=__flash_size=16M"
     ],


### PR DESCRIPTION
This PR adds the `ninafw` tag to the `nano-rp2040` target for ninafw BLE support in https://github.com/tinygo-org/bluetooth/pull/207