### PR TITLE
compileopts: fix race condition

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -74,7 +74,8 @@ func (c *Config) GOARM() string {
 
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
-	tags := append(c.Target.BuildTags, []string{
+	tags := append([]string(nil), c.Target.BuildTags...) // copy slice (avoid a race)
+	tags = append(tags, []string{
 		"tinygo",                                     // that's the compiler
 		"purego",                                     // to get various crypto packages to work
 		"math_big_pure_go",                           // to get math/big to work


### PR DESCRIPTION
Appending to a slice can lead to a race condition if the capacity of the slice is larger than the length (and therefore the returned slice will overwrite some fields in the underlying array).

This fixes that race condition. I don't know how severe this particular one is. It shouldn't be that severe, but it is a bug and fixing it makes it easier to hunt for possibly more serious race conditions.

See: https://github.com/tinygo-org/tinygo/issues/4206