### PR TITLE
Do not stop compilation on compiler warnings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -257,7 +257,7 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
 binaryen: build/wasm-opt$(EXE)
 build/wasm-opt$(EXE):
 	mkdir -p build
-	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON -DBUILD_TESTS=OFF $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
+	cd lib/binaryen && cmake -G Ninja . -DBUILD_STATIC_LIB=ON -DBUILD_TESTS=OFF -DENABLE_WERROR=OFF $(BINARYEN_OPTION) && ninja bin/wasm-opt$(EXE)
 	cp lib/binaryen/bin/wasm-opt$(EXE) build/wasm-opt$(EXE)
 endif
 


### PR DESCRIPTION
Compilers like GCC keep adding new checks that produce new warnings. Sometimes it can be false positives.

Do not treat such warnings in binaryen library as errors. tinygo won't be able to provide zero warnings in its dependencies.

Closes #4332