### PR TITLE
compiler: add inline assembly for i386 and amd64

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1836,9 +1836,9 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 		// applied) function call. If it is anonymous, it may be a closure.
 		name := fn.RelString(nil)
 		switch {
-		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/arm64.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
+		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/arm64.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm" || name == "device/i386.Asm" || name == "device/amd64.Asm":
 			return b.createInlineAsm(instr.Args)
-		case name == "device.AsmFull" || name == "device/arm.AsmFull" || name == "device/arm64.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull":
+		case name == "device.AsmFull" || name == "device/arm.AsmFull" || name == "device/arm64.AsmFull" || name == "device/avr.AsmFull" || name == "device/riscv.AsmFull" || name == "device/i386.AsmFull" || name == "device/amd64.AsmFull":
 			return b.createInlineAsmFull(instr)
 		case strings.HasPrefix(name, "device/arm.SVCall"):
 			return b.emitSVCall(instr.Args, getPos(instr))

--- a/src/device/amd64/amd64.go
+++ b/src/device/amd64/amd64.go
@@ -1,0 +1,21 @@
+package amd64
+
+// Run the given assembly code. The code will be marked as having side effects,
+// as it doesn't produce output and thus would normally be eliminated by the
+// optimizer.
+func Asm(asm string)
+
+// Run the given inline assembly. The code will be marked as having side
+// effects, as it would otherwise be optimized away. The inline assembly string
+// recognizes template values in the form {name}, like so:
+//
+//     amd64.AsmFull(
+//         "str {value}, {result}",
+//         map[string]interface{}{
+//             "value":  1
+//             "result": &dest,
+//         })
+//
+// You can use {} in the asm string (which expands to a register) to set the
+// return value.
+func AsmFull(asm string, regs map[string]interface{}) uintptr

--- a/src/device/i386/i386.go
+++ b/src/device/i386/i386.go
@@ -1,0 +1,21 @@
+package i386
+
+// Run the given assembly code. The code will be marked as having side effects,
+// as it doesn't produce output and thus would normally be eliminated by the
+// optimizer.
+func Asm(asm string)
+
+// Run the given inline assembly. The code will be marked as having side
+// effects, as it would otherwise be optimized away. The inline assembly string
+// recognizes template values in the form {name}, like so:
+//
+//     i386.AsmFull(
+//         "str {value}, {result}",
+//         map[string]interface{}{
+//             "value":  1
+//             "result": &dest,
+//         })
+//
+// You can use {} in the asm string (which expands to a register) to set the
+// return value.
+func AsmFull(asm string, regs map[string]interface{}) uintptr


### PR DESCRIPTION
Currently `tinygo` does not support inline assembly for x86 (neither 32-bit nor 64-bit).
This PR adds this functionality.