### PR TITLE
main: don't detect WebAssembly from the .wasm extension

### DIFF
--- a/main.go
+++ b/main.go
@@ -1685,9 +1685,6 @@ func main() {
 			usage(command)
 			os.Exit(1)
 		}
-		if options.Target == "" && filepath.Ext(outpath) == ".wasm" {
-			options.Target = "wasm"
-		}
 
 		err := Build(pkgName, outpath, options)
 		handleCompilerError(err)


### PR DESCRIPTION
Currently this overrides GOOS/GOARCH, which are also used for wasm. This will break people who rely on a command like this:

    tinygo build -o foo.wasm path/to/package

They will need to update to explicitly set the target, for example:

    tinygo build -o foo.wasm -target=wasm path/to/package

An alternative would be to only set the target when the environment variables are unset, but that gets hacky very quickly. I feel like a better solution is to not do anything and expect users to set the right target (wasm or wasip1).

Fixes: https://github.com/tinygo-org/tinygo/issues/4439