### PR TITLE
reflect: update to Go 1.22 semantics

### DIFF
--- a/src/reflect/benchmark_test.go
+++ b/src/reflect/benchmark_test.go
@@ -1,0 +1,10 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reflect_test
+
+type S struct {
+	i1 int64
+	i2 int64
+}

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -124,10 +124,9 @@ func (v Value) IsZero() bool {
 	case Uint, Uint8, Uint16, Uint32, Uint64, Uintptr:
 		return v.Uint() == 0
 	case Float32, Float64:
-		return math.Float64bits(v.Float()) == 0
+		return v.Float() == 0
 	case Complex64, Complex128:
-		c := v.Complex()
-		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
+		return v.Complex() == 0
 	case Array:
 		for i := 0; i < v.Len(); i++ {
 			if !v.Index(i).IsZero() {
@@ -141,7 +140,7 @@ func (v Value) IsZero() bool {
 		return v.Len() == 0
 	case Struct:
 		for i := 0; i < v.NumField(); i++ {
-			if !v.Field(i).IsZero() {
+			if !v.Field(i).IsZero() && v.Type().Field(i).Name != "_" {
 				return false
 			}
 		}


### PR DESCRIPTION
The IsZero function was changed slightly in Go 1.22, so we'll need to update it.

While this could in theory break existing programs that rely on the old behavior, they'd also break with the imminent Go 1.22 release so I don't think this is a real problem.