### PR TITLE
More testing.T and go-cmp compatibility

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1083,8 +1083,10 @@ func (t rawType) Method(i int) Method {
 	panic("unimplemented: (reflect.Type).Method()")
 }
 
-func (t rawType) MethodByName(name string) (Method, bool) {
-	panic("unimplemented: (reflect.Type).MethodByName()")
+func (t rawType) MethodByName(name string) (m Method, ok bool) {
+	// Avoid panic in in go-cmp t.MethodByName("Equal")
+	// https://github.com/google/go-cmp/blob/v0.6.0/cmp/compare.go#L312-L314
+	return // false
 }
 
 func (t *rawType) PkgPath() string {

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -982,7 +982,9 @@ func (v Value) MapIndex(key Value) Value {
 	vkey := v.typecode.key()
 
 	// compare key type with actual key type of map
-	if !key.typecode.AssignableTo(vkey) {
+	// AssignableTo is not implemented for interfaces
+	// avoid: "reflect: unimplemented: AssignableTo with interface"
+	if vkey.Kind() != Interface && !key.typecode.AssignableTo(vkey) {
 		// type error?
 		panic("reflect.Value.MapIndex: incompatible types for key")
 	}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -463,10 +463,23 @@ func (t *T) Run(name string, f func(t *T)) bool {
 	return !sub.failed
 }
 
+// Deadline reports the time at which the test binary will have
+// exceeded the timeout specified by the -timeout flag.
+//
+// The ok result is false if the -timeout flag indicates “no timeout” (0).
+// For now tinygo always return 0, false.
+//
+// Not Implemented.
+func (t *T) Deadline() (deadline time.Time, ok bool) {
+	deadline = t.context.deadline
+	return deadline, !deadline.IsZero()
+}
+
 // testContext holds all fields that are common to all tests. This includes
 // synchronization primitives to run at most *parallel tests.
 type testContext struct {
-	match *matcher
+	match    *matcher
+	deadline time.Time
 }
 
 func newTestContext(m *matcher) *testContext {

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -298,11 +298,22 @@
 
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (v_ref) => {
-						// Note: TinyGo does not support finalizers so this should never be
-						// called.
-						console.error('syscall/js.finalizeRef not implemented');
+						// Note: TinyGo does not support finalizers so this is only called
+						// for one specific case, by js.go:jsString. and can/might leak memory.
+						const id = mem().getUint32(unboxValue(v_ref), true);
+						if (this._goRefCounts?.[id] !== undefined) {
+							console.log("syscall/js.finalizeRef", id, this._goRefCounts[id]);
+							this._goRefCounts[id]--;
+							if (this._goRefCounts[id] === 0) {
+								const v = this._values[id];
+								this._values[id] = null;
+								this._ids.delete(v);
+								this._idPool.push(id);
+							}
+						} else {
+							console.log("syscall/js.finalizeRef: unknown id", id);
+						}
 					},
-
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (value_ptr, value_len) => {
 						const s = loadString(value_ptr, value_len);


### PR DESCRIPTION
- [x] Adding missing T.Deadline() (used by testscript) -> moved to #4362 
- [x] Avoid panic in deep equal with map of interfaces -> moved to #4360 
- [x] Avoid panic in [go-cmp](https://github.com/google/go-cmp/blob/v0.6.0/cmp/compare.go#L312-L314) when it tries to find an Equal method  -> moved to #4361 
  - This one is a bit dicey as I don't know how to make it conditionally crash/not crash (crash for people who think it works, not crash for people like go-cmp for which it's only one option)

Diff is stack on top of https://github.com/tinygo-org/tinygo/pull/4352 but once that one merges and I rebase it'll have only the top commit (not sure how you guys handle this)