### PR TITLE
duplicate big-go version tags functionality [ fix #4391 ]

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -33,14 +33,15 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 		return nil, fmt.Errorf("requires go version 1.19 through 1.22, got go%d.%d", major, minor)
 	}
 
+	// tinygo major / minor version
+	tgMajor, tgMinor := goenv.GetVersion()
+
 	return &compileopts.Config{
 		Options:        options,
 		Target:         spec,
 		GoMinorVersion: minor,
 		TestConfig:     options.TestConfig,
-
-		// tinygo version
-		VersionMajor:   goenv.VersionMajor,
-		VersionMinor:   goenv.VersionMinor,
+		VersionMajor:   tgMajor,
+		VersionMinor:   tgMinor,
 	}, nil
 }

--- a/builder/config.go
+++ b/builder/config.go
@@ -38,5 +38,9 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 		Target:         spec,
 		GoMinorVersion: minor,
 		TestConfig:     options.TestConfig,
+
+		// tinygo version
+		VersionMajor:   goenv.VersionMajor,
+		VersionMinor:   goenv.VersionMinor,
 	}, nil
 }

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	Target         *TargetSpec
 	GoMinorVersion int
 	TestConfig     TestConfig
+
+	// tinygo versions
+	VersionMajor int
+	VersionMinor int
 }
 
 // Triple returns the LLVM target triple, like armv6m-unknown-unknown-eabi.
@@ -81,9 +85,19 @@ func (c *Config) BuildTags() []string {
 		"math_big_pure_go",                           // to get math/big to work
 		"gc." + c.GC(), "scheduler." + c.Scheduler(), // used inside the runtime package
 		"serial." + c.Serial()}...) // used inside the machine package
+
+	// Go Version tags
 	for i := 1; i <= c.GoMinorVersion; i++ {
 		tags = append(tags, fmt.Sprintf("go1.%d", i))
 	}
+
+	// tinygo Version tags
+	for i := 0; i <= c.VersionMajor; i++ {
+		for j := 1; j <= c.VersionMinor; j++ {
+			tags = append(tags, fmt.Sprintf("tinygo%d.%d", i, j))
+		}
+	}
+
 	tags = append(tags, c.Options.Tags...)
 	return tags
 }

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -8,11 +8,8 @@ import (
 )
 
 // Version of TinyGo.
-// Update these value before release of new version of software.
-const VersionMajor = 0
-const VersionMinor = 33
-const VersionPatch = 0
-const VersionDev = "-dev" // "" for release
+// Update this value before release of new version of software.
+const version = "0.33.0-dev"
 
 var (
 	// This variable is set at build time using -ldflags parameters.
@@ -23,14 +20,18 @@ var (
 // Return TinyGo version, either in the form 0.30.0 or as a development version
 // (like 0.30.0-dev-abcd012).
 func Version() string {
-
-	v := fmt.Sprintf("%v.%v.%v%v", VersionMajor, VersionMinor, VersionPatch, VersionDev)
-
-	if strings.HasSuffix(v, "-dev") && GitSha1 != "" {
+	v := version
+	if strings.HasSuffix(version, "-dev") && GitSha1 != "" {
 		v += "-" + GitSha1
 	}
-
 	return v
+}
+
+// Return version as major / minor
+func GetVersion() (major, minor int) {
+	// version must be
+	fmt.Sscanf(version, "%d.%d", &major, &minor)
+	return
 }
 
 // GetGorootVersion returns the major and minor version for a given GOROOT path.

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -8,8 +8,11 @@ import (
 )
 
 // Version of TinyGo.
-// Update this value before release of new version of software.
-const version = "0.33.0-dev"
+// Update these value before release of new version of software.
+const VersionMajor = 0
+const VersionMinor = 33
+const VersionPatch = 0
+const VersionDev = "-dev" // "" for release
 
 var (
 	// This variable is set at build time using -ldflags parameters.
@@ -20,10 +23,13 @@ var (
 // Return TinyGo version, either in the form 0.30.0 or as a development version
 // (like 0.30.0-dev-abcd012).
 func Version() string {
-	v := version
-	if strings.HasSuffix(version, "-dev") && GitSha1 != "" {
+
+	v := fmt.Sprintf("%v.%v.%v%v", VersionMajor, VersionMinor, VersionPatch, VersionDev)
+
+	if strings.HasSuffix(v, "-dev") && GitSha1 != "" {
 		v += "-" + GitSha1
 	}
+
 	return v
 }
 

--- a/main.go
+++ b/main.go
@@ -1428,7 +1428,7 @@ func main() {
 	// development it can be useful to not emit debug information at all.
 	skipDwarf := flag.Bool("internal-nodwarf", false, "internal flag, use -no-debug instead")
 
-	var flagJSON, flagDeps, flagTest bool
+	var flagJSON, flagDeps, flagTest, flagFull bool
 	if command == "help" || command == "list" || command == "info" || command == "build" {
 		flag.BoolVar(&flagJSON, "json", false, "print data in JSON format")
 	}
@@ -1439,6 +1439,9 @@ func main() {
 	var outpath string
 	if command == "help" || command == "build" || command == "test" {
 		flag.StringVar(&outpath, "o", "", "output filename")
+	}
+	if command == "info" {
+		flag.BoolVar(&flagFull, "full", false, "output all tinygo version build-tags")
 	}
 
 	var witPackage, witWorld string
@@ -1720,6 +1723,12 @@ func main() {
 			os.Exit(1)
 		}
 		config.GoMinorVersion = 0 // this avoids creating the list of Go1.x build tags.
+		if !flagFull {
+			// avoid creating tinygoX.X build tags
+			config.VersionMinor = 0
+			config.VersionMajor = 0
+		}
+
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)


### PR DESCRIPTION
[ see #4391 for motivation ]
This attempts to duplicate big-Go go1.X build tags in tinygo with a series of build tags in the form `tinygo0.1,tinygo0.2,...`

Also adds a '-full' command-line flag to see all of the tags.

```
% ./build/tinygo info -json -full
{
  "goarch": "arm64",
  "goarm": "6",
  [...]
  "build_tags": [
    "darwin",
    "arm64",
    "tinygo",
    "purego",
    "math_big_pure_go",
    "gc.precise",
    "scheduler.tasks",
    "serial.none",
    "tinygo0.1",       <---
    "tinygo0.2",       <---
    [...]
    "tinygo0.32",      <---
    "tinygo0.33"       <---
  ],
  "garbage_collector": "precise",
  "scheduler": "tasks",
  "llvm_triple": "arm64-apple-macosx11.0.0"
}

```

TODO:
- tests
- Version specification is constantly confusing. I'd be inclined to create a separate package for clarity s.t. the constants were of the form`tinygoVersion.Major` etc. instead of goenv.VersionMajor etc.
- define `tinygo-dev` build tag if "-dev" ?
```
package tinygoVersion

const Major = 0
const Minor = 33
const Patch = 0
const Dev = "-dev" // "" for release
```