### PR TITLE
compiler: handle missing LLVM math intrinsics on wasm targets

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -830,7 +830,7 @@ func (c *compilerContext) createPackage(irbuilder llvm.Builder, pkg *ssa.Package
 			}
 			// Create the function definition.
 			b := newBuilder(c, irbuilder, member)
-			if _, ok := mathToLLVMMapping[member.RelString(nil)]; ok {
+			if intrinsic := b.mathToLLVMMapping(member.RelString(nil)); intrinsic != "" {
 				// The body of this function (if there is one) is ignored and
 				// replaced with a LLVM intrinsic call.
 				b.defineMathOp()

--- a/tests/math/math_bench_test.go
+++ b/tests/math/math_bench_test.go
@@ -1,0 +1,58 @@
+// //go:build tinygo.wasm
+
+package math_test
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+var tested float64
+
+var data [1024]float64
+
+func init() {
+	r := rand.New(rand.NewSource(0))
+	for i := range data {
+		data[i] = r.NormFloat64()
+	}
+}
+
+func BenchmarkMathAbs(b *testing.B) {
+	var f float64
+	for i := 0; i < b.N; i++ {
+		f = math.Abs(data[i%len(data)])
+	}
+	tested = f
+}
+func BenchmarkMathCeil(b *testing.B) {
+	var f float64
+	for i := 0; i < b.N; i++ {
+		f = math.Ceil(data[i%len(data)])
+	}
+	tested = f
+}
+func BenchmarkMathExp(b *testing.B) {
+	var f float64
+	for i := 0; i < b.N; i++ {
+		f = math.Exp(data[i%len(data)])
+	}
+	tested = f
+}
+
+func BenchmarkMathExp2(b *testing.B) {
+	var f float64
+	for i := 0; i < b.N; i++ {
+		f = math.Exp2(data[i%len(data)])
+	}
+	tested = f
+}
+
+func BenchmarkMathLog(b *testing.B) {
+	var f float64
+	for i := 0; i < b.N; i++ {
+		f = math.Log(data[i%len(data)])
+	}
+	tested = f
+}

--- a/tests/math/math_nolibc.go
+++ b/tests/math/math_nolibc.go
@@ -1,0 +1,27 @@
+//go:build nolibc
+
+package math_test
+
+//go:export exp
+func exp(f float64) float64 {
+	return mathExp(f)
+}
+
+//go:linkname mathExp math.exp
+func mathExp(float64) float64
+
+//go:export exp2
+func exp2(f float64) float64 {
+	return mathExp(f)
+}
+
+//go:linkname mathExp2 math.exp2
+func mathExp2(float64) float64
+
+//go:export log
+func log(f float64) float64 {
+	return mathLog(f)
+}
+
+//go:linkname mathLog math.log
+func mathLog(float64) float64

--- a/tests/math/math_nolibc.go
+++ b/tests/math/math_nolibc.go
@@ -2,6 +2,8 @@
 
 package math_test
 
+import _ "unsafe"
+
 //go:export exp
 func exp(f float64) float64 {
 	return mathExp(f)

--- a/tests/math/math_test.go
+++ b/tests/math/math_test.go
@@ -1,13 +1,15 @@
 package math_test
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
-	_ "unsafe"
 )
 
-var tested float64
+func testDone(f float64) {
+	fmt.Sprintf("%f", f)
+}
 
 var data [1024]float64
 
@@ -21,38 +23,43 @@ func init() {
 func BenchmarkMathAbs(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {
-		f = math.Abs(data[i%len(data)])
+		f += math.Abs(data[i%len(data)])
 	}
-	tested = f
+	b.StopTimer()
+	testDone(f)
 }
 func BenchmarkMathCeil(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {
-		f = math.Ceil(data[i%len(data)])
+		f += math.Ceil(data[i%len(data)])
 	}
-	tested = f
+	b.StopTimer()
+	testDone(f)
 }
 
 func BenchmarkMathExp(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {
-		f = math.Exp(data[i%len(data)])
+		f += math.Exp(data[i%len(data)])
 	}
-	tested = f
+	b.StopTimer()
+	testDone(f)
 }
 
 func BenchmarkMathExp2(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {
-		f = math.Exp2(data[i%len(data)])
+		f += math.Exp2(data[i%len(data)])
 	}
-	tested = f
+	b.StopTimer()
+	testDone(f)
 }
 
 func BenchmarkMathLog(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {
-		f = math.Log(data[i%len(data)])
+		f += math.Log(data[i%len(data)])
 	}
-	tested = f
+	b.StopTimer()
+	testDone(f)
 }

--- a/tests/math/math_test.go
+++ b/tests/math/math_test.go
@@ -1,11 +1,10 @@
-// //go:build tinygo.wasm
-
 package math_test
 
 import (
 	"math"
 	"math/rand"
 	"testing"
+	_ "unsafe"
 )
 
 var tested float64
@@ -33,6 +32,7 @@ func BenchmarkMathCeil(b *testing.B) {
 	}
 	tested = f
 }
+
 func BenchmarkMathExp(b *testing.B) {
 	var f float64
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This enables WebAssembly targets (unknown, wasip2) to use package math without linking libc.

The missing intrinsics are:

```
llvm.exp.f64
llvm.exp2.f64
llvm.log.f64
```

This is required for and cherry-picked from the WASI Preview 2 fork we’re working on with @dgryski.