### PR TITLE
machine, targets: ninafw support for arduino-nano33 and nano-rp2040

### DIFF
--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -63,6 +63,9 @@ var UART1 = &sercomUSART3
 // UART2 on the Arduino Nano 33 connects to the normal TX/RX pins.
 var UART2 = &sercomUSART5
 
+// UART_NINA on the Arduino Nano 33 connects to the NINA HCI.
+var UART_NINA = &sercomUSART2
+
 // I2C pins
 const (
 	SDA_PIN Pin = A4 // SDA: SERCOM4/PAD[1]
@@ -99,8 +102,16 @@ const (
 	NINA_GPIO0  Pin = PA27
 	NINA_RESETN Pin = PA08
 	NINA_ACK    Pin = PA28
-	NINA_TX     Pin = PA22
-	NINA_RX     Pin = PA23
+	NINA_TX     Pin = PA12
+	NINA_RX     Pin = PA13
+	NINA_RTS    Pin = PA14
+	NINA_CTS    Pin = PA15
+)
+
+// NINA-W102 settings
+const (
+	NINA_BAUDRATE       = 912600
+	NINA_RESET_INVERTED = true
 )
 
 // I2S pins

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -93,6 +93,12 @@ const (
 	NINA_RTS Pin = GPIO11
 )
 
+// NINA-W102 settings
+const (
+	NINA_BAUDRATE       = 115200
+	NINA_RESET_INVERTED = true
+)
+
 // Onboard crystal oscillator frequency, in MHz.
 const (
 	xoscFreq = 12 // MHz
@@ -131,6 +137,9 @@ var (
 		Buffer: NewRingBuffer(),
 		Bus:    rp.UART1,
 	}
+
+	// UART_NINA on the Arduino Nano RP2040 connects to the NINA HCI.
+	UART_NINA = UART1
 )
 
 var DefaultUART = UART0

--- a/targets/arduino-nano33.json
+++ b/targets/arduino-nano33.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
-    "build-tags": ["arduino_nano33"],
+    "build-tags": ["arduino_nano33", "ninafw"],
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",
     "serial-port": ["2341:8057", "2341:0057"],
     "flash-1200-bps-reset": "true"

--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -3,7 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2341:005e"],
-    "build-tags": ["nano_rp2040", "ninafw", "ninafw_reset_inverse"],
+    "build-tags": ["nano_rp2040", "ninafw"],
     "ldflags": [
         "--defsym=__flash_size=16M"
     ],


### PR DESCRIPTION
This PR adds ninafw pins and tags needed to support the `arduino-nano33` and `nano-rp2040` boards.