### PR TITLE
FIX #4409 : Use go os/user unless baremetal

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -84,6 +84,7 @@ func (c *Config) BuildTags() []string {
 	tags = append(tags, []string{
 		"tinygo",                                     // that's the compiler
 		"purego",                                     // to get various crypto packages to work
+		"osusergo",                                   // to get osuser to work when go sources used
 		"math_big_pure_go",                           // to get math/big to work
 		"gc." + c.GC(), "scheduler." + c.Scheduler(), // used inside the runtime package
 		"serial." + c.Serial()}...) // used inside the machine package

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -279,7 +279,7 @@ func (p *Program) getOriginalPath(path string) string {
 			originalPath = realgorootPath
 		}
 		maybeInTinyGoRoot := false
-		for prefix := range pathsToOverride(p.config.GoMinorVersion, needsSyscallPackage(p.config.BuildTags())) {
+		for prefix := range pathsToOverride(p.config) {
 			if runtime.GOOS == "windows" {
 				prefix = strings.ReplaceAll(prefix, "/", "\\")
 			}

--- a/src/os/user/unimplemented_user.go
+++ b/src/os/user/unimplemented_user.go
@@ -1,0 +1,31 @@
+package user
+
+/*
+   os/user stubbed functions
+
+TODO: these should return unsupported / unimplemented errors
+
+*/
+
+import (
+	"errors"
+)
+
+// Current returns the current user.
+//
+// The first call will cache the current user information.
+// Subsequent calls will return the cached value and will not reflect
+// changes to the current user.
+func Current() (*User, error) {
+	return nil, errors.New("user: Current not implemented")
+}
+
+// Lookup always returns an error.
+func Lookup(username string) (*User, error) {
+	return nil, errors.New("user: Lookup not implemented")
+}
+
+// LookupGroup always returns an error.
+func LookupGroup(name string) (*Group, error) {
+	return nil, errors.New("user: LookupGroup not implemented")
+}

--- a/src/os/user/user.go
+++ b/src/os/user/user.go
@@ -1,10 +1,18 @@
-// Copyright 2016 The Go Authors. All rights reserved.
+// Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/*
+Package user allows user account lookups by name or id.
+
+tinygo: Largely copied from go1.22.6
+This is merged to "cached GOROOT/src/os/user" for baremetal systems
+*/
 package user
 
-import "errors"
+import (
+	"strconv"
+)
 
 // User represents a user account.
 type User struct {
@@ -31,20 +39,6 @@ type User struct {
 	HomeDir string
 }
 
-// Current returns the current user.
-//
-// The first call will cache the current user information.
-// Subsequent calls will return the cached value and will not reflect
-// changes to the current user.
-func Current() (*User, error) {
-	return nil, errors.New("user: Current not implemented")
-}
-
-// Lookup always returns an error.
-func Lookup(username string) (*User, error) {
-	return nil, errors.New("user: Lookup not implemented")
-}
-
 // Group represents a grouping of users.
 //
 // On POSIX systems Gid contains a decimal number representing the group ID.
@@ -53,7 +47,33 @@ type Group struct {
 	Name string // group name
 }
 
-// LookupGroup always returns an error.
-func LookupGroup(name string) (*Group, error) {
-	return nil, errors.New("user: LookupGroup not implemented")
+// UnknownUserIdError is returned by LookupId when a user cannot be found.
+type UnknownUserIdError int
+
+func (e UnknownUserIdError) Error() string {
+	return "user: unknown userid " + strconv.Itoa(int(e))
+}
+
+// UnknownUserError is returned by Lookup when
+// a user cannot be found.
+type UnknownUserError string
+
+func (e UnknownUserError) Error() string {
+	return "user: unknown user " + string(e)
+}
+
+// UnknownGroupIdError is returned by LookupGroupId when
+// a group cannot be found.
+type UnknownGroupIdError string
+
+func (e UnknownGroupIdError) Error() string {
+	return "group: unknown groupid " + string(e)
+}
+
+// UnknownGroupError is returned by LookupGroup when
+// a group cannot be found.
+type UnknownGroupError string
+
+func (e UnknownGroupError) Error() string {
+	return "group: unknown group " + string(e)
 }


### PR DESCRIPTION
See #4409 

[src/os/user](https://github.com/tinygo-org/tinygo/tree/dd6fa89aa66a5113baa8883d4180ee090f35f784/src/os/user) is currently taken from tinygo sources in all cases

This change:
- pulls in tinygo/src/os/user only when `baremetal`
- uses go version otherwise
- defines the `osusergo` build tag which uses a pure-go implementation of os/user
- separates the declaration of types and errors to user.go and (stubbed) implementations to unimplemented_user.go
- (re)imports GO1.22.6/src/os/user/user.go to tinygo/src/os/user/user.go

Should add stubbed user.{LookupId,LookupGroupId}() ?
Are there other cases where tinygo's version of this package should be used?