### PR TITLE
tinygo: detect GOOS=wasip1 for relative WASI paths via config

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,13 +305,11 @@ func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options
 			//
 			// Ex. run --dir=.. --dir=../.. --dir=../../..
 			var dirs []string
-			switch config.Options.Target {
+			switch config.Target.GOOS {
 			case "wasip1":
 				dirs = dirsToModuleRootRel(result.MainDir, result.ModuleRoot)
-			case "wasip2":
-				dirs = dirsToModuleRootAbs(result.MainDir, result.ModuleRoot)
 			default:
-				return fmt.Errorf("unknown GOOS target: %v", config.Options.Target)
+				dirs = dirsToModuleRootAbs(result.MainDir, result.ModuleRoot)
 			}
 
 			args := []string{"run"}


### PR DESCRIPTION
Fixes running tests without `-target=wasip1`, e.g.:

```sh
GOOS=wasip1 GOARCH=wasm tinygo test ./...
```