### PR TITLE
unix, wasm: call exit(2) instead of abort or unreachable

### DIFF
--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -65,8 +65,14 @@ func now() (sec int64, nsec int32, mono int64) {
 	return
 }
 
-// Abort executes the wasm 'unreachable' instruction.
+// Abort exits the program with an error code.
 func abort() {
+	// Call out to the WASI exit function.
+	// This matches upstream Go (wasip1/wasm).
+	proc_exit(2)
+
+	// Insert a trap instruction, just to be sure (even if it should not be
+	// necessary: the code here is unreachable).
 	trap()
 }
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -20,8 +20,14 @@ func usleep(usec uint) int
 //export mmap
 func mmap(addr unsafe.Pointer, length uintptr, prot, flags, fd int, offset int64) unsafe.Pointer
 
-//export abort
-func abort()
+func abort() {
+	// Exit the program with exit status 2. This matches upstream Go.
+	exit(2)
+
+	// Insert a trap instruction, just to be sure (even if it should not be
+	// necessary: the code here is unreachable).
+	trap()
+}
 
 //export exit
 func exit(code int)


### PR DESCRIPTION
This matches upstream Go, and I think it's a better idea in general.

Specifically, it avoids triggering an 'undefined' instruction in wasm when there's a panic. Many people confuse this 'undefined' instruction (with associated backtrace) with the actual bug.

A possible downside is that this unreachable instruction does show a backtrace, which may be helpful in finding the underlying bug. Calling exit(2) doesn't have this behavior.