### PR TITLE
Make most RP2040 boards available for simulation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -525,6 +525,8 @@ ifneq ($(WASM), 0)
 	@$(MD5SUM) test.wasm
 	$(TINYGO) build -size short -o test.wasm -tags=mch2022              examples/serial
 	@$(MD5SUM) test.wasm
+	$(TINYGO) build -size short -o test.wasm -tags=gopher_badge         examples/blinky1
+	@$(MD5SUM) test.wasm
 endif
 	# test all targets/boards
 	$(TINYGO) build -size short -o test.hex -target=pca10040-s132v6     examples/blinky1

--- a/src/machine/board_ae_rp2040.go
+++ b/src/machine/board_ae_rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // GPIO pins
 const (
 	GP0  Pin = GPIO0
@@ -77,27 +72,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_badger2040.go
+++ b/src/machine/board_badger2040.go
@@ -7,11 +7,6 @@
 // - Badger 2040 schematic: https://cdn.shopify.com/s/files/1/0174/1800/files/badger_2040_schematic.pdf?v=1645702148
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	LED Pin = GPIO25
 
@@ -92,17 +87,4 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}

--- a/src/machine/board_challenger_rp2040.go
+++ b/src/machine/board_challenger_rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	LED = GPIO24
 
@@ -84,27 +79,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Onboard crystal oscillator frequency, in MHz.
 const xoscFreq = 12 // MHz
 
