### PR TITLE
feather-nrf52840-sense doesn't use LFXO

### DIFF
--- a/src/machine/board_feather-nrf52840-sense.go
+++ b/src/machine/board_feather-nrf52840-sense.go
@@ -2,7 +2,7 @@
 
 package machine
 
-const HasLowFrequencyCrystal = true
+const HasLowFrequencyCrystal = false
 
 // GPIO Pins
 const (


### PR DESCRIPTION
Submitting a PR based on discussion with @aykevl here: https://github.com/tinygo-org/bluetooth/issues/251

In the adafruit github comparing feather_nrf52840_express to feather_nrf52840_sense there does seem to be a difference between the two boards, this issue was also experienced with the ledglasses-nrf52840 board https://github.com/tinygo-org/tinygo/pull/4020#issuecomment-1837556982

Express
```
#define USE_LFXO      // Board uses 32khz crystal for LF
// define USE_LFRC    // Board uses RC for LF
```

Sense
```
#define USE_LFRC    // Board uses RC for LF
```

