### PR TITLE
Refactor compiler error messages and add tests

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -642,13 +642,6 @@ func (p *cgoPackage) addErrorAfter(pos token.Pos, after, msg string) {
 
 // addErrorAt is a utility function to add an error to the list of errors.
 func (p *cgoPackage) addErrorAt(position token.Position, msg string) {
-	if filepath.IsAbs(position.Filename) {
-		// Relative paths for readability, like other Go parser errors.
-		relpath, err := filepath.Rel(p.currentDir, position.Filename)
-		if err == nil {
-			position.Filename = relpath
-		}
-	}
 	p.errors = append(p.errors, scanner.Error{
 		Pos: position,
 		Msg: msg,

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tinygo-org/tinygo/compileopts"
+)
+
+// Test the error messages of the TinyGo compiler.
+func TestErrors(t *testing.T) {
+	for _, name := range []string{
+		"cgo",
+		"syntax",
+		"types",
+	} {
+		t.Run(name, func(t *testing.T) {
+			testErrorMessages(t, "./testdata/errors/"+name+".go")
+		})
+	}
+}
+
+func testErrorMessages(t *testing.T, filename string) {
+	// Parse expected error messages.
+	expected := readErrorMessages(t, filename)
+
+	// Try to build a binary (this should fail with an error).
+	tmpdir := t.TempDir()
+	err := Build(filename, tmpdir+"/out", &compileopts.Options{
+		Target:        "wasip1",
+		Semaphore:     sema,
+		InterpTimeout: 180 * time.Second,
+		Debug:         true,
+		VerifyIR:      true,
+		Opt:           "z",
+	})
+	if err == nil {
+		t.Fatal("expected to get a compiler error")
+	}
+
+	// Get the full ./testdata/errors directory.
+	wd, absErr := filepath.Abs("testdata/errors")
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+
+	// Write error message out as plain text.
+	var buf bytes.Buffer
+	printCompilerError(err, func(v ...interface{}) {
+		fmt.Fprintln(&buf, v...)
+	}, wd)
+	actual := strings.TrimRight(buf.String(), "\n")
+
+	// Check whether the error is as expected.
+	if actual != expected {
+		t.Errorf("expected error:\n%s\ngot:\n%s", indentText(expected, "> "), indentText(actual, "> "))
+	}
+}
+
+// Indent the given text with a given indentation string.
+func indentText(text, indent string) string {
+	return indent + strings.ReplaceAll(text, "\n", "\n"+indent)
+}
+
+// Read "// ERROR:" prefixed messages from the given file.
+func readErrorMessages(t *testing.T, file string) string {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal("could not read input file:", err)
+	}
+
+	var errors []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "// ERROR: ") {
+			errors = append(errors, strings.TrimRight(line[len("// ERROR: "):], "\r\n"))
+		}
+	}
+	return strings.Join(errors, "\n")
+}

