### PR TITLE
test: support GOOS/GOARCH pairs in the -target flag

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -297,6 +297,10 @@ func emuCheck(t *testing.T, options compileopts.Options) {
 }
 
 func optionsFromTarget(target string, sema chan struct{}) compileopts.Options {
+	separators := strings.Count(target, "/")
+	if (separators == 1 || separators == 2) && !strings.HasSuffix(target, ".json") {
+		return optionsFromOSARCH(target, sema)
+	}
 	return compileopts.Options{
 		// GOOS/GOARCH are only used if target == ""
 		GOOS:          goenv.Get("GOOS"),


### PR DESCRIPTION
This means it's possible to test just a particular OS/arch with a command like this:

    go test -run=Build -target=linux/arm

I found it useful while working on MIPS support.