### PR TITLE
flake.nix: explicitly add libcxx as dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             go
             llvmPackages_17.llvm
             llvmPackages_17.libclang
+            llvmPackages_17.libcxx
             # Additional dependencies needed at runtime, for building and/or
             # flashing.
             llvmPackages_17.lld


### PR DESCRIPTION
Without this change, my tinygo builds crash with

```
SIGSEGV: segmentation violation
PC=0x10884f87c m=16 sigcode=2
signal arrived during cgo execution

goroutine 378 [syscall]:
runtime.cgocall(0x100631e44, 0x1401755be88)
	/nix/store/4hf287252ilsdf2w36mfm8fa0rvbf33w-go-1.21.4/share/go/src/runtime/cgocall.go:157 +0x44 fp=0x1401755be50 sp=0x1401755be10 pc=0x1002a5084
tinygo.org/x/go-llvm._Cfunc_LLVMGoWriteThinLTOBitcodeToMemoryBuffer(0x123614160)
	_cgo_gotypes.go:6078 +0x34 fp=0x1401755be80 sp=0x1401755be50 pc=0x1004b66b4
...
```

and reports using LLVM 16:

```
$ tinygo version
tinygo version 0.31.0-dev darwin/arm64 (using go version go1.21.4 and LLVM version 16.0.6)
```

I don't know why libcxx-16 is being included, but explicitly specifying llvmPackages_17.libcxx fixes the crash and version skew.