@@ -73,27 +68,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_gopher-badge.go
+++ b/src/machine/board_gopher-badge.go
@@ -5,11 +5,6 @@
 // For more information, see: https://gopherbadge.com/
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	/*ADC0 Pin = GPIO26
 	ADC1 Pin = GPIO27
@@ -92,17 +87,4 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART1
-
-func init() {
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}

--- a/src/machine/board_kb2040.go
+++ b/src/machine/board_kb2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Onboard crystal oscillator frequency, in MHz.
 const xoscFreq = 12 // MHz
 
@@ -75,27 +70,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	NeopixelCount = 12
 
@@ -78,20 +73,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -11,11 +11,6 @@
 // - Nano RP2040 Connect technical reference: https://docs.arduino.cc/tutorials/nano-rp2040-connect/rp2040-01-technical-reference
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Digital Pins
 const (
 	D2  Pin = GPIO25
@@ -125,27 +120,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-
-	// UART_NINA on the Arduino Nano RP2040 connects to the NINA HCI.
-	UART_NINA = UART1
-)
+// UART_NINA on the Arduino Nano RP2040 connects to the NINA HCI.
+var UART_NINA = UART1
 
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // GPIO pins
 const (
 	GP0  Pin = GPIO0
@@ -79,27 +74,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_qtpy_rp2040.go
+++ b/src/machine/board_qtpy_rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Onboard crystal oscillator frequency, in MHz.
 const xoscFreq = 12 // MHz
 
@@ -84,27 +79,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -2,11 +2,6 @@
 
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Onboard crystal oscillator frequency, in MHz.
 const xoscFreq = 12 // MHz
 
@@ -90,20 +85,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}
 
 // USB identifiers
 const (

--- a/src/machine/board_thumby.go
+++ b/src/machine/board_thumby.go
@@ -5,11 +5,6 @@
 // https://thumby.us/
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	THUMBY_SCK_PIN = I2C1_SDA_PIN
 	THUMBY_SDA_PIN = I2C1_SCL_PIN
@@ -78,17 +73,4 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the Thumby
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}

--- a/src/machine/board_tufty2040.go
+++ b/src/machine/board_tufty2040.go
@@ -7,11 +7,6 @@
 // - Tufty 2040 schematic: https://cdn.shopify.com/s/files/1/0174/1800/files/tufty_schematic.pdf?v=1655385675
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 const (
 	LED Pin = GPIO25
 
@@ -87,17 +82,4 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}

--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -7,11 +7,6 @@
 // - https://www.waveshare.com/wiki/RP2040-Zero
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Digital Pins
 const (
 	D0  Pin = GPIO0
@@ -94,26 +89,7 @@ const (
 	UART1_RX_PIN = GPIO9
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-	UART1  = &_UART1
-	_UART1 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART1,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
-}
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -7,11 +7,6 @@
 // - https://wiki.seeedstudio.com/XIAO-RP2040/
 package machine
 
-import (
-	"device/rp"
-	"runtime/interrupt"
-)
-
 // Digital Pins
 const (
 	D0  Pin = GPIO26
@@ -81,20 +76,7 @@ const (
 	UART_RX_PIN  = UART0_RX_PIN
 )
 
-// UART on the RP2040
-var (
-	UART0  = &_UART0
-	_UART0 = UART{
-		Buffer: NewRingBuffer(),
-		Bus:    rp.UART0,
-	}
-)
-
 var DefaultUART = UART0
-
-func init() {
-	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
-}
 
 // USB CDC identifiers
 const (

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -7,15 +7,14 @@ package machine
 const deviceName = "generic"
 
 var (
-	UART0 = &UART{0}
-	USB   = &UART{100}
+	USB = &UART{100}
 )
 
 // The Serial port always points to the default UART in a simulated environment.
 //
 // TODO: perhaps this should be a special serial object that outputs via WASI
 // stdout calls.
-var Serial = UART0
+var Serial = hardwareUART0
 
 const (
 	PinInput PinMode = iota
@@ -175,6 +174,11 @@ func uartRead(bus uint8, buf *byte, bufLen int) int
 
 //export __tinygo_uart_write
 func uartWrite(bus uint8, buf *byte, bufLen int) int
+
+var (
+	hardwareUART0 = &UART{0}
+	hardwareUART1 = &UART{1}
+)
 
 // Some objects used by Atmel SAM D chips (samd21, samd51).
 // Defined here (without build tag) for convenience.

--- a/src/machine/machine_generic_peripherals.go
+++ b/src/machine/machine_generic_peripherals.go
@@ -6,6 +6,9 @@ package machine
 // boards that define their peripherals in the board file (e.g. board_qtpy.go).
 
 var (
-	SPI0 = SPI{0}
-	I2C0 = &I2C{0}
+	UART0 = hardwareUART0
+	UART1 = hardwareUART1
+	SPI0  = SPI{0}
+	SPI1  = SPI{1}
+	I2C0  = &I2C{0}
 )

--- a/src/machine/machine_rp2040.go
+++ b/src/machine/machine_rp2040.go
@@ -10,46 +10,6 @@ import (
 
 const deviceName = rp.Device
 
-const (
-	// GPIO pins
-	GPIO0  Pin = 0  // peripherals: PWM0 channel A
-	GPIO1  Pin = 1  // peripherals: PWM0 channel B
-	GPIO2  Pin = 2  // peripherals: PWM1 channel A
-	GPIO3  Pin = 3  // peripherals: PWM1 channel B
-	GPIO4  Pin = 4  // peripherals: PWM2 channel A
-	GPIO5  Pin = 5  // peripherals: PWM2 channel B
-	GPIO6  Pin = 6  // peripherals: PWM3 channel A
-	GPIO7  Pin = 7  // peripherals: PWM3 channel B
-	GPIO8  Pin = 8  // peripherals: PWM4 channel A
-	GPIO9  Pin = 9  // peripherals: PWM4 channel B
-	GPIO10 Pin = 10 // peripherals: PWM5 channel A
-	GPIO11 Pin = 11 // peripherals: PWM5 channel B
-	GPIO12 Pin = 12 // peripherals: PWM6 channel A
-	GPIO13 Pin = 13 // peripherals: PWM6 channel B
-	GPIO14 Pin = 14 // peripherals: PWM7 channel A
-	GPIO15 Pin = 15 // peripherals: PWM7 channel B
-	GPIO16 Pin = 16 // peripherals: PWM0 channel A
-	GPIO17 Pin = 17 // peripherals: PWM0 channel B
-	GPIO18 Pin = 18 // peripherals: PWM1 channel A
-	GPIO19 Pin = 19 // peripherals: PWM1 channel B
-	GPIO20 Pin = 20 // peripherals: PWM2 channel A
-	GPIO21 Pin = 21 // peripherals: PWM2 channel B
-	GPIO22 Pin = 22 // peripherals: PWM3 channel A
-	GPIO23 Pin = 23 // peripherals: PWM3 channel B
-	GPIO24 Pin = 24 // peripherals: PWM4 channel A
-	GPIO25 Pin = 25 // peripherals: PWM4 channel B
-	GPIO26 Pin = 26 // peripherals: PWM5 channel A
-	GPIO27 Pin = 27 // peripherals: PWM5 channel B
-	GPIO28 Pin = 28 // peripherals: PWM6 channel A
-	GPIO29 Pin = 29 // peripherals: PWM6 channel B
-
-	// Analog pins
-	ADC0 Pin = GPIO26
-	ADC1 Pin = GPIO27
-	ADC2 Pin = GPIO28
-	ADC3 Pin = GPIO29
-)
-
 //go:linkname machineInit runtime.machineInit
 func machineInit() {
 	// Reset all peripherals to put system into a known state,

--- a/src/machine/machine_rp2040_gpio.go
+++ b/src/machine/machine_rp2040_gpio.go
@@ -331,3 +331,23 @@ func (p Pin) ioIntBit(change PinChange) uint32 {
 func getIntChange(p Pin, status uint32) PinChange {
 	return PinChange(status>>(4*(p%8))) & 0xf
 }
+
+// UART on the RP2040
+var (
+	UART0  = &_UART0
+	_UART0 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART0,
+	}
+
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer: NewRingBuffer(),
+		Bus:    rp.UART1,
+	}
+)
+
+func init() {
+	UART0.Interrupt = interrupt.New(rp.IRQ_UART0_IRQ, _UART0.handleInterrupt)
+	UART1.Interrupt = interrupt.New(rp.IRQ_UART1_IRQ, _UART1.handleInterrupt)
+}

--- a/src/machine/machine_rp2040_pins.go
+++ b/src/machine/machine_rp2040_pins.go
@@ -1,0 +1,43 @@
+//go:build rp2040 || ae_rp2040 || badger2040 || challenger_rp2040 || feather_rp2040 || gopher_badge || kb2040 || macropad_rp2040 || nano_rp2040 || pico || qtpy_rp2040 || thingplus_rp2040 || thumby || tufty2040 || waveshare_rp2040_zero || xiao_rp2040
+
+package machine
+
+const (
+	// GPIO pins
+	GPIO0  Pin = 0  // peripherals: PWM0 channel A
+	GPIO1  Pin = 1  // peripherals: PWM0 channel B
+	GPIO2  Pin = 2  // peripherals: PWM1 channel A
+	GPIO3  Pin = 3  // peripherals: PWM1 channel B
+	GPIO4  Pin = 4  // peripherals: PWM2 channel A
+	GPIO5  Pin = 5  // peripherals: PWM2 channel B
+	GPIO6  Pin = 6  // peripherals: PWM3 channel A
+	GPIO7  Pin = 7  // peripherals: PWM3 channel B
+	GPIO8  Pin = 8  // peripherals: PWM4 channel A
+	GPIO9  Pin = 9  // peripherals: PWM4 channel B
+	GPIO10 Pin = 10 // peripherals: PWM5 channel A
+	GPIO11 Pin = 11 // peripherals: PWM5 channel B
+	GPIO12 Pin = 12 // peripherals: PWM6 channel A
+	GPIO13 Pin = 13 // peripherals: PWM6 channel B
+	GPIO14 Pin = 14 // peripherals: PWM7 channel A
+	GPIO15 Pin = 15 // peripherals: PWM7 channel B
+	GPIO16 Pin = 16 // peripherals: PWM0 channel A
+	GPIO17 Pin = 17 // peripherals: PWM0 channel B
+	GPIO18 Pin = 18 // peripherals: PWM1 channel A
+	GPIO19 Pin = 19 // peripherals: PWM1 channel B
+	GPIO20 Pin = 20 // peripherals: PWM2 channel A
+	GPIO21 Pin = 21 // peripherals: PWM2 channel B
+	GPIO22 Pin = 22 // peripherals: PWM3 channel A
+	GPIO23 Pin = 23 // peripherals: PWM3 channel B
+	GPIO24 Pin = 24 // peripherals: PWM4 channel A
+	GPIO25 Pin = 25 // peripherals: PWM4 channel B
+	GPIO26 Pin = 26 // peripherals: PWM5 channel A
+	GPIO27 Pin = 27 // peripherals: PWM5 channel B
+	GPIO28 Pin = 28 // peripherals: PWM6 channel A
+	GPIO29 Pin = 29 // peripherals: PWM6 channel B
+
+	// Analog pins
+	ADC0 Pin = GPIO26
+	ADC1 Pin = GPIO27
+	ADC2 Pin = GPIO28
+	ADC3 Pin = GPIO29
+)


### PR DESCRIPTION
This makes these boards available to be used on play.tinygo.org, once the appropriate board specs (SVG files etc) are created. In particular, this includes the Gopher Badge which I'm currently working on (but adding most other boards was trivial so I included those as well).