### PR TITLE
wasm: Allow multi-value return in wasmimport

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -356,10 +356,8 @@ func (c *compilerContext) checkWasmImport(f *ssa.Function, pragma string) {
 		c.addError(f.Pos(), fmt.Sprintf("can only use //go:wasmimport on declarations"))
 		return
 	}
-	if f.Signature.Results().Len() > 1 {
-		c.addError(f.Signature.Results().At(1).Pos(), fmt.Sprintf("%s: too many return values", pragma))
-	} else if f.Signature.Results().Len() == 1 {
-		result := f.Signature.Results().At(0)
+	for i := 0; i < f.Signature.Results().Len(); i++ {
+		result := f.Signature.Results().At(i)
 		if !isValidWasmType(result.Type(), true) {
 			c.addError(result.Pos(), fmt.Sprintf("%s: unsupported result type %s", pragma, result.Type().String()))
 		}

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -27,8 +27,6 @@ func invalidparam(a int, b string, c []byte, d *int32)
 //go:wasmimport modulename validreturn
 func validreturn() int32
 
-// ERROR: //go:wasmimport modulename manyreturns: too many return values
-//
 //go:wasmimport modulename manyreturns
 func manyreturns() (int32, int32)
 


### PR DESCRIPTION
## Background

There were some limitations imposed on `//go:wasmimport` last year. See https://github.com/tinygo-org/tinygo/pull/3734. The goal is to match the behavior of Go. See https://github.com/golang/go/issues/59149. Notably, there is a check that the imported function returns at most one value.

## Problem

The [multi-value proposal](https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md) was accepted 2 years ago and [all major runtimes support it](https://webassembly.org/features/). Even before the proposal was accepted, all major runtimes were prepared for the change because it was hinted right in the wasm MVP spec.

While the limit makes sense for wasip1 target, there is no reason to keep the limit for the wasi-unknown target. The multi-value returns will be required for the component model and so possibly for wasip3 target. The wasip2 spec, while already using the component model, relies on the current version of the component model spec which limits the return values to at most 1. This is a configurable value. [From the proposal](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening):

> The number of flattened results is currently limited to 1 due to various parts of the toolchain (notably the C ABI) not yet being able to express [multi-value](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md) returns. Hopefully this limitation is temporary and can be lifted before the Component Model is fully standardized.

While the initial motivation for the validation was to copy the Go's behavior, we should keep in mind that Go supports only wasm/js and wasm/wasi while TinyGo now supports wasm-unknown. Also, wasm is a very actively evolving technology, and decisions made 1 year ago may not hold.

## Proposal

I suggest removing the restriction for the sake of wasm-unknown and all other possible wasm-related future targets. The PR just removes the limit but I don't know TinyGo source code enough to tell if that's all that needs to be done.

## Backward compatibility

The change is backward compatible. All code that worked before will work.

## Considerations

Should we keep the limit for the `wasi` (aka `wasip1`) target?