### PR TITLE
GNUmakefile: add "help" target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,6 +28,21 @@ build tools to be built. Go is of course necessary to build TinyGo itself.
 The rest of this guide assumes you're running Linux, but it should be equivalent
 on a different system like Mac.
 
+## Using GNU Make
+
+The static build of TinyGo is driven by GNUmakefile, which provides a help target for quick reference:
+
+    % make help
+    clean                           Remove build directory
+    fmt                             Reformat source
+    fmt-check                       Warn if any source needs reformatting
+    gen-device                      Generate microcontroller-specific sources
+    llvm-source                     Get LLVM sources
+    llvm-build                      Build LLVM
+    tinygo                          Build the TinyGo compiler
+    lint                            Lint source tree
+    spell                           Spellcheck source tree
+
 ## Download the source
 
 The first step is to download the TinyGo sources (use `--recursive` if you clone

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -289,7 +289,7 @@ ifeq (, $(shell which node))
 endif
 	@if [ $(NODEJS_VERSION) -lt $(MIN_NODEJS_VERSION) ]; then echo "Install NodeJS version 18+ to run tests."; exit 1; fi
 
-tinygo: ## Build the Go compiler
+tinygo: ## Build the TinyGo compiler
 	@if [ ! -f "$(LLVM_BUILDDIR)/bin/llvm-config" ]; then echo "Fetch and build LLVM first by running:"; echo "  $(MAKE) llvm-source"; echo "  $(MAKE) $(LLVM_BUILDDIR)"; exit 1; fi
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GOENVFLAGS) $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags "byollvm osusergo" -ldflags="-X github.com/tinygo-org/tinygo/goenv.GitSha1=`git rev-parse --short HEAD`" .
 test: wasi-libc check-nodejs-version


### PR DESCRIPTION
Example output:

```
$ make help
clean                           Remove build directory
fmt                             Reformat source
fmt-check                       Warn if any source needs reformatting
gen-device                      Generate microcontroller-specific sources
llvm-source                     Get LLVM sources
llvm-build                      Build LLVM
lint                            Lint source tree
spell                           Spellcheck source tree
```

Might even work on windows, since git for windows comes with awk.