### PR TITLE
compileopts: remove workaround for LLVM 16

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -286,10 +286,6 @@ func (c *Config) CFlags(libclang bool) []string {
 		cflags = append(cflags,
 			"-resource-dir="+resourceDir,
 		)
-		if strings.HasPrefix(c.Triple(), "xtensa") {
-			// workaround needed in LLVM 16, see: https://github.com/espressif/llvm-project/issues/83
-			cflags = append(cflags, "-isystem", filepath.Join(resourceDir, "include"))
-		}
 	}
 	switch c.Target.Libc {
 	case "darwin-libSystem":


### PR DESCRIPTION
This workaround is no longer needed now that we've switched to LLVM 17 where this bug has been fixed upstream: https://github.com/espressif/llvm-project/pull/84
See: https://github.com/tinygo-org/tinygo/issues/3974 and https://github.com/tinygo-org/tinygo/pull/3975.