### PR TITLE
Add enough tls.ConnectionState and tls.CipherSuiteName() to compile fortio/log

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -23,9 +24,21 @@ import (
 // only supports Elliptic Curve based groups. See RFC 8446, Section 4.2.7.
 type CurveID uint16
 
+// CipherSuiteName returns the standard name for the passed cipher suite ID
+//
+// Not Implemented.
+func CipherSuiteName(id uint16) string {
+	return fmt.Sprintf("0x%04X", id)
+}
+
 // ConnectionState records basic TLS details about the connection.
 type ConnectionState struct {
-	// TINYGO: empty; TLS connection offloaded to device
+	// TINYGO: empty; TLS connection offloaded to device [?]
+	//
+	// Minimum (empty) fields for fortio.org/log http logging to
+	// compile:
+	PeerCertificates []*x509.Certificate
+	CipherSuite      uint16
 }
 
 // ClientAuthType declares the policy the server will follow for

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -33,10 +33,10 @@ func CipherSuiteName(id uint16) string {
 
 // ConnectionState records basic TLS details about the connection.
 type ConnectionState struct {
-	// TINYGO: empty; TLS connection offloaded to device [?]
+	// TINYGO: empty; TLS connection offloaded to device
 	//
-	// Minimum (empty) fields for fortio.org/log http logging to
-	// compile:
+	// Minimum (empty) fields for fortio.org/log http logging and others
+	// to compile and run.
 	PeerCertificates []*x509.Certificate
 	CipherSuite      uint16
 }


### PR DESCRIPTION
Note that net/http is broken on macOS but this allows it to work on Linux (and waspi)

edit: linux also doesn't work #4346 
