### PR TITLE
builder: remove workaround for generics race condition

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -353,10 +353,6 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		}
 		packageActionIDJobs[pkg.ImportPath] = packageActionIDJob
 
-		// Build the SSA for the given package.
-		ssaPkg := program.Package(pkg.Pkg)
-		ssaPkg.Build()
-
 		// Now create the job to actually build the package. It will exit early
 		// if the package is already compiled.
 		job := &compileJob{


### PR DESCRIPTION
This commit reverts commit 13a8eae0d.

It appars that the race has been fixed by https://github.com/golang/tools/commit/db513b091504, which we now use because it fixes another race condition as well.
See: https://github.com/tinygo-org/tinygo/issues/4206 for the other race condition.