### PR TITLE
runtime: add Frame.Entry field

### DIFF
--- a/src/runtime/symtab.go
+++ b/src/runtime/symtab.go
@@ -13,6 +13,8 @@ type Frame struct {
 
 	File string
 	Line int
+
+	Entry uintptr
 }
 
 func CallersFrames(callers []uintptr) *Frames {


### PR DESCRIPTION
This enables compatibility with golang.org/x/tools/internal/pkgbits.

https://github.com/golang/tools/blob/master/internal/pkgbits/frames_go17.go