### PR TITLE
Add STM32 Nucleo L476RG Support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -708,6 +708,8 @@ ifneq ($(STM32), 0)
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-l432kc       examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=nucleo-l476rg       examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-l552ze       examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nucleo-wl55jc       examples/blinky1

--- a/src/machine/board_nucleol476rg.go
+++ b/src/machine/board_nucleol476rg.go
@@ -1,0 +1,105 @@
+//go:build nucleol476rg
+
+// Schematic: https://www.st.com/resource/en/user_manual/um1724-stm32-nucleo64-boards-mb1136-stmicroelectronics.pdf
+// Datasheet: https://www.st.com/resource/en/datasheet/stm32l476je.pdf
+
+package machine
+
+import (
+	"device/stm32"
+	"runtime/interrupt"
+)
+
+const (
+	// Arduino Pins
+	A0 = PA0
+	A1 = PA1
+	A2 = PA4
+	A3 = PB0
+	A4 = PC1
+	A5 = PC0
+
+	D0  = PA3
+	D1  = PA2
+	D2  = PA10
+	D3  = PB3
+	D4  = PB5
+	D5  = PB4
+	D6  = PB10
+	D7  = PA8
+	D8  = PA9
+	D9  = PC7
+	D10 = PB6
+	D11 = PA7
+	D12 = PA6
+	D13 = PA5
+	D14 = PB9
+	D15 = PB8
+)
+
+// User LD2: the green LED is a user LED connected to ARDUINO® signal D13 corresponding
+// to STM32 I/O PA5 (pin 21) or PB13 (pin 34) depending on the STM32 target.
+const (
+	LED         = LED_BUILTIN
+	LED_BUILTIN = LED_GREEN
+	LED_GREEN   = PA5
+)
+
+const (
+	// This board does not have a user button, so
+	// use first GPIO pin by default
+	BUTTON = PA0
+)
+
+const (
+	// UART pins
+	// PA2 and PA3 are connected to the ST-Link Virtual Com Port (VCP)
+	UART_TX_PIN = PA2
+	UART_RX_PIN = PA3
+
+	// I2C pins
+	// With default solder bridge settings:
+	//    PB8 / Arduino D5 / CN3 Pin 8 is SCL
+	//    PB7 / Arduino D4 / CN3 Pin 7 is SDA
+	I2C0_SCL_PIN = PB8
+	I2C0_SDA_PIN = PB9
+
+	// SPI pins
+	SPI1_SCK_PIN = PA5
+	SPI1_SDI_PIN = PA6
+	SPI1_SDO_PIN = PA7
+	SPI0_SCK_PIN = SPI1_SCK_PIN
+	SPI0_SDI_PIN = SPI1_SDI_PIN
+	SPI0_SDO_PIN = SPI1_SDO_PIN
+)
+
+var (
+	// USART2 is the hardware serial port connected to the onboard ST-LINK
+	// debugger to be exposed as virtual COM port over USB on Nucleo boards.
+	UART1  = &_UART1
+	_UART1 = UART{
+		Buffer:            NewRingBuffer(),
+		Bus:               stm32.USART2,
+		TxAltFuncSelector: AF7_USART1_2_3,
+		RxAltFuncSelector: AF7_USART1_2_3,
+	}
+	DefaultUART = UART1
+
+	// I2C1 is documented, alias to I2C0 as well
+	I2C1 = &I2C{
+		Bus:             stm32.I2C1,
+		AltFuncSelector: AF4_I2C1_2_3,
+	}
+	I2C0 = I2C1
+
+	// SPI1 is documented, alias to SPI0 as well
+	SPI1 = &SPI{
+		Bus:             stm32.SPI1,
+		AltFuncSelector: AF5_SPI1_2,
+	}
+	SPI0 = SPI1
+)
+
+func init() {
+	UART1.Interrupt = interrupt.New(stm32.IRQ_USART2, _UART1.handleInterrupt)
+}

--- a/src/machine/machine_stm32l4x6.go
+++ b/src/machine/machine_stm32l4x6.go
@@ -1,0 +1,25 @@
+//go:build stm32l4x6
+
+package machine
+
+// Peripheral abstraction layer for the stm32l4x6
+
+func CPUFrequency() uint32 {
+	return 80e6
+}
+
+// Internal use: configured speed of the APB1 and APB2 timers, this should be kept
+// in sync with any changes to runtime package which configures the oscillators
+// and clock frequencies
+const APB1_TIM_FREQ = 80e6 // 80MHz
+const APB2_TIM_FREQ = 80e6 // 80MHz
+
+//---------- I2C related code
+
+// Gets the value for TIMINGR register
+func (i2c *I2C) getFreqRange() uint32 {
+	// This is a 'magic' value calculated by STM32CubeMX
+	// for 80MHz PCLK1.
+	// TODO: Do calculations based on PCLK1
+	return 0x10909CEC
+}

