### PR TITLE
Add 'make spell' target, fix what it finds.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -921,3 +921,7 @@ lint:
 	# Can't use grep with friendly formatter.  Plain output isn't too bad, though.
 	# Use 'grep .' to get rid of stray blank line
 	go run github.com/mgechev/revive -config revive.toml compiler/... src/{os,reflect}/*.go | grep -v "should have comment or be unexported" | grep '.' | awk '{print}; END {exit NR>0}'
+
+spell:
+	# Check for typos in comments.  Skip git submodules etc.
+	go run github.com/client9/misspell/cmd/misspell -i 'ackward,devided,extint,inbetween,programmmer,rela' $$( find . -depth 1 -type d  | egrep -w -v 'lib|llvm|src/net' )

--- a/builder/cc1as.h
+++ b/builder/cc1as.h
@@ -93,7 +93,7 @@ struct AssemblerInvocation {
   EmitDwarfUnwindType EmitDwarfUnwind;
 
   // Whether to emit compact-unwind for non-canonical entries.
-  // Note: maybe overriden by other constraints.
+  // Note: may be overridden by other constraints.
   unsigned EmitCompactUnwindNonCanonical : 1;
 
   /// The name of the relocation model to use.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/chromedp/cdproto v0.0.0-20220113222801-0725d94bb6ee
 	github.com/chromedp/chromedp v0.7.6
+	github.com/client9/misspell v0.3.4
 	github.com/gofrs/flock v0.8.1
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
@@ -16,6 +17,7 @@ require (
 	github.com/mgechev/revive v1.3.7
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
 	go.bug.st/serial v1.6.0
+	golang.org/x/net v0.20.0
 	golang.org/x/sys v0.16.0
 	golang.org/x/tools v0.17.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/chromedp/chromedp v0.7.6 h1:2juGaktzjwULlsn+DnvIZXFUckEp5xs+GOBroaea+
 github.com/chromedp/chromedp v0.7.6/go.mod h1:ayT4YU/MGAALNfOg9gNrpGSAdnU51PMx+FCeuT1iXzo=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -81,6 +83,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 go.bug.st/serial v1.6.0 h1:mAbRGN4cKE2J5gMwsMHC2KQisdLRQssO9WSM+rbZJ8A=
 go.bug.st/serial v1.6.0/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
 golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -5,5 +5,6 @@
 package tools
 
 import (
+	_ "github.com/client9/misspell"
 	_ "github.com/mgechev/revive"
 )

--- a/src/internal/task/task_stack_avr.S
+++ b/src/internal/task/task_stack_avr.S
@@ -28,7 +28,7 @@ tinygo_startTask:
     // After return, exit this goroutine. This is a tail call.
 #if __AVR_ARCH__ == 2 || __AVR_ARCH__ == 25
     // Small memory devices (≤8kB flash) that do not have the long call
-    // instruction availble will need to use rcall instead.
+    // instruction available will need to use rcall instead.
     // Note that they will probably not be able to run more than the main
     // goroutine anyway, but this file is compiled for all AVRs so it needs to
     // compile at least.

--- a/src/internal/task/task_stack_esp32.S
+++ b/src/internal/task/task_stack_esp32.S
@@ -78,7 +78,7 @@ tinygo_swapTask:
     // Switch to the new stack pointer (newStack).
     mov.n   sp, a2
 
-    // Load a0, which is the previous return addres from before the previous
+    // Load a0, which is the previous return address from before the previous
     // switch or the constructed return address to tinygo_startTask. This
     // register also stores the parent register window.
     l32i.n a0, sp, 0


### PR DESCRIPTION
In source files, only checks comments.

Seems to miss a few words, but it is fast and easy.

We can add more checks to "make spell" later.