### PR TITLE
ci: update apt repo for sizediff toolchain

### DIFF
--- a/.github/workflows/sizediff-install-pkgs.sh
+++ b/.github/workflows/sizediff-install-pkgs.sh
@@ -2,7 +2,7 @@
 # still works after checking out the dev branch (that is, when going from LLVM
 # 16 to LLVM 17 for example, both Clang 16 and Clang 17 are installed).
 
-echo 'deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' | sudo tee /etc/apt/sources.list.d/llvm.list
+echo 'deb https://apt.llvm.org/noble/ llvm-toolchain-noble-18 main' | sudo tee /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install --no-install-recommends -y \

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -9,6 +9,8 @@ concurrency:
 
 jobs:
   sizediff:
+    # Note: when updating the Ubuntu version, also update the Ubuntu version in
+    # sizediff-install-pkgs.sh
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write


### PR DESCRIPTION
This was still at jammy (22.04), while the CI container was noble (24.04). Somehow this didn't break, but it certainly isn't ideal to install packages across Ubuntu versions!

See: #4350 

Discovered while working on the CHANGELOG.