### PR TITLE
make: use release esp-17.0.1_20240419 tag for LLVM source build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -239,7 +239,7 @@ gen-device-renesas: build/gen-device-svd
 
 # Get LLVM sources.
 $(LLVM_PROJECTDIR)/llvm:
-	git clone -b xtensa_release_17.0.1 --depth=1 https://github.com/espressif/llvm-project $(LLVM_PROJECTDIR)
+	git clone -b esp-17.0.1_20240419 --depth=1 https://github.com/espressif/llvm-project $(LLVM_PROJECTDIR)
 llvm-source: $(LLVM_PROJECTDIR)/llvm
 
 # Configure LLVM.


### PR DESCRIPTION
This PR changes the makefile to use the release `esp-17.0.1_20240419` tag for LLVM source from the Espressif LLVM fork for the TinyGo builds. This is intended to make our builds more reproducible since the current branch based approach the target branch can change at any time.