### PR TITLE
add waveshare pico variants

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -670,6 +670,10 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=ae-rp2040           examples/echo
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=waveshare-rp2040-lora examples/blinky1
+	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=waveshare-rp2040-plus examples/blinky1
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/src/machine/board_waveshare-rp2040-lora.go
+++ b/src/machine/board_waveshare-rp2040-lora.go
@@ -1,0 +1,141 @@
+//go:build waveshare_rp2040_lora
+// +build waveshare_rp2040_lora
+
+// This file contains the pin mappings for the Waveshare RP2040-LoRa boards.
+//
+// Waveshare RP2040-Lora is a microcontroller using the Raspberry Pi RP2040 chip.
+//
+// - https://www.waveshare.com/wiki/RP2040-LoRa
+package machine
+
+import (
+	"device/rp"
+	"runtime/interrupt"
+)
+
+// Digital Pins
+const (
+	D0  Pin = GPIO0
+	D1  Pin = GPIO1
+	D2  Pin = GPIO2
+	D3  Pin = GPIO3
+	D4  Pin = GPIO4
+	D5  Pin = GPIO5
+	D6  Pin = GPIO6
+	D7  Pin = GPIO7
+	D8  Pin = GPIO8
+	D9  Pin = GPIO9
+	D10 Pin = GPIO10
+	D11 Pin = GPIO11
+	D12 Pin = GPIO12
+	D13 Pin = GPIO13
+	D14 Pin = GPIO14
+	D15 Pin = GPIO15
+	D16 Pin = GPIO16
+	D17 Pin = GPIO17
+	D18 Pin = GPIO18
+	D19 Pin = GPIO19
+	D20 Pin = GPIO20
+	D21 Pin = GPIO21
+	D22 Pin = GPIO22
+	D23 Pin = GPIO23
+	D24 Pin = GPIO24
+	D25 Pin = GPIO25
+	D26 Pin = GPIO26
+	D27 Pin = GPIO27
+	D28 Pin = GPIO28
+	D29 Pin = GPIO29
+)
+
+// Analog pins
+const (
+	A0 Pin = D26
+	A1 Pin = D27
+	A2 Pin = D28
+	A3 Pin = D29
+)
+
+// Onboard LEDs
+const (
+	LED = D25
+)
+
+// I2C pins
+const (
+	I2C0_SDA_PIN Pin = D0
+	I2C0_SCL_PIN Pin = D1
+
+	I2C1_SDA_PIN Pin = D2
+	I2C1_SCL_PIN Pin = D3
+)
+
+// LoRa default pins
+const (
+	LORA_CS     = GPIO13
+	LORA_CLK    = GPIO14
+	LORA_MOSI   = GPIO15
+	LORA_MISO   = GPIO24
+	LORA_DIO1   = GPIO16
+	LORA_ANT_SW = GPIO17
+	LORA_BUSY   = GPIO18
+	LORA_RESET  = GPIO23
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN Pin = D6
+	SPI0_SDO_PIN Pin = D3
+	SPI0_SDI_PIN Pin = D4
+
+	// SPI1 is designated for the sx1262 LoRa radio
+	SPI1_SCK_PIN Pin = LORA_CLK
+	SPI1_SDO_PIN Pin = LORA_MOSI
+	SPI1_SDI_PIN Pin = LORA_MISO
+)
+
+// Onboard crystal oscillator frequency, in MHz.
+const (
+	xoscFreq = 12 // MHz
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+	UART1_TX_PIN = GPIO8
+	UART1_RX_PIN = GPIO9
+)
+
+// UART on the RP2040
+var (
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART0,
+	}
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
+)
+
+var DefaultUART = UART0
+
+func init() {
+	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
+}
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "RP2040-LoRa"
+	usb_STRING_MANUFACTURER = "Waveshare"
+)
+
+var (
+	usb_VID uint16 = 0x2e8a
+	usb_PID uint16 = 0x000a
+)

--- a/src/machine/board_waveshare-rp2040-lora.go
+++ b/src/machine/board_waveshare-rp2040-lora.go
@@ -1,5 +1,4 @@
 //go:build waveshare_rp2040_lora
