### PR TITLE
mips: use MIPS32 (instead of MIPS32R2) as the instruction set

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -336,7 +336,7 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			spec.Features = "+fp-armv8,+neon,-fmv,-outline-atomics"
 		}
 	case "mips", "mipsle":
-		spec.CPU = "mips32r2"
+		spec.CPU = "mips32"
 		spec.CFlags = append(spec.CFlags, "-fno-pic")
 		if options.GOOS == "mips" {
 			llvmarch = "mips" // big endian
@@ -345,10 +345,10 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 		}
 		switch options.GOMIPS {
 		case "hardfloat":
-			spec.Features = "+fpxx,+mips32r2,+nooddspreg,-noabicalls"
+			spec.Features = "+fpxx,+mips32,+nooddspreg,-noabicalls"
 		case "softfloat":
 			spec.SoftFloat = true
-			spec.Features = "+mips32r2,+soft-float,-noabicalls"
+			spec.Features = "+mips32,+soft-float,-noabicalls"
 			spec.CFlags = append(spec.CFlags, "-msoft-float")
 		default:
 			return nil, fmt.Errorf("invalid GOMIPS=%s: must be hardfloat or softfloat", options.GOMIPS)


### PR DESCRIPTION
This should widen compatibility a bit, so that older CPUs can also execute programs built by TinyGo. The performance may be lower, if that's an issue we can look into implementing the proposal here: https://github.com/golang/go/issues/60072

This still wouldn't make programs usable on MIPS II CPUs, I suppose we can lower compatiblity down to that CPU if needed.

I tried setting the -cpu flag in the QEMU command line to be able to test this, but it looks like there are no QEMU CPU models that are mips32r1 and have a FPU. So it's difficult to test this.