### PR TITLE
reflect: move binary flag into map type

### DIFF
--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -22,7 +22,7 @@ target triple = "wasm32-unknown-wasi"
 @"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00 " }
 @"runtime/gc.layout:62-0001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00\00" }
 @"reflect/types.type:basic:complex128" = linkonce_odr constant { i8, ptr } { i8 80, ptr @"reflect/types.type:pointer:basic:complex128" }, align 4
-@"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:basic:complex128" }, align 4
+@"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr } { i8 85, i16 0, ptr @"reflect/types.type:basic:complex128" }, align 4
 
 ; Function Attrs: allockind("alloc,zeroed") allocsize(0)
 declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0

--- a/compiler/testdata/interface.ll
+++ b/compiler/testdata/interface.ll
@@ -6,14 +6,14 @@ target triple = "wasm32-unknown-wasi"
 %runtime._interface = type { ptr, ptr }
 %runtime._string = type { ptr, i32 }
 
-@"reflect/types.type:basic:int" = linkonce_odr constant { i8, ptr } { i8 -62, ptr @"reflect/types.type:pointer:basic:int" }, align 4
-@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:basic:int" }, align 4
-@"reflect/types.type:pointer:named:error" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:named:error" }, align 4
+@"reflect/types.type:basic:int" = linkonce_odr constant { i8, ptr } { i8 66, ptr @"reflect/types.type:pointer:basic:int" }, align 4
+@"reflect/types.type:pointer:basic:int" = linkonce_odr constant { i8, i16, ptr } { i8 85, i16 0, ptr @"reflect/types.type:basic:int" }, align 4
+@"reflect/types.type:pointer:named:error" = linkonce_odr constant { i8, i16, ptr } { i8 85, i16 0, ptr @"reflect/types.type:named:error" }, align 4
 @"reflect/types.type:named:error" = linkonce_odr constant { i8, i16, ptr, ptr, ptr, [7 x i8] } { i8 116, i16 1, ptr @"reflect/types.type:pointer:named:error", ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}", ptr @"reflect/types.type.pkgpath.empty", [7 x i8] c".error\00" }, align 4
 @"reflect/types.type.pkgpath.empty" = linkonce_odr unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @"reflect/types.type:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, ptr } { i8 84, ptr @"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" }, align 4
-@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
-@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:interface:{String:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{Error:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 85, i16 0, ptr @"reflect/types.type:interface:{Error:func:{}{basic:string}}" }, align 4
+@"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, i16, ptr } { i8 85, i16 0, ptr @"reflect/types.type:interface:{String:func:{}{basic:string}}" }, align 4
 @"reflect/types.type:interface:{String:func:{}{basic:string}}" = linkonce_odr constant { i8, ptr } { i8 84, ptr @"reflect/types.type:pointer:interface:{String:func:{}{basic:string}}" }, align 4
 @"reflect/types.typeid:basic:int" = external constant i8
 

--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -947,9 +947,10 @@ func (v Value) MapKeys() []Value {
 	k := New(v.typecode.Key())
 	e := New(v.typecode.Elem())
 
+	typecode := (*mapType)(unsafe.Pointer((v.typecode.underlying())))
 	keyType := v.typecode.key()
 	keyTypeIsEmptyInterface := keyType.Kind() == Interface && keyType.NumMethod() == 0
-	shouldUnpackInterface := !keyTypeIsEmptyInterface && keyType.Kind() != String && !keyType.isBinary()
+	shouldUnpackInterface := !keyTypeIsEmptyInterface && keyType.Kind() != String && !typecode.isBinaryKey()
 
 	for hashmapNext(v.pointer(), it, k.value, e.value) {
 		if shouldUnpackInterface {
@@ -979,6 +980,7 @@ func (v Value) MapIndex(key Value) Value {
 		panic(&ValueError{Method: "MapIndex", Kind: v.Kind()})
 	}
 
+	typecode := (*mapType)(unsafe.Pointer(v.typecode.underlying()))
 	vkey := v.typecode.key()
 
 	// compare key type with actual key type of map
@@ -997,7 +999,7 @@ func (v Value) MapIndex(key Value) Value {
 			return Value{}
 		}
 		return elem.Elem()
-	} else if vkey.isBinary() {
+	} else if typecode.isBinaryKey() {
 		var keyptr unsafe.Pointer
 		if key.isIndirect() || key.typecode.Size() > unsafe.Sizeof(uintptr(0)) {
 			keyptr = key.value
@@ -1028,10 +1030,11 @@ func (v Value) MapRange() *MapIter {
 		panic(&ValueError{Method: "MapRange", Kind: v.Kind()})
 	}
 
+	typecode := (*mapType)(unsafe.Pointer(v.typecode.underlying()))
 	keyType := v.typecode.key()
 
 	keyTypeIsEmptyInterface := keyType.Kind() == Interface && keyType.NumMethod() == 0
-	shouldUnpackInterface := !keyTypeIsEmptyInterface && keyType.Kind() != String && !keyType.isBinary()
+	shouldUnpackInterface := !keyTypeIsEmptyInterface && keyType.Kind() != String && !typecode.isBinaryKey()
 
 	return &MapIter{
 		m:                  v,
@@ -1824,6 +1827,7 @@ func (v Value) SetMapIndex(key, elem Value) {
 	}
 
 	vkey := v.typecode.key()
+	typecode := (*mapType)(unsafe.Pointer(v.typecode.underlying()))
 
 	// compare key type with actual key type of map
 	if !key.typecode.AssignableTo(vkey) {
@@ -1859,7 +1863,7 @@ func (v Value) SetMapIndex(key, elem Value) {
 			hashmapStringSet(v.pointer(), *(*string)(key.value), elemptr)
 		}
 
-	} else if key.typecode.isBinary() {
+	} else if typecode.isBinaryKey() {
 		var keyptr unsafe.Pointer
 		if key.isIndirect() || key.typecode.Size() > unsafe.Sizeof(uintptr(0)) {
 			keyptr = key.value
@@ -1965,14 +1969,15 @@ func MakeMapWithSize(typ Type, n int) Value {
 		panic("reflect.MakeMapWithSize: negative size hint")
 	}
 
-	key := typ.Key().(*rawType)
-	val := typ.Elem().(*rawType)
+	typecode := (*mapType)(unsafe.Pointer(typ.(*rawType).underlying()))
+	key := typecode.rawType.key()
+	val := typecode.rawType.elem()
 
 	var alg uint8
 
 	if key.Kind() == String {
 		alg = hashmapAlgorithmString
-	} else if key.isBinary() {
+	} else if typecode.isBinaryKey() {
 		alg = hashmapAlgorithmBinary
 	} else {
 		alg = hashmapAlgorithmInterface


### PR DESCRIPTION
The map type had a byte of padding ready for such a flag (on all systems except AVR). So it's basically free to use.

I want to use the now-free flag bit in the meta byte in a future change, this just lays the groundwork.