### PR TITLE
mips: fix big-endian (GOARCH=mips) support

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -338,7 +338,7 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 	case "mips", "mipsle":
 		spec.CPU = "mips32r2"
 		spec.CFlags = append(spec.CFlags, "-fno-pic")
-		if options.GOOS == "mips" {
+		if options.GOARCH == "mips" {
 			llvmarch = "mips" // big endian
 		} else {
 			llvmarch = "mipsel" // little endian

--- a/main_test.go
+++ b/main_test.go
@@ -177,6 +177,14 @@ func TestBuild(t *testing.T) {
 				})
 			}
 		}
+		t.Run("MIPS big-endian", func(t *testing.T) {
+			// Run a single test for GOARCH=mips to see whether it works at all.
+			// Big-endian MIPS isn't fully supported yet, but simple examples
+			// should work.
+			t.Parallel()
+			options := optionsFromOSARCH("linux/mips/softfloat", sema)
+			runTest("alias.go", options, t, nil, nil)
+		})
 		t.Run("WebAssembly", func(t *testing.T) {
 			t.Parallel()
 			runPlatTests(optionsFromTarget("wasm", sema), tests, t)


### PR DESCRIPTION
I made an awkward mistake, mixing up GOOS and GOARCH. So here is a fix, with an associated test.