### PR TITLE
machine/samd51: add UART hardware flow control support

### DIFF
--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1015,14 +1015,14 @@ func (uart *UART) Configure(config UARTConfig) error {
 	if !ok {
 		return ErrInvalidOutputPin
 	}
-	var txPinOut uint32
+	var txPadOut uint32
 	// See CTRLA.RXPO bits of the SERCOM USART peripheral (page 945-946) for how
 	// pads are mapped to pinout values.
 	switch txPad {
 	case 0:
-		txPinOut = 0
+		txPadOut = 0
 	default:
-		// TODO: flow control (RTS/CTS)
+		// should be flow control (RTS/CTS) pin
 		return ErrInvalidOutputPin
 	}
 
@@ -1033,11 +1033,31 @@ func (uart *UART) Configure(config UARTConfig) error {
 	}
 	// As you can see in the CTRLA.RXPO bits of the SERCOM USART peripheral
 	// (page 945), input pins are mapped directly.
-	rxPinOut := rxPad
+	rxPadOut := rxPad
 
 	// configure pins
 	config.TX.Configure(PinConfig{Mode: txPinMode})
 	config.RX.Configure(PinConfig{Mode: rxPinMode})
+
+	// configure RTS/CTS pins if provided
+	if config.RTS != 0 && config.CTS != 0 {
+		rtsPinMode, _, ok := findPinPadMapping(uart.SERCOM, config.RTS)
+		if !ok {
+			return ErrInvalidOutputPin
+		}
+
+		ctsPinMode, _, ok := findPinPadMapping(uart.SERCOM, config.CTS)
+		if !ok {
+			return ErrInvalidInputPin
+		}
+
+		// See CTRLA.RXPO bits of the SERCOM USART peripheral (page 945-946) for how
+		// pads are mapped to pinout values.
+		txPadOut = 2
+
+		config.RTS.Configure(PinConfig{Mode: rtsPinMode})
+		config.CTS.Configure(PinConfig{Mode: ctsPinMode})
+	}
 
 	// reset SERCOM
 	uart.Bus.CTRLA.SetBits(sam.SERCOM_USART_INT_CTRLA_SWRST)
@@ -1075,8 +1095,8 @@ func (uart *UART) Configure(config UARTConfig) error {
 	// set UART pads. This is not same as pins...
 	//  SERCOM_USART_CTRLA_TXPO(txPad) |
 	//   SERCOM_USART_CTRLA_RXPO(rxPad);
-	uart.Bus.CTRLA.SetBits((txPinOut << sam.SERCOM_USART_INT_CTRLA_TXPO_Pos) |
-		(rxPinOut << sam.SERCOM_USART_INT_CTRLA_RXPO_Pos))
+	uart.Bus.CTRLA.SetBits((txPadOut << sam.SERCOM_USART_INT_CTRLA_TXPO_Pos) |
+		(rxPadOut << sam.SERCOM_USART_INT_CTRLA_RXPO_Pos))
 
 	// Enable Transceiver and Receiver
 	//sercom->USART.CTRLB.reg |= SERCOM_USART_CTRLB_TXEN | SERCOM_USART_CTRLB_RXEN ;


### PR DESCRIPTION
This PR extends the `machine/samd51` package to add UART hardware flow control support.