### PR TITLE
compileopts: set 'purego' build tag by default

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -74,7 +74,12 @@ func (c *Config) GOARM() string {
 
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
-	tags := append(c.Target.BuildTags, []string{"tinygo", "math_big_pure_go", "gc." + c.GC(), "scheduler." + c.Scheduler(), "serial." + c.Serial()}...)
+	tags := append(c.Target.BuildTags, []string{
+		"tinygo",                                     // that's the compiler
+		"purego",                                     // to get various crypto packages to work
+		"math_big_pure_go",                           // to get math/big to work
+		"gc." + c.GC(), "scheduler." + c.Scheduler(), // used inside the runtime package
+		"serial." + c.Serial()}...) // used inside the machine package
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}

--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -24,12 +24,12 @@
 
 - repo: github.com/buger/jsonparser
 - repo: github.com/dgryski/go-bloomindex
-  tags: purego noasm
+  tags: noasm
 - repo: github.com/dgryski/go-arc
 - repo: github.com/dgryski/go-camellia
 - repo: github.com/dgryski/go-change
 - repo: github.com/dgryski/go-chaskey
-  tags: appengine purego noasm
+  tags: appengine noasm
   skipwasi: true # siphash has build tag issues
 - repo: github.com/dgryski/go-clefia
 - repo: github.com/dgryski/go-clockpro
@@ -40,7 +40,7 @@
 - repo: github.com/dgryski/go-expirecache
 - repo: github.com/dgryski/go-factor
 - repo: github.com/dgryski/go-farm
-  tags: purego noasm
+  tags: noasm
 - repo: github.com/dgryski/go-fuzzstr
 - repo: github.com/dgryski/go-hollow
 - repo: github.com/dgryski/go-idea
@@ -58,13 +58,12 @@
   tags: appengine # for dchest/siphash
   skipwasi: true
 - repo: github.com/dgryski/go-marvin32
-  tags: purego
 - repo: github.com/dgryski/go-md5crypt
 - repo: github.com/dgryski/go-metro
-  tags: purego noasm
+  tags: noasm
 - repo: github.com/dgryski/go-misty1
 - repo: github.com/dgryski/go-mph
-  tags: purego noasm
+  tags: noasm
 - repo: github.com/dgryski/go-mpchash
   tags: appengine # for dchest/siphash
   skipwasi: true
@@ -82,7 +81,7 @@
 - repo: github.com/dgryski/go-s4lru
 - repo: github.com/dgryski/go-sequitur
 - repo: github.com/dgryski/go-sip13
-  tags: purego noasm
+  tags: noasm
 - repo: github.com/dgryski/go-skinny
 - repo: github.com/dgryski/go-skip32
 - repo: github.com/dgryski/go-skipjack
@@ -97,9 +96,9 @@
 - repo: github.com/dgryski/go-xoshiro
 - repo: github.com/dgryski/go-zlatlong
 - repo: github.com/dgryski/go-postings
-  tags: purego noasm
+  tags: noasm
 - repo: golang.org/x/crypto
-  tags: purego noasm
+  tags: noasm
   subdirs:
   - pkg: argon2
   - pkg: bcrypt


### PR DESCRIPTION
This is needed for various crypto libraries.
It adds the `purego` build tag, and removes it from testdata/corpus.yaml.

Tested by running `make test-corpus` and `make test-corpus-wasi`, both passed on this PR.

CC @FiloSottile who told me yesterday the `purego` build tag is most definitely supported for cryptographic libraries to avoid Go assembly.