### PR TITLE
targets: remove import-memory flag from wasm-unknown target to fix #4319

### DIFF
--- a/targets/wasm-unknown.json
+++ b/targets/wasm-unknown.json
@@ -19,8 +19,7 @@
 	"ldflags": [
 		"--stack-first",
 		"--no-demangle",
-		"--no-entry",
-		"--import-memory"
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"


### PR DESCRIPTION
This PR modifies the wasm-unknown target by removing the `-import-memory` flag as discussed in #4319