### PR TITLE
Add chromeos bind mount support for flash command

### DIFF
--- a/main.go
+++ b/main.go
@@ -1072,7 +1072,8 @@ func findFATMounts(options *compileopts.Options) ([]mountPoint, error) {
 				continue
 			}
 			fstype := fields[2]
-			if fstype != "vfat" {
+			// chromeos bind mounts use 9p
+			if !(fstype == "vfat" || fstype == "9p") {
 				continue
 			}
 			fspath := strings.ReplaceAll(fields[1], "\\040", " ")


### PR DESCRIPTION
ChromeOS uses the Plan 9 9p protocol for sharing files, drives, etc. The code in `findFATMounts` splits on the mount type using `strings.Fields`. Therefore, the vfat mounts actual mount type is obscured, and the /proc/mount file shows 9p in place of vfat.
![image](https://github.com/tinygo-org/tinygo/assets/8261498/fcf1f36d-0052-42bc-8a9c-bb1d15bd3bae)

I am marking this PR as a draft, as the function is named `findFATMounts` and likely should be renamed, or the logic may need to be moved elsewhere, as this new (one-line) fix will allow ext3/ext4 etc. filesystem types to leak through if they are mounted through the 9p protocol. I don't think this is a huge deal, but is less than ideal. 