### PR TITLE
Avoid error spam on wasm finalizer call and ship a potentially functional version

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -302,7 +302,6 @@
 						// for one specific case, by js.go:jsString. and can/might leak memory.
 						const id = mem().getUint32(unboxValue(v_ref), true);
 						// Note that this if is so far seemingly never true. Someone should investigate why.
-						// (ie we are silently, no log even, ignoring an unexpected case)
 						if (this._goRefCounts?.[id] !== undefined) {
 							this._goRefCounts[id]--;
 							if (this._goRefCounts[id] === 0) {
@@ -311,6 +310,9 @@
 								this._ids.delete(v);
 								this._idPool.push(id);
 							}
+						} else {
+							// Log as a hint and reminder that something is probably off.
+							console.log("syscall/js.finalizeRef: unknown id", id);
 						}
 					},
 

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -298,11 +298,22 @@
 
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (v_ref) => {
-						// Note: TinyGo does not support finalizers so this should never be
-						// called.
-						console.error('syscall/js.finalizeRef not implemented');
+						// Note: TinyGo does not support finalizers so this is only called
+						// for one specific case, by js.go:jsString. and can/might leak memory.
+						const id = mem().getUint32(unboxValue(v_ref), true);
+						if (this._goRefCounts?.[id] !== undefined) {
+							console.log("syscall/js.finalizeRef", id, this._goRefCounts[id]);
+							this._goRefCounts[id]--;
+							if (this._goRefCounts[id] === 0) {
+								const v = this._values[id];
+								this._values[id] = null;
+								this._ids.delete(v);
+								this._idPool.push(id);
+							}
+						} else {
+							console.log("syscall/js.finalizeRef: unknown id", id);
+						}
 					},
-
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (value_ptr, value_len) => {
 						const s = loadString(value_ptr, value_len);

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -301,8 +301,9 @@
 						// Note: TinyGo does not support finalizers so this is only called
 						// for one specific case, by js.go:jsString. and can/might leak memory.
 						const id = mem().getUint32(unboxValue(v_ref), true);
+						// Note that this if is so far seemingly never true. Someone should investigate why.
+						// (ie we are silently, no log even, ignoring an unexpected case)
 						if (this._goRefCounts?.[id] !== undefined) {
-							console.log("syscall/js.finalizeRef", id, this._goRefCounts[id]);
 							this._goRefCounts[id]--;
 							if (this._goRefCounts[id] === 0) {
 								const v = this._values[id];
@@ -310,10 +311,9 @@
 								this._ids.delete(v);
 								this._idPool.push(id);
 							}
-						} else {
-							console.log("syscall/js.finalizeRef: unknown id", id);
 						}
 					},
+
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (value_ptr, value_len) => {
 						const s = loadString(value_ptr, value_len);


### PR DESCRIPTION
This is a slighly modified version of https://github.com/tinygo-org/tinygo/issues/1140#issuecomment-1697415864 credit to @evilnoxx and @FrankReh

Fixes #1140 

Note that... it's not set so noop mostly, you can see on https://grol.io where it's running, open the console, click run:

<img width="482" alt="Screenshot 2024-07-21 at 8 46 21 AM" src="https://github.com/user-attachments/assets/92d4e80d-2a5b-4523-b09c-2990fb6c0f9d">

but hopefully for some other tinygo code it does something useful, at least it doesn't ~~crash~~ show errors all the time anymore

