### PR TITLE
wasm-unknown: make sure the os package can be imported

### DIFF
--- a/src/examples/hello-wasm-unknown/main.go
+++ b/src/examples/hello-wasm-unknown/main.go
@@ -3,6 +3,10 @@
 // tinygo build -size short -o hello-unknown.wasm -target wasm-unknown -gc=leaking -no-debug ./src/examples/hello-wasm-unknown/
 package main
 
+// Smoke test: make sure the fmt package can be imported (even if it isn't
+// really useful for wasm-unknown).
+import _ "os"
+
 var x int32
 
 //go:wasmimport hosted echo_i32

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows
+//go:build baremetal || js || windows || wasm_unknown
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasip1
+//go:build linux && !baremetal && !wasip1 && !wasm_unknown
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasip1
+//go:build !baremetal && !js && !wasip1 && !wasm_unknown
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !wasm_unknown
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1)
+//go:build baremetal || (tinygo.wasm && !wasip1)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasip1
+//go:build !baremetal && !js && !wasip1 && !wasm_unknown
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi || wasip1
+//go:build baremetal || js || wasi || wasip1 || wasm_unknown
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_linuxlike.go
+++ b/src/os/stat_linuxlike.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal) || wasip1
+//go:build (linux && !baremetal && !wasm_unknown) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1)
+//go:build baremetal || (tinygo.wasm && !wasip1)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !wasm_unknown
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || wasm_unknown
 
 package runtime
 

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -23,8 +23,6 @@ func init() {
 	__wasm_call_ctors()
 }
 
-var args []string
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks)
 }


### PR DESCRIPTION
See: https://github.com/tinygo-org/tinygo/issues/4314

The os package isn't particularly useful on wasm-unknown, but just like on baremetal systems it's imported by a lot of packages so it should at least be possible to import this package.