### PR TITLE
runtime: implement dummy getAuxv to satisfy golang.org/x/sys/cpu

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -122,3 +122,8 @@ func write(fd uintptr, p unsafe.Pointer, n int32) int32 {
 	}
 	return 0
 }
+
+// getAuxv is linknamed from golang.org/x/sys/cpu.
+func getAuxv() []uintptr {
+	return nil
+}


### PR DESCRIPTION
Fixes the program

```go
  package main

  import _ "golang.org/x/sys/cpu"

  func main() {
  }
```