### PR TITLE
fix: add missing Truncate() function stub to os/file for bare-metal systems

### DIFF
--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -135,3 +135,17 @@ func Readlink(name string) (string, error) {
 func tempDir() string {
 	return "/tmp"
 }
+
+// Truncate is unsupported on this system.
+func Truncate(filename string, size int64) (err error) {
+	return ErrUnsupported
+}
+
+// Truncate is unsupported on this system.
+func (f *File) Truncate(size int64) (err error) {
+	if f.handle == nil {
+		return ErrClosed
+	}
+
+	return Truncate(f.name, size)
+}


### PR DESCRIPTION
This PR adds the missing `Truncate()` function stub to `os/file` for bare-metal systems. Discovered when attempting to compile the latest Wazero with the latest TinyGo.