### PR TITLE
Optimize `[]byte` to `string` conversions

### DIFF
--- a/transform/allocs.go
+++ b/transform/allocs.go
@@ -136,7 +136,7 @@ func valueEscapesAt(value llvm.Value) llvm.Value {
 			panic("expected instruction use")
 		}
 		switch use.InstructionOpcode() {
-		case llvm.GetElementPtr:
+		case llvm.GetElementPtr, llvm.ExtractValue:
 			if at := valueEscapesAt(use); !at.IsNil() {
 				return at
 			}

--- a/transform/optimizer.go
+++ b/transform/optimizer.go
@@ -65,6 +65,7 @@ func Optimize(mod llvm.Module, config *compileopts.Config) []error {
 
 		// Run TinyGo-specific optimization passes.
 		OptimizeStringToBytes(mod)
+		OptimizeBytesToString(mod)
 		OptimizeReflectImplements(mod)
 		maxStackSize := config.MaxStackAlloc()
 		OptimizeAllocs(mod, nil, maxStackSize, nil)


### PR DESCRIPTION
This enables the optimization of functions such as "bytes.Equal()", which is currently implemented as:

```go
func Equal(a, b []byte) bool { return string(a) == string(b) }
```

Which causes allocations and copies in TinyGo, but not in Big Go.

Since we can prove that neither conversions will escape in this case, we can convert the calls to `runtime.stringFromBytes()` to an inlined version of it that doesn't allocate or copies the original string. 

This is a draft PR, because, although I can verify that the relevant calls to the runtime alloc calls are removed from the final binary in a simple test program, `make test` is failing.  I'd like some help here to understand what's happening.

Another thing that I didn't have time today to check was why `isReadOnly()` was returning `false` for my test program; I'll pick this up on Monday to take a closer look, but for now, I'm omitting the call here, which is most likely why `make test` isn't happy.

Closes: #4045
CC: @aykevl @dgryski 