### PR TITLE
unix: print a message when a fatal signal happens

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -346,6 +346,8 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			"-arch", llvmarch,
 			"-platform_version", "macos", platformVersion, platformVersion,
 		)
+		spec.ExtraFiles = append(spec.ExtraFiles,
+			"src/runtime/runtime_unix.c")
 	case "linux":
 		spec.Linker = "ld.lld"
 		spec.RTLib = "compiler-rt"
@@ -365,6 +367,8 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			// proper threading.
 			spec.CFlags = append(spec.CFlags, "-mno-outline-atomics")
 		}
+		spec.ExtraFiles = append(spec.ExtraFiles,
+			"src/runtime/runtime_unix.c")
 	case "windows":
 		spec.Linker = "ld.lld"
 		spec.Libc = "mingw-w64"

--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -9,7 +9,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 5 // "call someFunction" is 5 bytes
 
-const linux_MAP_ANONYMOUS = 0x20
+const (
+	linux_MAP_ANONYMOUS = 0x20
+	linux_SIGBUS        = 7
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // Align on word boundary.
 func align(ptr uintptr) uintptr {

--- a/src/runtime/arch_amd64.go
+++ b/src/runtime/arch_amd64.go
@@ -9,7 +9,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 5 // "call someFunction" is 5 bytes
 
-const linux_MAP_ANONYMOUS = 0x20
+const (
+	linux_MAP_ANONYMOUS = 0x20
+	linux_SIGBUS        = 7
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // Align a pointer.
 // Note that some amd64 instructions (like movaps) expect 16-byte aligned

--- a/src/runtime/arch_arm.go
+++ b/src/runtime/arch_arm.go
@@ -11,7 +11,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 4 // "bl someFunction" is 4 bytes
 
-const linux_MAP_ANONYMOUS = 0x20
+const (
+	linux_MAP_ANONYMOUS = 0x20
+	linux_SIGBUS        = 7
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // Align on the maximum alignment for this platform (double).
 func align(ptr uintptr) uintptr {

--- a/src/runtime/arch_arm64.go
+++ b/src/runtime/arch_arm64.go
@@ -9,7 +9,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 4 // "bl someFunction" is 4 bytes
 
-const linux_MAP_ANONYMOUS = 0x20
+const (
+	linux_MAP_ANONYMOUS = 0x20
+	linux_SIGBUS        = 7
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // Align on word boundary.
 func align(ptr uintptr) uintptr {

--- a/src/runtime/arch_mips.go
+++ b/src/runtime/arch_mips.go
@@ -9,7 +9,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 8 // "jal someFunc" is 4 bytes, plus a MIPS delay slot
 
-const linux_MAP_ANONYMOUS = 0x800
+const (
+	linux_MAP_ANONYMOUS = 0x800
+	linux_SIGBUS        = 10
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // It appears that MIPS has a maximum alignment of 8 bytes.
 func align(ptr uintptr) uintptr {

--- a/src/runtime/arch_mipsle.go
+++ b/src/runtime/arch_mipsle.go
@@ -9,7 +9,12 @@ const deferExtraRegs = 0
 
 const callInstSize = 8 // "jal someFunc" is 4 bytes, plus a MIPS delay slot
 
-const linux_MAP_ANONYMOUS = 0x800
+const (
+	linux_MAP_ANONYMOUS = 0x800
+	linux_SIGBUS        = 10
+	linux_SIGILL        = 4
+	linux_SIGSEGV       = 11
+)
 
 // It appears that MIPS has a maximum alignment of 8 bytes.
 func align(ptr uintptr) uintptr {

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -22,6 +22,14 @@ const (
 	clock_MONOTONIC_RAW = 4
 )
 
+// Source:
+// https://opensource.apple.com/source/xnu/xnu-7195.141.2/bsd/sys/signal.h.auto.html
+const (
+	sig_SIGBUS  = 10
+	sig_SIGILL  = 4
+	sig_SIGSEGV = 11
+)
+
 // https://opensource.apple.com/source/xnu/xnu-7195.141.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
 type machHeader struct {
 	magic      uint32

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -23,6 +23,12 @@ const (
 	clock_MONOTONIC_RAW = 4
 )
 
+const (
+	sig_SIGBUS  = linux_SIGBUS
+	sig_SIGILL  = linux_SIGILL
+	sig_SIGSEGV = linux_SIGSEGV
+)
+
 // For the definition of the various header structs, see:
 // https://refspecs.linuxfoundation.org/elf/elf.pdf
 // Also useful:

--- a/src/runtime/runtime_unix.c
+++ b/src/runtime/runtime_unix.c
@@ -1,0 +1,56 @@
+//go:build none
+
+// This file is included on Darwin and Linux (despite the //go:build line above).
+
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE
+#include <signal.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <ucontext.h>
+#include <string.h>
+
+void tinygo_handle_fatal_signal(int sig, uintptr_t addr);
+
+static void signal_handler(int sig, siginfo_t *info, void *context) {
+	ucontext_t* uctx = context;
+	uintptr_t addr = 0;
+	#if __APPLE__
+		#if __arm64__
+			addr = uctx->uc_mcontext->__ss.__pc;
+		#elif __x86_64__
+			addr = uctx->uc_mcontext->__ss.__rip;
+		#else
+			#error unknown architecture
+		#endif
+	#elif __linux__
+		// Note: this can probably be simplified using the MC_PC macro in musl,
+		// but this works for now.
+		#if __arm__
+			addr = uctx->uc_mcontext.arm_pc;
+		#elif __i386__
+			addr = uctx->uc_mcontext.gregs[REG_EIP];
+		#elif __x86_64__
+			addr = uctx->uc_mcontext.gregs[REG_RIP];
+		#else // aarch64, mips, maybe others
+			addr = uctx->uc_mcontext.pc;
+		#endif
+	#else
+		#error unknown platform
+	#endif
+	tinygo_handle_fatal_signal(sig, addr);
+}
+
+void tinygo_register_fatal_signals(void) {
+	struct sigaction act = { 0 };
+	// SA_SIGINFO:   we want the 2 extra parameters
+	// SA_RESETHAND: only catch the signal once (the handler will re-raise the signal)
+	act.sa_flags = SA_SIGINFO | SA_RESETHAND;
+	act.sa_sigaction = &signal_handler;
+
+	// Register the signal handler for common issues. There are more signals,
+	// which can be added if needed.
+	sigaction(SIGBUS, &act, NULL);
+	sigaction(SIGILL, &act, NULL);
+	sigaction(SIGSEGV, &act, NULL);
+}


### PR DESCRIPTION
Print a message for SIGBUS, SIGSEGV, and SIGILL when they happen. These signals are always fatal, but it's very useful to know which of them happened.

Also, it prints the location in the binary which can then be parsed by `tinygo run` (see https://github.com/tinygo-org/tinygo/pull/4383).

While this does add some extra binary size, it's for Linux and MacOS (systems that typically have plenty of RAM/storage) and could be very useful when debugging some low-level crash such as a runtime bug.

---

I still need to make this work on MacOS.