### PR TITLE
Add nodejs_20 to flake.nix, as it's required to run `make llvm-source`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
             # these tools are available in the host environment.
             #gdb
             #openocd
+            nodejs_20
           ];
           shellHook= ''
             # Configure CLANG, LLVM_AR, and LLVM_NM for `make wasi-libc`.


### PR DESCRIPTION
When running through the commands listed in `flake.nix` for building locally, I found that I would get a build failure when running `make llvm-source` without having node available. As I don't have a global node install this failed, but it was easy enough to pin a version in `flake.nix`.
