### PR TITLE
docker: update final build stage to go1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cd /tinygo/ && \
 
 # tinygo-compiler copies the compiler build over to a base Go container (without
 # all the build tools etc).
-FROM golang:1.21 AS tinygo-compiler
+FROM golang:1.22 AS tinygo-compiler
 
 # Copy tinygo build.
 COPY --from=tinygo-compiler-build /tinygo/build/release/tinygo /tinygo


### PR DESCRIPTION
This PR updates the docker dev build final stage to use go1.22 as it should have been. :crying_cat_face: 