### PR TITLE
mips: add GOMIPS=softfloat support

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -745,6 +745,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				ldflags = append(ldflags, dependency.result)
 			}
 			ldflags = append(ldflags, "-mllvm", "-mcpu="+config.CPU())
+			ldflags = append(ldflags, "-mllvm", "-mattr="+config.Features()) // needed for MIPS softfloat
 			if config.GOOS() == "windows" {
 				// Options for the MinGW wrapper for the lld COFF linker.
 				ldflags = append(ldflags,

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -57,8 +57,10 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "linux", GOARCH: "arm", GOARM: "6"},
 		{GOOS: "linux", GOARCH: "arm", GOARM: "7"},
 		{GOOS: "linux", GOARCH: "arm64"},
-		{GOOS: "linux", GOARCH: "mips"},
-		{GOOS: "linux", GOARCH: "mipsle"},
+		{GOOS: "linux", GOARCH: "mips", GOMIPS: "hardfloat"},
+		{GOOS: "linux", GOARCH: "mipsle", GOMIPS: "hardfloat"},
+		{GOOS: "linux", GOARCH: "mips", GOMIPS: "softfloat"},
+		{GOOS: "linux", GOARCH: "mipsle", GOMIPS: "softfloat"},
 		{GOOS: "darwin", GOARCH: "amd64"},
 		{GOOS: "darwin", GOARCH: "arm64"},
 		{GOOS: "windows", GOARCH: "amd64"},
@@ -68,6 +70,9 @@ func TestClangAttributes(t *testing.T) {
 		name := "GOOS=" + options.GOOS + ",GOARCH=" + options.GOARCH
 		if options.GOARCH == "arm" {
 			name += ",GOARM=" + options.GOARM
+		}
+		if options.GOARCH == "mips" || options.GOARCH == "mipsle" {
+			name += ",GOMIPS=" + options.GOMIPS
 		}
 		t.Run(name, func(t *testing.T) {
 			testClangAttributes(t, options)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -64,7 +64,6 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "windows", GOARCH: "amd64"},
 		{GOOS: "windows", GOARCH: "arm64"},
 		{GOOS: "wasip1", GOARCH: "wasm"},
-		{GOOS: "wasip2", GOARCH: "wasm"},
 	} {
 		name := "GOOS=" + options.GOOS + ",GOARCH=" + options.GOARCH
 		if options.GOARCH == "arm" {

--- a/builder/library.go
+++ b/builder/library.go
@@ -185,6 +185,11 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 	if strings.HasPrefix(target, "mips") {
 		args = append(args, "-fno-pic")
 	}
+	if config.Target.SoftFloat {
+		// Use softfloat instead of floating point instructions. This is
+		// supported on many architectures.
+		args = append(args, "-msoft-float")
+	}
 
 	var once sync.Once
 

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -72,6 +72,12 @@ func (c *Config) GOARM() string {
 	return c.Options.GOARM
 }
 
+// GOMIPS will return the GOMIPS environment variable given to the compiler when
+// building a program.
+func (c *Config) GOMIPS() string {
+	return c.Options.GOMIPS
+}
+
 // BuildTags returns the complete list of build tags used during this build.
 func (c *Config) BuildTags() []string {
 	tags := append([]string(nil), c.Target.BuildTags...) // copy slice (avoid a race)
@@ -230,6 +236,9 @@ func (c *Config) LibcPath(name string) (path string, precompiled bool) {
 	}
 	if c.ABI() != "" {
 		archname += "-" + c.ABI()
+	}
+	if c.Target.SoftFloat {
+		archname += "-softfloat"
 	}
 
 	// Try to load a precompiled library.

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	GOOS            string // environment variable
 	GOARCH          string // environment variable
 	GOARM           string // environment variable (only used with GOARCH=arm)
+	GOMIPS          string // environment variable (only used with GOARCH=mips and GOARCH=mipsle)
 	Directory       string // working dir, leave it unset to use the current working dir
 	Target          string
 	Opt             string

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -30,8 +30,11 @@ var Keys = []string{
 }
 
 func init() {
-	if Get("GOARCH") == "arm" {
+	switch Get("GOARCH") {
+	case "arm":
 		Keys = append(Keys, "GOARM")
+	case "mips", "mipsle":
+		Keys = append(Keys, "GOMIPS")
 	}
 }
 
@@ -128,6 +131,13 @@ func Get(name string) string {
 		// difference between ARMv6 and ARMv7. ARMv6 binaries are much smaller,
 		// especially when floating point instructions are involved.
 		return "6"
+	case "GOMIPS":
+		gomips := os.Getenv("GOMIPS")
+		if gomips == "" {
+			// Default to hardfloat (this matches the Go toolchain).
+			gomips = "hardfloat"
+		}
+		return gomips
 	case "GOROOT":
 		readGoEnvVars()
 		return goEnvVars.GOROOT

--- a/main.go
+++ b/main.go
@@ -1498,6 +1498,7 @@ func main() {
 		GOOS:            goenv.Get("GOOS"),
 		GOARCH:          goenv.Get("GOARCH"),
 		GOARM:           goenv.Get("GOARM"),
+		GOMIPS:          goenv.Get("GOMIPS"),
 		Target:          *target,
 		StackSize:       stackSize,
 		Opt:             *opt,
@@ -1780,6 +1781,7 @@ func main() {
 				GOOS       string                  `json:"goos"`
 				GOARCH     string                  `json:"goarch"`
 				GOARM      string                  `json:"goarm"`
+				GOMIPS     string                  `json:"gomips"`
 				BuildTags  []string                `json:"build_tags"`
 				GC         string                  `json:"garbage_collector"`
 				Scheduler  string                  `json:"scheduler"`
@@ -1790,6 +1792,7 @@ func main() {
 				GOOS:       config.GOOS(),
 				GOARCH:     config.GOARCH(),
 				GOARM:      config.GOARM(),
+				GOMIPS:     config.GOMIPS(),
 				BuildTags:  config.BuildTags(),
 				GC:         config.GC(),
 				Scheduler:  config.Scheduler(),

--- a/main_test.go
+++ b/main_test.go
@@ -37,7 +37,7 @@ var supportedLinuxArches = map[string]string{
 	"X86Linux":   "linux/386",
 	"ARMLinux":   "linux/arm/6",
 	"ARM64Linux": "linux/arm64",
-	"MIPSLinux":  "linux/mipsle",
+	"MIPSLinux":  "linux/mipsle/hardfloat",
 	"WASIp1":     "wasip1/wasm",
 }
 
@@ -326,6 +326,7 @@ func optionsFromTarget(target string, sema chan struct{}) compileopts.Options {
 		GOOS:          goenv.Get("GOOS"),
 		GOARCH:        goenv.Get("GOARCH"),
 		GOARM:         goenv.Get("GOARM"),
+		GOMIPS:        goenv.Get("GOMIPS"),
 		Target:        target,
 		Semaphore:     sema,
 		InterpTimeout: 180 * time.Second,
@@ -349,8 +350,11 @@ func optionsFromOSARCH(osarch string, sema chan struct{}) compileopts.Options {
 		VerifyIR:      true,
 		Opt:           "z",
 	}
-	if options.GOARCH == "arm" {
+	switch options.GOARCH {
+	case "arm":
 		options.GOARM = parts[2]
+	case "mips", "mipsle":
+		options.GOMIPS = parts[2]
 	}
 	return options
 }


### PR DESCRIPTION
Previously, the compiler would default to hardfloat. This is not supported by some MIPS CPUs.

This took me much longer than it should have because of a quirk in the LLVM Mips backend: if the target-features string is not set (like during LTO), the Mips backend picks the first function in the module and uses that. Unfortunately, in the case of TinyGo this first function is `llvm.dbg.value`, which is an LLVM intrinsic and doesn't have the target-features string.
I fixed it by adding a `-mllvm -mattr=` flag to the linker.