### PR TITLE
wasm: fix symbol table index for archives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tinygo-org/tinygo
 go 1.18
 
 require (
-	github.com/aykevl/go-wasm v0.0.2-0.20220616010729-4a0a888aebdc
+	github.com/aykevl/go-wasm v0.0.2-0.20240312204833-50275154210c
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/chromedp/cdproto v0.0.0-20220113222801-0725d94bb6ee
 	github.com/chromedp/chromedp v0.7.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aykevl/go-wasm v0.0.2-0.20220616010729-4a0a888aebdc h1:Yp49g+qqgQRPk/gcRSmAsXgnT16XPJ6Y5JM1poc6gYM=
-github.com/aykevl/go-wasm v0.0.2-0.20220616010729-4a0a888aebdc/go.mod h1:7sXyiaA0WtSogCu67R2252fQpVmJMh9JWJ9ddtGkpWw=
+github.com/aykevl/go-wasm v0.0.2-0.20240312204833-50275154210c h1:4T0Vj1UkGgcpkRrmn7SbokebnlfxJcMZPgWtOYACAAA=
+github.com/aykevl/go-wasm v0.0.2-0.20240312204833-50275154210c/go.mod h1:7sXyiaA0WtSogCu67R2252fQpVmJMh9JWJ9ddtGkpWw=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=


### PR DESCRIPTION
The symbol table was generated incorrectly. The correct way is to use the custom linking WebAssembly section, which I implemented in go-wasm for this purpose (see https://github.com/aykevl/go-wasm/commit/50275154210c1816c2a4ef2fdd33b78e412f08a2).

This fixes https://github.com/tinygo-org/tinygo/issues/4114 and is a prerequisite for https://github.com/tinygo-org/tinygo/pull/4176.