### PR TITLE
 Better output when `tinygo build` has nothing to do (e.g. build constraints) fix #4392

### DIFF
--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,6 +1,9 @@
 package loader
 
-import "go/scanner"
+import (
+	"fmt"
+	"go/scanner"
+)
 
 // Errors contains a list of parser errors or a list of typechecker errors for
 // the given package.
@@ -21,6 +24,9 @@ type Error struct {
 }
 
 func (e Error) Error() string {
+	if 0 < len(e.ImportStack) {
+		return fmt.Sprintf("package %v: %v", e.ImportStack[0], e.Err.Error())
+	}
 	return e.Err.Error()
 }
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -250,10 +250,7 @@ func Load(config *compileopts.Config, inputPkg string, typeChecker types.Config)
 	}
 
 	if len(pkgErrors) != 0 {
-		// TODO: use errors.Join in Go 1.20.
-		return nil, Errors{
-			Errs: pkgErrors,
-		}
+		return nil, errors.Join(pkgErrors...)
 	}
 
 	if config.TestConfig.CompileTestBinary && !strings.HasSuffix(p.sorted[len(p.sorted)-1].ImportPath, ".test") {


### PR DESCRIPTION
See issue #4392 

```
% cat foo.go
//go:build foo
package main
func main() {
}
% go build
package foo: build constraints exclude all Go files in /tmp/nowork
% tinygo build
package foo <<==== ???
```

After patch:
```
% tinygo build
package foo: build constraints exclude all Go files in /tmp/nowork
% echo $?
1
```

Marked 'draft' as I'm unsure of implications. Sure enough, from `make test`:
```
    --- FAIL: TestErrors/loader-importcycle (0.01s)
        errors_test.go:67: expected error:
            > package command-line-arguments
            > 	imports github.com/tinygo-org/tinygo/testdata/errors/importcycle
            > 	imports github.com/tinygo-org/tinygo/testdata/errors/importcycle: import cycle not allowed
            got:
            > package command-line-arguments: import cycle not allowed
```