### PR TITLE
targets/wasip2: add wasmtime -S options for network access

### DIFF
--- a/targets/wasip2.json
+++ b/targets/wasip2.json
@@ -23,7 +23,7 @@
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator": "wasmtime --wasm component-model --dir={tmpDir}::/tmp {}",
+	"emulator": "wasmtime --wasm component-model -Sinherit-network -Sallow-ip-name-lookup --dir={tmpDir}::/tmp {}",
 	"wit-package": "{root}/lib/wasi-cli/wit/",
 	"wit-world": "wasi:cli/command"
 }


### PR DESCRIPTION
This adds `wasmtime` emulator args in the `wasip2` target: `-Sinherit-network -Sallow-ip-name-lookup`

This enables prototyping an implementation of package `net` using `wasi:sockets`. It grants access to the host machine’s network, with effectively equal privileges to a non-wasm process.