### PR TITLE
wasip1: add `//go:wasmexport` support

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -33,6 +33,17 @@ func (c *Config) CPU() string {
 	return c.Target.CPU
 }
 
+// The current build mode (like the `-buildmode` command line flag).
+func (c *Config) BuildMode() string {
+	if c.Options.BuildMode != "" {
+		return c.Options.BuildMode
+	}
+	if c.Target.BuildMode != "" {
+		return c.Target.BuildMode
+	}
+	return "default"
+}
+
 // Features returns a list of features this CPU supports. For example, for a
 // RISC-V processor, that could be "+a,+c,+m". For many targets, an empty list
 // will be returned.

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	validBuildModeOptions     = []string{"default", "c-shared"}
 	validGCOptions            = []string{"none", "leaking", "conservative", "custom", "precise"}
 	validSchedulerOptions     = []string{"none", "tasks", "asyncify"}
 	validSerialOptions        = []string{"none", "uart", "usb", "rtt"}
@@ -26,6 +27,7 @@ type Options struct {
 	GOMIPS          string // environment variable (only used with GOARCH=mips and GOARCH=mipsle)
 	Directory       string // working dir, leave it unset to use the current working dir
 	Target          string
+	BuildMode       string // -buildmode flag
 	Opt             string
 	GC              string
 	PanicStrategy   string
@@ -61,6 +63,14 @@ type Options struct {
 
 // Verify performs a validation on the given options, raising an error if options are not valid.
 func (o *Options) Verify() error {
+	if o.BuildMode != "" {
+		valid := isInArray(validBuildModeOptions, o.BuildMode)
+		if !valid {
+			return fmt.Errorf(`invalid buildmode option '%s': valid values are %s`,
+				o.BuildMode,
+				strings.Join(validBuildModeOptions, ", "))
+		}
+	}
 	if o.GC != "" {
 		valid := isInArray(validGCOptions, o.GC)
 		if !valid {

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -32,6 +32,7 @@ type TargetSpec struct {
 	GOARCH           string   `json:"goarch,omitempty"`
 	SoftFloat        bool     // used for non-baremetal systems (GOMIPS=softfloat etc)
 	BuildTags        []string `json:"build-tags,omitempty"`
+	BuildMode        string   `json:"buildmode,omitempty"` // default build mode (if nothing specified)
 	GC               string   `json:"gc,omitempty"`
 	Scheduler        string   `json:"scheduler,omitempty"`
 	Serial           string   `json:"serial,omitempty"` // which serial output to use (uart, usb, none)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -44,6 +44,7 @@ type Config struct {
 	ABI             string
 	GOOS            string
 	GOARCH          string
+	BuildMode       string
 	CodeModel       string
 	RelocationModel string
 	SizeLevel       int
@@ -1383,6 +1384,11 @@ func (b *builder) createFunction() {
 		b := newBuilder(b.compilerContext, b.Builder, sub)
 		b.llvmFn.SetLinkage(llvm.InternalLinkage)
 		b.createFunction()
+	}
+
+	// Create wrapper function that can be called externally.
+	if b.info.wasmExport != "" {
+		b.createWasmExport()
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-tty v0.0.4
 	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
+	github.com/tetratelabs/wazero v1.6.0
 	go.bug.st/serial v1.6.0
 	golang.org/x/net v0.26.0
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,6 @@ github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moA
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
@@ -45,19 +44,18 @@ github.com/mattn/go-tty v0.0.4/go.mod h1:u5GGXBtZU6RQoKV8gY5W6UhMudbR5vXnUe7j3px
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 h1:aQKxg3+2p+IFXXg97McgDGT5zcMrQoi0EICZs8Pgchs=
 github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
+github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 go.bug.st/serial v1.6.0 h1:mAbRGN4cKE2J5gMwsMHC2KQisdLRQssO9WSM+rbZJ8A=
 go.bug.st/serial v1.6.0/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
-golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -76,6 +74,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tinygo.org/x/go-llvm v0.0.0-20240627184919-3b50c76783a8 h1:bLsZXRUBavt++CJlMN7sppNziqu3LyamESLhFJcpqFQ=
 tinygo.org/x/go-llvm v0.0.0-20240627184919-3b50c76783a8/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=

--- a/main.go
+++ b/main.go
@@ -1500,6 +1500,7 @@ func main() {
 	var tags buildutil.TagsFlag
 	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
+	buildMode := flag.String("buildmode", "", "build mode to use (default, c-shared)")
 	var stackSize uint64
 	flag.Func("stack-size", "goroutine stack size (if unknown at compile time)", func(s string) error {
 		size, err := bytesize.Parse(s)
@@ -1608,6 +1609,7 @@ func main() {
 		GOARM:           goenv.Get("GOARM"),
 		GOMIPS:          goenv.Get("GOMIPS"),
 		Target:          *target,
+		BuildMode:       *buildMode,
 		StackSize:       stackSize,
 		Opt:             *opt,
 		GC:              *gc,

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"flag"
 	"io"
@@ -21,6 +22,9 @@ import (
 	"time"
 
 	"github.com/aykevl/go-wasm"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tinygo-org/tinygo/builder"
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/diagnostics"
@@ -517,6 +521,189 @@ func TestWebAssembly(t *testing.T) {
 				}
 				if !slices.Equal(imports, tc.imports) {
 					t.Errorf("import list not as expected!\nexpected: %v\nactual:   %v", tc.imports, imports)
+				}
+			}
+		})
+	}
+}
+
+func TestWasmExport(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name      string
+		target    string
+		buildMode string
+		scheduler string
+		file      string
+		noOutput  bool
+		command   bool // call _start (command mode) instead of _initialize
+	}
+
+	tests := []testCase{
+		// "command mode" WASI
+		{
+			name:    "WASIp1-command",
+			target:  "wasip1",
+			command: true,
+		},
+		// "reactor mode" WASI (with -buildmode=c-shared)
+		{
+			name:      "WASIp1-reactor",
+			target:    "wasip1",
+			buildMode: "c-shared",
+		},
+		// Make sure reactor mode also works without a scheduler.
+		{
+			name:      "WASIp1-reactor-noscheduler",
+			target:    "wasip1",
+			buildMode: "c-shared",
+			scheduler: "none",
+			file:      "wasmexport-noscheduler.go",
+		},
+		// Test -target=wasm-unknown with the default build mode (which is
+		// c-shared).
+		{
+			name:     "wasm-unknown-reactor",
+			target:   "wasm-unknown",
+			file:     "wasmexport-noscheduler.go",
+			noOutput: true, // wasm-unknown cannot produce output
+		},
+		// Test -target=wasm-unknown with -buildmode=default, which makes it run
+		// in command mode.
+		{
+			name:      "wasm-unknown-command",
+			target:    "wasm-unknown",
+			buildMode: "default",
+			file:      "wasmexport-noscheduler.go",
+			noOutput:  true, // wasm-unknown cannot produce output
+			command:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build the wasm binary.
+			tmpdir := t.TempDir()
+			options := optionsFromTarget(tc.target, sema)
+			options.BuildMode = tc.buildMode
+			options.Scheduler = tc.scheduler
+			buildConfig, err := builder.NewConfig(&options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			filename := "wasmexport.go"
+			if tc.file != "" {
+				filename = tc.file
+			}
+			result, err := builder.Build("testdata/"+filename, ".wasm", tmpdir, buildConfig)
+			if err != nil {
+				t.Fatal("failed to build binary:", err)
+			}
+
+			// Read the wasm binary back into memory.
+			data, err := os.ReadFile(result.Binary)
+			if err != nil {
+				t.Fatal("could not read wasm binary: ", err)
+			}
+
+			// Set up the wazero runtime.
+			output := &bytes.Buffer{}
+			ctx := context.Background()
+			r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
+			defer r.Close(ctx)
+			config := wazero.NewModuleConfig().
+				WithStdout(output).WithStderr(output).
+				WithStartFunctions()
+
+			// Prepare for testing.
+			var mod api.Module
+			mustCall := func(results []uint64, err error) []uint64 {
+				if err != nil {
+					t.Error("failed to run function:", err)
+				}
+				return results
+			}
+			checkResult := func(name string, results []uint64, expected []uint64) {
+				if len(results) != len(expected) {
+					t.Errorf("%s: expected %v but got %v", name, expected, results)
+				}
+				for i, result := range results {
+					if result != expected[i] {
+						t.Errorf("%s: expected %v but got %v", name, expected, results)
+						break
+					}
+				}
+			}
+			runTests := func() {
+				// Test an exported function without params or return value.
+				checkResult("hello()", mustCall(mod.ExportedFunction("hello").Call(ctx)), nil)
+
+				// Test that we can call an exported function more than once.
+				checkResult("add(3, 5)", mustCall(mod.ExportedFunction("add").Call(ctx, 3, 5)), []uint64{8})
+				checkResult("add(7, 9)", mustCall(mod.ExportedFunction("add").Call(ctx, 7, 9)), []uint64{16})
+				checkResult("add(6, 1)", mustCall(mod.ExportedFunction("add").Call(ctx, 6, 1)), []uint64{7})
+
+				// Test that imported functions can call exported functions
+				// again.
+				checkResult("reentrantCall(2, 3)", mustCall(mod.ExportedFunction("reentrantCall").Call(ctx, 2, 3)), []uint64{5})
+				checkResult("reentrantCall(1, 8)", mustCall(mod.ExportedFunction("reentrantCall").Call(ctx, 1, 8)), []uint64{9})
+			}
+
+			// Add wasip1 module.
+			wasi_snapshot_preview1.MustInstantiate(ctx, r)
+
+			// Add custom "tester" module.
+			callOutside := func(a, b int32) int32 {
+				results, err := mod.ExportedFunction("add").Call(ctx, uint64(a), uint64(b))
+				if err != nil {
+					t.Error("could not call exported add function:", err)
+				}
+				return int32(results[0])
+			}
+			callTestMain := func() {
+				runTests()
+			}
+			builder := r.NewHostModuleBuilder("tester")
+			builder.NewFunctionBuilder().WithFunc(callOutside).Export("callOutside")
+			builder.NewFunctionBuilder().WithFunc(callTestMain).Export("callTestMain")
+			_, err = builder.Instantiate(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Parse and instantiate the wasm.
+			mod, err = r.InstantiateWithConfig(ctx, data, config)
+			if err != nil {
+				t.Fatal("could not instantiate wasm module:", err)
+			}
+
+			// Initialize the module and run the tests.
+			if tc.command {
+				// Call _start (the entry point), which calls
+				// tester.callTestMain, which then runs all the tests.
+				mustCall(mod.ExportedFunction("_start").Call(ctx))
+			} else {
+				// Run the _initialize call, because this is reactor mode wasm.
+				mustCall(mod.ExportedFunction("_initialize").Call(ctx))
+				runTests()
+			}
+
+			// Check that the output matches the expected output.
+			// (Skip this for wasm-unknown because it can't produce output).
+			if !tc.noOutput {
+				expectedOutput, err := os.ReadFile("testdata/wasmexport.txt")
+				if err != nil {
+					t.Fatal("could not read output file:", err)
+				}
+				actual := output.Bytes()
+				expectedOutput = bytes.ReplaceAll(expectedOutput, []byte("\r\n"), []byte("\n"))
+				actual = bytes.ReplaceAll(actual, []byte("\r\n"), []byte("\n"))
+				if !bytes.Equal(actual, expectedOutput) {
+					t.Error(string(Diff("expected", expectedOutput, "actual", actual)))
 				}
 			}
 		})

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,5 +1,8 @@
 //go:build tinygo.wasm && !wasm_unknown && !wasip2
 
+// This file is for wasm/wasip1 and for wasm/js, which both use much of the
+// WASIp1 API.
+
 package runtime
 
 import (

--- a/src/runtime/runtime_wasip1.go
+++ b/src/runtime/runtime_wasip1.go
@@ -13,15 +13,6 @@ type timeUnit int64
 //export __wasm_call_ctors
 func __wasm_call_ctors()
 
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-	__stdio_exit()
-}
-
 // Read the command line arguments from WASI.
 // For example, they can be passed to a program with wasmtime like this:
 //
@@ -98,6 +89,10 @@ func ticks() timeUnit {
 	var nano uint64
 	clock_time_get(0, timePrecisionNanoseconds, &nano)
 	return timeUnit(nano)
+}
+
+func beforeExit() {
+	__stdio_exit()
 }
 
 // Implementations of WASI APIs

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -14,7 +14,7 @@ func resume() {
 	}
 
 	wasmNested = true
-	scheduler()
+	scheduler(false)
 	wasmNested = false
 }
 
@@ -26,6 +26,6 @@ func go_scheduler() {
 	}
 
 	wasmNested = true
-	scheduler()
+	scheduler(false)
 	wasmNested = false
 }

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -2,7 +2,8 @@
 
 package runtime
 
-import "unsafe"
+// TODO: this is essentially reactor mode wasm. So we might want to support
+// -buildmode=c-shared (and default to it).
 
 type timeUnit int64
 
@@ -10,14 +11,6 @@ type timeUnit int64
 //
 //export __wasm_call_ctors
 func __wasm_call_ctors()
-
-//export _initialize
-func _initialize() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	initAll()
-}
 
 func init() {
 	__wasm_call_ctors()
@@ -39,4 +32,7 @@ func sleepTicks(d timeUnit) {
 
 func ticks() timeUnit {
 	return timeUnit(0)
+}
+
+func beforeExit() {
 }

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -1,0 +1,100 @@
+//go:build tinygo.wasm && !wasip2 && !js
+
+package runtime
+
+// Entry points for WebAssembly modules, and runtime support for
+// //go:wasmexport: runtime.wasmExport* function calls are inserted by the
+// compiler for //go:wasmexport support.
+
+import (
+	"internal/task"
+	"unsafe"
+)
+
+// This is the _start entry point, when using -buildmode=default.
+func wasmEntryCommand() {
+	// These need to be initialized early so that the heap can be initialized.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	wasmExportState = wasmExportStateInMain
+	run()
+	wasmExportState = wasmExportStateExited
+	beforeExit()
+}
+
+// This is the _initialize entry point, when using -buildmode=c-shared.
+func wasmEntryReactor() {
+	// This function is called before any //go:wasmexport functions are called
+	// to initialize everything. It must not block.
+
+	// Initialize the heap.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	initHeap()
+
+	if hasScheduler {
+		// A package initializer might do funky stuff like start a goroutine and
+		// wait until it completes, so we have to run package initializers in a
+		// goroutine.
+		go func() {
+			initAll()
+			wasmExportState = wasmExportStateReactor
+		}()
+		scheduler(true)
+		if wasmExportState != wasmExportStateReactor {
+			// Unlikely, but if package initializers do something blocking (like
+			// time.Sleep()), that's a bug.
+			runtimePanic("package initializer blocks")
+		}
+	} else {
+		// There are no goroutines (except for the main one, if you can call it
+		// that), so we can just run all the package initializers.
+		initAll()
+		wasmExportState = wasmExportStateReactor
+	}
+}
+
+// Track which state we're in: before (or during) init, running inside
+// main.main, after main.main returned, or reactor mode (after init).
+var wasmExportState uint8
+
+const (
+	wasmExportStateInit = iota
+	wasmExportStateInMain
+	wasmExportStateExited
+	wasmExportStateReactor
+)
+
+func wasmExportCheckRun() {
+	switch wasmExportState {
+	case wasmExportStateInit:
+		runtimePanic("//go:wasmexport function called before runtime initialization")
+	case wasmExportStateExited:
+		runtimePanic("//go:wasmexport function called after main.main returned")
+	}
+}
+
+// Called from within a //go:wasmexport wrapper (the one that's exported from
+// the wasm module) after the goroutine has been queued. Just run the scheduler,
+// and check that the goroutine finished when the scheduler is idle (as required
+// by the //go:wasmexport proposal).
+//
+// This function is not called when the scheduler is disabled.
+func wasmExportRun(done *bool) {
+	scheduler(true)
+	if !*done {
+		runtimePanic("//go:wasmexport function did not finish")
+	}
+}
+
+// Called from the goroutine wrapper for the //go:wasmexport function. It just
+// signals to the runtime that the //go:wasmexport call has finished, and can
+// switch back to the wasmExportRun function.
+//
+// This function is not called when the scheduler is disabled.
+func wasmExportExit() {
+	task.Pause()
+
+	// TODO: we could cache the allocated stack so we don't have to keep
+	// allocating a new stack on every //go:wasmexport call.
+}

--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -25,7 +25,7 @@ func run() {
 		callMain()
 		schedulerDone = true
 	}()
-	scheduler()
+	scheduler(false)
 }
 
 const hasScheduler = true

--- a/targets/wasm-unknown.json
+++ b/targets/wasm-unknown.json
@@ -3,6 +3,7 @@
 	"cpu":           "generic",
 	"features":      "+mutable-globals,+nontrapping-fptoint,+sign-ext,-bulk-memory",
 	"build-tags":    ["tinygo.wasm", "wasm_unknown"],
+	"buildmode":    "c-shared",
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",

--- a/testdata/wasmexport-noscheduler.go
+++ b/testdata/wasmexport-noscheduler.go
@@ -1,0 +1,35 @@
+package main
+
+func init() {
+	println("called init")
+}
+
+//go:wasmimport tester callTestMain
+func callTestMain()
+
+func main() {
+	// main.main is not used when using -buildmode=c-shared.
+	callTestMain()
+}
+
+//go:wasmexport hello
+func hello() {
+	println("hello!")
+}
+
+//go:wasmexport add
+func add(a, b int) int {
+	println("called add:", a, b)
+	return a + b
+}
+
+//go:wasmimport tester callOutside
+func callOutside(a, b int) int
+
+//go:wasmexport reentrantCall
+func reentrantCall(a, b int) int {
+	println("reentrantCall:", a, b)
+	result := callOutside(a, b)
+	println("reentrantCall result:", result)
+	return result
+}

--- a/testdata/wasmexport.go
+++ b/testdata/wasmexport.go
@@ -1,0 +1,52 @@
+package main
+
+import "time"
+
+func init() {
+	println("called init")
+	go adder()
+}
+
+//go:wasmimport tester callTestMain
+func callTestMain()
+
+func main() {
+	// main.main is not used when using -buildmode=c-shared.
+	callTestMain()
+}
+
+//go:wasmexport hello
+func hello() {
+	println("hello!")
+}
+
+//go:wasmexport add
+func add(a, b int) int {
+	println("called add:", a, b)
+	addInputs <- a
+	addInputs <- b
+	return <-addOutput
+}
+
+var addInputs = make(chan int)
+var addOutput = make(chan int)
+
+func adder() {
+	for {
+		a := <-addInputs
+		b := <-addInputs
+		time.Sleep(time.Millisecond)
+		addOutput <- a + b
+	}
+}
+
+//go:wasmimport tester callOutside
+func callOutside(a, b int) int
+
+//go:wasmexport reentrantCall
+func reentrantCall(a, b int) int {
+	println("reentrantCall:", a, b)
+	result := callOutside(a, b)
+	println("reentrantCall result:", result)
+	return result
+}

--- a/testdata/wasmexport.txt
+++ b/testdata/wasmexport.txt
@@ -1,0 +1,11 @@
+called init
+hello!
+called add: 3 5
+called add: 7 9
+called add: 6 1
+reentrantCall: 2 3
+called add: 2 3
+reentrantCall result: 5
+reentrantCall: 1 8
+called add: 1 8
+reentrantCall result: 9


### PR DESCRIPTION
This adds support for the `//go:wasmexport` pragma as proposed here: https://github.com/golang/go/issues/65199

It is currently implemented only for wasip1, but it is certainly possible to extend it to other targets like `GOOS=js`, `-target=wasm-unknown`, or `-target=wasip2`. ~It is also currently limited to `-buildmode=c-shared`, this is a limitation that could easily be lifted in the future.~

WIP: this needs tests, but I'm not entirely sure how to test this (I've tested it by using the `--invoke` flag to `wasmtime`).

This will likely replace #4082.

If you want fast calls into the binary, I'd recommend to disable the scheduler (`-scheduler=none`). That should give a significant speedup since lots of complexity is avoided. Though there are also some possible optimizations that I haven't implemented yet (like caching stacks).