### PR TITLE
machine: use native WriteRegister/ReadRegister functions on mimxrt1062

### DIFF
--- a/src/machine/i2c-register.go
+++ b/src/machine/i2c-register.go
@@ -1,0 +1,29 @@
+//go:build atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || (esp32c3 && !m5stamp_c3)
+
+package machine
+
+// This file implements WriteRegister and ReadRegister for chips that do not
+// have direct hardware support for this feature.
+
+// WriteRegister transmits first the register and then the data to the
+// peripheral device.
+//
+// Many I2C-compatible devices are organized in terms of registers. This method
+// is a shortcut to easily write to such registers. Also, it only works for
+// devices with 7-bit addresses, which is the vast majority.
+func (i2c *I2C) WriteRegister(address uint8, register uint8, data []byte) error {
+	buf := make([]uint8, len(data)+1)
+	buf[0] = register
+	copy(buf[1:], data)
+	return i2c.Tx(uint16(address), buf, nil)
+}
+
+// ReadRegister transmits the register, restarts the connection as a read
+// operation, and reads the response.
+//
+// Many I2C-compatible devices are organized in terms of registers. This method
+// is a shortcut to easily read such registers. Also, it only works for devices
+// with 7-bit addresses, which is the vast majority.
+func (i2c *I2C) ReadRegister(address uint8, register uint8, data []byte) error {
+	return i2c.Tx(uint16(address), []byte{register}, data)
+}

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -15,6 +15,8 @@ var _ interface { // 2
 	Configure(config I2CConfig) error
 	Tx(addr uint16, w, r []byte) error
 	SetBaudRate(br uint32) error
+	WriteRegister(address, register uint8, data []byte) error
+	ReadRegister(address, register uint8, data []byte) error
 } = (*I2C)(nil)
 
 // TWI_FREQ is the I2C bus speed. Normally either 100 kHz, or 400 kHz for high-speed bus.
@@ -67,26 +69,3 @@ const (
 	// I2CModeTarget represents an I2C peripheral in target mode.
 	I2CModeTarget
 )
-
-// WriteRegister transmits first the register and then the data to the
-// peripheral device.
-//
-// Many I2C-compatible devices are organized in terms of registers. This method
-// is a shortcut to easily write to such registers. Also, it only works for
-// devices with 7-bit addresses, which is the vast majority.
-func (i2c *I2C) WriteRegister(address uint8, register uint8, data []byte) error {
-	buf := make([]uint8, len(data)+1)
-	buf[0] = register
-	copy(buf[1:], data)
-	return i2c.Tx(uint16(address), buf, nil)
-}
-
-// ReadRegister transmits the register, restarts the connection as a read
-// operation, and reads the response.
-//
-// Many I2C-compatible devices are organized in terms of registers. This method
-// is a shortcut to easily read such registers. Also, it only works for devices
-// with 7-bit addresses, which is the vast majority.
-func (i2c *I2C) ReadRegister(address uint8, register uint8, data []byte) error {
-	return i2c.Tx(uint16(address), []byte{register}, data)
-}

--- a/src/machine/machine_mimxrt1062_i2c.go
+++ b/src/machine/machine_mimxrt1062_i2c.go
@@ -207,13 +207,13 @@ func (i2c I2C) Tx(addr uint16, w, r []byte) error {
 	return nil
 }
 
-// WriteRegisterEx transmits first the register and then the data to the
+// WriteRegister transmits first the register and then the data to the
 // peripheral device.
 //
 // Many I2C-compatible devices are organized in terms of registers. This method
 // is a shortcut to easily write to such registers. Also, it only works for
 // devices with 7-bit addresses, which is the vast majority.
-func (i2c I2C) WriteRegisterEx(address uint8, register uint8, data []byte) error {
+func (i2c I2C) WriteRegister(address uint8, register uint8, data []byte) error {
 	option := transferOption{
 		flags:          transferDefault,  // transfer options bit mask (0 = normal transfer)
 		peripheral:     uint16(address),  // 7-bit peripheral address
@@ -227,13 +227,13 @@ func (i2c I2C) WriteRegisterEx(address uint8, register uint8, data []byte) error
 	return nil
 }
 
-// ReadRegisterEx transmits the register, restarts the connection as a read
+// ReadRegister transmits the register, restarts the connection as a read
 // operation, and reads the response.
 //
 // Many I2C-compatible devices are organized in terms of registers. This method
 // is a shortcut to easily read such registers. Also, it only works for devices
 // with 7-bit addresses, which is the vast majority.
-func (i2c I2C) ReadRegisterEx(address uint8, register uint8, data []byte) error {
+func (i2c I2C) ReadRegister(address uint8, register uint8, data []byte) error {
 	option := transferOption{
 		flags:          transferDefault,  // transfer options bit mask (0 = normal transfer)
 		peripheral:     uint16(address),  // 7-bit peripheral address


### PR DESCRIPTION
This seems better than adding extra WriteRegisterEx/ReadRegisterEx methods that do the same thing but use hardware features instead of implementing it in software.

Note: **I have not actually tested this** except for checking that it compiles on the teensy41.

See: https://github.com/tinygo-org/tinygo/pull/3406/files#r1489950066