### PR TITLE
wasip2: do not export the _start function

### DIFF
--- a/src/runtime/runtime_wasm_wasip2.go
+++ b/src/runtime/runtime_wasm_wasip2.go
@@ -13,19 +13,11 @@ type timeUnit int64
 
 //export wasi:cli/run@0.2.0#run
 func __wasi_cli_run_run() uint32 {
-	_start()
-	return 0
-}
-
-//export _start
-func _start() {
 	// These need to be initialized early so that the heap can be initialized.
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
 	run()
-}
-
-func init() {
+	return 0
 }
 
 var args []string

--- a/targets/wasip2.json
+++ b/targets/wasip2.json
@@ -17,7 +17,8 @@
 	],
 	"ldflags": [
 		"--stack-first",
-		"--no-demangle"
+		"--no-demangle",
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"


### PR DESCRIPTION
It seems to have been replaced with the Component Model `run` function.

Maybe I'm misunderstanding something, but at least to me I don't see why we would need two separate ways to start a module when a Component Model `run` also works. It simplifies things.