### PR TITLE
machine: add __tinygo_spi_tx function to simulator

### DIFF
--- a/src/machine/spi_tx.go
+++ b/src/machine/spi_tx.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build atmega || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 // This file implements the SPI Tx function for targets that don't have a custom
 // (faster) implementation for it.


### PR DESCRIPTION
This is much, _much_ faster than `__tinygo_spi_transfer` which can only transfer a single byte at a time. This is especially important for simulated displays.

I've already implemented the browser side of this on the playground and have used this patch for local testing where it massively speeds up display operations.