### PR TITLE
machine/thingplus_rp2040, machine/waveshare-rp2040-zero:add WS2812 definition

### DIFF
--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -46,7 +46,11 @@ const (
 	A3 = GPIO29
 )
 
-const LED = GPIO25
+// Onboard LEDs
+const (
+	LED    = GPIO25
+	WS2812 = GPIO8
+)
 
 // I2C Pins.
 const (

--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -52,6 +52,7 @@ const (
 // Onboard LEDs
 const (
 	NEOPIXEL = GPIO16
+	WS2812   = GPIO16
 )
 
 // I2C pins


### PR DESCRIPTION
This PR adds the definition for WS2812, which simplifies drivers/examples/ws2812.

https://github.com/tinygo-org/drivers/tree/release/examples/ws2812



After this PR is merged, the following files can be deleted.
https://github.com/tinygo-org/drivers/blob/release/examples/ws2812/thingplus-rp2040.go