### PR TITLE
reflect, runtime: remove *UnsafePointer wrappers for functions

### DIFF
--- a/src/reflect/value.go
+++ b/src/reflect/value.go
@@ -646,10 +646,10 @@ func (v Value) Slice3(i, j, k int) Value {
 	panic("unimplemented: (reflect.Value).Slice3()")
 }
 
-//go:linkname maplen runtime.hashmapLenUnsafePointer
+//go:linkname maplen runtime.hashmapLen
 func maplen(p unsafe.Pointer) int
 
-//go:linkname chanlen runtime.chanLenUnsafePointer
+//go:linkname chanlen runtime.chanLen
 func chanlen(p unsafe.Pointer) int
 
 // Len returns the length of this value for slices, strings, arrays, channels,
@@ -671,7 +671,7 @@ func (v Value) Len() int {
 	}
 }
 
-//go:linkname chancap runtime.chanCapUnsafePointer
+//go:linkname chancap runtime.chanCap
 func chancap(p unsafe.Pointer) int
 
 // Cap returns the capacity of this value for arrays, channels and slices.
@@ -965,13 +965,13 @@ func (v Value) MapKeys() []Value {
 	return keys
 }
 
-//go:linkname hashmapStringGet runtime.hashmapStringGetUnsafePointer
+//go:linkname hashmapStringGet runtime.hashmapStringGet
 func hashmapStringGet(m unsafe.Pointer, key string, value unsafe.Pointer, valueSize uintptr) bool
 
-//go:linkname hashmapBinaryGet runtime.hashmapBinaryGetUnsafePointer
+//go:linkname hashmapBinaryGet runtime.hashmapBinaryGet
 func hashmapBinaryGet(m unsafe.Pointer, key, value unsafe.Pointer, valueSize uintptr) bool
 
-//go:linkname hashmapInterfaceGet runtime.hashmapInterfaceGetUnsafePointer
+//go:linkname hashmapInterfaceGet runtime.hashmapInterfaceGet
 func hashmapInterfaceGet(m unsafe.Pointer, key interface{}, value unsafe.Pointer, valueSize uintptr) bool
 
 func (v Value) MapIndex(key Value) Value {
@@ -1018,7 +1018,7 @@ func (v Value) MapIndex(key Value) Value {
 //go:linkname hashmapNewIterator runtime.hashmapNewIterator
 func hashmapNewIterator() unsafe.Pointer
 
-//go:linkname hashmapNext runtime.hashmapNextUnsafePointer
+//go:linkname hashmapNext runtime.hashmapNext
 func hashmapNext(m unsafe.Pointer, it unsafe.Pointer, key, value unsafe.Pointer) bool
 
 func (v Value) MapRange() *MapIter {
@@ -1786,22 +1786,22 @@ func (v Value) Grow(n int) {
 	slice.cap = newslice.cap
 }
 
-//go:linkname hashmapStringSet runtime.hashmapStringSetUnsafePointer
+//go:linkname hashmapStringSet runtime.hashmapStringSet
 func hashmapStringSet(m unsafe.Pointer, key string, value unsafe.Pointer)
 
-//go:linkname hashmapBinarySet runtime.hashmapBinarySetUnsafePointer
+//go:linkname hashmapBinarySet runtime.hashmapBinarySet
 func hashmapBinarySet(m unsafe.Pointer, key, value unsafe.Pointer)
 
-//go:linkname hashmapInterfaceSet runtime.hashmapInterfaceSetUnsafePointer
+//go:linkname hashmapInterfaceSet runtime.hashmapInterfaceSet
 func hashmapInterfaceSet(m unsafe.Pointer, key interface{}, value unsafe.Pointer)
 
-//go:linkname hashmapStringDelete runtime.hashmapStringDeleteUnsafePointer
+//go:linkname hashmapStringDelete runtime.hashmapStringDelete
 func hashmapStringDelete(m unsafe.Pointer, key string)
 
-//go:linkname hashmapBinaryDelete runtime.hashmapBinaryDeleteUnsafePointer
+//go:linkname hashmapBinaryDelete runtime.hashmapBinaryDelete
 func hashmapBinaryDelete(m unsafe.Pointer, key unsafe.Pointer)
 
-//go:linkname hashmapInterfaceDelete runtime.hashmapInterfaceDeleteUnsafePointer
+//go:linkname hashmapInterfaceDelete runtime.hashmapInterfaceDelete
 func hashmapInterfaceDelete(m unsafe.Pointer, key interface{})
 
 func (v Value) SetMapIndex(key, elem Value) {
@@ -1930,7 +1930,7 @@ func (v Value) FieldByNameFunc(match func(string) bool) Value {
 	return Value{}
 }
 
-//go:linkname hashmapMake runtime.hashmapMakeUnsafePointer
+//go:linkname hashmapMake runtime.hashmapMake
 func hashmapMake(keySize, valueSize uintptr, sizeHint uintptr, alg uint8) unsafe.Pointer
 
 // MakeMapWithSize creates a new map with the specified type and initial space

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -148,12 +148,6 @@ func chanLen(c *channel) int {
 	return int(c.bufUsed)
 }
 
-// wrapper for use in reflect
-func chanLenUnsafePointer(p unsafe.Pointer) int {
-	c := (*channel)(p)
-	return chanLen(c)
-}
-
 // Return the capacity of this chan, called from the cap builtin.
 // A nil chan is defined as having capacity 0.
 //
@@ -163,12 +157,6 @@ func chanCap(c *channel) int {
 		return 0
 	}
 	return int(c.bufSize)
-}
-
-// wrapper for use in reflect
-func chanCapUnsafePointer(p unsafe.Pointer) int {
-	c := (*channel)(p)
-	return chanCap(c)
 }
 
 // resumeRX resumes the next receiver and returns the destination pointer.

--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -87,10 +87,6 @@ func hashmapMake(keySize, valueSize uintptr, sizeHint uintptr, alg uint8) *hashm
 	}
 }
 
-func hashmapMakeUnsafePointer(keySize, valueSize uintptr, sizeHint uintptr, alg uint8) unsafe.Pointer {
-	return (unsafe.Pointer)(hashmapMake(keySize, valueSize, sizeHint, alg))
-}
-
 // Remove all entries from the map, without actually deallocating the space for
 // it. This is used for the clear builtin, and can be used to reuse a map (to
 // avoid extra heap allocations).
@@ -176,10 +172,6 @@ func hashmapLen(m *hashmap) int {
 		return 0
 	}
 	return int(m.count)
-}
-
-func hashmapLenUnsafePointer(m unsafe.Pointer) int {
-	return hashmapLen((*hashmap)(m))
 }
 
 //go:inline
