### PR TITLE
rp2040: add definition for machine.PinToggle

### DIFF
--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -241,6 +241,8 @@ const (
 	PinFalling PinChange = 4 << iota
 	// Edge rising
 	PinRising
+
+	PinToggle = PinFalling | PinRising
 )
 
 // Callbacks to be called for pins configured with SetInterrupt.


### PR DESCRIPTION
@soypat To your knowledge, is this correct? It seems to be working as expected in this example - https://github.com/tinygo-org/drivers/pull/648/files#diff-a95e9433f1eeac9e6a4babe7393dc048b03c22d172365ff9016d42862c7cc71a - However I'm still reading through the datasheet and stepping through interrupt setup trying to be sure, and your opinion is appreciated.