### PR TITLE
Revert "flake.nix: explicitly add libcxx as dependency"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,6 @@
             go
             llvmPackages_17.llvm
             llvmPackages_17.libclang
-            llvmPackages_17.libcxx
             # Additional dependencies needed at runtime, for building and/or
             # flashing.
             llvmPackages_17.lld


### PR DESCRIPTION
Reverts tinygo-org/tinygo#4107

After debugging the root cause of #4107 in https://github.com/tinygo-org/tinygo/pull/4107#issuecomment-1924049952, I'm no longer able to debug the crash and version skew. This PR reverts the "fix".

I'm very sorry for the noise, I'm pretty sure I was able to flip back and forth between working and crashing, but apparently not. If I hit this issue again, I'll be more careful in analysis.