### PR TITLE
esp32: switch over to the official SVD file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -200,8 +200,8 @@ build/gen-device-svd: ./tools/gen-device-svd/*.go
 	$(GO) build -o $@ ./tools/gen-device-svd/
 
 gen-device-esp: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif -interrupts=software lib/cmsis-svd/data/Espressif/ src/device/esp/
 	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif-Community -interrupts=software lib/cmsis-svd/data/Espressif-Community/ src/device/esp/
+	./build/gen-device-svd -source=https://github.com/posborne/cmsis-svd/tree/master/data/Espressif -interrupts=software lib/cmsis-svd/data/Espressif/ src/device/esp/
 	GO111MODULE=off $(GO) fmt ./src/device/esp
 
 gen-device-nrf: build/gen-device-svd

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -237,13 +237,13 @@ func (p Pin) mux() *volatile.Register32 {
 	case 27:
 		return &esp.IO_MUX.GPIO27
 	case 14:
-		return &esp.IO_MUX.MTMS
+		return &esp.IO_MUX.GPIO14
 	case 12:
-		return &esp.IO_MUX.MTDI
+		return &esp.IO_MUX.GPIO12
 	case 13:
-		return &esp.IO_MUX.MTCK
+		return &esp.IO_MUX.GPIO13
 	case 15:
-		return &esp.IO_MUX.MTDO
+		return &esp.IO_MUX.GPIO15
 	case 2:
 		return &esp.IO_MUX.GPIO2
 	case 0:
@@ -255,17 +255,17 @@ func (p Pin) mux() *volatile.Register32 {
 	case 17:
 		return &esp.IO_MUX.GPIO17
 	case 9:
-		return &esp.IO_MUX.SD_DATA2
+		return &esp.IO_MUX.GPIO9
 	case 10:
-		return &esp.IO_MUX.SD_DATA3
+		return &esp.IO_MUX.GPIO10
 	case 11:
-		return &esp.IO_MUX.SD_CMD
+		return &esp.IO_MUX.GPIO11
 	case 6:
-		return &esp.IO_MUX.SD_CLK
+		return &esp.IO_MUX.GPIO6
 	case 7:
-		return &esp.IO_MUX.SD_DATA0
+		return &esp.IO_MUX.GPIO7
 	case 8:
-		return &esp.IO_MUX.SD_DATA1
+		return &esp.IO_MUX.GPIO8
 	case 5:
 		return &esp.IO_MUX.GPIO5
 	case 18:
@@ -279,9 +279,9 @@ func (p Pin) mux() *volatile.Register32 {
 	case 22:
 		return &esp.IO_MUX.GPIO22
 	case 3:
-		return &esp.IO_MUX.U0RXD
+		return &esp.IO_MUX.GPIO3
 	case 1:
-		return &esp.IO_MUX.U0TXD
+		return &esp.IO_MUX.GPIO1
 	case 23:
 		return &esp.IO_MUX.GPIO23
 	case 24:
@@ -320,7 +320,8 @@ func (uart *UART) writeByte(b byte) error {
 		// many bytes there are in the transmit buffer. Wait until there are
 		// less than 128 bytes in this buffer (the default buffer size).
 	}
-	uart.Bus.TX_FIFO.Set(b)
+	// Write to the TX_FIFO register.
+	(*volatile.Register8)(unsafe.Add(unsafe.Pointer(uart.Bus), 0x200C0000)).Set(b)
 	return nil
 }
 

--- a/src/runtime/runtime_esp32.go
+++ b/src/runtime/runtime_esp32.go
@@ -15,31 +15,31 @@ import (
 func main() {
 	// Disable the protection on the watchdog timer (needed when started from
 	// the bootloader).
-	esp.RTCCNTL.WDTWPROTECT.Set(0x050D83AA1)
+	esp.RTC_CNTL.WDTWPROTECT.Set(0x050D83AA1)
 
 	// Disable both watchdog timers that are enabled by default on startup.
 	// Note that these watchdogs can be protected, but the ROM bootloader
 	// doesn't seem to protect them.
-	esp.RTCCNTL.WDTCONFIG0.Set(0)
+	esp.RTC_CNTL.WDTCONFIG0.Set(0)
 	esp.TIMG0.WDTCONFIG0.Set(0)
 
 	// Switch SoC clock source to PLL (instead of the default which is XTAL).
 	// This switches the CPU (and APB) clock from 40MHz to 80MHz.
 	// Options:
-	//   RTCCNTL_CLK_CONF_SOC_CLK_SEL:       PLL    (default XTAL)
-	//   RTCCNTL_CLK_CONF_CK8M_DIV_SEL:      2      (default)
-	//   RTCCNTL_CLK_CONF_DIG_CLK8M_D256_EN: Enable (default)
-	//   RTCCNTL_CLK_CONF_CK8M_DIV:          DIV256 (default)
-	// The only real change made here is modifying RTCCNTL_CLK_CONF_SOC_CLK_SEL,
+	//   RTC_CNTL_CLK_CONF_SOC_CLK_SEL:       PLL (1)       (default XTAL)
+	//   RTC_CNTL_CLK_CONF_CK8M_DIV_SEL:      2             (default)
+	//   RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN: Enable        (default)
+	//   RTC_CNTL_CLK_CONF_CK8M_DIV:          divide by 256 (default)
+	// The only real change made here is modifying RTC_CNTL_CLK_CONF_SOC_CLK_SEL,
 	// but setting a fixed value produces smaller code.
-	esp.RTCCNTL.CLK_CONF.Set((esp.RTCCNTL_CLK_CONF_SOC_CLK_SEL_PLL << esp.RTCCNTL_CLK_CONF_SOC_CLK_SEL_Pos) |
-		(2 << esp.RTCCNTL_CLK_CONF_CK8M_DIV_SEL_Pos) |
-		(esp.RTCCNTL_CLK_CONF_DIG_CLK8M_D256_EN_Enable << esp.RTCCNTL_CLK_CONF_DIG_CLK8M_D256_EN_Pos) |
-		(esp.RTCCNTL_CLK_CONF_CK8M_DIV_DIV256 << esp.RTCCNTL_CLK_CONF_CK8M_DIV_Pos))
+	esp.RTC_CNTL.CLK_CONF.Set((1 << esp.RTC_CNTL_CLK_CONF_SOC_CLK_SEL_Pos) |
+		(2 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_SEL_Pos) |
+		(1 << esp.RTC_CNTL_CLK_CONF_DIG_CLK8M_D256_EN_Pos) |
+		(1 << esp.RTC_CNTL_CLK_CONF_CK8M_DIV_Pos))
 
 	// Switch CPU from 80MHz to 160MHz. This doesn't affect the APB clock,
 	// which is still running at 80MHz.
-	esp.DPORT.CPU_PER_CONF.Set(esp.DPORT_CPU_PER_CONF_CPUPERIOD_SEL_SEL_160)
+	esp.DPORT.CPU_PER_CONF.Set(1) // PLL_CLK / 2, see table 3-3 in the reference manual
 
 	// Clear .bss section. .data has already been loaded by the ROM bootloader.
 	// Do this after increasing the CPU clock to possibly make startup slightly


### PR DESCRIPTION
This change only affects the esp32. The esp8266 is still community-only and other chips (like the esp32c3) were never supported by community SVD files.

I think it's a good idea to use the official SVD files instead of the community maintained ones (which probably won't really be maintained now anymore).

I've checked that examples/blinky1 and examples/serial produce the same binary, so they won't have any change in behavior.