### PR TITLE
support for riscv syscalls

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -881,6 +881,8 @@ endif
 	@cp -rp lib/musl/arch/generic        build/release/tinygo/lib/musl/arch
 	@cp -rp lib/musl/arch/i386           build/release/tinygo/lib/musl/arch
 	@cp -rp lib/musl/arch/mips           build/release/tinygo/lib/musl/arch
+	@cp -rp lib/musl/arch/riscv32        build/release/tinygo/lib/musl/arch
+	@cp -rp lib/musl/arch/riscv64        build/release/tinygo/lib/musl/arch
 	@cp -rp lib/musl/arch/x86_64         build/release/tinygo/lib/musl/arch
 	@cp -rp lib/musl/crt/crt1.c          build/release/tinygo/lib/musl/crt
 	@cp -rp lib/musl/COPYRIGHT           build/release/tinygo/lib/musl

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -59,6 +59,8 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "linux", GOARCH: "arm64"},
 		{GOOS: "linux", GOARCH: "mips"},
 		{GOOS: "linux", GOARCH: "mipsle"},
+		{GOOS: "linux", GOARCH: "riscv"},
+		{GOOS: "linux", GOARCH: "riscv64"},
 		{GOOS: "darwin", GOARCH: "amd64"},
 		{GOOS: "darwin", GOARCH: "arm64"},
 		{GOOS: "windows", GOARCH: "amd64"},

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -220,6 +220,11 @@ func CanonicalArchName(triple string) string {
 	if arch == "mipsel" {
 		return "mips"
 	}
+
+	if arch == "riscv32" {
+		return "riscv"
+	}
+
 	return arch
 }
 

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -199,6 +199,8 @@ func LoadTarget(options *Options) (*TargetSpec, error) {
 			llvmarch = "mipsel"
 		case "wasm":
 			llvmarch = "wasm32"
+		case "riscv":
+			llvmarch = "riscv64"
 		default:
 			llvmarch = options.GOARCH
 		}
@@ -344,6 +346,11 @@ func defaultTarget(goos, goarch, triple string) (*TargetSpec, error) {
 			"-mnontrapping-fptoint",
 			"-msign-ext",
 		)
+	case "riscv64":
+		// TODO: are these the features we really need? What does SiFive use? what does qemu support?
+		spec.CPU = "generic-rv64"
+		spec.Features = "+a,+c,+d,+f,+m,+q,+rvc,+zbb,+zbp"
+		spec.CFlags = append(spec.CFlags, "-march=rv64gc")
 	}
 	if goos == "darwin" {
 		spec.Linker = "ld.lld"


### PR DESCRIPTION
Intention to add riscv syscall support to tinygo. I have no prior experience with porting tinygo to another architecture, also I am not sure if all the efforts I am making here are required for that. It is an experiment. 

I am orienting myself at https://github.com/tinygo-org/tinygo/pull/4308.