### PR TITLE
Refactor error message printing and sort them

### DIFF
--- a/diagnostics/diagnostics.go
+++ b/diagnostics/diagnostics.go
@@ -1,0 +1,196 @@
+// Package diagnostics formats compiler errors and prints them in a consistent
+// way.
+package diagnostics
+
+import (
+	"bytes"
+	"fmt"
+	"go/scanner"
+	"go/token"
+	"go/types"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/tinygo-org/tinygo/builder"
+	"github.com/tinygo-org/tinygo/goenv"
+	"github.com/tinygo-org/tinygo/interp"
+	"github.com/tinygo-org/tinygo/loader"
+)
+
+// A single diagnostic.
+type Diagnostic struct {
+	Pos token.Position
+	Msg string
+}
+
+// One or multiple errors of a particular package.
+// It can also represent whole-program errors (like linker errors) that can't
+// easily be connected to a single package.
+type PackageDiagnostic struct {
+	ImportPath  string // the same ImportPath as in `go list -json`
+	Diagnostics []Diagnostic
+}
+
+// Diagnostics of a whole program. This can include errors belonging to multiple
+// packages, or just a single package.
+type ProgramDiagnostic []PackageDiagnostic
+
+// CreateDiagnostics reads the underlying errors in the error object and creates
+// a set of diagnostics that's sorted and can be readily printed.
+func CreateDiagnostics(err error) ProgramDiagnostic {
+	if err == nil {
+		return nil
+	}
+	switch err := err.(type) {
+	case *builder.MultiError:
+		var diags ProgramDiagnostic
+		for _, err := range err.Errs {
+			diags = append(diags, createPackageDiagnostic(err))
+		}
+		return diags
+	default:
+		return ProgramDiagnostic{
+			createPackageDiagnostic(err),
+		}
+	}
+}
+
+// Create diagnostics for a single package (though, in practice, it may also be
+// used for whole-program diagnostics in some cases).
+func createPackageDiagnostic(err error) PackageDiagnostic {
+	var pkgDiag PackageDiagnostic
+	switch err := err.(type) {
+	case loader.Errors:
+		if err.Pkg != nil {
+			pkgDiag.ImportPath = err.Pkg.ImportPath
+		}
+		for _, err := range err.Errs {
+			diags := createDiagnostics(err)
+			pkgDiag.Diagnostics = append(pkgDiag.Diagnostics, diags...)
+		}
+	case *interp.Error:
+		pkgDiag.ImportPath = err.ImportPath
+		w := &bytes.Buffer{}
+		fmt.Fprintln(w, err.Error())
+		if len(err.Inst) != 0 {
+			fmt.Fprintln(w, err.Inst)
+		}
+		if len(err.Traceback) > 0 {
+			fmt.Fprintln(w, "\ntraceback:")
+			for _, line := range err.Traceback {
+				fmt.Fprintln(w, line.Pos.String()+":")
+				fmt.Fprintln(w, line.Inst)
+			}
+		}
+		pkgDiag.Diagnostics = append(pkgDiag.Diagnostics, Diagnostic{
+			Msg: w.String(),
+		})
+	default:
+		pkgDiag.Diagnostics = createDiagnostics(err)
+	}
+	// TODO: sort
+	return pkgDiag
+}
+
+// Extract diagnostics from the given error message and return them as a slice
+// of errors (which in many cases will just be a single diagnostic).
+func createDiagnostics(err error) []Diagnostic {
+	switch err := err.(type) {
+	case types.Error:
+		return []Diagnostic{
+			{
+				Pos: err.Fset.Position(err.Pos),
+				Msg: err.Msg,
+			},
+		}
+	case scanner.Error:
+		return []Diagnostic{
+			{
+				Pos: err.Pos,
+				Msg: err.Msg,
+			},
+		}
+	case scanner.ErrorList:
+		var diags []Diagnostic
+		for _, err := range err {
+			diags = append(diags, createDiagnostics(*err)...)
+		}
+		return diags
+	case loader.Error:
+		if err.Err.Pos.Filename != "" {
+			// Probably a syntax error in a dependency.
+			return createDiagnostics(err.Err)
+		} else {
+			// Probably an "import cycle not allowed" error.
+			buf := &bytes.Buffer{}
+			fmt.Fprintln(buf, "package", err.ImportStack[0])
+			for i := 1; i < len(err.ImportStack); i++ {
+				pkgPath := err.ImportStack[i]
+				if i == len(err.ImportStack)-1 {
+					// last package
+					fmt.Fprintln(buf, "\timports", pkgPath+": "+err.Err.Error())
+				} else {
+					// not the last pacakge
+					fmt.Fprintln(buf, "\timports", pkgPath)
+				}
+			}
+			return []Diagnostic{
+				{Msg: buf.String()},
+			}
+		}
+	default:
+		return []Diagnostic{
+			{Msg: err.Error()},
+		}
+	}
+}
+
+// Write program diagnostics to the given writer with 'wd' as the relative
+// working directory.
+func (progDiag ProgramDiagnostic) WriteTo(w io.Writer, wd string) {
+	for _, pkgDiag := range progDiag {
+		pkgDiag.WriteTo(w, wd)
+	}
+}
+
+// Write package diagnostics to the given writer with 'wd' as the relative
+// working directory.
+func (pkgDiag PackageDiagnostic) WriteTo(w io.Writer, wd string) {
+	if pkgDiag.ImportPath != "" {
+		fmt.Fprintln(w, "#", pkgDiag.ImportPath)
+	}
+	for _, diag := range pkgDiag.Diagnostics {
+		diag.WriteTo(w, wd)
+	}
+}
+
+// Write this diagnostic to the given writer with 'wd' as the relative working
+// directory.
+func (diag Diagnostic) WriteTo(w io.Writer, wd string) {
+	if diag.Pos == (token.Position{}) {
+		fmt.Fprintln(w, diag.Msg)
+		return
+	}
+	pos := diag.Pos // make a copy
+	if !strings.HasPrefix(pos.Filename, filepath.Join(goenv.Get("GOROOT"), "src")) && !strings.HasPrefix(pos.Filename, filepath.Join(goenv.Get("TINYGOROOT"), "src")) {
+		// This file is not from the standard library (either the GOROOT or the
+		// TINYGOROOT). Make the path relative, for easier reading.  Ignore any
+		// errors in the process (falling back to the absolute path).
+		pos.Filename = tryToMakePathRelative(pos.Filename, wd)
+	}
+	fmt.Fprintf(w, "%s: %s\n", pos, diag.Msg)
+}
+
+// try to make the path relative to the current working directory. If any error
+// occurs, this error is ignored and the absolute path is returned instead.
+func tryToMakePathRelative(dir, wd string) string {
+	if wd == "" {
+		return dir // working directory not found
+	}
+	relpath, err := filepath.Rel(wd, dir)
+	if err != nil {
+		return dir
+	}
+	return relpath
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -23,6 +23,7 @@ func TestErrors(t *testing.T) {
 		"loader-invaliddep",
 		"loader-invalidpackage",
 		"loader-nopackage",
+		"optimizer",
 		"syntax",
 		"types",
 	} {

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,6 +17,7 @@ import (
 func TestErrors(t *testing.T) {
 	for _, name := range []string{
 		"cgo",
+		"compiler",
 		"interp",
 		"loader-importcycle",
 		"loader-invaliddep",

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,6 +17,7 @@ import (
 func TestErrors(t *testing.T) {
 	for _, name := range []string{
 		"cgo",
+		"interp",
 		"loader-importcycle",
 		"loader-invaliddep",
 		"loader-invalidpackage",

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/diagnostics"
 )
 
 // Test the error messages of the TinyGo compiler.
@@ -59,9 +59,7 @@ func testErrorMessages(t *testing.T, filename string) {
 
 	// Write error message out as plain text.
 	var buf bytes.Buffer
-	printCompilerError(err, func(v ...interface{}) {
-		fmt.Fprintln(&buf, v...)
-	}, wd)
+	diagnostics.CreateDiagnostics(err).WriteTo(&buf, wd)
 	actual := strings.TrimRight(buf.String(), "\n")
 
 	// Check whether the error is as expected.

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -417,6 +417,10 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				} else {
 					locals[inst.localIndex] = literalValue{uint8(0)}
 				}
+			case callFn.name == "__tinygo_interp_raise_test_error":
+				// Special function that will trigger an error.
+				// This is used to test error reporting.
+				return nil, mem, r.errorAt(inst, errors.New("test error"))
 			case strings.HasSuffix(callFn.name, ".$typeassert"):
 				if r.debug {
 					fmt.Fprintln(os.Stderr, indent+"interface assert:", operands[1:])

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aykevl/go-wasm"
 	"github.com/tinygo-org/tinygo/builder"
 	"github.com/tinygo-org/tinygo/compileopts"
+	"github.com/tinygo-org/tinygo/diagnostics"
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
@@ -380,7 +381,11 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		return cmd.Run()
 	})
 	if err != nil {
-		printCompilerError(err, t.Log, "")
+		w := &bytes.Buffer{}
+		diagnostics.CreateDiagnostics(err).WriteTo(w, "")
+		for _, line := range strings.Split(strings.TrimRight(w.String(), "\n"), "\n") {
+			t.Log(line)
+		}
 		t.Fail()
 		return
 	}

--- a/testdata/errors/compiler.go
+++ b/testdata/errors/compiler.go
@@ -1,0 +1,13 @@
+package main
+
+//go:wasmimport foo bar
+func foo() {
+}
+
+//go:align 7
+var global int
+
+// TODO: include package name in the error message
+
+// ERROR: compiler.go:4:6: can only use //go:wasmimport on declarations
+// ERROR: compiler.go:8:5: global variable alignment must be a positive power of two

--- a/testdata/errors/interp.go
+++ b/testdata/errors/interp.go
@@ -1,0 +1,31 @@
+package main
+
+import _ "unsafe"
+
+func init() {
+	foo()
+}
+
+func foo() {
+	interp_test_error()
+}
+
+// This is a function that always causes an error in interp, for testing.
+//
+//go:linkname interp_test_error __tinygo_interp_raise_test_error
+func interp_test_error()
+
+func main() {
+}
+
+// ERROR: # main
+// ERROR: {{.*testdata[\\/]errors[\\/]interp\.go}}:10:19: test error
+// ERROR:   call void @__tinygo_interp_raise_test_error{{.*}}
+// ERROR: {{}}
+// ERROR: traceback:
+// ERROR: {{.*testdata[\\/]errors[\\/]interp\.go}}:10:19:
+// ERROR:   call void @__tinygo_interp_raise_test_error{{.*}}
+// ERROR: {{.*testdata[\\/]errors[\\/]interp\.go}}:6:5:
+// ERROR:   call void @main.foo{{.*}}
+// ERROR: {{.*testdata[\\/]errors}}:
+// ERROR:   call void @"main.init#1"{{.*}}

--- a/testdata/errors/loader-invaliddep.go
+++ b/testdata/errors/loader-invaliddep.go
@@ -5,4 +5,4 @@ import _ "github.com/tinygo-org/tinygo/testdata/errors/invaliddep"
 func main() {
 }
 
-// ERROR: invaliddep/invaliddep.go:1:1: expected 'package', found ppackage
+// ERROR: invaliddep{{[\\/]}}invaliddep.go:1:1: expected 'package', found ppackage

--- a/testdata/errors/optimizer.go
+++ b/testdata/errors/optimizer.go
@@ -1,0 +1,18 @@
+package main
+
+import "runtime/interrupt"
+
+var num = 5
+
+func main() {
+	// Error coming from LowerInterrupts.
+	interrupt.New(num, func(interrupt.Interrupt) {
+	})
+
+	// 2nd error
+	interrupt.New(num, func(interrupt.Interrupt) {
+	})
+}
+
+// ERROR: optimizer.go:9:15: interrupt ID is not a constant
+// ERROR: optimizer.go:13:15: interrupt ID is not a constant

--- a/testdata/errors/types.go
+++ b/testdata/errors/types.go
@@ -7,6 +7,6 @@ func main() {
 }
 
 // ERROR: # command-line-arguments
+// ERROR: types.go:4:6: a declared and not used
 // ERROR: types.go:5:6: cannot use "foobar" (untyped string constant) as int value in assignment
 // ERROR: types.go:6:2: undefined: nonexisting
-// ERROR: types.go:4:6: a declared and not used


### PR DESCRIPTION
This is a big refactor of error messages (enabled by #4330) that should enable a number of future improvements to error messages. Because it's a refactor, there's a decent chance it will break some existing error messages. That's why I added a load of tests for these error messages: the hope is that with all those tests, no major issues will arrive.

And as a bonus to show why this refactor is needed, I've made a small change that will sort error messages. This is something that's been bugging me for a while but was difficult to fix in a nice way with the previous design.

~This is a draft because it depends on #4330.~