### PR TITLE
compiler/empty basic block

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1204,7 +1204,14 @@ func (b *builder) createFunctionStart(intrinsic bool) {
 			b.blockExits[block] = llvmBlock
 		}
 		// Normal functions have an entry block.
-		entryBlock = b.blockEntries[b.fn.Blocks[0]]
+		// If Blocks is nil, this indicates an external function for which no Go source code is available.
+		if b.fn.Blocks == nil {
+			errValue := "\n\tfunction is external, no go source code available"
+			b.addError(b.fn.Pos(), errValue)
+			return
+		} else {
+			entryBlock = b.blockEntries[b.fn.Blocks[0]]
+		}
 	}
 	b.SetInsertPointAtEnd(entryBlock)
 


### PR DESCRIPTION
To generate a function, tinygo builds a function using llvm and a list of pre-defined basic blocks. Therefore it needs the first basic block for the entry point of a function. If the list of `BasicBlock`s is empty, this indicates that the function is external [1].
Getting the first basic block is then impossible and results in a panic (observed in [2]).

This PR aims to fix this issue and end the compilation gracefully. Since my experience with compiler development is non though, it would be great if the original authors (@aykevl) could take care of the logic behind this and probably make it behave sanely.

[1]: https://cs.opensource.google/go/x/tools/+/refs/tags/v0.21.0:go/ssa/ssa.go;l=338
[2]: https://github.com/tinygo-org/tinygo/actions/runs/9365468429/job/25780736332?pr=4218#step:14:17686