### PR TITLE
ci: add macOS ARM64 builder

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -14,7 +14,17 @@ concurrency:
 jobs:
   build-macos:
     name: build-macos
-    runs-on: macos-11
+    strategy:
+      matrix:
+        # macos-12: amd64 (oldest supported version as of 05-02-2024)
+        # macos-14: arm64 (oldest arm64 version)
+        os: [macos-12, macos-14]
+        include:
+          - os: macos-12
+            goarch: amd64
+          - os: macos-14
+            goarch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Install Dependencies
         shell: bash
@@ -33,7 +43,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-source
         with:
-          key: llvm-source-17-macos-v1
+          key: llvm-source-17-${{ matrix.os }}-v1
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -58,7 +68,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-llvm-build
         with:
-          key: llvm-build-17-macos-v1
+          key: llvm-build-17-${{ matrix.os }}-v1
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -82,7 +92,7 @@ jobs:
         uses: actions/cache@v3
         id: cache-wasi-libc
         with:
-          key: wasi-libc-sysroot-v5
+          key: wasi-libc-sysroot-${{ matrix.os }}-v1
           path: lib/wasi-libc/sysroot
       - name: Build wasi-libc
         if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
@@ -98,7 +108,7 @@ jobs:
         run: make tinygo-test
       - name: Make release artifact
         shell: bash
-        run: cp -p build/release.tar.gz build/tinygo.darwin-amd64.tar.gz 
+        run: cp -p build/release.tar.gz build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
         # Note: this release artifact is double-zipped, see:
         # https://github.com/actions/upload-artifact/issues/39
@@ -108,8 +118,8 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v3
         with:
-          name: darwin-amd64-double-zipped
-          path: build/tinygo.darwin-amd64.tar.gz
+          name: darwin-${{ matrix.goarch }}-double-zipped
+          path: build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Smoke tests
         shell: bash
         run: make smoketest TINYGO=$(PWD)/build/tinygo


### PR DESCRIPTION
This means we can finally release native arm64 builds of TinyGo on macOS!