### PR TITLE
tweaks for wasm-opt running logic

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -825,10 +825,18 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					args = append(args, "--asyncify")
 				}
 
+				exeunopt := result.Executable
+
+				if config.Options.Work {
+					// Keep the work direction around => don't overwrite the .wasm binary with the optimized version
+					exeunopt += ".pre-wasm-opt"
+					os.Rename(result.Executable, exeunopt)
+				}
+
 				args = append(args,
 					opt,
 					"-g",
-					result.Executable,
+					exeunopt,
 					"--output", result.Executable,
 				)
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -840,6 +840,10 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					"--output", result.Executable,
 				)
 
+				if config.Options.PrintCommands != nil {
+					config.Options.PrintCommands(goenv.Get("WASMOPT"), args...)
+				}
+
 				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr


### PR DESCRIPTION
1) if `-work` was passed don't overwrite original. .wasm binary
2) if `-x` was passed print out wasm-opt command line.