### PR TITLE
crypto/ed25519 

### DIFF
--- a/compiler/alias.go
+++ b/compiler/alias.go
@@ -16,8 +16,8 @@ import "tinygo.org/x/go-llvm"
 
 var stdlibAliases = map[string]string{
 	// crypto packages
-	"crypto/ed25519/internal/edwards25519/field.feMul":    "crypto/ed25519/internal/edwards25519/field.feMulGeneric",
-	"crypto/ed25519/internal/edwards25519/field.feSquare": "crypto/ed25519/internal/edwards25519/field.feSquareGeneric",
+	"crypto/ed25519/internal/edwards25519/field.feMul": "crypto/ed25519/internal/edwards25519/field.feMulGeneric",
+	"crypto/internal/edwards25519/field.feSquare":      "crypto/ed25519/internal/edwards25519/field.feSquareGeneric",
 	"crypto/md5.block":         "crypto/md5.blockGeneric",
 	"crypto/sha1.block":        "crypto/sha1.blockGeneric",
 	"crypto/sha1.blockAMD64":   "crypto/sha1.blockGeneric",


### PR DESCRIPTION
This PR should fix the compile error for crypto/ed25519. Changing the path for the aliasing resolved the issue on the website [1].
Using an example program to verify the functionality yields success for me [2]. 

Note:
Contrary to the standard implementation for `ed25519.GenerateKey` the call in `tinygo` always generates a different key [3].
Maybe we should look into this issue.

[1]: https://tinygo.org/docs/reference/lang-support/stdlib/#cryptoed25519
[2]: https://asecuritysite.com/golang/ed25519
[3]: https://pkg.go.dev/crypto/ed25519#GenerateKey