### PR TITLE
Allows compilation of code using debug.BuildInfo and show correct tinygo version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+.vscode
 go.work
 go.work.sum
 

--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -1,6 +1,8 @@
 // Package debug is a dummy package that is not yet implemented.
 package debug
 
+import "runtime"
+
 // SetMaxStack sets the maximum amount of memory that can be used by a single
 // goroutine stack.
 //
@@ -27,16 +29,17 @@ func Stack() []byte {
 //
 // Not implemented.
 func ReadBuildInfo() (info *BuildInfo, ok bool) {
-	return nil, false
+	return &BuildInfo{GoVersion: "tinygo" + runtime.Version()}, true
 }
 
 // BuildInfo represents the build information read from
 // the running binary.
 type BuildInfo struct {
-	Path     string    // The main package path
-	Main     Module    // The module containing the main package
-	Deps     []*Module // Module dependencies
-	Settings []BuildSetting
+	GoVersion string    // version of the Go toolchain that built the binary, e.g. "go1.19.2"
+	Path      string    // The main package path
+	Main      Module    // The module containing the main package
+	Deps      []*Module // Module dependencies
+	Settings  []BuildSetting
 }
 
 type BuildSetting struct {
@@ -57,4 +60,11 @@ type Module struct {
 // Not implemented.
 func SetGCPercent(n int) int {
 	return n
+}
+
+// String implements Stringer for BuildInfo.
+//
+// Not implemented.
+func (bi *BuildInfo) String() string {
+	return "<build info placeholder>\n"
 }

--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -29,7 +29,7 @@ func Stack() []byte {
 //
 // Not implemented.
 func ReadBuildInfo() (info *BuildInfo, ok bool) {
-	return &BuildInfo{GoVersion: "tinygo" + runtime.Version()}, true
+	return &BuildInfo{GoVersion: runtime.Compiler + runtime.Version()}, true
 }
 
 // BuildInfo represents the build information read from

--- a/src/runtime/debug/debug.go
+++ b/src/runtime/debug/debug.go
@@ -1,4 +1,8 @@
-// Package debug is a dummy package that is not yet implemented.
+// Portions copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package debug is a very partially implemented package to allow compilation.
 package debug
 
 import (


### PR DESCRIPTION
That let's me build a 245k tinygo target https://github.com/grol-io/grol/pull/37
(also needed some change in fortio.org/log)


Many thanks to @ydnar and @dankegel for their help and guidance.

