### PR TITLE
fix(wasip2): fix environment initialization in reactors

### DIFF
--- a/src/syscall/env_wasip2.go
+++ b/src/syscall/env_wasip2.go
@@ -4,7 +4,7 @@ package syscall
 
 func Environ() []string {
 	var env []string
-	for k, v := range libc_envs {
+	for k, v := range libc_envs() {
 		env = append(env, k+"="+v)
 	}
 	return env

--- a/src/syscall/libc_wasip2.go
+++ b/src/syscall/libc_wasip2.go
@@ -22,6 +22,12 @@ import (
 	"internal/wasi/random/v0.2.0/random"
 )
 
+func init() {
+	libc_envs()
+	wasiPreopens()
+	wasiStreams()
+}
+
 func goString(cstr *byte) string {
 	return unsafe.String(cstr, strlen(cstr))
 }


### PR DESCRIPTION
Using `init()` to initialize stdio or environment is prone to race conditions for reactor-style components, e.g.
`wasi:http/incoming-handler` interface implementations due to the fact that `init()` is normally used to "register" the export implementation

In result, using e.g. `fmt.Println` may cause a runtime panic as follows:

```
ERROR wasmtime_cli::commands::serve: [125] :: Error {
    context: "error while executing at wasm backtrace:\n    0: 0x548e9 - wit-component:shim!indirect-wasi:io/streams@0.2.0-[method]output-stream.blocking-write-and-flush\n    1: 0x4d56 - main!(internal/wasi/io/v0.2.0/streams.OutputStream).BlockingWriteAndFlush\n    2: 0x99f0 - main!syscall.writeStream\n    3: 0x96a0 - main!write\n    4: 0x4623 - main!(os.unixFileHandle).Write\n    5: 0x3cf5 - main!wasi:http/incoming-handler@0.2.0#handle\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information",
    source: "unknown handle index 0",
}
error: hyper::Error(User(Service), guest never invoked `response-outparam::set` method: error while executing at wasm backtrace:
    0: 0x548e9 - wit-component:shim!indirect-wasi:io/streams@0.2.0-[method]output-stream.blocking-write-and-flush
    1: 0x4d56 - main!(internal/wasi/io/v0.2.0/streams.OutputStream).BlockingWriteAndFlush
    2: 0x99f0 - main!syscall.writeStream
    3: 0x96a0 - main!write
    4: 0x4623 - main!(os.unixFileHandle).Write
    5: 0x3cf5 - main!wasi:http/incoming-handler@0.2.0#handle
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information

Caused by:
    unknown handle index 0)
```

~using `sync.OnceValue` to lazily initialize the environment instead of `init()` ensures correctness and should improve cold start times as a nice side effect (especially for applications not utilizing this functionality)~ I had to preserve the "eager" initialization approach in `init()`, to allow tests to pass but not exactly sure why

This issue can be reproduced using a `wasi:http/incoming-handler` implementation run in wasmtime 24

For example, I used https://github.com/Mossaka/hello-wasi-http-tinygo, to which I've added a `fmt.Println` line at the top