### PR TITLE
syscall: add wasm_unknown to some additional files

### DIFF
--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1)
+//go:build baremetal || (wasm && !wasip1) || wasm_unknown
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !(baremetal || (wasm && !wasip1))
+//go:build !(baremetal || (wasm && !wasip1) || wasm_unknown)
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || wasm_unknown
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js
+//go:build baremetal || nintendoswitch || js || wasm_unknown
 
 package syscall
 


### PR DESCRIPTION
This PR modifies the `syscall` package to add the `wasm_unknown` tag to some additional files so more code can successfully compile.