### PR TITLE
Add signal stubs

### DIFF
--- a/src/os/exec.go
+++ b/src/os/exec.go
@@ -72,3 +72,8 @@ func (p *Process) Kill() error {
 func (p *Process) Signal(sig Signal) error {
 	return ErrNotImplemented
 }
+
+func Ignore(sig ...Signal) {
+	// leave all the signals unaltered
+	return
+}

--- a/src/os/signal/signal.go
+++ b/src/os/signal/signal.go
@@ -1,0 +1,14 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package signal
+
+import (
+	"os"
+)
+
+// Just stubbing the functions for now since signal handling is not yet implemented in tinygo
+func Reset(sig ...os.Signal)                      {}
+func Ignore(sig ...os.Signal)                     {}
+func Notify(c chan<- os.Signal, sig ...os.Signal) {}


### PR DESCRIPTION
To make more u-root commands build using tinygo, add stubs for signaling capabilities.