### PR TITLE
rp2040: fix timeUnit type

### DIFF
--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -14,7 +14,7 @@ func machineTicks() uint64
 // machineLightSleep is provided by package machine.
 func machineLightSleep(uint64)
 
-type timeUnit uint64
+type timeUnit int64
 
 // ticks returns the number of ticks (microseconds) elapsed since power up.
 func ticks() timeUnit {


### PR DESCRIPTION
It should be int64 like for all other systems, not uint64.

See: https://github.com/tinygo-org/tinygo/pull/4239