### PR TITLE
runtime maps: random iteration and maps.clone

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,8 +42,8 @@ func TestBinarySize(t *testing.T) {
 	tests := []sizeTest{
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4484, 280, 0, 2252},
-		{"microbit", "examples/serial", 2732, 388, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 6016, 1484, 116, 6816},
+		{"microbit", "examples/serial", 2808, 388, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 6064, 1484, 116, 6816},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/main_test.go
+++ b/main_test.go
@@ -470,20 +470,21 @@ func TestWebAssembly(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		name          string
+		target        string
 		panicStrategy string
 		imports       []string
 	}
 	for _, tc := range []testCase{
 		// Test whether there really are no imports when using -panic=trap. This
 		// tests the bugfix for https://github.com/tinygo-org/tinygo/issues/4161.
-		{name: "panic-default", imports: []string{"wasi_snapshot_preview1.fd_write"}},
-		{name: "panic-trap", panicStrategy: "trap", imports: []string{}},
+		{name: "panic-default", target: "wasip1", imports: []string{"wasi_snapshot_preview1.fd_write", "wasi_snapshot_preview1.random_get"}},
+		{name: "panic-trap", target: "wasm-unknown", panicStrategy: "trap", imports: []string{}},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tmpdir := t.TempDir()
-			options := optionsFromTarget("wasi", sema)
+			options := optionsFromTarget(tc.target, sema)
 			options.PanicStrategy = tc.panicStrategy
 			config, err := builder.NewConfig(&options)
 			if err != nil {

--- a/src/internal/binary/binary.go
+++ b/src/internal/binary/binary.go
@@ -30,3 +30,8 @@ func (littleEndian) AppendUint16(b []byte, v uint16) []byte {
 func (littleEndian) Uint32(b []byte) uint32 {
 	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
 }
+
+func (littleEndian) Uint64(b []byte) uint64 {
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}

--- a/src/runtime/algorithm.go
+++ b/src/runtime/algorithm.go
@@ -23,7 +23,13 @@ func fastrand() uint32 {
 	return xorshift32State
 }
 
-var xorshift32State uint32 = 1
+func init() {
+	r, _ := hardwareRand()
+	xorshift64State = uint64(r | 1) // protect against 0
+	xorshift32State = uint32(xorshift64State)
+}
+
+var xorshift32State uint32
 
 func xorshift32(x uint32) uint32 {
 	// Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs".
@@ -43,7 +49,7 @@ func fastrand64() uint64 {
 	return xorshift64State
 }
 
-var xorshift64State uint64 = 1
+var xorshift64State uint64
 
 // 64-bit xorshift multiply rng from http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
 func xorshiftMult64(x uint64) uint64 {

--- a/src/runtime/memhash_tsip.go
+++ b/src/runtime/memhash_tsip.go
@@ -10,7 +10,7 @@
 package runtime
 
 import (
-	"encoding/binary"
+	"internal/binary"
 	"math/bits"
 	"unsafe"
 )


### PR DESCRIPTION
This PR fixes a few map-related issues:

* make map iteration less predictable.  It's still not a fully random key, but then again neither is Big Go's. 
* fix building the tsip runtime hash.  At some point this broken when an import cycle was introduced, so just inline the bits we need from `math/bits` and `encoding/binary`. 
* add `maps.clone` so the `maps` package can use it.
* initialize fastrand() on process startup so we actually get random numbers for map seeds
* fix build for tsip memhash