### PR TITLE
build: update llvm cache to use tagged LLVM source version

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-${{ matrix.os }}-v1
+          key: llvm-source-17-${{ matrix.os }}-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-17-${{ matrix.os }}-v1
+          key: llvm-build-17-${{ matrix.os }}-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-linux-alpine-v1
+          key: llvm-source-17-linux-alpine-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-17-linux-alpine-v1
+          key: llvm-build-17-linux-alpine-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -196,7 +196,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-linux-asserts-v1
+          key: llvm-source-17-linux-asserts-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -221,7 +221,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-17-linux-asserts-v1
+          key: llvm-build-17-linux-asserts-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -309,7 +309,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-linux-v1
+          key: llvm-source-17-linux-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -334,7 +334,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-17-linux-${{ matrix.goarch }}-v1
+          key: llvm-build-17-linux-${{ matrix.goarch }}-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-linux-nix-v1
+          key: llvm-source-17-linux-nix-v2
           path: |
             llvm-project/compiler-rt
       - name: Download LLVM source

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-sizediff-v1
+          key: llvm-source-17-sizediff-v2
           path: |
             llvm-project/compiler-rt
       - name: Download LLVM source
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Go
         uses: actions/cache@v4
         with:
-          key: go-cache-linux-sizediff-v1-${{ hashFiles('go.mod') }}
+          key: go-cache-linux-sizediff-v2-${{ hashFiles('go.mod') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-17-windows-v1
+          key: llvm-source-17-windows-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-17-windows-v1
+          key: llvm-build-17-windows-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR is the followup to #4252 to update the cached LLVM builds to use the tagged version.