### PR TITLE
add support for unix.Syscall* invocations

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1846,9 +1846,9 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.emitSV64Call(instr.Args, getPos(instr))
 		case strings.HasPrefix(name, "(device/riscv.CSR)."):
 			return b.emitCSROperation(instr)
-		case strings.HasPrefix(name, "syscall.Syscall") || strings.HasPrefix(name, "syscall.RawSyscall") || strings.HasPrefix(name, "Syscall") || strings.HasPrefix(name, "golang.org/x/sys/unix.Syscall"):
+		case strings.HasPrefix(name, "syscall.Syscall") || strings.HasPrefix(name, "syscall.RawSyscall") || strings.HasPrefix(name, "golang.org/x/sys/unix.Syscall") || strings.HasPrefix(name, "golang.org/x/sys/unix.RawSyscall"):
 			return b.createSyscall(instr)
-		case strings.HasPrefix(name, "syscall.rawSyscallNoError"):
+		case strings.HasPrefix(name, "syscall.rawSyscallNoError") || strings.HasPrefix(name, "golang.org/x/sys/unix.RawSyscallNoError"):
 			return b.createRawSyscallNoError(instr)
 		case name == "runtime.supportsRecover":
 			supportsRecover := uint64(0)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1846,7 +1846,7 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			return b.emitSV64Call(instr.Args, getPos(instr))
 		case strings.HasPrefix(name, "(device/riscv.CSR)."):
 			return b.emitCSROperation(instr)
-		case strings.HasPrefix(name, "syscall.Syscall") || strings.HasPrefix(name, "syscall.RawSyscall"):
+		case strings.HasPrefix(name, "syscall.Syscall") || strings.HasPrefix(name, "syscall.RawSyscall") || strings.HasPrefix(name, "Syscall") || strings.HasPrefix(name, "golang.org/x/sys/unix.Syscall"):
 			return b.createSyscall(instr)
 		case strings.HasPrefix(name, "syscall.rawSyscallNoError"):
 			return b.createRawSyscallNoError(instr)


### PR DESCRIPTION
In linux userland applications, the following error (and similar ones for Syscall6 and RawSyscall)occurred, when building applications that use the `unix.Syscall` package:

```
ld.lld: error: undefined symbol: golang.org/x/sys/unix.Syscall
>>> referenced by zsyscall_linux.go:1490 (.../golang.org/x/sys/unix/zsyscall_linux.go:1490)
error: failed to link /tmp/tinygo3353455449/main: exit status 1
```

This patch adds the functionality to use tinygo's syscalls for any linux userland application for the architectures that tinygo supports.

P.S: For me this was the easiest solution, although this might not be super clean. I would be happy to discuss with anyone interested in the tinygo compiler development if we can improve this in any way, but for now it seems to do the job.
Also I'm not quite sure how to test this in a good way, maybe someone has any good ideas on that as well.