-// +build waveshare_rp2040_lora
 
 // This file contains the pin mappings for the Waveshare RP2040-LoRa boards.
 //

--- a/src/machine/board_waveshare-rp2040-plus.go
+++ b/src/machine/board_waveshare-rp2040-plus.go
@@ -1,0 +1,113 @@
+//go:build waveshare_rp2040_plus
+
+package machine
+
+import (
+	"device/rp"
+	"runtime/interrupt"
+)
+
+// GPIO pins
+const (
+	GP0  Pin = GPIO0
+	GP1  Pin = GPIO1
+	GP2  Pin = GPIO2
+	GP3  Pin = GPIO3
+	GP4  Pin = GPIO4
+	GP5  Pin = GPIO5
+	GP6  Pin = GPIO6
+	GP7  Pin = GPIO7
+	GP8  Pin = GPIO8
+	GP9  Pin = GPIO9
+	GP10 Pin = GPIO10
+	GP11 Pin = GPIO11
+	GP12 Pin = GPIO12
+	GP13 Pin = GPIO13
+	GP14 Pin = GPIO14
+	GP15 Pin = GPIO15
+	GP16 Pin = GPIO16
+	GP17 Pin = GPIO17
+	GP18 Pin = GPIO18
+	GP19 Pin = GPIO19
+	GP20 Pin = GPIO20
+	GP21 Pin = GPIO21
+	GP22 Pin = GPIO22
+	GP26 Pin = GPIO26
+	GP27 Pin = GPIO27
+	GP28 Pin = GPIO28
+
+	// Onboard LED
+	LED Pin = GPIO25
+
+	// Onboard crystal oscillator frequency, in MHz.
+	xoscFreq = 12 // MHz
+)
+
+// I2C Default pins on Raspberry Pico.
+const (
+	I2C0_SDA_PIN = GP4
+	I2C0_SCL_PIN = GP5
+
+	I2C1_SDA_PIN = GP2
+	I2C1_SCL_PIN = GP3
+)
+
+// SPI default pins
+const (
+	// Default Serial Clock Bus 0 for SPI communications
+	SPI0_SCK_PIN = GPIO18
+	// Default Serial Out Bus 0 for SPI communications
+	SPI0_SDO_PIN = GPIO19 // Tx
+	// Default Serial In Bus 0 for SPI communications
+	SPI0_SDI_PIN = GPIO16 // Rx
+
+	// Default Serial Clock Bus 1 for SPI communications
+	SPI1_SCK_PIN = GPIO10
+	// Default Serial Out Bus 1 for SPI communications
+	SPI1_SDO_PIN = GPIO11 // Tx
+	// Default Serial In Bus 1 for SPI communications
+	SPI1_SDI_PIN = GPIO12 // Rx
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART1_TX_PIN = GPIO8
+	UART1_RX_PIN = GPIO9
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+// UART on the RP2040
+var (
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART0,
+	}
+
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
+)
+
+var DefaultUART = UART0
+
+func init() {
+	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
+}
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "RP2040-Plus"
+	usb_STRING_MANUFACTURER = "Waveshare"
+)
+
+var (
+	usb_VID uint16 = 0x2E8A
+	usb_PID uint16 = 0x0003
+)

--- a/targets/waveshare-rp2040-lora.json
+++ b/targets/waveshare-rp2040-lora.json
@@ -1,0 +1,13 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial-port": ["2e8a:000a"],
+    "build-tags": ["waveshare_rp2040_lora"],
+    "ldflags": [
+        "--defsym=__flash_size=1020K"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}

--- a/targets/waveshare-rp2040-plus.json
+++ b/targets/waveshare-rp2040-plus.json
@@ -1,0 +1,13 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial-port": ["2e8a:0003"],
+    "build-tags": ["waveshare_rp2040_plus"],
+    "ldflags": [
+        "--defsym=__flash_size=1020K"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}


### PR DESCRIPTION
Adds board and target files for Waveshare 2040 LoRa and Plus boards. 