### PR TITLE
crypto/generic

### DIFF
--- a/compiler/alias.go
+++ b/compiler/alias.go
@@ -24,6 +24,10 @@ var stdlibAliases = map[string]string{
 	"crypto/sha256.block":      "crypto/sha256.blockGeneric",
 	"crypto/sha512.blockAMD64": "crypto/sha512.blockGeneric",
 
+	// AES
+	"crypto/aes.decryptBlockAsm": "crypto/aes.decryptBlock",
+	"crypto/aes.encryptBlockAsm": "crypto/aes.encryptBlock",
+
 	// math package
 	"math.archHypot": "math.hypot",
 	"math.archMax":   "math.max",


### PR DESCRIPTION
Building applications with cryptographic operations still lacks a lot of support due to excessive usage of assembly in the golang standard library. This PR intends to replace them in the tinygo build process with the generic implementations.