### PR TITLE
reflect: return correct name for unsafe.Pointer type

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -1060,8 +1060,10 @@ func (t *rawType) Name() string {
 		panic("corrupt name data")
 	}
 
-	if t.Kind() <= UnsafePointer {
+	if kind := t.Kind(); kind < UnsafePointer {
 		return t.Kind().String()
+	} else if kind == UnsafePointer {
+		return "Pointer"
 	}
 
 	return ""

--- a/testdata/reflect.go
+++ b/testdata/reflect.go
@@ -423,6 +423,9 @@ func showValue(rv reflect.Value, indent string) {
 	if !rt.Comparable() {
 		print(" comparable=false")
 	}
+	if name := rt.Name(); name != "" {
+		print(" name=", name)
+	}
 	println()
 	switch rt.Kind() {
 	case reflect.Bool:

--- a/testdata/reflect.txt
+++ b/testdata/reflect.txt
@@ -7,140 +7,140 @@ false
 false
 
 values of interfaces
-reflect type: bool
+reflect type: bool name=bool
   bool: true
-reflect type: bool
+reflect type: bool name=bool
   bool: false
-reflect type: int
+reflect type: int name=int
   int: 2000
-reflect type: int
+reflect type: int name=int
   int: -2000
-reflect type: uint
+reflect type: uint name=uint
   uint: 2000
-reflect type: int8
+reflect type: int8 name=int8
   int: -3
-reflect type: int8
+reflect type: int8 name=int8
   int: 3
-reflect type: uint8
+reflect type: uint8 name=uint8
   uint: 200
-reflect type: int16
+reflect type: int16 name=int16
   int: -300
-reflect type: int16
+reflect type: int16 name=int16
   int: 300
-reflect type: uint16
+reflect type: uint16 name=uint16
   uint: 50000
-reflect type: int32
+reflect type: int32 name=int32
   int: 7340032
-reflect type: int32
+reflect type: int32 name=int32
   int: -7340032
-reflect type: uint32
+reflect type: uint32 name=uint32
   uint: 7340032
-reflect type: int64
+reflect type: int64 name=int64
   int: 9895604649984
-reflect type: int64
+reflect type: int64 name=int64
   int: -9895604649984
-reflect type: uint64
+reflect type: uint64 name=uint64
   uint: 9895604649984
-reflect type: uintptr
+reflect type: uintptr name=uintptr
   uint: 12345
-reflect type: float32
+reflect type: float32 name=float32
   float: +3.140000e+000
-reflect type: float64
+reflect type: float64 name=float64
   float: +3.140000e+000
-reflect type: complex64
+reflect type: complex64 name=complex64
   complex: (+1.200000e+000+3.000000e-001i)
-reflect type: complex128
+reflect type: complex128 name=complex128
   complex: (+1.300000e+000+4.000000e-001i)
-reflect type: int
+reflect type: int name=myint
   int: 32
-reflect type: string
+reflect type: string name=string
   string: foo 3
-  reflect type: uint8
+  reflect type: uint8 name=uint8
     uint: 102
-  reflect type: uint8
+  reflect type: uint8 name=uint8
     uint: 111
-  reflect type: uint8
+  reflect type: uint8 name=uint8
     uint: 111
-reflect type: unsafe.Pointer
+reflect type: unsafe.Pointer name=Pointer
   pointer: true
 reflect type: chan
   chan: int
   nil: true
-reflect type: chan
+reflect type: chan name=mychan
   chan: int
   nil: true
 reflect type: ptr
   pointer: true int
   nil: false
-  reflect type: int settable=true addrable=true
+  reflect type: int settable=true addrable=true name=int
     int: 0
 reflect type: ptr
   pointer: true interface
   nil: false
-  reflect type: interface settable=true addrable=true
+  reflect type: interface settable=true addrable=true name=error
     interface
     nil: true
     NumMethod: 1
 reflect type: ptr
   pointer: true int
   nil: false
-  reflect type: int settable=true addrable=true
+  reflect type: int settable=true addrable=true name=int
     int: 42
-reflect type: ptr
+reflect type: ptr name=myptr
   pointer: true int
   nil: false
-  reflect type: int settable=true addrable=true
+  reflect type: int settable=true addrable=true name=int
     int: 0
 reflect type: slice comparable=false
   slice: uint8 3 3
   pointer: true
   nil: false
   indexing: 0
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 1
   indexing: 1
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 2
   indexing: 2
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 3
 reflect type: slice comparable=false
   slice: uint8 2 5
   pointer: true
   nil: false
   indexing: 0
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 0
   indexing: 1
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 0
 reflect type: slice comparable=false
   slice: int32 2 2
   pointer: true
   nil: false
   indexing: 0
-  reflect type: int32 settable=true addrable=true
+  reflect type: int32 settable=true addrable=true name=int32
     int: 3
   indexing: 1
-  reflect type: int32 settable=true addrable=true
+  reflect type: int32 settable=true addrable=true name=int32
     int: 5
 reflect type: slice comparable=false
   slice: string 2 2
   pointer: true
   nil: false
   indexing: 0
-  reflect type: string settable=true addrable=true
+  reflect type: string settable=true addrable=true name=string
     string: xyz 3
-    reflect type: uint8
+    reflect type: uint8 name=uint8
       uint: 120
-    reflect type: uint8
+    reflect type: uint8 name=uint8
       uint: 121
-    reflect type: uint8
+    reflect type: uint8 name=uint8
       uint: 122
   indexing: 1
-  reflect type: string settable=true addrable=true
+  reflect type: string settable=true addrable=true name=string
     string: Z 1
-    reflect type: uint8
+    reflect type: uint8 name=uint8
       uint: 90
 reflect type: slice comparable=false
   slice: uint8 0 0
@@ -155,67 +155,67 @@ reflect type: slice comparable=false
   pointer: true
   nil: false
   indexing: 0
-  reflect type: float32 settable=true addrable=true
+  reflect type: float32 settable=true addrable=true name=float32
     float: +1.000000e+000
   indexing: 1
-  reflect type: float32 settable=true addrable=true
+  reflect type: float32 settable=true addrable=true name=float32
     float: +1.320000e+000
 reflect type: slice comparable=false
   slice: float64 2 2
   pointer: true
   nil: false
   indexing: 0
-  reflect type: float64 settable=true addrable=true
+  reflect type: float64 settable=true addrable=true name=float64
     float: +1.000000e+000
   indexing: 1
-  reflect type: float64 settable=true addrable=true
+  reflect type: float64 settable=true addrable=true name=float64
     float: +1.640000e+000
 reflect type: slice comparable=false
   slice: complex64 2 2
   pointer: true
   nil: false
   indexing: 0
-  reflect type: complex64 settable=true addrable=true
+  reflect type: complex64 settable=true addrable=true name=complex64
     complex: (+1.000000e+000+0.000000e+000i)
   indexing: 1
-  reflect type: complex64 settable=true addrable=true
+  reflect type: complex64 settable=true addrable=true name=complex64
     complex: (+1.640000e+000+3.000000e-001i)
 reflect type: slice comparable=false
   slice: complex128 2 2
   pointer: true
   nil: false
   indexing: 0
-  reflect type: complex128 settable=true addrable=true
+  reflect type: complex128 settable=true addrable=true name=complex128
     complex: (+1.000000e+000+0.000000e+000i)
   indexing: 1
-  reflect type: complex128 settable=true addrable=true
+  reflect type: complex128 settable=true addrable=true name=complex128
     complex: (+1.128000e+000+4.000000e-001i)
-reflect type: slice comparable=false
+reflect type: slice comparable=false name=myslice
   slice: uint8 3 3
   pointer: true
   nil: false
   indexing: 0
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 5
   indexing: 1
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 3
   indexing: 2
-  reflect type: uint8 settable=true addrable=true
+  reflect type: uint8 settable=true addrable=true name=uint8
     uint: 11
 reflect type: array
   array: 3 int64 24
-  reflect type: int64
+  reflect type: int64 name=int64
     int: 5
-  reflect type: int64
+  reflect type: int64 name=int64
     int: 8
-  reflect type: int64
+  reflect type: int64 name=int64
     int: 2
 reflect type: array
   array: 2 uint8 2
-  reflect type: uint8
+  reflect type: uint8 name=uint8
     uint: 3
-  reflect type: uint8
+  reflect type: uint8 name=uint8
     uint: 5
 reflect type: func comparable=false
   func
@@ -238,7 +238,7 @@ reflect type: struct
   tag: ""
   embedded: true
   exported: false
-  reflect type: interface caninterface=false
+  reflect type: interface caninterface=false name=error
     interface
     nil: true
     NumMethod: 1
@@ -249,51 +249,51 @@ reflect type: struct
   tag: ""
   embedded: false
   exported: false
-  reflect type: uint8 caninterface=false
+  reflect type: uint8 caninterface=false name=uint8
     uint: 42
   field: 1 b
   pkg: main
   tag: ""
   embedded: false
   exported: false
-  reflect type: int16 caninterface=false
+  reflect type: int16 caninterface=false name=int16
     int: 321
   field: 2 c
   pkg: main
   tag: ""
   embedded: false
   exported: false
-  reflect type: int8 caninterface=false
+  reflect type: int8 caninterface=false name=int8
     int: 123
-reflect type: struct comparable=false
+reflect type: struct comparable=false name=mystruct
   struct: 5
   field: 0 n
   pkg: main
   tag: "foo:\"bar\""
   embedded: false
   exported: false
-  reflect type: int caninterface=false
+  reflect type: int caninterface=false name=int
     int: 5
   field: 1 some
   pkg: main
   tag: "some\x00tag"
   embedded: false
   exported: false
-  reflect type: struct caninterface=false
+  reflect type: struct caninterface=false name=point
     struct: 2
     field: 0 X
     pkg: 
     tag: ""
     embedded: false
     exported: true
-    reflect type: int16 caninterface=false
+    reflect type: int16 caninterface=false name=int16
       int: -5
     field: 1 Y
     pkg: 
     tag: ""
     embedded: false
     exported: true
-    reflect type: int16 caninterface=false
+    reflect type: int16 caninterface=false name=int16
       int: 3
   field: 2 zero
   pkg: main
@@ -312,10 +312,10 @@ reflect type: struct comparable=false
     pointer: true
     nil: false
     indexing: 0
-    reflect type: uint8 addrable=true caninterface=false
+    reflect type: uint8 addrable=true caninterface=false name=uint8
       uint: 71
     indexing: 1
-    reflect type: uint8 addrable=true caninterface=false
+    reflect type: uint8 addrable=true caninterface=false name=uint8
       uint: 111
   field: 4 Buf
   pkg: 
@@ -327,12 +327,12 @@ reflect type: struct comparable=false
     pointer: true
     nil: false
     indexing: 0
-    reflect type: uint8 settable=true addrable=true
+    reflect type: uint8 settable=true addrable=true name=uint8
       uint: 88
 reflect type: ptr
   pointer: true struct
   nil: false
-  reflect type: struct settable=true addrable=true
+  reflect type: struct settable=true addrable=true name=linkedList
     struct: 2
     field: 0 next
     pkg: main
@@ -347,7 +347,7 @@ reflect type: ptr
     tag: ""
     embedded: false
     exported: false
-    reflect type: int addrable=true caninterface=false
+    reflect type: int addrable=true caninterface=false name=int
       int: 42
 reflect type: struct
   struct: 2
@@ -356,14 +356,14 @@ reflect type: struct
   tag: ""
   embedded: false
   exported: true
-  reflect type: uintptr
+  reflect type: uintptr name=uintptr
     uint: 2
   field: 1 B
   pkg: 
   tag: ""
   embedded: false
   exported: true
-  reflect type: uintptr
+  reflect type: uintptr name=uintptr
     uint: 3
 reflect type: slice comparable=false
   slice: interface 3 3
@@ -374,52 +374,52 @@ reflect type: slice comparable=false
     interface
     nil: false
     NumMethod: 0
-    reflect type: int
+    reflect type: int name=int
       int: 3
   indexing: 1
   reflect type: interface settable=true addrable=true
     interface
     nil: false
     NumMethod: 0
-    reflect type: string
+    reflect type: string name=string
       string: str 3
-      reflect type: uint8
+      reflect type: uint8 name=uint8
         uint: 115
-      reflect type: uint8
+      reflect type: uint8 name=uint8
         uint: 116
-      reflect type: uint8
+      reflect type: uint8 name=uint8
         uint: 114
   indexing: 2
   reflect type: interface settable=true addrable=true
     interface
     nil: false
     NumMethod: 0
-    reflect type: complex128
+    reflect type: complex128 name=complex128
       complex: (-4.000000e+000+2.500000e+000i)
 reflect type: ptr
   pointer: true int8
   nil: false
-  reflect type: int8 settable=true addrable=true
+  reflect type: int8 settable=true addrable=true name=int8
     int: 5
 reflect type: ptr
   pointer: true int16
   nil: false
-  reflect type: int16 settable=true addrable=true
+  reflect type: int16 settable=true addrable=true name=int16
     int: -800
 reflect type: ptr
   pointer: true int32
   nil: false
-  reflect type: int32 settable=true addrable=true
+  reflect type: int32 settable=true addrable=true name=int32
     int: 100000000
 reflect type: ptr
   pointer: true int64
   nil: false
-  reflect type: int64 settable=true addrable=true
+  reflect type: int64 settable=true addrable=true name=int64
     int: -1000000000000
 reflect type: ptr
   pointer: true complex128
   nil: false
-  reflect type: complex128 settable=true addrable=true
+  reflect type: complex128 settable=true addrable=true name=complex128
     complex: (-8.000000e+000-2.000000e+006i)
 
 sizes:


### PR DESCRIPTION
For some reason, the type kind name is "unsafe.Pointer" while the .Name() method just returns "Pointer".

Not sure why this difference exists, but to be able to test .Name() in testdata/reflect.go it needs to match.