### PR TITLE
fix: set ubuntu version to 24.04 to address #4347

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   sizediff:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
This PR intends to provide a fix for #4347 by setting the Ubuntu version to 24.04