### PR TITLE
Support UF2 drives with space in their name on Linux

### DIFF
--- a/main.go
+++ b/main.go
@@ -1033,9 +1033,10 @@ func findFATMounts(options *compileopts.Options) ([]mountPoint, error) {
 			if fstype != "vfat" {
 				continue
 			}
+			fspath := strings.ReplaceAll(fields[1], "\\040", " ")
 			points = append(points, mountPoint{
-				name: filepath.Base(fields[1]),
-				path: fields[1],
+				name: filepath.Base(fspath),
+				path: fspath,
 			})
 		}
 		return points, nil


### PR DESCRIPTION
I've updated the factory bootloader on one of my Seeed Studio XIAOs to the latest version provided by Adafruit. Their bootloader uses different name for UF2 device, "Seeed XIAO", instead of "Arduino".

Unfortunately, after the update `tinygo flash` was no longer able to detect the device, even if the board configuration was correct. It looks like the entry in `/proc/mounts` file uses `\040` instead of a ` `, and the `findFATMounts` function can't handle such a case:

```
/dev/sda /media/matt/Seeed\040XIAO vfat ...... 0 0
```

```
error: failed to flash /tmp/tinygo2815790133/main.uf2: unable to locate any volume: [Arduino,Seeed XIAO]
```

This PR fixes the issue on Linux. I've tested it on my PC (Debian 12) against dev branch, with both original bootloader and the updated one.