### PR TITLE
build: only use GHA cache for docker dev builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-contexts: tinygo-llvm-build=docker-image://tinygo/llvm-17
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Trigger Drivers repo build on Github Actions


### PR DESCRIPTION
This PR modifies the build to only use the GHA cache for docker dev builds, ignoring the previously saved build-context.

Needed to address apparent cache issue with the `dev` image.