### PR TITLE
compileopts: add CanonicalArchName to centralize architecture detection

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -149,27 +149,24 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 	if config.ABI() != "" {
 		args = append(args, "-mabi="+config.ABI())
 	}
-	if strings.HasPrefix(target, "arm") || strings.HasPrefix(target, "thumb") {
+	switch compileopts.CanonicalArchName(target) {
+	case "arm":
 		if strings.Split(target, "-")[2] == "linux" {
 			args = append(args, "-fno-unwind-tables", "-fno-asynchronous-unwind-tables")
 		} else {
 			args = append(args, "-fshort-enums", "-fomit-frame-pointer", "-mfloat-abi=soft", "-fno-unwind-tables", "-fno-asynchronous-unwind-tables")
 		}
-	}
-	if strings.HasPrefix(target, "avr") {
+	case "avr":
 		// AVR defaults to C float and double both being 32-bit. This deviates
 		// from what most code (and certainly compiler-rt) expects. So we need
 		// to force the compiler to use 64-bit floating point numbers for
 		// double.
 		args = append(args, "-mdouble=64")
-	}
-	if strings.HasPrefix(target, "riscv32-") {
+	case "riscv32":
 		args = append(args, "-march=rv32imac", "-fforce-enable-int128")
-	}
-	if strings.HasPrefix(target, "riscv64-") {
+	case "riscv64":
 		args = append(args, "-march=rv64gc")
-	}
-	if strings.HasPrefix(target, "mips") {
+	case "mips":
 		args = append(args, "-fno-pic")
 	}
 

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -207,10 +207,13 @@ func (c *Config) RP2040BootPatch() bool {
 	return false
 }
 
-// MuslArchitecture returns the architecture name as used in musl libc. It is
-// usually the same as the first part of the LLVM triple, but not always.
-func MuslArchitecture(triple string) string {
+// Return a canonicalized architecture name, so we don't have to deal with arm*
+// vs thumb* vs arm64.
+func CanonicalArchName(triple string) string {
 	arch := strings.Split(triple, "-")[0]
+	if arch == "arm64" {
+		return "aarch64"
+	}
 	if strings.HasPrefix(arch, "arm") || strings.HasPrefix(arch, "thumb") {
 		return "arm"
 	}
@@ -218,6 +221,12 @@ func MuslArchitecture(triple string) string {
 		return "mips"
 	}
 	return arch
+}
+
+// MuslArchitecture returns the architecture name as used in musl libc. It is
+// usually the same as the first part of the LLVM triple, but not always.
+func MuslArchitecture(triple string) string {
+	return CanonicalArchName(triple)
 }
 
 // LibcPath returns the path to the libc directory. The libc path will be either

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/compiler/llvmutil"
 	"tinygo.org/x/go-llvm"
 )
@@ -422,17 +423,7 @@ func (c *compilerContext) getPointerBitmap(typ llvm.Type, pos token.Pos) *big.In
 // architecture names ("armv6", "thumbv7m", etc) merged into a single
 // architecture name ("arm").
 func (c *compilerContext) archFamily() string {
-	arch := strings.Split(c.Triple, "-")[0]
-	if strings.HasPrefix(arch, "arm64") {
-		return "aarch64"
-	}
-	if strings.HasPrefix(arch, "arm") || strings.HasPrefix(arch, "thumb") {
-		return "arm"
-	}
-	if arch == "mipsel" {
-		return "mips"
-	}
-	return arch
+	return compileopts.CanonicalArchName(c.Triple)
 }
 
 // isThumb returns whether we're in ARM or in Thumb mode. It panics if the


### PR DESCRIPTION
It's possible to detect the architecture from the target triple, but there are a number of exceptions that make it unpleasant to use for this purpose. There are just too many weird exceptions (like mips vs mipsel, and armv6m vs thumv6m vs arm64 vs aarch64) so it's better to centralize these to canonical architecture names.

I picked the architecture names that happen to match the musl architecture names, because those seem the most natural to me.