### PR TITLE
targets: add cyw43439 tag to badger2040-w and also add new pico-w target

### DIFF
--- a/targets/badger2040-w.json
+++ b/targets/badger2040-w.json
@@ -3,7 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
-    "build-tags": ["badger2040_w"],
+    "build-tags": ["badger2040_w", "cyw43439"],
     "ldflags": [
         "--defsym=__flash_size=1020K"
     ],

--- a/targets/pico-w.json
+++ b/targets/pico-w.json
@@ -1,0 +1,4 @@
+{
+    "inherits": ["pico"],
+    "build-tags": ["pico-w", "cyw43439"]
+}


### PR DESCRIPTION
This PR adds to the targets, first by adding the `cyw43439` tag to the `badger2040-w` target, and then also adding a new `pico-w` target for seamless wireless support, initially as part of the tinygo bluetooth package.