### PR TITLE
build: remove more files from host on Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,11 +22,14 @@ jobs:
       - name: Free Disk space
         shell: bash
         run: |
+          df -h
+          sudo rm -rf /opt/hostedtoolcache
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/graalvm
           sudo rm -rf /usr/local/share/boost
+          df -h
       - name: Check out the repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR modifies the build to remove more files from the GH action host runner for the Docker build to avoid running out of disk space.