### PR TITLE
make: fetch tags for binaryen before trying to build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -256,7 +256,7 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
 binaryen: build/wasm-opt$(EXE)
 build/wasm-opt$(EXE):
 	mkdir -p build
-	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
+	cd lib/binaryen && git fetch --tags && cmake -G Ninja . -DBUILD_STATIC_LIB=ON $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
 	cp lib/binaryen/bin/wasm-opt$(EXE) build/wasm-opt$(EXE)
 endif
 


### PR DESCRIPTION
This PR modifies the make task for Binaryen to fetch tags for before trying to build due to hitting this error:

https://github.com/WebAssembly/binaryen/blob/version_116/CMakeLists.txt#L63