@@ -268,10 +260,6 @@ func hashmapSet(m *hashmap, key unsafe.Pointer, value unsafe.Pointer, hash uint3
 	*emptySlotTophash = tophash
 }
 
-func hashmapSetUnsafePointer(m unsafe.Pointer, key unsafe.Pointer, value unsafe.Pointer, hash uint32) {
-	hashmapSet((*hashmap)(m), key, value, hash)
-}
-
 // hashmapInsertIntoNewBucket creates a new bucket, inserts the given key and
 // value into the bucket, and returns a pointer to this bucket.
 func hashmapInsertIntoNewBucket(m *hashmap, key, value unsafe.Pointer, tophash uint8) *hashmapBucket {
@@ -350,10 +338,6 @@ func hashmapGet(m *hashmap, key, value unsafe.Pointer, valueSize uintptr, hash u
 	// Did not find the key.
 	memzero(value, m.valueSize)
 	return false
-}
-
-func hashmapGetUnsafePointer(m unsafe.Pointer, key, value unsafe.Pointer, valueSize uintptr, hash uint32) bool {
-	return hashmapGet((*hashmap)(m), key, value, valueSize, hash)
 }
 
 // Delete a given key from the map. No-op when the key does not exist in the
@@ -456,10 +440,6 @@ func hashmapNext(m *hashmap, it *hashmapIterator, key, value unsafe.Pointer) boo
 	}
 }
 
