### PR TITLE
compileopts: always enable CGo

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -87,12 +87,6 @@ func (c *Config) BuildTags() []string {
 	return tags
 }
 
-// CgoEnabled returns true if (and only if) CGo is enabled. It is true by
-// default and false if CGO_ENABLED is set to "0".
-func (c *Config) CgoEnabled() bool {
-	return goenv.Get("CGO_ENABLED") == "1"
-}
-
 // GC returns the garbage collection strategy in use on this platform. Valid
 // values are "none", "leaking", "conservative" and "precise".
 func (c *Config) GC() string {

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -142,11 +142,8 @@ func Get(name string) string {
 		}
 		return filepath.Join(dir, "tinygo")
 	case "CGO_ENABLED":
-		val := os.Getenv("CGO_ENABLED")
-		if val == "1" || val == "0" {
-			return val
-		}
-		// Default to enabling CGo.
+		// Always enable CGo. It is required by a number of targets, including
+		// macOS and the rp2040.
 		return "1"
 	case "TINYGOROOT":
 		return sourceDir()

--- a/loader/list.go
+++ b/loader/list.go
@@ -22,12 +22,8 @@ func List(config *compileopts.Config, extraArgs, pkgs []string) (*exec.Cmd, erro
 		args = append(args, "-tags", strings.Join(config.BuildTags(), " "))
 	}
 	args = append(args, pkgs...)
-	cgoEnabled := "0"
-	if config.CgoEnabled() {
-		cgoEnabled = "1"
-	}
 	cmd := exec.Command(filepath.Join(goenv.Get("GOROOT"), "bin", "go"), args...)
-	cmd.Env = append(os.Environ(), "GOROOT="+goroot, "GOOS="+config.GOOS(), "GOARCH="+config.GOARCH(), "CGO_ENABLED="+cgoEnabled)
+	cmd.Env = append(os.Environ(), "GOROOT="+goroot, "GOOS="+config.GOOS(), "GOARCH="+config.GOARCH(), "CGO_ENABLED=1")
 	if config.Options.Directory != "" {
 		cmd.Dir = config.Options.Directory
 	}


### PR DESCRIPTION
CGo is needed for the rp2040 and for macOS (GOOS=darwin), without it these targets just won't work. And there really isn't a benefit from disabling CGo: we don't need any external linkers for example.

This avoids a somewhat common issue of people having CGO_ENABLED=0 somewhere in their environment and not understanding why things don't work. See for example: https://github.com/tinygo-org/tinygo/issues/3450