### PR TITLE
circleci: our version of misspell is not supported with go < 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ jobs:
     steps:
       - test-linux:
           llvm: "15"
+          # "make lint" fails before go 1.21 because internal/tools/go.mod specifies packages that require go 1.21
+          fmt-check: false
     resource_class: large
   test-llvm18-go122:
     docker:


### PR DESCRIPTION
I jumped through quite a few hoops to get test-llvm15-go119 to work, but this last hoop seems not worth jumping through.
Here's the log from circleci:

  cd internal/tools && go generate -tags tools ./
  /go/pkg/mod/github.com/golangci/misspell@v0.6.0/mime.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)
  tools.go:12: running "go": exit status 1
  make: *** [GNUmakefile:952: tools] Error 1

Disable lint in go 1.19 ci job, since it depends on tools, which depends on misspell, which needs go 1.21's slices package.

I mean, we could patch misspell to not use slices, or to use the prerelease slices, but...