### PR TITLE
targets: add ninafw pins and settings to additional boards

### DIFF
--- a/src/machine/board_metro-m4-airlift.go
+++ b/src/machine/board_metro-m4-airlift.go
@@ -62,6 +62,15 @@ var (
 	UART2 = &sercomUSART0
 
 	DefaultUART = UART1
+
+	UART_NINA = UART2
+)
+
+// NINA-W102 settings
+const (
+	NINA_BAUDRATE         = 115200
+	NINA_RESET_INVERTED   = true
+	NINA_SOFT_FLOWCONTROL = true
 )
 
 const (
@@ -70,9 +79,12 @@ const (
 	NINA_GPIO0  = PB01
 	NINA_RESETN = PB05
 
+	// pins used for the ESP32 connection do not allow hardware
+	// flow control, which is required. have to emulate with software.
 	NINA_TX  = PA04
 	NINA_RX  = PA07
-	NINA_RTS = PB23
+	NINA_CTS = NINA_ACK
+	NINA_RTS = NINA_GPIO0
 )
 
 // I2C pins

--- a/src/machine/board_pybadge.go
+++ b/src/machine/board_pybadge.go
@@ -130,3 +130,33 @@ var (
 	usb_VID uint16 = 0x239A
 	usb_PID uint16 = 0x8033
 )
+
+// NINA-W102 settings when using AirLift WiFi FeatherWing
+const (
+	NINA_BAUDRATE         = 115200
+	NINA_RESET_INVERTED   = true
+	NINA_SOFT_FLOWCONTROL = true
+)
+
+const (
+	NINA_CS     = D13
+	NINA_ACK    = D11
+	NINA_GPIO0  = D10
+	NINA_RESETN = D12
+
+	// pins used for the ESP32 connection do not allow hardware
+	// flow control, which is required. have to emulate with software.
+	NINA_TX  = UART_TX_PIN
+	NINA_RX  = UART_RX_PIN
+	NINA_CTS = NINA_ACK
+	NINA_RTS = NINA_GPIO0
+
+	NINA_SDO = SPI0_SDO_PIN
+	NINA_SDI = SPI0_SDI_PIN
+	NINA_SCK = SPI0_SCK_PIN
+)
+
+var (
+	NINA_SPI  = SPI0
+	UART_NINA = UART1
+)

--- a/targets/arduino-mkrwifi1010.json
+++ b/targets/arduino-mkrwifi1010.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd21g18a"],
-    "build-tags": ["arduino_mkrwifi1010"],
+    "build-tags": ["arduino_mkrwifi1010", "ninafw"],
     "serial": "usb",
     "serial-port": ["2341:8054", "2341:0054"],
     "flash-command": "bossac -i -e -w -v -R -U --port={port} --offset=0x2000 {bin}",

--- a/targets/matrixportal-m4.json
+++ b/targets/matrixportal-m4.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd51j19a"],
-    "build-tags": ["matrixportal_m4"],
+    "build-tags": ["matrixportal_m4", "ninafw"],
     "serial": "usb",
     "serial-port": ["239a:80c9", "239a:80ca"],
     "flash-1200-bps-reset": "true",

--- a/targets/metro-m4-airlift.json
+++ b/targets/metro-m4-airlift.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd51j19a"],
-    "build-tags": ["metro_m4_airlift"],
+    "build-tags": ["metro_m4_airlift", "ninafw"],
     "serial": "usb",
     "serial-port": ["239A:8037"],
     "flash-1200-bps-reset": "true",

--- a/targets/pybadge.json
+++ b/targets/pybadge.json
@@ -1,6 +1,6 @@
 {
     "inherits": ["atsamd51j19a"],
-    "build-tags": ["pybadge"],
+    "build-tags": ["pybadge", "ninafw"],
     "serial": "usb",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",


### PR DESCRIPTION
This PR adds the `ninafw` pins and settings to the Adafruit Metro M4 Airlift board definition and target.

UPDATE: I have also added the mapping for the PyBadge when using AirLift FeatherWing in a separate commit. Lastly I have added a third commit that adds the `ninafw` tag to a couple of other boards. This will help simplify the maintenance of the `drivers` repo.