### PR TITLE
wasm: add `//go:wasmexport` support to js/wasm 

### DIFF
--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -2,25 +2,14 @@
 
 package runtime
 
-import "unsafe"
-
 type timeUnit float64 // time in milliseconds, just like Date.now() in JavaScript
 
 // wasmNested is used to detect scheduler nesting (WASM calls into JS calls back into WASM).
 // When this happens, we need to use a reduced version of the scheduler.
+//
+// TODO: this variable can probably be removed once //go:wasmexport is the only
+// allowed way to export a wasm function (currently, //export also works).
 var wasmNested bool
-
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-
-	wasmNested = true
-	run()
-	__stdio_exit()
-	wasmNested = false
-}
 
 var handleEvent func()
 
@@ -50,3 +39,7 @@ func sleepTicks(d timeUnit)
 
 //go:wasmimport gojs runtime.ticks
 func ticks() timeUnit
+
+func beforeExit() {
+	__stdio_exit()
+}

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !js
+//go:build tinygo.wasm
 
 package runtime
 

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -466,20 +466,13 @@
 			this._idPool = [];      // unused ids that have been garbage collected
 			this.exited = false;    // whether the Go program has exited
 
-			while (true) {
-				const callbackPromise = new Promise((resolve) => {
-					this._resolveCallbackPromise = () => {
-						if (this.exited) {
-							throw new Error("bad callback: Go program has already exited");
-						}
-						setTimeout(resolve, 0); // make sure it is asynchronous
-					};
-				});
+			if (this._inst.exports._start) {
 				this._inst.exports._start();
-				if (this.exited) {
-					break;
-				}
-				await callbackPromise;
+
+				// TODO: wait until the program exists.
+				await new Promise(() => {});
+			} else {
+				this._inst.exports._initialize();
 			}
 		}
 

--- a/testdata/wasmexport.js
+++ b/testdata/wasmexport.js
@@ -1,0 +1,40 @@
+require('../targets/wasm_exec.js');
+
+function runTests() {
+    let testCall = (name, params, expected) => {
+        let result = go._inst.exports[name].apply(null, params);
+        if (result !== expected) {
+            console.error(`${name}(...${params}): expected result ${expected}, got ${result}`);
+        }
+    }
+
+    // These are the same tests as in TestWasmExport.
+    testCall('hello', [], undefined);
+    testCall('add', [3, 5], 8);
+    testCall('add', [7, 9], 16);
+    testCall('add', [6, 1], 7);
+    testCall('reentrantCall', [2, 3], 5);
+    testCall('reentrantCall', [1, 8], 9);
+}
+
+let go = new Go();
+go.importObject.tester = {
+    callOutside: (a, b) => {
+        return go._inst.exports.add(a, b);
+    },
+    callTestMain: () => {
+        runTests();
+    },
+};
+WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then((result) => {
+    let buildMode = process.argv[3];
+    if (buildMode === 'default') {
+        go.run(result.instance);
+    } else if (buildMode === 'c-shared') {
+        go.run(result.instance);
+        runTests();
+    }
+}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
This adds support for //go:wasmexport with `-target=wasm` (in the browser). This follows the //go:wasmexport proposal, meaning that blocking functions are not allowed.

Both `-buildmode=default` and `-buildmode=c-shared` are supported. The latter allows calling exported functions after `go.run()` has returned.

This PR depends on #4451 so will remain a draft until that one is merged.