### PR TITLE
cgo: implement shift operations in preprocessor macros

### DIFF
--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -40,6 +40,10 @@ func TestParseConst(t *testing.T) {
 		{`5&5`, `5 & 5`},
 		{`5|5`, `5 | 5`},
 		{`5^5`, `5 ^ 5`},
+		{`5<<5`, `5 << 5`},
+		{`5>>5`, `5 >> 5`},
+		{`5>>5 + 3`, `5 >> (5 + 3)`},
+		{`5>>5 ^ 3`, `5>>5 ^ 3`},
 		{`5||5`, `error: 1:2: unexpected token ||, expected end of expression`}, // logical binops aren't supported yet
 		{`(5/5)`, `(5 / 5)`},
 		{`1 - 2`, `1 - 2`},


### PR DESCRIPTION
This fixes https://github.com/tinygo-org/tinygo/issues/4285.