--- a/main.go
+++ b/main.go
@@ -1288,10 +1288,9 @@ func usage(command string) {
 
 // try to make the path relative to the current working directory. If any error
 // occurs, this error is ignored and the absolute path is returned instead.
-func tryToMakePathRelative(dir string) string {
-	wd, err := os.Getwd()
-	if err != nil {
-		return dir
+func tryToMakePathRelative(dir, wd string) string {
+	if wd == "" {
+		return dir // working directory not found
 	}
 	relpath, err := filepath.Rel(wd, dir)
 	if err != nil {
@@ -1302,28 +1301,25 @@ func tryToMakePathRelative(dir string) string {
 
 // printCompilerError prints compiler errors using the provided logger function
 // (similar to fmt.Println).
-//
-// There is one exception: interp errors may print to stderr unconditionally due
-// to limitations in the LLVM bindings.
-func printCompilerError(logln func(...interface{}), err error) {
+func printCompilerError(err error, logln func(...interface{}), wd string) {
 	switch err := err.(type) {
 	case types.Error:
-		printCompilerError(logln, scanner.Error{
+		printCompilerError(scanner.Error{
 			Pos: err.Fset.Position(err.Pos),
 			Msg: err.Msg,
-		})
+		}, logln, wd)
 	case scanner.Error:
 		if !strings.HasPrefix(err.Pos.Filename, filepath.Join(goenv.Get("GOROOT"), "src")) && !strings.HasPrefix(err.Pos.Filename, filepath.Join(goenv.Get("TINYGOROOT"), "src")) {
 			// This file is not from the standard library (either the GOROOT or
 			// the TINYGOROOT). Make the path relative, for easier reading.
 			// Ignore any errors in the process (falling back to the absolute
 			// path).
-			err.Pos.Filename = tryToMakePathRelative(err.Pos.Filename)
+			err.Pos.Filename = tryToMakePathRelative(err.Pos.Filename, wd)
 		}
 		logln(err)
 	case scanner.ErrorList:
 		for _, scannerErr := range err {
-			printCompilerError(logln, *scannerErr)
+			printCompilerError(*scannerErr, logln, wd)
 		}
 	case *interp.Error:
 		logln("#", err.ImportPath)
@@ -1341,7 +1337,7 @@ func printCompilerError(logln func(...interface{}), err error) {
 	case loader.Errors:
 		logln("#", err.Pkg.ImportPath)
 		for _, err := range err.Errs {
-			printCompilerError(logln, err)
+			printCompilerError(err, logln, wd)
 		}
 	case loader.Error:
 		logln(err.Err.Error())
@@ -1351,7 +1347,7 @@ func printCompilerError(logln func(...interface{}), err error) {
 		}
 	case *builder.MultiError:
 		for _, err := range err.Errs {
-			printCompilerError(logln, err)
+			printCompilerError(err, logln, wd)
 		}
 	default:
 		logln("error:", err)
@@ -1360,9 +1356,13 @@ func printCompilerError(logln func(...interface{}), err error) {
 
 func handleCompilerError(err error) {
 	if err != nil {
-		printCompilerError(func(args ...interface{}) {
+		wd, getwdErr := os.Getwd()
+		if getwdErr != nil {
+			wd = ""
+		}
+		printCompilerError(err, func(args ...interface{}) {
 			fmt.Fprintln(os.Stderr, args...)
-		}, err)
+		}, wd)
 		os.Exit(1)
 	}
 }
@@ -1764,9 +1764,13 @@ func main() {
 				stderr := (*testStderr)(buf)
 				passed, err := Test(pkgName, stdout, stderr, options, outpath)
 				if err != nil {
-					printCompilerError(func(args ...interface{}) {
+					wd, getwdErr := os.Getwd()
+					if getwdErr != nil {
+						wd = ""
+					}
+					printCompilerError(err, func(args ...interface{}) {
 						fmt.Fprintln(stderr, args...)
-					}, err)
+					}, wd)
 				}
 				if !passed {
 					select {

--- a/main.go
+++ b/main.go
@@ -1335,15 +1335,31 @@ func printCompilerError(err error, logln func(...interface{}), wd string) {
 			}
 		}
 	case loader.Errors:
-		logln("#", err.Pkg.ImportPath)
+		// Parser errors, typechecking errors, or `go list` errors.
+		// err.Pkg is nil for `go list` errors.
+		if err.Pkg != nil {
+			logln("#", err.Pkg.ImportPath)
+		}
 		for _, err := range err.Errs {
 			printCompilerError(err, logln, wd)
 		}
 	case loader.Error:
-		logln(err.Err.Error())
-		logln("package", err.ImportStack[0])
-		for _, pkgPath := range err.ImportStack[1:] {
-			logln("\timports", pkgPath)
+		if err.Err.Pos.Filename != "" {
+			// Probably a syntax error in a dependency.
+			printCompilerError(err.Err, logln, wd)
+		} else {
+			// Probably an "import cycle not allowed" error.
+			logln("package", err.ImportStack[0])
+			for i := 1; i < len(err.ImportStack); i++ {
+				pkgPath := err.ImportStack[i]
+				if i == len(err.ImportStack)-1 {
+					// last package
+					logln("\timports", pkgPath+": "+err.Err.Error())
+				} else {
+					// not the last pacakge
+					logln("\timports", pkgPath)
+				}
+			}
 		}
 	case *builder.MultiError:
 		for _, err := range err.Errs {

--- a/main_test.go
+++ b/main_test.go
@@ -380,7 +380,7 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		return cmd.Run()
 	})
 	if err != nil {
-		printCompilerError(t.Log, err)
+		printCompilerError(err, t.Log, "")
 		t.Fail()
 		return
 	}

--- a/testdata/errors/cgo.go
+++ b/testdata/errors/cgo.go
@@ -1,0 +1,15 @@
+package main
+
+// #error hello
+// )))
+import "C"
+
+func main() {
+}
+
+// TODO: this error should be relative to the current directory (so cgo.go
+// instead of testdata/errors/cgo.go).
+
+// ERROR: # command-line-arguments
+// ERROR: testdata/errors/cgo.go:3:5: error: hello
+// ERROR: testdata/errors/cgo.go:4:4: error: expected identifier or '('

--- a/testdata/errors/cgo.go
+++ b/testdata/errors/cgo.go
@@ -7,9 +7,6 @@ import "C"
 func main() {
 }
 
-// TODO: this error should be relative to the current directory (so cgo.go
-// instead of testdata/errors/cgo.go).
-
 // ERROR: # command-line-arguments
-// ERROR: testdata/errors/cgo.go:3:5: error: hello
-// ERROR: testdata/errors/cgo.go:4:4: error: expected identifier or '('
+// ERROR: cgo.go:3:5: error: hello
+// ERROR: cgo.go:4:4: error: expected identifier or '('

--- a/testdata/errors/importcycle/cycle.go
+++ b/testdata/errors/importcycle/cycle.go
@@ -1,0 +1,3 @@
+package importcycle
+
+import _ "github.com/tinygo-org/tinygo/testdata/errors/importcycle"

--- a/testdata/errors/invaliddep/invaliddep.go
+++ b/testdata/errors/invaliddep/invaliddep.go
@@ -1,0 +1,1 @@
+ppackage // syntax error

--- a/testdata/errors/loader-importcycle.go
+++ b/testdata/errors/loader-importcycle.go
@@ -1,0 +1,10 @@
+package main
+
+import _ "github.com/tinygo-org/tinygo/testdata/errors/importcycle"
+
+func main() {
+}
+
+// ERROR: package command-line-arguments
+// ERROR: 	imports github.com/tinygo-org/tinygo/testdata/errors/importcycle
+// ERROR: 	imports github.com/tinygo-org/tinygo/testdata/errors/importcycle: import cycle not allowed

--- a/testdata/errors/loader-invaliddep.go
+++ b/testdata/errors/loader-invaliddep.go
@@ -1,0 +1,8 @@
+package main
+
+import _ "github.com/tinygo-org/tinygo/testdata/errors/invaliddep"
+
+func main() {
+}
+
+// ERROR: invaliddep/invaliddep.go:1:1: expected 'package', found ppackage

--- a/testdata/errors/loader-invalidpackage.go
+++ b/testdata/errors/loader-invalidpackage.go
@@ -1,0 +1,3 @@
+ppackage // syntax error
+
+// ERROR: loader-invalidpackage.go:1:1: expected 'package', found ppackage

--- a/testdata/errors/loader-nopackage.go
+++ b/testdata/errors/loader-nopackage.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	_ "github.com/tinygo-org/tinygo/testdata/errors/non-existing-package"
+	_ "github.com/tinygo-org/tinygo/testdata/errors/non-existing-package-2"
+)
+
+func main() {
+}
+
+// ERROR: loader-nopackage.go:4:2: no required module provides package github.com/tinygo-org/tinygo/testdata/errors/non-existing-package; to add it:
+// ERROR: 	go get github.com/tinygo-org/tinygo/testdata/errors/non-existing-package
+// ERROR: loader-nopackage.go:5:2: no required module provides package github.com/tinygo-org/tinygo/testdata/errors/non-existing-package-2; to add it:
+// ERROR: 	go get github.com/tinygo-org/tinygo/testdata/errors/non-existing-package-2

--- a/testdata/errors/syntax.go
+++ b/testdata/errors/syntax.go
@@ -1,0 +1,7 @@
+package main
+
+func main(var) { // syntax error
+}
+
+// ERROR: # command-line-arguments
+// ERROR: syntax.go:3:11: expected ')', found 'var'

--- a/testdata/errors/types.go
+++ b/testdata/errors/types.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	var a int
+	a = "foobar"
+	nonexisting()
+}
+
+// ERROR: # command-line-arguments
+// ERROR: types.go:5:6: cannot use "foobar" (untyped string constant) as int value in assignment
+// ERROR: types.go:6:2: undefined: nonexisting
+// ERROR: types.go:4:6: a declared and not used


### PR DESCRIPTION
This refactors the compiler error messages in various ways. It should not (significantly) change the behavior, but it will make it easier to change things later on with confidence that nothing breaks.

There are a few things that I'd like to implement some day, maybe:

* Provide JSON output for error messages, so that tools (in particular the playground) can show better error messages.
* Provide nicely formatted error messages, like you can see in GCC, Clang and Rust.