### PR TITLE
Add lint make target, use it in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,13 @@ commands:
           condition: <<parameters.fmt-check>>
           steps:
           - run:
+              name: Install linter
+              command: go install github.com/mgechev/revive@v1.3.7
+          - run:
               # Do this before gen-device so that it doesn't check the
               # formatting of generated files.
               name: Check Go code formatting
-              command: make fmt-check
+              command: make fmt-check lint
       - run: make gen-device -j4
       - run: make smoketest XTENSA=0
       - save_cache:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,6 +113,10 @@ jobs:
           gem install --version 4.0.7 public_suffix
           gem install --version 2.7.6 dotenv
           gem install --no-document fpm
+      - name: Install linter
+        run: go install github.com/mgechev/revive@v1.3.7
+      - name: Run linter
+        run: make lint
       - name: Build TinyGo release
         run: |
           make release deb -j3 STATIC=1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -896,3 +896,9 @@ ifneq ($(RELEASEONLY), 1)
 release: build/release
 deb: build/release
 endif
+
+lint:
+	# Only run on compiler dir for now, expand as we clean up other dirs
+	# Only check comments on exported symbols for now, expand regexp as we clean up other errors
+	# This obviously won't scale, but it's a start, and it's fast
+	if revive --config revive.toml compiler/... | egrep "comment on exported|your favorite error|your other favorite error"; then echo lint failed; exit 1; fi

--- a/compiler/llvmutil/llvm.go
+++ b/compiler/llvmutil/llvm.go
@@ -173,7 +173,7 @@ func SplitBasicBlock(builder llvm.Builder, afterInst llvm.Value, insertAfter llv
 	return newBlock
 }
 
-// Append the given values to a global array like llvm.used. The global might
+// AppendToGlobal appends the given values to a global array like llvm.used. The global might
 // not exist yet. The values can be any pointer type, they will be cast to i8*.
 func AppendToGlobal(mod llvm.Module, globalName string, values ...llvm.Value) {
 	// Read the existing values in the llvm.used array (if it exists).

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+# Enable these as we fix them
+#[rule.blank-imports]
+#[rule.context-as-argument]
+#[rule.context-keys-type]
+#[rule.dot-imports]
+#[rule.error-return]
+#[rule.error-strings]
+#[rule.error-naming]
+[rule.exported]
+#[rule.increment-decrement]
+#[rule.var-naming]
+#[rule.var-declaration]
+#[rule.package-comments]
+#[rule.range]
+#[rule.receiver-naming]
+#[rule.time-naming]
+#[rule.unexported-return]
+#[rule.indent-error-flow]
+#[rule.errorf]
+#[rule.empty-block]
+#[rule.superfluous-else]
+#[rule.unused-parameter]
+#[rule.unreachable-code]
+#[rule.redefines-builtin-id]


### PR DESCRIPTION
Seems to work, and seems fast enough.

This is just a proof of concept of the first step in fixing https://github.com/tinygo-org/tinygo/issues/4225
It only checks a subset of files with a subset of revive rules, and ignores all but a small subset of those errors.
The first commit finds one error, and its build on circleci is red.
The 2nd commit fixes one such error, and its build on circleci gets past the lint check.

Also runs lint check in github ci, since pull requests don't run circleci (?).
