### PR TITLE
compileopts: apply OpenOCD commands after target configuration

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -475,9 +475,6 @@ func (c *Config) OpenOCDConfiguration() (args []string, err error) {
 		return nil, fmt.Errorf("unknown OpenOCD transport: %#v", c.Target.OpenOCDTransport)
 	}
 	args = []string{"-f", "interface/" + openocdInterface + ".cfg"}
-	for _, cmd := range c.Target.OpenOCDCommands {
-		args = append(args, "-c", cmd)
-	}
 	if c.Target.OpenOCDTransport != "" {
 		transport := c.Target.OpenOCDTransport
 		if transport == "swd" {
@@ -489,6 +486,9 @@ func (c *Config) OpenOCDConfiguration() (args []string, err error) {
 		args = append(args, "-c", "transport select "+transport)
 	}
 	args = append(args, "-f", "target/"+c.Target.OpenOCDTarget+".cfg")
+	for _, cmd := range c.Target.OpenOCDCommands {
+		args = append(args, "-c", cmd)
+	}
 	return args, nil
 }
 


### PR DESCRIPTION
The openocd-commands option cannot refer to commands defined by the target configuration. Lift this restriction by moving the commands to after target loading.

The other two users of 'openocd-commands' are:

```text
$ rg openocd-commands
targets/bluepill-clone.json
3:	"openocd-commands": ["set CPUTAPID 0x2ba01477"]

targets/esp32c3.json
20: 	"openocd-commands": ["gdb_memory_map disable"],
```

I don't know whether this change affects them, nor users of the `-ocd-commands` command line option. Let me know if you'd rather have some other way of achieving the goal.