### PR TITLE
runtime: skip negative sleep durations in sleepTicks

### DIFF
--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -31,7 +31,7 @@ func nanosecondsToTicks(ns int64) timeUnit {
 }
 
 func sleepTicks(d timeUnit) {
-	if d == 0 {
+	if d <= 0 {
 		return
 	}
 


### PR DESCRIPTION
I can't get `make test` to run on my Nix/macOS setup, but here's a program that hangs without this change on target `pico`:

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	timer := time.NewTicker(10 * time.Millisecond)
	defer timer.Stop()
	ticks := 0
	for i := 0; i < 10; i++ {
		select {
		case <-timer.C:
			ticks++
		}
	}
	for i := 0; i < 10; i++ {
		secondary()
		fmt.Println("tick", ticks, i)
	}
	fmt.Println("PASS")
}

func secondary() {
	ticks := 0
	timer2 := time.NewTicker(10 * time.Microsecond)
	defer timer2.Stop()
	done := make(chan struct{})
loop:
	for i := 0; i < 100; i++ {
		select {
		case <-timer2.C:
			ticks++
		case <-done:
			break loop
		}
	}
	fmt.Println("tick2", ticks)
}
```

I tried minimizing it even further, but removing a print or dummy channel makes the hang disappear.