### PR TITLE
simulator: fix I2C support

### DIFF
--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-//go:build atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || mimxrt1062 || (esp32c3 && !m5stamp_c3)
+//go:build !baremetal || atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || mimxrt1062 || (esp32c3 && !m5stamp_c3)
 
 package machine
 

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -150,7 +150,17 @@ func (i2c *I2C) SetBaudRate(br uint32) error {
 
 // Tx does a single I2C transaction at the specified address.
 func (i2c *I2C) Tx(addr uint16, w, r []byte) error {
-	i2cTransfer(i2c.Bus, &w[0], len(w), &r[0], len(r))
+	var wptr, rptr *byte
+	var wlen, rlen int
+	if len(w) != 0 {
+		wptr = &w[0]
+		wlen = len(w)
+	}
+	if len(r) != 0 {
+		rptr = &r[0]
+		rlen = len(r)
+	}
+	i2cTransfer(i2c.Bus, wptr, wlen, rptr, rlen)
 	// TODO: do something with the returned error code.
 	return nil
 }


### PR DESCRIPTION
  - Add ReadRegister and WriteRegister (because they're still used by some packages).
  - Fix out-of-bounds panic in I2C.Tx when either w or r has a length of zero (or is nil).
