### PR TITLE
renesas: update Renesas svd generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ src/device/stm32/*.go
 src/device/stm32/*.s
 src/device/kendryte/*.go
 src/device/kendryte/*.s
+src/device/renesas/*.go
+src/device/renesas/*.s
 src/device/rp/*.go
 src/device/rp/*.s
 ./vendor

--- a/.gitmodules
+++ b/.gitmodules
@@ -32,9 +32,6 @@
 [submodule "lib/macos-minimal-sdk"]
 	path = lib/macos-minimal-sdk
 	url = https://github.com/aykevl/macos-minimal-sdk.git
-[submodule "lib/renesas-svd"]
-	path = lib/renesas-svd
-	url = https://github.com/tinygo-org/renesas-svd.git
 [submodule "src/net"]
 	path = src/net
 	url = https://github.com/tinygo-org/net.git

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -185,7 +185,7 @@ fmt-check: ## Warn if any source needs reformatting
 	@unformatted=$$(gofmt -l $(FMT_PATHS)); [ -z "$$unformatted" ] && exit 0; echo "Unformatted:"; for fn in $$unformatted; do echo "  $$fn"; done; exit 1
 
 
-gen-device: gen-device-avr gen-device-esp gen-device-nrf gen-device-sam gen-device-sifive gen-device-kendryte gen-device-nxp gen-device-rp ## Generate microcontroller-specific sources
+gen-device: gen-device-avr gen-device-esp gen-device-nrf gen-device-sam gen-device-sifive gen-device-kendryte gen-device-nxp gen-device-rp gen-device-renesas ## Generate microcontroller-specific sources
 ifneq ($(STM32), 0)
 gen-device: gen-device-stm32
 endif
@@ -234,7 +234,7 @@ gen-device-rp: build/gen-device-svd
 	GO111MODULE=off $(GO) fmt ./src/device/rp
 
 gen-device-renesas: build/gen-device-svd
-	./build/gen-device-svd -source=https://github.com/tinygo-org/renesas-svd lib/renesas-svd/ src/device/renesas/
+	./build/gen-device-svd -source=https://github.com/cmsis-svd/cmsis-svd-data/tree/master/data/Renesas lib/cmsis-svd/data/Renesas/ src/device/renesas/
 	GO111MODULE=off $(GO) fmt ./src/device/renesas
 
 $(LLVM_PROJECTDIR)/llvm:


### PR DESCRIPTION
This PR updates the still incomplete support for the Renesas family of processors by switching to the main `cmsis-svd` repo for the SVD data, and removing the separate repo that we had previously added ourselves.