### PR TITLE
add `node:` specifier to `wasm_exec.js`

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -29,7 +29,7 @@
 	}
 
 	if (!global.fs && global.require) {
-		global.fs = require("fs");
+		global.fs = require("node:fs");
 	}
 
 	const enosys = () => {
@@ -101,7 +101,7 @@
 	}
 
 	if (!global.crypto) {
-		const nodeCrypto = require("crypto");
+		const nodeCrypto = require("node:crypto");
 		global.crypto = {
 			getRandomValues(b) {
 				nodeCrypto.randomFillSync(b);
@@ -119,11 +119,11 @@
 	}
 
 	if (!global.TextEncoder) {
-		global.TextEncoder = require("util").TextEncoder;
+		global.TextEncoder = require("node:util").TextEncoder;
 	}
 
 	if (!global.TextDecoder) {
-		global.TextDecoder = require("util").TextDecoder;
+		global.TextDecoder = require("node:util").TextDecoder;
 	}
 
 	// End of polyfills for common API.


### PR DESCRIPTION
When using TinyGo with Cloudflare Workers and the `compatibility_flags = ["nodejs_compat"]` setting, it is necessary to import Node.js APIs with the `node:` prefix. The current `wasm_exec.js` file provided by TinyGo does not include this prefix, causing compatibility issues.
Update the `wasm_exec.js` file to include the node: prefix for all Node.js API imports. This change will ensure compatibility with Cloudflare Workers and adhere to the required import syntax.

Reference: https://blog.cloudflare.com/workers-node-js-asynclocalstorage

Issue: https://github.com/tinygo-org/tinygo/issues/4396