### PR TITLE
machine: use new internal/binary package

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -236,6 +236,7 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"device/":               false,
 		"examples/":             false,
 		"internal/":             true,
+		"internal/binary/":      false,
 		"internal/bytealg/":     false,
 		"internal/fuzz/":        false,
 		"internal/reflectlite/": false,

--- a/src/internal/binary/binary.go
+++ b/src/internal/binary/binary.go
@@ -1,0 +1,32 @@
+// Package binary is a lightweight replacement package for encoding/binary.
+package binary
+
+// This file contains small helper functions for working with binary data.
+
+var LittleEndian = littleEndian{}
+
+type littleEndian struct{}
+
+// Encode data like encoding/binary.LittleEndian.Uint16.
+func (littleEndian) Uint16(b []byte) uint16 {
+	return uint16(b[0]) | uint16(b[1])<<8
+}
+
+// Store data like binary.LittleEndian.PutUint16.
+func (littleEndian) PutUint16(b []byte, v uint16) {
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+}
+
+// Append data like binary.LittleEndian.AppendUint16.
+func (littleEndian) AppendUint16(b []byte, v uint16) []byte {
+	return append(b,
+		byte(v),
+		byte(v>>8),
+	)
+}
+
+// Encode data like encoding/binary.LittleEndian.Uint32.
+func (littleEndian) Uint32(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"device/arm"
 	"device/sam"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 	"runtime/interrupt"
 	"unsafe"
 )

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"device/arm"
 	"device/sam"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 	"runtime/interrupt"
 	"unsafe"
 )

--- a/src/machine/machine_nrf.go
+++ b/src/machine/machine_nrf.go
@@ -5,7 +5,7 @@ package machine
 import (
 	"bytes"
 	"device/nrf"
-	"encoding/binary"
+	"internal/binary"
 	"runtime/interrupt"
 	"unsafe"
 )

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -6,8 +6,8 @@ package machine
 
 import (
 	"device/stm32"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 	"math/bits"
 	"runtime/interrupt"
 	"runtime/volatile"

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -4,8 +4,8 @@ package machine
 
 import (
 	"device/stm32"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 	"runtime/interrupt"
 	"runtime/volatile"
 	"unsafe"

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -6,8 +6,8 @@ package machine
 
 import (
 	"device/stm32"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 	"math/bits"
 	"runtime/interrupt"
 	"runtime/volatile"

--- a/src/machine/usb/descriptor/configuration.go
+++ b/src/machine/usb/descriptor/configuration.go
@@ -1,7 +1,7 @@
 package descriptor
 
 import (
-	"encoding/binary"
+	"internal/binary"
 )
 
 const (

--- a/src/machine/usb/descriptor/device.go
+++ b/src/machine/usb/descriptor/device.go
@@ -1,7 +1,7 @@
 package descriptor
 
 import (
-	"encoding/binary"
+	"internal/binary"
 )
 
 const (

--- a/src/machine/usb/descriptor/endpoint.go
+++ b/src/machine/usb/descriptor/endpoint.go
@@ -1,7 +1,7 @@
 package descriptor
 
 import (
-	"encoding/binary"
+	"internal/binary"
 )
 
 var endpointEP1IN = [endpointTypeLen]byte{

--- a/src/machine/usb/descriptor/hid.go
+++ b/src/machine/usb/descriptor/hid.go
@@ -2,8 +2,8 @@ package descriptor
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
+	"internal/binary"
 )
 
 var configurationCDCHID = [configurationTypeLen]byte{


### PR DESCRIPTION
The encoding/binary package in Go 1.23 imports the slices package, which results in circular import when imported from the machine package. Therefore, encoding/binary cannot be used in the machine package.

This commit fixes that by introducing a new internal/binary package that is just plain Go code without dependencies. It can be safely used anywhere (including the runtime if needed).

---

This PR is in preparation of Go 1.23 (see #4305), but it made sense to me to extract it and review separately.