### PR TITLE
runtime: add runtime.fcntl link directives

### DIFF
--- a/builder/musl.go
+++ b/builder/musl.go
@@ -135,6 +135,7 @@ var libMusl = Library{
 			"thread/*.c",
 			"time/*.c",
 			"unistd/*.c",
+			"fcntl/*.c",
 		}
 		if arch == "arm" {
 			// These files need to be added to the start for some reason.

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -142,6 +142,6 @@ func hardwareRand() (n uint64, ok bool) {
 //export getrandom
 func libc_getrandom(buf unsafe.Pointer, buflen uintptr, flags uint32) uint32
 
-//go:linknam runtime_fcntl syscall/syscall_fcntl
-//go:export
-func runtime_fcntl(fd, cmd, arg int32) (ret int32, errno int32)
+func fcntl(fd, cmd, arg int32) (ret int32, errno int32){
+    return 0, 0
+}

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -5,7 +5,9 @@ package runtime
 // This file is for systems that are _actually_ Linux (not systems that pretend
 // to be Linux, like baremetal systems).
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 const GOOS = "linux"
 
@@ -139,3 +141,7 @@ func hardwareRand() (n uint64, ok bool) {
 //
 //export getrandom
 func libc_getrandom(buf unsafe.Pointer, buflen uintptr, flags uint32) uint32
+
+//go:linknam runtime_fcntl syscall/syscall_fcntl
+//go:export
+func runtime_fcntl(fd, cmd, arg int32) (ret int32, errno int32)

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -142,6 +142,5 @@ func hardwareRand() (n uint64, ok bool) {
 //export getrandom
 func libc_getrandom(buf unsafe.Pointer, buflen uintptr, flags uint32) uint32
 
-func fcntl(fd, cmd, arg int32) (ret int32, errno int32){
-    return 0, 0
-}
+//go:linkname fcntl syscall.Fcntl
+func fcntl(fd, cmd, arg int32) (ret int32, errno int32)

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -212,7 +212,7 @@ func Truncate(path string, length int64) (err error) {
 	return
 }
 
-//go:linkname syscall_fcntl runtime.fcntl
+//go:linkname syscall_fcntl runtime/runtime.fcntl
 func syscall_fcntl(fd, cmd, arg int32) (ret int32, errno int32) {
 	// https://cs.opensource.google/go/go/+/master:src/runtime/os_linux.go;l=452?q=runtime.fcntl&ss=go%2Fgo
 	r, _, err := Syscall6(SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -212,6 +212,13 @@ func Truncate(path string, length int64) (err error) {
 	return
 }
 
+//go:linkname syscall_fcntl runtime.fcntl
+func syscall_fcntl(fd, cmd, arg int32) (ret int32, errno int32) {
+	// https://cs.opensource.google/go/go/+/master:src/runtime/os_linux.go;l=452?q=runtime.fcntl&ss=go%2Fgo
+	r, _, err := Syscall6(SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+	return int32(r), int32(err)
+}
+
 func Faccessat(dirfd int, path string, mode uint32, flags int) (err error)
 
 func Kill(pid int, sig Signal) (err error) {

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -212,11 +212,22 @@ func Truncate(path string, length int64) (err error) {
 	return
 }
 
+/*
 //go:linkname syscall_fcntl runtime/runtime.fcntl
 func syscall_fcntl(fd, cmd, arg int32) (ret int32, errno int32) {
 	// https://cs.opensource.google/go/go/+/master:src/runtime/os_linux.go;l=452?q=runtime.fcntl&ss=go%2Fgo
 	r, _, err := Syscall6(SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
 	return int32(r), int32(err)
+}
+*/
+
+//go:linkname Fcntl runtime/runtime.fcntl
+func Fcntl(fd int, cmd int, args ...int) (int, error) {
+	ret := libc_fcntl(fd, cmd, args...)
+	if ret < 0 {
+		return 0, getErrno()
+	}
+	return ret, nil
 }
 
 func Faccessat(dirfd int, path string, mode uint32, flags int) (err error)
@@ -472,3 +483,8 @@ func libc_execve(filename *byte, argv **byte, envp **byte) int
 //
 //export truncate
 func libc_truncate(path *byte, length int64) int32
+
+// int fcntl(int, int, ...);
+//
+// export fcntl
+func libc_fcntl(fd int, cmd int, args ...int) int

--- a/src/syscall/syscall_unix.go
+++ b/src/syscall/syscall_unix.go
@@ -1,3 +1,5 @@
+//go:build tinygo && unix && !baremetal && !tinygo.wasm
+
 package syscall
 
 func Exec(argv0 string, argv []string, envv []string) (err error)
@@ -15,4 +17,11 @@ type SockaddrInet6 struct {
 	ZoneId uint32
 	Addr   [16]byte
 	raw    RawSockaddrInet6
+}
+
+//go:linkname syscall_fcntl runtime/runtime.fcntl
+func syscall_fcntl(fd, cmd, arg int32) (ret int32, errno int32) {
+	// https://cs.opensource.google/go/go/+/master:src/runtime/os_linux.go;l=452?q=runtime.fcntl&ss=go%2Fgo
+	r, _, err := Syscall6(SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+	return int32(r), int32(err)
 }


### PR DESCRIPTION
Building u-root commands with tinygo (see https://github.com/u-root/u-root/issues/2979) returns linking errors for the system runtime function `runtime.fcntl`. This PR intends to fix this issue. Affected u-root cmdlets:

* localboot
* netbootxyz
* newsshd
* systemboot
