### PR TITLE
Dockerfile: don't remove cached files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,7 @@
 FROM golang:1.22 AS tinygo-llvm
 
 RUN apt-get update && \
-    apt-get install -y apt-utils make cmake clang-15 ninja-build && \
-    rm -rf \
-        /var/lib/apt/lists/* \
-        /var/log/* \
-        /var/tmp/* \
-        /tmp/*
+    apt-get install -y apt-utils make cmake clang-15 ninja-build
 
 COPY ./GNUmakefile /tinygo/GNUmakefile
 


### PR DESCRIPTION
This reverts 649f49e00080e2317617e19c76450eeb2af491f7. It is not necessary anymore: the container is an intermediary container so doesn't need to be extra small.

Not sure whether this is really needed but it seems a little cleaner to me.