### PR TITLE
wasm/js: use standard library syscall package

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -239,7 +239,8 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 				// already be emitted in initAll.
 				continue
 			case strings.HasPrefix(callFn.name, "runtime.print") || callFn.name == "runtime._panic" || callFn.name == "runtime.hashmapGet" || callFn.name == "runtime.hashmapInterfaceHash" ||
-				callFn.name == "os.runtime_args" || callFn.name == "internal/task.start" || callFn.name == "internal/task.Current" ||
+				callFn.name == "os.runtime_args" || callFn.name == "syscall.runtime_envs" ||
+				callFn.name == "internal/task.start" || callFn.name == "internal/task.Current" ||
 				callFn.name == "time.startTimer" || callFn.name == "time.stopTimer" || callFn.name == "time.resetTimer":
 				// These functions should be run at runtime. Specifically:
 				//   * Print and panic functions are best emitted directly without

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -218,7 +218,7 @@ func listGorootMergeLinks(goroot, tinygoroot string, overrides map[string]bool) 
 // with the TinyGo version. This is the case on some targets.
 func needsSyscallPackage(buildTags []string) bool {
 	for _, tag := range buildTags {
-		if tag == "baremetal" || tag == "nintendoswitch" || tag == "tinygo.wasm" {
+		if tag == "baremetal" || tag == "nintendoswitch" || tag == "wasip1" || tag == "wasip2" || tag == "wasm_unknown" {
 			return true
 		}
 	}

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1 && !wasip2) || wasm_unknown
+//go:build baremetal || wasm_unknown
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !(baremetal || (wasm && !wasip1 && !wasip2) || wasm_unknown)
+//go:build !(baremetal || wasm_unknown)
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasm_unknown
+//go:build baremetal || wasm_unknown
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js || wasm_unknown
+//go:build baremetal || nintendoswitch || wasm_unknown
 
 package syscall
 


### PR DESCRIPTION
This switches `-target=wasm` (browser wasm) over from our own syscall package to the one used in the Go standard library.

While this doesn't remove any code (so we can't simplify anything), the idea is that this improves compatibility with existing code a bit more. So It's a similar reasoning as for https://github.com/tinygo-org/tinygo/pull/4417.