### PR TITLE
mksnanov3: limit programming speed to 1800 kHz

### DIFF
--- a/targets/mksnanov3.json
+++ b/targets/mksnanov3.json
@@ -7,6 +7,7 @@
     "src/device/stm32/stm32f407.s"
   ],
   "flash-method": "openocd",
-  "openocd-interface": "stlink-v2",
-  "openocd-target": "stm32f4x"
+  "openocd-interface": "stlink",
+  "openocd-target": "stm32f4x",
+  "openocd-commands": ["stm32f4x.cpu configure -event reset-init { adapter speed 1800 }"]
 }


### PR DESCRIPTION
Fixes stability problems when programming the Mks Nano v3.x boards.

Depends on https://github.com/tinygo-org/tinygo/pull/4180.