### PR TITLE
ci: switch to Go 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,16 +105,9 @@ jobs:
       - test-linux:
           llvm: "15"
     resource_class: large
-  test-llvm16-go122:
+  test-llvm17-go122:
     docker:
-      - image: golang:1.22-rc-bullseye
-    steps:
-      - test-linux:
-          llvm: "16"
-    resource_class: large
-  test-llvm17-go121:
-    docker:
-      - image: golang:1.21-bullseye
+      - image: golang:1.22-bullseye
     steps:
       - test-linux:
           llvm: "17"
@@ -126,7 +119,5 @@ workflows:
       # This tests our lowest supported versions of Go and LLVM, to make sure at
       # least the smoke tests still pass.
       - test-llvm15-go118
-      # This tests the upcoming Go 1.22 support.
-      - test-llvm16-go122
       # This tests LLVM 17 support when linking against system libraries.
-      - test-llvm17-go121
+      - test-llvm17-go122

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21-alpine
+      image: golang:1.22-alpine
     steps:
       - name: Install apk dependencies
         # tar: needed for actions/cache@v3
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Install wasmtime
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -301,7 +301,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v3
@@ -143,7 +143,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v3
@@ -173,7 +173,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v3
@@ -209,7 +209,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.21 AS tinygo-llvm
+FROM golang:1.22 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-15 ninja-build && \


### PR DESCRIPTION
Let's see how well it runs.

I have removed the Go 1.22 test from .circleci/config.yml because it's not needed anymore: we're testing everything in the normal CI process now.