### PR TITLE
Use LLVM 17 by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,5 +128,5 @@ workflows:
       - test-llvm15-go118
       # This tests the upcoming Go 1.22 support.
       - test-llvm16-go122
-      # This tests the upcoming LLVM 17 support.
+      # This tests LLVM 17 support when linking against system libraries.
       - test-llvm17-go121

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -142,8 +142,8 @@ jobs:
       - name: Check binary
         run: tinygo version
       - name: Build TinyGo (default LLVM)
-        if: matrix.version == 16
+        if: matrix.version == 17
         run: go install
       - name: Check binary
-        if: matrix.version == 16
+        if: matrix.version == 17
         run: tinygo version

--- a/.github/workflows/sizediff-install-pkgs.sh
+++ b/.github/workflows/sizediff-install-pkgs.sh
@@ -2,11 +2,11 @@
 # still works after checking out the dev branch (that is, when going from LLVM
 # 16 to LLVM 17 for example, both Clang 16 and Clang 17 are installed).
 
-echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main' | sudo tee /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install --no-install-recommends -y \
-    llvm-16-dev \
-    clang-16 \
-    libclang-16-dev \
-    lld-16
+    llvm-17-dev \
+    clang-17 \
+    libclang-17-dev \
+    lld-17

--- a/.github/workflows/sizediff-install-pkgs.sh
+++ b/.github/workflows/sizediff-install-pkgs.sh
@@ -1,0 +1,12 @@
+# Command that's part of sizediff.yml. This is put in a separate file so that it
+# still works after checking out the dev branch (that is, when going from LLVM
+# 16 to LLVM 17 for example, both Clang 16 and Clang 17 are installed).
+
+echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install --no-install-recommends -y \
+    llvm-16-dev \
+    clang-16 \
+    libclang-16-dev \
+    lld-16

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -23,15 +23,7 @@ jobs:
           fetch-depth: 0 # fetch all history (no sparse checkout)
           submodules: true
       - name: Install apt dependencies
-        run: |
-          echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' | sudo tee /etc/apt/sources.list.d/llvm.list
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-              llvm-16-dev \
-              clang-16 \
-              libclang-16-dev \
-              lld-16
+        run: ./.github/workflows/sizediff-install-pkgs.sh
       - name: Restore LLVM source cache
         uses: actions/cache@v3
         id: cache-llvm-source
@@ -66,6 +58,9 @@ jobs:
         run: |
           git reset --hard origin/dev
           git checkout --no-recurse-submodules `git merge-base HEAD origin/dev`
+      - name: Install apt dependencies on the dev branch
+        # this is only needed on a PR that changes the LLVM version
+        run: ./.github/workflows/sizediff-install-pkgs.sh
       - name: Build tinygo binary for the dev branch
         run: go install
       - name: Determine binary sizes on the dev branch

--- a/cgo/libclang_config_llvm16.go
+++ b/cgo/libclang_config_llvm16.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && !llvm15 && !llvm17
+//go:build !byollvm && llvm16
 
 package cgo
 

--- a/cgo/libclang_config_llvm17.go
+++ b/cgo/libclang_config_llvm17.go
@@ -1,4 +1,4 @@
-//go:build !byollvm && llvm17
+//go:build !byollvm && !llvm15 && !llvm16
 
 package cgo
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,11 +49,11 @@
           buildInputs = [
             # These dependencies are required for building tinygo (go install).
             go
-            llvmPackages_16.llvm
-            llvmPackages_16.libclang
+            llvmPackages_17.llvm
+            llvmPackages_17.libclang
             # Additional dependencies needed at runtime, for building and/or
             # flashing.
-            llvmPackages_16.lld
+            llvmPackages_17.lld
             avrdude
             binaryen
             # Additional dependencies needed for on-chip debugging.
@@ -68,7 +68,7 @@
             # Without setting these explicitly, Homebrew versions might be used
             # or the default `ar` and `nm` tools might be used (which don't
             # support wasi).
-            export CLANG="clang-16 -resource-dir ${llvmPackages_16.clang.cc.lib}/lib/clang/16"
+            export CLANG="clang-17 -resource-dir ${llvmPackages_17.clang.cc.lib}/lib/clang/17"
             export LLVM_AR=llvm-ar
             export LLVM_NM=llvm-nm
 
@@ -77,7 +77,7 @@
             export MD5SUM=md5sum
 
             # Ugly hack to make the Clang resources directory available.
-            export GOFLAGS="\"-ldflags=-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${llvmPackages_16.clang.cc.lib}/lib/clang/16"\"
+            export GOFLAGS="\"-ldflags=-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${llvmPackages_17.clang.cc.lib}/lib/clang/17"\"
           '';
         };
       }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	golang.org/x/sys v0.16.0
 	golang.org/x/tools v0.17.0
 	gopkg.in/yaml.v2 v2.4.0
-	tinygo.org/x/go-llvm v0.0.0-20231014233752-75a8a9fe6f74
+	tinygo.org/x/go-llvm v0.0.0-20240106122909-c2c543540318
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -69,5 +69,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-tinygo.org/x/go-llvm v0.0.0-20231014233752-75a8a9fe6f74 h1:tW8XhLI9gUZLL+2pG0HYb5dc6bpMj1aqtESpizXPnMY=
-tinygo.org/x/go-llvm v0.0.0-20231014233752-75a8a9fe6f74/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20240106122909-c2c543540318 h1:4KjZvPtcN1UwobevcGbdzeinx0L1i8HDdJu84bu7NI8=
+tinygo.org/x/go-llvm v0.0.0-20240106122909-c2c543540318/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
This switches the `go install` command on Linux and macOS to use LLVM 17 by default, instead of LLVM 16. These versions have been out a long time, so it's about time we switched the default.