### PR TITLE
make go-cmp Equal succeed

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1083,8 +1083,10 @@ func (t rawType) Method(i int) Method {
 	panic("unimplemented: (reflect.Type).Method()")
 }
 
-func (t rawType) MethodByName(name string) (Method, bool) {
-	panic("unimplemented: (reflect.Type).MethodByName()")
+func (t rawType) MethodByName(name string) (m Method, ok bool) {
+	// Avoid panic in in go-cmp t.MethodByName("Equal")
+	// https://github.com/google/go-cmp/blob/v0.6.0/cmp/compare.go#L312-L314
+	return // false
 }
 
 func (t *rawType) PkgPath() string {


### PR DESCRIPTION

- [x] Avoid panic in [go-cmp](https://github.com/google/go-cmp/blob/v0.6.0/cmp/compare.go#L312-L314) when it tries to find an Equal method 
  - This one is a bit dicey as I don't know how to make it conditionally crash/not crash (crash for people who think it works, not crash for people like go-cmp for which it's only one option)
  
Splitting commits from #4356 