### PR TITLE
nix: fix wasi-libc include headers

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -310,7 +310,9 @@ func (c *Config) CFlags(libclang bool) []string {
 		)
 	case "wasi-libc":
 		root := goenv.Get("TINYGOROOT")
-		cflags = append(cflags, "--sysroot="+root+"/lib/wasi-libc/sysroot")
+		cflags = append(cflags,
+			"-nostdlibinc",
+			"-isystem", root+"/lib/wasi-libc/sysroot/include")
 	case "wasmbuiltins":
 		// nothing to add (library is purely for builtins)
 	case "mingw-w64":


### PR DESCRIPTION
Apparently Nix really doesn't like --sysroot, so we have to use `-nostdlibinc` and `-isystem` instead.

~I've also added some tests to try to detect common issues like these.~ these tests would actually slow down the Nix test a lot with little benefit (the main tests are already done for other OSes) so I've removed them again.

This issue was reported to me by someone on Telegram.