### PR TITLE
transform/rtcalls: Bail fast if can't convert pointer

### DIFF
--- a/transform/rtcalls.go
+++ b/transform/rtcalls.go
@@ -34,7 +34,7 @@ func OptimizeStringToBytes(mod llvm.Module) {
 			if use.IsAExtractValueInst().IsNil() {
 				// Expected an extractvalue, but this is something else.
 				canConvertPointer = false
-				continue
+				break
 			}
 			switch use.Type().TypeKind() {
 			case llvm.IntegerTypeKind:
@@ -49,7 +49,7 @@ func OptimizeStringToBytes(mod llvm.Module) {
 					// There is a store to the byte slice. This means that none
 					// of the pointer uses can't be propagated.
 					canConvertPointer = false
-					continue
+					break
 				}
 				// It may be that the pointer value can be propagated, if all of
 				// the pointer uses are readonly.


### PR DESCRIPTION
There's no need to keep looping if one of the uses makes it impossible to convert a call to `runtime.stringToBytes()` with a raw pointer.