### PR TITLE
machine/pyportal: add needed values to board file for ninafw BLE support

### DIFF
--- a/src/machine/board_arduino_nano33.go
+++ b/src/machine/board_arduino_nano33.go
@@ -110,8 +110,9 @@ const (
 
 // NINA-W102 settings
 const (
-	NINA_BAUDRATE       = 912600
-	NINA_RESET_INVERTED = true
+	NINA_BAUDRATE         = 912600
+	NINA_RESET_INVERTED   = true
+	NINA_SOFT_FLOWCONTROL = false
 )
 
 // I2S pins

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -95,8 +95,9 @@ const (
 
 // NINA-W102 settings
 const (
-	NINA_BAUDRATE       = 115200
-	NINA_RESET_INVERTED = true
+	NINA_BAUDRATE         = 115200
+	NINA_RESET_INVERTED   = true
+	NINA_SOFT_FLOWCONTROL = false
 )
 
 // Onboard crystal oscillator frequency, in MHz.

--- a/src/machine/board_pyportal.go
+++ b/src/machine/board_pyportal.go
@@ -53,9 +53,12 @@ const (
 	NINA_GPIO0  = D6
 	NINA_RESETN = D7
 
+	// pins used for the ESP32 connection do not allow hardware
+	// flow control, which is required. have to emulate with software.
 	NINA_TX  = D1
 	NINA_RX  = D0
-	NINA_RTS = D51
+	NINA_CTS = NINA_ACK
+	NINA_RTS = NINA_GPIO0
 
 	LCD_DATA0 = D34
 
@@ -111,6 +114,15 @@ var (
 	UART1 = &sercomUSART4
 
 	DefaultUART = UART1
+
+	UART_NINA = UART1
+)
+
+// NINA-W102 settings
+const (
+	NINA_BAUDRATE         = 115200
+	NINA_RESET_INVERTED   = true
+	NINA_SOFT_FLOWCONTROL = true
 )
 
 // I2C pins

--- a/targets/pyportal.json
+++ b/targets/pyportal.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd51j20a"],
-    "build-tags": ["pyportal"],
+    "build-tags": ["pyportal", "ninafw"],
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",


### PR DESCRIPTION
This PR adds needed values to the `machine` package board file for the Adafruit `PyPortal` for ninafw BLE support.