### PR TITLE
Checking for methodset existance

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -427,13 +427,20 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err)
 				}
+				// typecodePtr always point to the numMethod field in the type
+				// description struct. The methodSet, when present, comes right
+				// before the numMethod field (the compiler doesn't generate
+				// method sets for concrete types without methods).
+				// Considering that the compiler doesn't emit interface type
+				// asserts for interfaces with no methods (as the always succeed)
+				// then if the offset is zero, this assert must always fail.
 				if typecodePtr.offset() == 0 {
 					locals[inst.localIndex] = literalValue{uint8(0)}
 					break
 				}
 				typecodePtrOffset, err := typecodePtr.addOffset(-int64(r.pointerSize))
 				if err != nil {
-					return nil, mem, r.errorAt(inst, err) // unlikely
+					return nil, mem, r.errorAt(inst, err)
 				}
 				methodSetPtr, err := mem.load(typecodePtrOffset, r.pointerSize).asPointer(r)
 				if err != nil {

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -427,6 +427,10 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err)
 				}
+				if typecodePtr.offset() == 0 {
+					locals[inst.localIndex] = literalValue{uint8(0)}
+					break
+				}
 				typecodePtrOffset, err := typecodePtr.addOffset(-int64(r.pointerSize))
 				if err != nil {
 					return nil, mem, r.errorAt(inst, err) // unlikely

--- a/testdata/init.go
+++ b/testdata/init.go
@@ -109,3 +109,14 @@ func sliceString(s string, start, end int) string {
 func sliceSlice(s []int, start, end int) []int {
 	return s[start:end]
 }
+
+type outside struct{}
+
+func init() {
+	_, _ = any(0).(interface{ DoesNotExist() })
+	_, _ = any("").(interface{ DoesNotExist() })
+	_, _ = any(outside{}).(interface{ DoesNotExist() })
+
+	type inside struct{}
+	_, _ = any(inside{}).(interface{ DoesNotExist() })
+}


### PR DESCRIPTION
This PR adds a check for the existence of the methodset in the interpreter implementation of typeasserts. This is necessary since this [field is optional](https://github.com/tinygo-org/tinygo/blob/release/compiler/interface.go#L250).

This should be the last bit that fixes #3788 since pull #3986 only covers `XXX.(any)` cases and still crashes if the interface has methods. As such, it should also fix #4079.

As a last note, I also tried a different approach [here](https://github.com/marco6/tinygo/tree/mandatory-methodset) where I forced the methodset to be mandatory as I felt it was more robust, but the simplicity of these 4 lines seems to be unmatched.