### PR TITLE
ci: don't include prebuilt libraries in the release

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -867,9 +867,6 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/arch
 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@mkdir -p build/release/tinygo/lib/wasi-cli/
-	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0
-	@mkdir -p build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus
-	@mkdir -p build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4
 	@echo copying source files
 	@cp -p  build/tinygo$(EXE)           build/release/tinygo/bin
 ifneq ($(USE_SYSTEM_BINARYEN),1)
@@ -932,12 +929,6 @@ endif
 	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
 	@cp -rp src                          build/release/tinygo/src
 	@cp -rp targets                      build/release/tinygo/targets
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/compiler-rt     compiler-rt
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/compiler-rt compiler-rt
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/compiler-rt    compiler-rt
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0     -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0/picolibc     picolibc
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m0plus -o build/release/tinygo/pkg/thumbv6m-unknown-unknown-eabi-cortex-m0plus/picolibc picolibc
-	./build/release/tinygo/bin/tinygo build-library -target=cortex-m4     -o build/release/tinygo/pkg/thumbv7em-unknown-unknown-eabi-cortex-m4/picolibc    picolibc
 
 release:
 	tar -czf build/release.tar.gz -C build/release tinygo

--- a/builder/build.go
+++ b/builder/build.go
@@ -148,7 +148,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		job := makeDarwinLibSystemJob(config, tmpdir)
 		libcDependencies = append(libcDependencies, job)
 	case "musl":
-		job, unlock, err := Musl.load(config, tmpdir)
+		job, unlock, err := libMusl.load(config, tmpdir)
 		if err != nil {
 			return BuildResult{}, err
 		}
@@ -156,7 +156,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		libcDependencies = append(libcDependencies, dummyCompileJob(filepath.Join(filepath.Dir(job.result), "crt1.o")))
 		libcDependencies = append(libcDependencies, job)
 	case "picolibc":
-		libcJob, unlock, err := Picolibc.load(config, tmpdir)
+		libcJob, unlock, err := libPicolibc.load(config, tmpdir)
 		if err != nil {
 			return BuildResult{}, err
 		}
@@ -169,14 +169,14 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		}
 		libcDependencies = append(libcDependencies, dummyCompileJob(path))
 	case "wasmbuiltins":
-		libcJob, unlock, err := WasmBuiltins.load(config, tmpdir)
+		libcJob, unlock, err := libWasmBuiltins.load(config, tmpdir)
 		if err != nil {
 			return BuildResult{}, err
 		}
 		defer unlock()
 		libcDependencies = append(libcDependencies, libcJob)
 	case "mingw-w64":
-		_, unlock, err := MinGW.load(config, tmpdir)
+		_, unlock, err := libMinGW.load(config, tmpdir)
 		if err != nil {
 			return BuildResult{}, err
 		}
