### PR TITLE
governance: add initial documentation for project governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,28 @@
+TinyGo Team Members
+===================
+
+The team of humans who maintain TinyGo.
+
+*   **Purpose**: To maintain the community, code, documentation, and tools for the TinyGo compiler.
+*   **Board**: The group of people who share responsibility for key decisions for the TinyGo organization.  
+    *   **Majority Voting**: The board makes decisions by majority vote.
+    *   **Membership**: The board elects its own members.
+*   **Do-ocracy**: Those who step forward to do a given task propose how it should be done. Then other interested people can make comments.
+*   **Proof of Work**: Power in decision-making is slightly weighted based on a participant's labor for the community.
+*   **Initiation**: We need to establish a procedure for how people join the team of maintainers.
+*   **Transparency**: Important information should be made publicly available, ideally in a way that allows for public comment.
+*   **Code of Conduct**: Participants agree to abide by the current project Code of Conduct.
+
+## Members
+
+* Ayke van Laethem (@aykevl)
+* Ron Evans (@deadprogram)
+
+
+## Experimental
+
+*   **Monthly Meeting**: A monthly meeting for the team and any other interested participants.  
+    Duration: 1 hour  
+    Facilitation: @deadprogram
+    Schedule: TBD
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,13 +16,17 @@ The team of humans who maintain TinyGo.
 ## Members
 
 * Ayke van Laethem (@aykevl)
+* Daniel Esteban (@conejoninja)
 * Ron Evans (@deadprogram)
-
+* Damian Gryski (@dgryski)
+* Masaaki Takasago (@sago35)
+* Patricio Whittingslow (@soypat)
+* Yurii Soldak (@ysoldak)
 
 ## Experimental
 
 *   **Monthly Meeting**: A monthly meeting for the team and any other interested participants.  
     Duration: 1 hour  
     Facilitation: @deadprogram
-    Schedule: TBD
+    Schedule: See https://github.com/tinygo-org/tinygo/wiki/Meetings for more information
 


### PR DESCRIPTION
This PR is an initial attempt to document and establish some governance policies and procedures for the TinyGo project.

I used https://communityrule.info/ to generate it initially, which I in turn located via https://governingopen.com/resources/