### PR TITLE
Fix #4421: Add `-C DIR` flag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -483,8 +483,17 @@ tinygo-baremetal:
 	# regression test for #2666: e.g. encoding/hex must pass on baremetal
 	$(TINYGO) test -target cortex-m-qemu encoding/hex
 
+.PHONY: testchdir
+testchdir:
+	# test 'build' command with{,out} -C argument
+	$(TINYGO) build -C tests/testing/chdir chdir.go && rm tests/testing/chdir/chdir
+	$(TINYGO) build ./tests/testing/chdir/chdir.go && rm chdir
+	# test 'run' command with{,out} -C argument
+	EXPECT_DIR=$(PWD)/tests/testing/chdir $(TINYGO) run -C tests/testing/chdir chdir.go
+	EXPECT_DIR=$(PWD) $(TINYGO) run ./tests/testing/chdir/chdir.go
+
 .PHONY: smoketest
-smoketest:
+smoketest: testchdir
 	$(TINYGO) version
 	$(TINYGO) targets > /dev/null
 	# regression test for #2892

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1461,6 +1462,7 @@ func main() {
 
 	// Early command processing, before commands are interpreted by the Go flag
 	// library.
+	handleChdirFlag()
 	switch command {
 	case "clang", "ld.lld", "wasm-ld":
 		err := builder.RunTool(command, os.Args[2:]...)
@@ -1945,4 +1947,45 @@ func (out *testStderr) Write(data []byte) (int, error) {
 type outputEntry struct {
 	stderr bool
 	data   []byte
+}
+
+// handleChdirFlag handles the -C flag before doing anything else.
+// The -C flag must be the first flag on the command line, to make it easy to find
+// even with commands that have custom flag parsing.
+// handleChdirFlag handles the flag by chdir'ing to the directory
+// and then removing that flag from the command line entirely.
+//
+// We have to handle the -C flag this way for two reasons:
+//
+//  1. Toolchain selection needs to be in the right directory to look for go.mod and go.work.
+//
+//  2. A toolchain switch later on reinvokes the new go command with the same arguments.
+//     The parent toolchain has already done the chdir; the child must not try to do it again.
+func handleChdirFlag() {
+	used := 2 // b.c. command at os.Args[1]
+	if used >= len(os.Args) {
+		return
+	}
+
+	var dir string
+	switch a := os.Args[used]; {
+	default:
+		return
+
+	case a == "-C", a == "--C":
+		if used+1 >= len(os.Args) {
+			return
+		}
+		dir = os.Args[used+1]
+		os.Args = slices.Delete(os.Args, used, used+2)
+
+	case strings.HasPrefix(a, "-C="), strings.HasPrefix(a, "--C="):
+		_, dir, _ = strings.Cut(a, "=")
+		os.Args = slices.Delete(os.Args, used, used+1)
+	}
+
+	if err := os.Chdir(dir); err != nil {
+		fmt.Fprintln(os.Stderr, "cannot chdir:", err)
+		os.Exit(1)
+	}
 }

--- a/tests/testing/chdir/chdir.go
+++ b/tests/testing/chdir/chdir.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 /*
@@ -19,9 +19,9 @@ func main() {
 		log.Fatal(err)
 	}
 	if runtime.GOOS == "windows" {
-		strings.Replace(cwd, "\\", "/", -1)
+		cwd = filepath.ToSlash(cwd)
 	}
 	if cwd != expectDir {
-		log.Fatal("expected:\"%v\" != os.Getwd():\"%v\"", expectDir, cwd)
+		log.Fatalf("expected:\"%v\" != os.Getwd():\"%v\"", expectDir, cwd)
 	}
 }

--- a/tests/testing/chdir/chdir.go
+++ b/tests/testing/chdir/chdir.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"os"
+	"runtime"
+	"strings"
+)
+
+/*
+Test that this program is 'run' in expected directory. 'run' with expected
+working-directory in 'EXPECT_DIR' environment variable' with{,out} a -C
+argument.
+*/
+func main() {
+	expectDir := os.Getenv("EXPECT_DIR")
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		strings.Replace(cwd, "\\", "/", -1)
+	}
+	if cwd != expectDir {
+		log.Fatal("expected:\"%v\" != os.Getwd():\"%v\"", expectDir, cwd)
+	}
+}


### PR DESCRIPTION
See #4421 

Implementation is copied from BigGo 1.22.5 with minor modification.

https://github.com/golang/go/blob/d79c350916c637de911d93af689a5e4e7ab5a5bb/src/cmd/go/main.go#L330