### PR TITLE
gc_leaking: Don't zero out new allocations on Wasm targets

### DIFF
--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -44,7 +44,7 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 		runtimePanic("out of memory")
 	}
 	pointer := unsafe.Pointer(addr)
-	memzero(pointer, size)
+	zero_new_alloc(pointer, size)
 	return pointer
 }
 

--- a/src/runtime/zero_new_alloc.go
+++ b/src/runtime/zero_new_alloc.go
@@ -1,0 +1,12 @@
+//go:build gc.leaking && (baremetal || nintendoswitch)
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//go:inline
+func zero_new_alloc(ptr unsafe.Pointer, size uintptr) {
+	memzero(ptr, size)
+}

--- a/src/runtime/zero_new_alloc_noop.go
+++ b/src/runtime/zero_new_alloc_noop.go
@@ -1,0 +1,14 @@
+//go:build gc.leaking && !baremetal && !nintendoswitch
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//go:inline
+func zero_new_alloc(ptr unsafe.Pointer, size uintptr) {
+	// Wasm linear memory is initialized to zero by default, so
+	// there's no need to do anything.  This is also the case for
+	// fresh-allocated memory from an mmap() system call.
+}


### PR DESCRIPTION
Wasm linear memory is always initialized to zero by definition, so there's no need to waste time zeroing out this allocation.