### PR TITLE
interp: do not register runtime timers during interp

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -239,7 +239,8 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				// already be emitted in initAll.
 				continue
 			case strings.HasPrefix(callFn.name, "runtime.print") || callFn.name == "runtime._panic" || callFn.name == "runtime.hashmapGet" || callFn.name == "runtime.hashmapInterfaceHash" ||
-				callFn.name == "os.runtime_args" || callFn.name == "internal/task.start" || callFn.name == "internal/task.Current":
+				callFn.name == "os.runtime_args" || callFn.name == "internal/task.start" || callFn.name == "internal/task.Current" ||
+				callFn.name == "time.startTimer" || callFn.name == "time.stopTimer" || callFn.name == "time.resetTimer":
 				// These functions should be run at runtime. Specifically:
 				//   * Print and panic functions are best emitted directly without
 				//     interpreting them, otherwise we get a ton of putchar (etc.)
@@ -252,6 +253,8 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				//     at runtime.
 				//   * internal/task.start, internal/task.Current: start and read shcheduler state,
 				//     which is modified elsewhere.
+				//   * Timer functions access runtime internal state which may
+				//     not be initialized.
 				err := r.runAtRuntime(fn, inst, locals, &mem, indent)
 				if err != nil {
 					return nil, mem, err

--- a/testdata/timers.go
+++ b/testdata/timers.go
@@ -2,6 +2,8 @@ package main
 
 import "time"
 
+var timer = time.NewTimer(time.Millisecond)
+
 func main() {
 	// Test ticker.
 	ticker := time.NewTicker(time.Millisecond * 500)


### PR DESCRIPTION
The runtime hasn't been initialized yet so this leads to problems.

This fixes https://github.com/tinygo-org/tinygo/issues/4123.