### PR TITLE
Don't add `--recursive` to `git submodule update --init`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
     steps:
       - run:
           name: "Pull submodules"
-          command: git submodule update --init --recursive
+          command: git submodule update --init
   llvm-source-linux:
     steps:
       - restore_cache:
@@ -33,13 +33,13 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - binaryen-linux-v2
+            - binaryen-linux-v3
       - run:
           name: "Build Binaryen"
           command: |
             make binaryen
       - save_cache:
-          key: binaryen-linux-v2
+          key: binaryen-linux-v3
           paths:
             - build/wasm-opt
   test-linux:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,13 +356,13 @@ jobs:
         uses: actions/cache@v4
         id: cache-binaryen
         with:
-          key: binaryen-linux-${{ matrix.goarch }}-v3
+          key: binaryen-linux-${{ matrix.goarch }}-v4
           path: build/wasm-opt
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: |
           sudo apt-get install --no-install-recommends ninja-build
-          git submodule update --init --recursive lib/binaryen
+          git submodule update --init lib/binaryen
           make CROSS=${{ matrix.toolchain }} binaryen
       - name: Install fpm
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,7 +85,7 @@ Now that we have a working static build, it's time to make a release tarball:
 
 If you did not clone the repository with the `--recursive` option, you will get errors until you initialize the project submodules:
 
-    git submodule update --init --recursive
+    git submodule update --init
 
 The release tarball is stored in build/release.tar.gz, and can be extracted with
 the following command (for example in ~/lib):

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . /tinygo
 
 # build the compiler and tools
 RUN cd /tinygo/ && \
-    git submodule update --init --recursive && \
+    git submodule update --init && \
     make gen-device -j4 && \
     make build/release
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -190,7 +190,7 @@ gen-device: gen-device-stm32
 endif
 
 gen-device-avr:
-	@if [ ! -e lib/avr/README.md ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init --recursive"; exit 1; fi
+	@if [ ! -e lib/avr/README.md ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
 	$(GO) build -o ./build/gen-device-avr ./tools/gen-device-avr/
 	./build/gen-device-avr lib/avr/packs/atmega src/device/avr/
 	./build/gen-device-avr lib/avr/packs/tiny src/device/avr/
@@ -264,7 +264,7 @@ endif
 .PHONY: wasi-libc
 wasi-libc: lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a
 lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
-	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init --recursive"; exit 1; fi
+	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
 	cd lib/wasi-libc && $(MAKE) -j4 EXTRA_CFLAGS="-O2 -g -DNDEBUG -mnontrapping-fptoint -msign-ext" MALLOC_IMPL=none CC="$(CLANG)" AR=$(LLVM_AR) NM=$(LLVM_NM)
 
 # Check for Node.js used during WASM tests.

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,10 @@
 #
 # But you'll need a bit more to make TinyGo actually able to compile code:
 #
-#   make llvm-source                        # fetch compiler-rt
-#   git submodule update --init --recursive # fetch lots of other libraries and SVD files
-#   make gen-device -j4                     # build src/device/*/*.go files
-#   make wasi-libc                          # build support for wasi/wasm
+#   make llvm-source            # fetch compiler-rt
+#   git submodule update --init # fetch lots of other libraries and SVD files
+#   make gen-device -j4         # build src/device/*/*.go files
+#   make wasi-libc              # build support for wasi/wasm
 #
 # With this, you should have an environment that can compile anything - except
 # for the Xtensa architecture (ESP8266/ESP32) because support for that lives in

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Docker hub does a recursive clone, then checks the branch out,
 # so when a PR adds a submodule (or updates it), it fails.
-git submodule update --init --recursive
+git submodule update --init


### PR DESCRIPTION
It's not generally needed. It was added in https://github.com/tinygo-org/tinygo/pull/3958 to fix an issue with binaryen that has since been fixed in #4154, so we don't need the googletest dependency anymore.

Draft until the release is done. #4154 is the hotfix, this cleans up some things after the hotfix and is more risky.