--- a/src/runtime/runtime_stm32l4x6.go
+++ b/src/runtime/runtime_stm32l4x6.go
@@ -1,0 +1,29 @@
+//go:build stm32 && stm32l4x6
+
+package runtime
+
+import (
+	"device/stm32"
+)
+
+/*
+clock settings
+
+	+-------------+-----------+
+	| LSE         | 32.768khz |
+	| SYSCLK      | 80mhz    |
+	| HCLK        | 80mhz    |
+	| APB1(PCLK1) | 80mhz    |
+	| APB2(PCLK2) | 80mhz    |
+	+-------------+-----------+
+*/
+const (
+	HSE_STARTUP_TIMEOUT = 0x0500
+	PLL_M               = 1
+	PLL_N               = 40
+	PLL_P               = RCC_PLLP_DIV7
+	PLL_Q               = RCC_PLLQ_DIV2
+	PLL_R               = RCC_PLLR_DIV2
+
+	MSIRANGE = stm32.RCC_CR_MSIRANGE_Range4M
+)

--- a/targets/nucleo-l476rg.json
+++ b/targets/nucleo-l476rg.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["cortex-m4"],
+    "build-tags": ["nucleol476rg", "stm32l476", "stm32l4x6", "stm32l4", "stm32"],
+    "serial": "uart",
+    "linkerscript": "targets/stm32l4x6.ld",
+    "extra-files": [
+      "src/device/stm32/stm32l4x6.s"
+    ],
+    "flash-method": "openocd",
+    "openocd-interface": "stlink-v2-1",
+    "openocd-target": "stm32l4x"
+  }

--- a/targets/stm32l4x6.ld
+++ b/targets/stm32l4x6.ld
@@ -1,0 +1,11 @@
+
+MEMORY
+{
+  FLASH_TEXT (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+  RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 96K
+  RAM2 (xrw)      : ORIGIN = 0x10000000, LENGTH = 32K
+}
+
+_stack_size = 4K;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
Adding support for STM32 L476RG
datasheet: https://www.st.com/resource/en/datasheet/stm32l476je.pdf
board layout: https://www.st.com/resource/en/user_manual/um1724-stm32-nucleo64-boards-mb1136-stmicroelectronics.pdf

Running `blinky3.go` Notes:
* Serial / UART2 works. ~~Serial out prints out garbage~~
* LED blinking works.
* Button works after jumping PC13 PIN to PA0 / A0 PIN.

```bash
$ tinygo flash  -target=nucleo-l476rg src/examples/blinky3/blinky3.go
xPack Open On-Chip Debugger 0.12.0+dev-01557-gdd1758272-dirty (2024-04-02-07:26)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
Info : auto-selecting first available session transport "hla_swd". To override use 'transport select <transport>'.
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 500 kHz
Info : STLINK V2J33M25 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.258383
Info : [stm32l4x.cpu] Cortex-M4 r0p1 processor detected
Info : [stm32l4x.cpu] target has 6 breakpoints, 4 watchpoints
Info : [stm32l4x.cpu] Examination succeed
Info : starting gdb server for stm32l4x.cpu on 3333
Info : Listening on port 3333 for gdb connections
Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
[stm32l4x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080031a4 msp: 0x20001000
** Programming Started **
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev 4 : 0x1007)
Info : RDP level 0 (0xAA)
Info : flash size = 1024 KiB
Info : flash mode : dual-bank
Info : Padding image section 0 at 0x0800c264 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x0800c268 .. 0x0800c7ff
** Programming Finished **
** Resetting Target **
Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
```

~~it looks like the code flashes fine as the LED blinks every second as expected, but monitoring the serial port outputs garbage. i'm trying to figure out why.~~




building something similar using platformio:
```bash
 *  Executing task: platformio run --target upload 

Processing nucleo_l476rg (platform: ststm32; board: nucleo_l476rg; framework: arduino)
-------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/ststm32/nucleo_l476rg.html
PLATFORM: ST STM32 (17.3.0) > ST Nucleo L476RG
HARDWARE: STM32L476RGT6 80MHz, 96KB RAM, 1MB Flash
DEBUG: Current (stlink) On-board (stlink) External (blackmagic, cmsis-dap, jlink)
PACKAGES: 
 - framework-arduinoststm32 @ 4.20701.0 (2.7.1) 
 - framework-cmsis @ 2.50900.0 (5.9.0) 
 - tool-dfuutil @ 1.11.0 
 - tool-dfuutil-arduino @ 1.11.0 
 - tool-openocd @ 3.1200.0 (12.0) 
 - tool-stm32duino @ 1.0.1 
 - toolchain-gccarmnoneeabi @ 1.120301.0 (12.3.1)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 14 compatible libraries
Scanning dependencies...
No dependencies
Building in release mode
Checking size .pio/build/nucleo_l476rg/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   1.5% (used 1488 bytes from 98304 bytes)
Flash: [          ]   2.2% (used 23240 bytes from 1048576 bytes)
Configuring upload protocol...
AVAILABLE: blackmagic, cmsis-dap, jlink, mbed, stlink
CURRENT: upload_protocol = stlink
Uploading .pio/build/nucleo_l476rg/firmware.elf
xPack Open On-Chip Debugger 0.12.0-01004-g9ea7f3d64-dirty (2023-01-30-15:03)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
debug_level: 1

srst_only separate srst_nogate srst_open_drain connect_deassert_srst

Warn : target stm32l4x.cpu examination failed
[stm32l4x.cpu] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000ff8 msp: 0x20000800
** Programming Started **
Warn : Adding extra erase range, 0x08005c78 .. 0x08005fff
** Programming Finished **
** Verify Started **
** Verified OK **
** Resetting Target **
shutdown command invoked
=============================== [SUCCESS] Took 5.81 seconds ===============================
 *  Terminal will be reused by tasks, press any key to close it. 
```