### PR TITLE
build: use llvm-17 base image correctly for faster docker dev builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,21 +54,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push LLVM base image
-        uses: docker/build-push-action@v5
-        with:
-          target: tinygo-llvm-build
-          context: .
-          push: true
-          tags: |
-            tinygo/llvm-17
-            tinygo/llvm-17:latest
-            ghcr.io/tinygo-org/llvm-17
-            ghcr.io/tinygo-org/llvm-17:latest
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Build and push tinygo-dev image
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -35,8 +35,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            tinygo/llvm-16
-            ghcr.io/${{ github.repository_owner }}/llvm-16
+            tinygo/llvm-17
+            ghcr.io/${{ github.repository_owner }}/llvm-17
           tags: |
             type=sha,format=long
             type=raw,value=latest


### PR DESCRIPTION
This PR corrects the GH actions docker builds to use the caches from the separate `llvm` and `docker` builds correctly.

A change to the major version of LLVM needs to be pushed to the `build-llvm-image` branch, which I have now done for `llvm-17`. This PR picks up that change, and also corrects the slowness I introduced myself with some other recent build changes.