### PR TITLE
cgo: do a basic test that math functions work

### DIFF
--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "main.h"
 
 int global = 3;
@@ -66,4 +67,8 @@ void unionSetData(short f0, short f1, short f2) {
 
 void arraydecay(int buf1[5], int buf2[3][8], int buf3[4][7][2]) {
 	// Do nothing.
+}
+
+double doSqrt(double x) {
+	return sqrt(x);
 }

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -2,6 +2,7 @@ package main
 
 /*
 #include <stdio.h>
+#include <math.h>
 int fortytwo(void);
 #include "main.h"
 #include "test.h"
@@ -170,6 +171,10 @@ func main() {
 	buf2 := make([]byte, len(buf1))
 	C.strcpy((*C.char)(unsafe.Pointer(&buf2[0])), (*C.char)(unsafe.Pointer(&buf1[0])))
 	println("copied string:", string(buf2[:C.strlen((*C.char)(unsafe.Pointer(&buf2[0])))]))
+
+	// libc: test libm functions (normally bundled in libc)
+	println("CGo sqrt(3):", C.sqrt(3))
+	println("C   sqrt(3):", C.doSqrt(3))
 
 	// libc: test basic stdio functionality
 	putsBuf := []byte("line written using C puts\x00")

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -150,3 +150,5 @@ extern int global;
 // Test array decaying into a pointer.
 typedef int arraydecay_buf3[4][7][2];
 void arraydecay(int buf1[5], int buf2[3][8], arraydecay_buf3 buf3);
+
+double doSqrt(double);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -74,4 +74,6 @@ C.GoString(nil):
 len(C.GoStringN(nil, 0)): 0
 len(C.GoBytes(nil, 0)): 0
 copied string: foobar
+CGo sqrt(3): +1.732051e+000
+C   sqrt(3): +1.732051e+000
 line written using C puts


### PR DESCRIPTION
They should, but we weren't testing this.
I discovered this while working on https://github.com/tinygo-org/macos-minimal-sdk/pull/4 which will likely make math.h not work anymore (it will need a single-line fix in TinyGo). So I wanted to make sure we have a test in place before we update that dependency.