@@ -651,7 +651,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 	// Add compiler-rt dependency if needed. Usually this is a simple load from
 	// a cache.
 	if config.Target.RTLib == "compiler-rt" {
-		job, unlock, err := CompilerRT.load(config, tmpdir)
+		job, unlock, err := libCompilerRT.load(config, tmpdir)
 		if err != nil {
 			return result, err
 		}

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -169,12 +169,12 @@ var avrBuiltins = []string{
 	"avr/udivmodqi4.S",
 }
 
-// CompilerRT is a library with symbols required by programs compiled with LLVM.
-// These symbols are for operations that cannot be emitted with a single
+// libCompilerRT is a library with symbols required by programs compiled with
+// LLVM. These symbols are for operations that cannot be emitted with a single
 // instruction or a short sequence of instructions for that target.
 //
 // For more information, see: https://compiler-rt.llvm.org/
-var CompilerRT = Library{
+var libCompilerRT = Library{
 	name: "compiler-rt",
 	cflags: func(target, headerPath string) []string {
 		return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"}

--- a/builder/library.go
+++ b/builder/library.go
@@ -35,19 +35,6 @@ type Library struct {
 	crt1Source string
 }
 
-// Load the library archive, possibly generating and caching it if needed.
-// The resulting directory may be stored in the provided tmpdir, which is
-// expected to be removed after the Load call.
-func (l *Library) Load(config *compileopts.Config, tmpdir string) (dir string, err error) {
-	job, unlock, err := l.load(config, tmpdir)
-	if err != nil {
-		return "", err
-	}
-	defer unlock()
-	err = runJobs(job, config.Options.Semaphore)
-	return filepath.Dir(job.result), err
-}
-
 // load returns a compile job to build this library file for the given target
 // and CPU. It may return a dummy compileJob if the library build is already
 // cached. The path is stored as job.result but is only valid after the job has

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
-var MinGW = Library{
+var libMinGW = Library{
 	name: "mingw-w64",
 	makeHeaders: func(target, includeDir string) error {
 		// copy _mingw.h

--- a/builder/musl.go
+++ b/builder/musl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
-var Musl = Library{
+var libMusl = Library{
 	name: "musl",
 	makeHeaders: func(target, includeDir string) error {
 		bits := filepath.Join(includeDir, "bits")

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -8,9 +8,9 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
-// Picolibc is a C library for bare metal embedded devices. It was originally
+// libPicolibc is a C library for bare metal embedded devices. It was originally
 // based on newlib.
-var Picolibc = Library{
+var libPicolibc = Library{
 	name: "picolibc",
 	makeHeaders: func(target, includeDir string) error {
 		f, err := os.Create(filepath.Join(includeDir, "picolibc.h"))

--- a/builder/wasmbuiltins.go
+++ b/builder/wasmbuiltins.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tinygo-org/tinygo/goenv"
 )
 
-var WasmBuiltins = Library{
+var libWasmBuiltins = Library{
 	name: "wasmbuiltins",
 	makeHeaders: func(target, includeDir string) error {
 		if err := os.Mkdir(includeDir+"/bits", 0o777); err != nil {

--- a/main.go
+++ b/main.go
@@ -1437,7 +1437,7 @@ func main() {
 		flag.BoolVar(&flagTest, "test", false, "supply -test flag to go list")
 	}
 	var outpath string
-	if command == "help" || command == "build" || command == "build-library" || command == "test" {
+	if command == "help" || command == "build" || command == "test" {
 		flag.StringVar(&outpath, "o", "", "output filename")
 	}
 
@@ -1570,50 +1570,6 @@ func main() {
 
 		err := Build(pkgName, outpath, options)
 		handleCompilerError(err)
-	case "build-library":
-		// Note: this command is only meant to be used while making a release!
-		if outpath == "" {
-			fmt.Fprintln(os.Stderr, "No output filename supplied (-o).")
-			usage(command)
-			os.Exit(1)
-		}
-		if *target == "" {
-			fmt.Fprintln(os.Stderr, "No target (-target).")
-		}
-		if flag.NArg() != 1 {
-			fmt.Fprintf(os.Stderr, "Build-library only accepts exactly one library name as argument, %d given\n", flag.NArg())
-			usage(command)
-			os.Exit(1)
-		}
-		var lib *builder.Library
-		switch name := flag.Arg(0); name {
-		case "compiler-rt":
-			lib = &builder.CompilerRT
-		case "picolibc":
-			lib = &builder.Picolibc
-		default:
-			fmt.Fprintf(os.Stderr, "Unknown library: %s\n", name)
-			os.Exit(1)
-		}
-		tmpdir, err := os.MkdirTemp("", "tinygo*")
-		if err != nil {
-			handleCompilerError(err)
-		}
-		defer os.RemoveAll(tmpdir)
-		spec, err := compileopts.LoadTarget(options)
-		if err != nil {
-			handleCompilerError(err)
-		}
-		config := &compileopts.Config{
-			Options: options,
-			Target:  spec,
-		}
-		path, err := lib.Load(config, tmpdir)
-		handleCompilerError(err)
-		err = copyFile(path, outpath)
-		if err != nil {
-			handleCompilerError(err)
-		}
 	case "flash", "gdb", "lldb":
 		pkgName := filepath.ToSlash(flag.Arg(0))
 		if command == "flash" {


### PR DESCRIPTION
These libraries will be automatically built when needed and cached.

The main reason these were needed is for play.tinygo.org, but I've now prebuilt them there directly (so they don't need to be built for every tarball).