### PR TITLE
targets/wasm_unknown: use proper defaults in target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -773,7 +773,7 @@ endif
 ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/export
 	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/main
-	$(TINYGO) build -size short -o wasm.wasm -target=wasm-unknown -gc=leaking -no-debug examples/hello-wasm-unknown
+	$(TINYGO) build -size short -o wasm.wasm -target=wasm-unknown       examples/hello-wasm-unknown
 endif
 	# test various compiler flags
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -gc=none -scheduler=none examples/blinky1

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -35,6 +35,7 @@ func TestClangAttributes(t *testing.T) {
 		"riscv-qemu",
 		"wasi",
 		"wasm",
+		"wasm-unknown",
 	}
 	if hasBuiltinTools {
 		// hasBuiltinTools is set when TinyGo is statically linked with LLVM,

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -16,7 +16,7 @@ func _start() {
 	// These need to be initialized early so that the heap can be initialized.
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
+	initAll()
 }
 
 func init() {

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -11,8 +11,8 @@ type timeUnit int64
 //export __wasm_call_ctors
 func __wasm_call_ctors()
 
-//export _start
-func _start() {
+//export _initialize
+func _initialize() {
 	// These need to be initialized early so that the heap can be initialized.
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)

--- a/targets/wasm-unknown.json
+++ b/targets/wasm-unknown.json
@@ -1,13 +1,14 @@
 {
 	"llvm-target":   "wasm32-unknown-unknown",
 	"cpu":           "generic",
-	"features":      "+mutable-globals,+nontrapping-fptoint,+sign-ext",
+	"features":      "+mutable-globals,+nontrapping-fptoint,+sign-ext,-bulk-memory",
 	"build-tags":    ["tinygo.wasm", "wasm_unknown"],
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",
 	"rtlib":         "compiler-rt",
 	"scheduler":     "none",
+	"gc":            "leaking",
 	"default-stack-size": 4096,
 	"cflags": [
 		"-mno-bulk-memory",
@@ -15,6 +16,7 @@
 		"-msign-ext"
 	],
 	"ldflags": [
+		"--stack-first",
 		"--no-demangle",
 		"--no-entry",
 		"--import-memory"


### PR DESCRIPTION
This PR improves `targets/wasm_unknown` by using proper defaults for GC to avoid always needing to add the extra flag which is now required for this target.