### PR TITLE
loader: make sure Go version is plumbed through

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	GOOS            string // environment variable
 	GOARCH          string // environment variable
 	GOARM           string // environment variable (only used with GOARCH=arm)
+	Directory       string // working dir, leave it unset to use the current working dir
 	Target          string
 	Opt             string
 	GC              string
@@ -48,7 +49,6 @@ type Options struct {
 	Programmer      string
 	OpenOCDCommands []string
 	LLVMFeatures    string
-	Directory       string
 	PrintJSON       bool
 	Monitor         bool
 	BaudRate        int

--- a/loader/loader_go122.go
+++ b/loader/loader_go122.go
@@ -1,0 +1,17 @@
+//go:build go1.22
+
+// types.Info.FileVersions was added in Go 1.22, so we can only initialize it
+// when built with Go 1.22.
+
+package loader
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func init() {
+	initFileVersions = func(info *types.Info) {
+		info.FileVersions = make(map[*ast.File]string)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -69,6 +69,7 @@ func TestBuild(t *testing.T) {
 		"json.go",
 		"map.go",
 		"math.go",
+		"oldgo/",
 		"print.go",
 		"reflect.go",
 		"slice.go",
@@ -91,7 +92,7 @@ func TestBuild(t *testing.T) {
 		tests = append(tests, "go1.21.go")
 	}
 	if minor >= 22 {
-		tests = append(tests, "go1.22.go")
+		tests = append(tests, "go1.22/")
 	}
 
 	if *testTarget != "" {
@@ -336,8 +337,11 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 	path := TESTDATA + "/" + name
 	// Get the expected output for this test.
 	txtpath := path[:len(path)-3] + ".txt"
+	pkgName := "./" + path
 	if path[len(path)-1] == '/' {
 		txtpath = path + "out.txt"
+		options.Directory = path
+		pkgName = "."
 	}
 	expected, err := os.ReadFile(txtpath)
 	if err != nil {
@@ -351,7 +355,7 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 
 	// Build the test binary.
 	stdout := &bytes.Buffer{}
-	_, err = buildAndRun("./"+path, config, stdout, cmdArgs, environmentVars, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+	_, err = buildAndRun(pkgName, config, stdout, cmdArgs, environmentVars, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
 		return cmd.Run()
 	})
 	if err != nil {

--- a/testdata/go1.22/go.mod
+++ b/testdata/go1.22/go.mod
@@ -1,0 +1,3 @@
+module github.com/tinygo-org/tinygo/testdata/go1.22
+
+go 1.22

--- a/testdata/go1.22/main.go
+++ b/testdata/go1.22/main.go
@@ -19,15 +19,13 @@ func testLoopVar() {
 			f = func() int { return i }
 		}
 	}
-	// Prints 1 in Go 1.21, or 0 in Go 1.22.
-	// TODO: this still prints Go 1.21 even in Go 1.22. We probably need to
-	// specify the Go version somewhere.
+	// Variable n is 1 in Go 1.21, or 0 in Go 1.22.
 	n := f()
 	if n == 0 {
-		println("behaves like Go 1.22")
+		println("loops behave like Go 1.22")
 	} else if n == 1 {
-		println("behaves like Go 1.21")
+		println("loops behave like Go 1.21")
 	} else {
-		println("unknown behavior")
+		println("unknown loop behavior")
 	}
 }

--- a/testdata/go1.22/out.txt
+++ b/testdata/go1.22/out.txt
@@ -9,4 +9,4 @@
 2
 1
 go1.22 has lift-off!
-behaves like Go 1.21
+loops behave like Go 1.22

--- a/testdata/oldgo/go.mod
+++ b/testdata/oldgo/go.mod
@@ -1,0 +1,5 @@
+module github.com/tinygo-org/tinygo/testdata/oldgo
+
+// Go version doesn't matter much, as long as it's old.
+
+go 1.15

--- a/testdata/oldgo/main.go
+++ b/testdata/oldgo/main.go
@@ -1,0 +1,26 @@
+package main
+
+// This package verifies that the Go language version is correctly picked up
+// from the go.mod file.
+
+func main() {
+	testLoopVar()
+}
+
+func testLoopVar() {
+	var f func() int
+	for i := 0; i < 1; i++ {
+		if i == 0 {
+			f = func() int { return i }
+		}
+	}
+	// Variable n is 1 in Go 1.21, or 0 in Go 1.22.
+	n := f()
+	if n == 0 {
+		println("loops behave like Go 1.22")
+	} else if n == 1 {
+		println("loops behave like Go 1.21")
+	} else {
+		println("unknown loop behavior")
+	}
+}

--- a/testdata/oldgo/out.txt
+++ b/testdata/oldgo/out.txt
@@ -1,0 +1,1 @@
+loops behave like Go 1.21


### PR DESCRIPTION
This fixes the new loop variable behavior in Go 1.22.

Specifically:
  * The compiler (actually, the x/tools/go/ssa package) now correctly picks up the Go version.
  * If a module doesn't specify the Go version, the current Go version (from the `go` tool and standard library) is used. This fixes `go run`. As a side effect, this also fixes the Go version of the standard library (though for that we should really copy the go.mod file from the standard library).
  * The tests in testdata/ that use a separate directory are now actually run in that directory. This makes it possible to use a go.mod file there.
  * There is a test to make sure old Go modules still work with the old Go behavior, even on a newer Go version.