### PR TITLE
add os.Truncate(name, size) (see #4209)

### DIFF
--- a/src/os/file_windows.go
+++ b/src/os/file_windows.go
@@ -63,6 +63,12 @@ func (f *unixFileHandle) Truncate(size int64) error {
 	return ErrNotImplemented
 }
 
+// Truncate changes the size of the named file.
+// If the file is a symbolic link, it changes the size of the link's target.
+func Truncate(name string, size int64) error {
+	return &PathError{Op: "truncate", Path: name, Err: ErrNotImplemented}
+}
+
 func tempDir() string {
 	n := uint32(syscall.MAX_PATH)
 	for {
@@ -110,14 +116,13 @@ func (f unixFileHandle) Sync() error {
 	return ErrNotImplemented
 }
 
+// Truncate changes the size of the named file.
+// If the file is a symbolic link, it changes the size of the link's target.
 func (f *File) Truncate(size int64) error {
-	var err error
 	if f.handle == nil {
-		err = ErrClosed
-	} else {
-		err = ErrNotImplemented
+		return &PathError{Op: "truncate", Path: f.name, Err: ErrClosed}
 	}
-	return &PathError{Op: "truncate", Path: f.name, Err: err}
+	return Truncate(f.name, size)
 }
 
 // isWindowsNulName reports whether name is os.DevNull ('NUL') on Windows.


### PR DESCRIPTION
See https://pkg.go.dev/os#Truncate

@leongross authored #4209 which defined the *os.File receiver Truncate but was missing os.Truncate(filename, size).