### PR TITLE
nrf52840: generic board support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -684,6 +684,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=feather-nrf52840    examples/usb-midi
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nrf52840-s140v6-uf2-generic	examples/serial
+	@$(MD5SUM) test.hex
 ifneq ($(STM32), 0)
 	$(TINYGO) build -size short -o test.hex -target=bluepill            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/machine/board_nrf52840_generic.go
+++ b/src/machine/board_nrf52840_generic.go
@@ -1,0 +1,27 @@
+//go:build nrf52840 && nrf52840_generic
+
+package machine
+
+const HasLowFrequencyCrystal = true
+
+var (
+	LED          = NoPin
+	SDA_PIN      = NoPin
+	SCL_PIN      = NoPin
+	UART_TX_PIN  = NoPin
+	UART_RX_PIN  = NoPin
+	SPI0_SCK_PIN = NoPin
+	SPI0_SDO_PIN = NoPin
+	SPI0_SDI_PIN = NoPin
+
+	// https://pid.codes/org/TinyGo/
+	usb_VID uint16 = 0x1209
+	usb_PID uint16 = 0x9090
+
+	usb_STRING_MANUFACTURER = "TinyGo"
+	usb_STRING_PRODUCT      = "nRF52840 Generic board"
+)
+
+var (
+	DefaultUART = UART0
+)

--- a/src/machine/board_nrf52840_generic.go
+++ b/src/machine/board_nrf52840_generic.go
@@ -2,8 +2,6 @@
 
 package machine
 
-const HasLowFrequencyCrystal = true
-
 var (
 	LED          = NoPin
 	SDA_PIN      = NoPin

--- a/src/machine/machine_nrf52840_lfxtal_false.go
+++ b/src/machine/machine_nrf52840_lfxtal_false.go
@@ -1,0 +1,5 @@
+//go:build nrf52840 && nrf52840_lfxtal_false
+
+package machine
+
+const HasLowFrequencyCrystal = false

--- a/src/machine/machine_nrf52840_lfxtal_true.go
+++ b/src/machine/machine_nrf52840_lfxtal_true.go
@@ -1,0 +1,5 @@
+//go:build nrf52840 && ((nrf52840_generic && !nrf52840_lfxtal_false) || nrf52840_lfxtal_true)
+
+package machine
+
+const HasLowFrequencyCrystal = true

--- a/targets/nrf52840-s140v6-uf2-generic.json
+++ b/targets/nrf52840-s140v6-uf2-generic.json
@@ -1,0 +1,5 @@
+{
+  "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
+  "build-tags": ["nrf52840_generic"],
+  "serial-port": ["1209:9090"]
+}


### PR DESCRIPTION
Adding minimum definitions need to compile firmware for generic nRF52840 boards not otherwise defined in the `machine` package.  The following sort of target file can be used to take advantage of this feature (the key element being the `nrf52840_generic` build tag:

```json
{
  "inherits": ["nrf52840", "nrf52840-s140v6-uf2"],
  "build-tags": ["adv360pro", "nrf52840_generic"],
  "serial-port": ["1209:9090", "29ea:0362", "239a:00b3"],
  "msd-volume-name": ["ADV360PRO"]
}
```

The pin definitions can be overridden by end users in an `init()` function such as:  https://github.com/bgould/kinadv360pro-firmware/blob/split-refactor/main_generic.go#L1-L13

The USB vendor and product ID are valid as documented at: https://pid.codes/org/TinyGo/

USB details can also be easily overridden by end users, such as: https://github.com/bgould/kinadv360pro-firmware/blob/split-refactor/main.go#L27-L33