### PR TITLE
goenv: put back @sago35 update to new v0.32.0 development version

### DIFF
--- a/goenv/version.go
+++ b/goenv/version.go
@@ -9,7 +9,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const version = "0.31.2"
+const version = "0.32.0-dev"
 
 var (
 	// This variable is set at build time using -ldflags parameters.


### PR DESCRIPTION
This PR puts back the @sago35 update to new v0.32.0 development version.