### PR TITLE
compiler, runtime: enable go:wasmexport for wasip2

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -389,6 +389,13 @@ func (c *compilerContext) parsePragmas(info *functionInfo, f *ssa.Function) {
 			}
 		}
 	}
+
+	// If both //go:wasmexport and //go:export or //export are declared,
+	// only honor go:wasmexport.
+	if info.wasmExport != "" {
+		// TODO: log warning?
+		info.exported = false
+	}
 }
 
 // Check whether this function can be used in //go:wasmimport or

--- a/src/runtime/runtime_wasip2.go
+++ b/src/runtime/runtime_wasip2.go
@@ -6,18 +6,19 @@ import (
 	"unsafe"
 
 	"internal/wasi/cli/v0.2.0/environment"
+	wasi_run "internal/wasi/cli/v0.2.0/run"
 	monotonicclock "internal/wasi/clocks/v0.2.0/monotonic-clock"
+
+	"internal/cm"
 )
 
 type timeUnit int64
 
-//export wasi:cli/run@0.2.0#run
-func __wasi_cli_run_run() uint32 {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-	return 0
+func init() {
+	wasi_run.Exports.Run = func() cm.BoolResult {
+		callMain()
+		return false
+	}
 }
 
 var args []string
@@ -50,4 +51,7 @@ func sleepTicks(d timeUnit) {
 
 func ticks() timeUnit {
 	return timeUnit(monotonicclock.Now())
+}
+
+func beforeExit() {
 }

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !wasip2 && !js
+//go:build tinygo.wasm && !js
 
 package runtime
 

--- a/targets/wasip2.json
+++ b/targets/wasip2.json
@@ -3,6 +3,7 @@
 	"cpu":           "generic",
 	"features":      "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext",
 	"build-tags":    ["tinygo.wasm", "wasip2"],
+	"buildmode":     "c-shared",
 	"goos":          "linux",
 	"goarch":        "arm",
 	"linker":        "wasm-ld",


### PR DESCRIPTION
This builds on #4451 to enable `//go:wasmexport` for `wasip2` (WASI Preview 2).

- `//go:wasmexport` is now permitted and supersedes `//go:export` and `//export` if both are present.
- The `wasip2` target now defaults to `-buildmode=c-shared`, since all WASI 0.2+ programs are reactors.
- `main.main` is called by the `wasi:cli/run#run` export in a `wasmexport`.