### PR TITLE
machine/stm32: add i2c Frequency and SetBaudRate() function for missing boards

### DIFF
--- a/src/machine/machine_stm32f7x2.go
+++ b/src/machine/machine_stm32f7x2.go
@@ -51,9 +51,20 @@ func (uart *UART) setRegisters() {
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
 	// for 27MHz PCLK1 (216MHz CPU Freq / 8).
 	// TODO: Do calculations based on PCLK1
-	return 0x00606A9B
+	switch br {
+	case 10 * KHz:
+		return 0x5010C0FF
+	case 100 * KHz:
+		return 0x00606A9B
+	case 400 * KHz:
+		return 0x00201625
+	case 500 * KHz:
+		return 0x00100429
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -298,9 +298,20 @@ func (spi SPI) configurePins(config SPIConfig) {
 //---------- I2C related types and code
 
 // Gets the value for TIMINGR register
-func (i2c I2C) getFreqRange() uint32 {
+func (i2c I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
-	// for 80MHz PCLK1.
+	// for 16MHz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x00303D5B
+	switch br {
+	case 10 * KHz:
+		return 0x40003EFF
+	case 100 * KHz:
+		return 0x00303D5B
+	case 400 * KHz:
+		return 0x0010061A
+	case 500 * KHz:
+		return 0x00000117
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32l4x2.go
+++ b/src/machine/machine_stm32l4x2.go
@@ -17,9 +17,20 @@ const APB2_TIM_FREQ = 80e6 // 80MHz
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
-	// This is a 'magic' value calculated by STM32CubeMX
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
+	// These are 'magic' values calculated by STM32CubeMX
 	// for 80MHz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x10909CEC
+	switch br {
+	case 10 * KHz:
+		return 0xF010F3FE
+	case 100 * KHz:
+		return 0x10909CEC
+	case 400 * KHz:
+		return 0x00702991
+	case 500 * KHz:
+		return 0x00300E84
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32l4x5.go
+++ b/src/machine/machine_stm32l4x5.go
@@ -17,9 +17,20 @@ const APB2_TIM_FREQ = 120e6 // 120MHz
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
 	// for 120MHz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x307075B1
+	switch br {
+	case 10 * KHz:
+		return 0x0 // does this even work? zero is weird here.
+	case 100 * KHz:
+		return 0x307075B1
+	case 400 * KHz:
+		return 0x00B03FDB
+	case 500 * KHz:
+		return 0x005017C7
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32l4x6.go
+++ b/src/machine/machine_stm32l4x6.go
@@ -17,9 +17,20 @@ const APB2_TIM_FREQ = 80e6 // 80MHz
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
 	// for 80MHz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x10909CEC
+	switch br {
+	case 10 * KHz:
+		return 0xF010F3FE
+	case 100 * KHz:
+		return 0x10909CEC
+	case 400 * KHz:
+		return 0x00702991
+	case 500 * KHz:
+		return 0x00300E84
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32l5x2.go
+++ b/src/machine/machine_stm32l5x2.go
@@ -49,9 +49,20 @@ func (uart *UART) setRegisters() {
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
 	// for 110MHz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x40505681
+	switch br {
+	case 10 * KHz:
+		return 0x0 // does this even work? zero is weird here.
+	case 100 * KHz:
+		return 0x40505681
+	case 400 * KHz:
+		return 0x00A03AC8
+	case 500 * KHz:
+		return 0x005015B6
+	default:
+		return 0
+	}
 }

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -289,11 +289,22 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 //---------- I2C related code
 
 // Gets the value for TIMINGR register
-func (i2c *I2C) getFreqRange() uint32 {
+func (i2c *I2C) getFreqRange(br uint32) uint32 {
 	// This is a 'magic' value calculated by STM32CubeMX
 	// for 48Mhz PCLK1.
 	// TODO: Do calculations based on PCLK1
-	return 0x20303E5D
+	switch br {
+	case 10 * KHz:
+		return 0x9010DEFF
+	case 100 * KHz:
+		return 0x20303E5D
+	case 400 * KHz:
+		return 0x2010091A
+	case 500 * KHz:
+		return 0x00201441
+	default:
+		return 0
+	}
 }
 
 //---------- UART related code


### PR DESCRIPTION
This PR adds i2c config `Frequency` and `SetBaudRate()` function for STM32 boards that were lacking this implementation.

Addresses #2311 