### PR TITLE
stub runtime_{Before,After}Exec for linkage

### DIFF
--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1,0 +1,19 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+// Called from syscall package before Exec.
+//
+//go:linkname syscall_runtime_BeforeExec syscall.runtime_BeforeExec
+func syscall_runtime_BeforeExec() {
+	// Used in BigGo to serialize exec / thread creation. Stubbing to
+	// satisfy link.
+}
+
+// Called from syscall package after Exec.
+//
+//go:linkname syscall_runtime_AfterExec syscall.runtime_AfterExec
+func syscall_runtime_AfterExec() {
+}


### PR DESCRIPTION
Fixes:
   
    u-root/cmds/core/init$ GOARCH={arm64,amd64} tinygo build -tags noasm
    /usr/lib/go-1.22/src/syscall/exec_unix.go:282: linker could not find symbol syscall.runtime_BeforeExec
    /usr/lib/go-1.22/src/syscall/exec_unix.go:308: linker could not find symbol syscall.runtime_AfterExec

I copied BigGo/src/runtime/proc.go for this, duplicating the `//go:linkname`

In BigGo, exec calls are serialized because of golang/go#19546 but uses a rwlock whose implementation would require a lot of file import from BigGo or a merge of tinygo/bigGo runtime against current policy. I may follow this up with a simple sync/Mutex.

@leongross ?