-func hashmapNextUnsafePointer(m unsafe.Pointer, it unsafe.Pointer, key, value unsafe.Pointer) bool {
-	return hashmapNext((*hashmap)(m), (*hashmapIterator)(it), key, value)
-}
-
 // Hashmap with plain binary data keys (not containing strings etc.).
 func hashmapBinarySet(m *hashmap, key, value unsafe.Pointer) {
 	if m == nil {
@@ -467,10 +447,6 @@ func hashmapBinarySet(m *hashmap, key, value unsafe.Pointer) {
 	}
 	hash := hash32(key, m.keySize, m.seed)
 	hashmapSet(m, key, value, hash)
-}
-
-func hashmapBinarySetUnsafePointer(m unsafe.Pointer, key, value unsafe.Pointer) {
-	hashmapBinarySet((*hashmap)(m), key, value)
 }
 
 func hashmapBinaryGet(m *hashmap, key, value unsafe.Pointer, valueSize uintptr) bool {
@@ -482,20 +458,12 @@ func hashmapBinaryGet(m *hashmap, key, value unsafe.Pointer, valueSize uintptr) 
 	return hashmapGet(m, key, value, valueSize, hash)
 }
 
-func hashmapBinaryGetUnsafePointer(m unsafe.Pointer, key, value unsafe.Pointer, valueSize uintptr) bool {
-	return hashmapBinaryGet((*hashmap)(m), key, value, valueSize)
-}
-
 func hashmapBinaryDelete(m *hashmap, key unsafe.Pointer) {
 	if m == nil {
 		return
 	}
 	hash := hash32(key, m.keySize, m.seed)
 	hashmapDelete(m, key, hash)
-}
-
-func hashmapBinaryDeleteUnsafePointer(m unsafe.Pointer, key unsafe.Pointer) {
-	hashmapBinaryDelete((*hashmap)(m), key)
 }
 
 // Hashmap with string keys (a common case).
@@ -522,10 +490,6 @@ func hashmapStringSet(m *hashmap, key string, value unsafe.Pointer) {
 	hashmapSet(m, unsafe.Pointer(&key), value, hash)
 }
 
-func hashmapStringSetUnsafePointer(m unsafe.Pointer, key string, value unsafe.Pointer) {
-	hashmapStringSet((*hashmap)(m), key, value)
-}
-
 func hashmapStringGet(m *hashmap, key string, value unsafe.Pointer, valueSize uintptr) bool {
 	if m == nil {
 		memzero(value, uintptr(valueSize))
@@ -535,20 +499,12 @@ func hashmapStringGet(m *hashmap, key string, value unsafe.Pointer, valueSize ui
 	return hashmapGet(m, unsafe.Pointer(&key), value, valueSize, hash)
 }
 
-func hashmapStringGetUnsafePointer(m unsafe.Pointer, key string, value unsafe.Pointer, valueSize uintptr) bool {
-	return hashmapStringGet((*hashmap)(m), key, value, valueSize)
-}
-
 func hashmapStringDelete(m *hashmap, key string) {
 	if m == nil {
 		return
 	}
 	hash := hashmapStringHash(key, m.seed)
 	hashmapDelete(m, unsafe.Pointer(&key), hash)
-}
-
-func hashmapStringDeleteUnsafePointer(m unsafe.Pointer, key string) {
-	hashmapStringDelete((*hashmap)(m), key)
 }
 
 // Hashmap with interface keys (for everything else).
@@ -654,10 +610,6 @@ func hashmapInterfaceSet(m *hashmap, key interface{}, value unsafe.Pointer) {
 	hashmapSet(m, unsafe.Pointer(&key), value, hash)
 }
 
-func hashmapInterfaceSetUnsafePointer(m unsafe.Pointer, key interface{}, value unsafe.Pointer) {
-	hashmapInterfaceSet((*hashmap)(m), key, value)
-}
-
 func hashmapInterfaceGet(m *hashmap, key interface{}, value unsafe.Pointer, valueSize uintptr) bool {
 	if m == nil {
 		memzero(value, uintptr(valueSize))
@@ -667,18 +619,10 @@ func hashmapInterfaceGet(m *hashmap, key interface{}, value unsafe.Pointer, valu
 	return hashmapGet(m, unsafe.Pointer(&key), value, valueSize, hash)
 }
 
-func hashmapInterfaceGetUnsafePointer(m unsafe.Pointer, key interface{}, value unsafe.Pointer, valueSize uintptr) bool {
-	return hashmapInterfaceGet((*hashmap)(m), key, value, valueSize)
-}
-
 func hashmapInterfaceDelete(m *hashmap, key interface{}) {
 	if m == nil {
 		return
 	}
 	hash := hashmapInterfaceHash(key, m.seed)
 	hashmapDelete(m, unsafe.Pointer(&key), hash)
-}
-
-func hashmapInterfaceDeleteUnsafePointer(m unsafe.Pointer, key interface{}) {
-	hashmapInterfaceDelete((*hashmap)(m), key)
 }


### PR DESCRIPTION
This was needed in the past because LLVM used typed pointers and there was a mismatch between pointer types. But we've dropped support for typed pointers a while ago so now we can remove these wrappers.

This is just a cleanup, it shouldn't have any practical effect.