### PR TITLE
all: make TinyGo code usable with "big Go" CGo

### DIFF
--- a/src/internal/task/task_stack_arm.S
+++ b/src/internal/task/task_stack_arm.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 // Only generate .debug_frame, don't generate .eh_frame.
 .cfi_sections .debug_frame
 

--- a/src/internal/task/task_stack_avr.S
+++ b/src/internal/task/task_stack_avr.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 .section .bss.tinygo_systemStack
 .global tinygo_systemStack
 .type   tinygo_systemStack, %object

--- a/src/internal/task/task_stack_cortexm.S
+++ b/src/internal/task/task_stack_cortexm.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 // Only generate .debug_frame, don't generate .eh_frame.
 .cfi_sections .debug_frame
 

--- a/src/internal/task/task_stack_cortexm.go
+++ b/src/internal/task/task_stack_cortexm.go
@@ -52,17 +52,17 @@ func (s *state) archInit(r *calleeSavedRegs, fn uintptr, args unsafe.Pointer) {
 }
 
 func (s *state) resume() {
-	switchToTask(s.sp)
+	tinygo_switchToTask(s.sp)
 }
 
 //export tinygo_switchToTask
-func switchToTask(uintptr)
+func tinygo_switchToTask(uintptr)
 
 //export tinygo_switchToScheduler
-func switchToScheduler(*uintptr)
+func tinygo_switchToScheduler(*uintptr)
 
 func (s *state) pause() {
-	switchToScheduler(&s.sp)
+	tinygo_switchToScheduler(&s.sp)
 }
 
 // SystemStack returns the system stack pointer. On Cortex-M, it is always

--- a/src/internal/task/task_stack_esp32.S
+++ b/src/internal/task/task_stack_esp32.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 .section .text.tinygo_startTask,"ax",@progbits
 .global  tinygo_startTask
 .type    tinygo_startTask, %function

--- a/src/internal/task/task_stack_esp8266.S
+++ b/src/internal/task/task_stack_esp8266.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 .section .text.tinygo_startTask,"ax",@progbits
 .global  tinygo_startTask
 .type    tinygo_startTask, %function

--- a/src/internal/task/task_stack_tinygoriscv.S
+++ b/src/internal/task/task_stack_tinygoriscv.S
@@ -1,3 +1,5 @@
+//go:build tinygo
+
 .section .text.tinygo_startTask
 .global  tinygo_startTask
 .type    tinygo_startTask, %function

--- a/src/machine/machine_rp2040_rom.go
+++ b/src/machine/machine_rp2040_rom.go
@@ -1,4 +1,4 @@
-//go:build rp2040
+//go:build tinygo && rp2040
 
 package machine
 


### PR DESCRIPTION
I managed to get CGo sort-of working in VSCode (meaning that it will typecheck code in the IDE itself) using a few crude hacks, but it requires a few minor changes to the TinyGo standard library.

I intend to eventually add this support in the TinyGo extension for VSCode directly, but for now I've manually updated .vscode/settings.json to get IDE support. In any case, it would be nice to have this for when I hopefully add this to the TinyGo extension eventually.

For reference, I'm using TinyGo target "gopher-badge" in VSCode with the following custom settings:

```json
{
    "cmake.configureOnOpen": false,
    "go.toolsEnvVars": {
        "CGO_ENABLED": "1",
        "CC": "clang",
        "GOOS": "linux",
        "GOARCH": "arm",{
        "CGO_CFLAGS": "-Werror -fshort-enums -fomit-frame-pointer -mfloat-abi=soft -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -nostdlibinc -isystem /home/ayke/.cache/tinygo/picolibc-thumbv6m-unknown-unknown-eabi-cortex-m0plus/include -isystem /home/ayke/src/tinygo/tinygo/lib/picolibc/newlib/libc/include -isystem /home/ayke/src/tinygo/tinygo/lib/picolibc/newlib/libc/tinystdio -Oz --target=thumbv6m-unknown-unknown-eabi -mcpu=cortex-m0plus -mthumb -fno-PIC",
        "GOROOT": "/home/ayke/.cache/tinygo/goroot-8d8f8a7da5d85cd177e3196b59dcd519d76b00dc6a0aae2635059910f11c4e8c",
        "GOFLAGS": "-tags=cortexm,baremetal,linux,arm,rp2040,rp,gopher_badge,math_big_pure_go,gc.conservative,scheduler.tasks,serial.usb",
        "CCC_OVERRIDE_OPTIONS": "+-mthumb",
    },
}
```

Some notes:

  * I got the list of CFlags by patching the tinygo binary, I should make a separate PR for that too.
  * I had to remove the `tinygo` build tag to get things to work (the `tinygo` files often can't be parsed by upstream CGo).
  * The `CCC_OVERRIDE_OPTIONS` is the especially crude hack: Go adds `-marm` and there doesn't appear to be a way to override it, except using this special (undocumented) environment variable. It's really meant to be used for tests, not for production code.