### PR TITLE
build: add package ID to compiler and optimization error messages

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -375,7 +375,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				defer mod.Context().Dispose()
 				defer mod.Dispose()
 				if errs != nil {
-					return newMultiError(errs)
+					return newMultiError(errs, pkg.ImportPath)
 				}
 				if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 					return errors.New("verification error after compiling package " + pkg.ImportPath)
@@ -1130,7 +1130,7 @@ func optimizeProgram(mod llvm.Module, config *compileopts.Config, globalValues m
 	// O0/O1/O2/Os/Oz optimization pipeline).
 	errs := transform.Optimize(mod, config)
 	if len(errs) > 0 {
-		return newMultiError(errs)
+		return newMultiError(errs, "")
 	}
 	if err := llvm.VerifyModule(mod, llvm.PrintMessageAction); err != nil {
 		return errors.New("verification failure after LLVM optimization passes")

--- a/builder/error.go
+++ b/builder/error.go
@@ -3,7 +3,8 @@ package builder
 // MultiError is a list of multiple errors (actually: diagnostics) returned
 // during LLVM IR generation.
 type MultiError struct {
-	Errs []error
+	ImportPath string
+	Errs       []error
 }
 
 func (e *MultiError) Error() string {
@@ -15,14 +16,15 @@ func (e *MultiError) Error() string {
 // newMultiError returns a *MultiError if there is more than one error, or
 // returns that error directly when there is only one. Passing an empty slice
 // will lead to a panic.
-func newMultiError(errs []error) error {
+// The importPath may be passed if this error is for a single package.
+func newMultiError(errs []error, importPath string) error {
 	switch len(errs) {
 	case 0:
 		panic("attempted to create empty MultiError")
 	case 1:
 		return errs[0]
 	default:
-		return &MultiError{errs}
+		return &MultiError{importPath, errs}
 	}
 }
 

--- a/testdata/errors/compiler.go
+++ b/testdata/errors/compiler.go
@@ -7,7 +7,6 @@ func foo() {
 //go:align 7
 var global int
 
-// TODO: include package name in the error message
-
+// ERROR: # command-line-arguments
 // ERROR: compiler.go:4:6: can only use //go:wasmimport on declarations
 // ERROR: compiler.go:8:5: global variable alignment must be a positive power of two

--- a/testdata/errors/optimizer.go
+++ b/testdata/errors/optimizer.go
@@ -14,5 +14,6 @@ func main() {
 	})
 }
 
+// ERROR: # command-line-arguments
 // ERROR: optimizer.go:9:15: interrupt ID is not a constant
 // ERROR: optimizer.go:13:15: interrupt ID is not a constant


### PR DESCRIPTION
This improves error reporting slightly. You can see the improvements in the changed tests.