### PR TITLE
compiler: conform to latest iteration of wasm types proposal

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -448,7 +448,9 @@ func isValidWasmType(typ types.Type, site wasmSite) bool {
 		switch typ.Kind() {
 		case types.Bool:
 			return true
-		case types.Int, types.Uint, types.Int8, types.Uint8, types.Int16, types.Uint16, types.Int32, types.Uint32, types.Int64, types.Uint64:
+		case types.Int8, types.Uint8, types.Int16, types.Uint16:
+			return site == siteIndirect
+		case types.Int32, types.Uint32, types.Int64, types.Uint64:
 			return true
 		case types.Float32, types.Float64:
 			return true

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -16,28 +16,27 @@ type Uint uint32
 type S struct {
 	a [4]uint32
 	b uintptr
-	c int
 	d float32
 	e float64
 }
 
 //go:wasmimport modulename validparam
-func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g string, h *int32, i *S)
+func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g string, h *int32, i *S, j *[8]uint8)
 
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type [4]uint32
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type []byte
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type struct{a int}
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type chan struct{}
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type func()
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type int
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type uint
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type [8]int
 //
 //go:wasmimport modulename invalidparam
-func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func())
+func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func(), f int, g uint, h [8]int)
 
 //go:wasmimport modulename validreturn_int32
 func validreturn_int32() int32
-
-//go:wasmimport modulename validreturn_int
-func validreturn_int() int
 
 //go:wasmimport modulename validreturn_ptr_int32
 func validreturn_ptr_int32() *int32
@@ -48,6 +47,9 @@ func validreturn_ptr_string() *string
 //go:wasmimport modulename validreturn_ptr_struct
 func validreturn_ptr_struct() *S
 
+//go:wasmimport modulename validreturn_ptr_array
+func validreturn_ptr_array() *[8]uint8
+
 //go:wasmimport modulename validreturn_unsafe_pointer
 func validreturn_unsafe_pointer() unsafe.Pointer
 
@@ -56,10 +58,25 @@ func validreturn_unsafe_pointer() unsafe.Pointer
 //go:wasmimport modulename manyreturns
 func manyreturns() (int32, int32)
 
+// ERROR: //go:wasmimport modulename invalidreturn_int: unsupported result type int
+//
+//go:wasmimport modulename invalidreturn_int
+func invalidreturn_int() int
+
+// ERROR: //go:wasmimport modulename invalidreturn_int: unsupported result type uint
+//
+//go:wasmimport modulename invalidreturn_int
+func invalidreturn_uint() uint
+
 // ERROR: //go:wasmimport modulename invalidreturn_func: unsupported result type func()
 //
 //go:wasmimport modulename invalidreturn_func
 func invalidreturn_func() func()
+
+// ERROR: //go:wasmimport modulename invalidreturn_pointer_array_int: unsupported result type *[8]int
+//
+//go:wasmimport modulename invalidreturn_pointer_array_int
+func invalidreturn_pointer_array_int() *[8]int
 
 // ERROR: //go:wasmimport modulename invalidreturn_slice_byte: unsupported result type []byte
 //

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -1,6 +1,9 @@
 package main
 
-import "unsafe"
+import (
+	"structs"
+	"unsafe"
+)
 
 //go:wasmimport modulename empty
 func empty()
@@ -14,6 +17,7 @@ func implementation() {
 type Uint uint32
 
 type S struct {
+	_ structs.HostLayout
 	a [4]uint32
 	b uintptr
 	d float32
@@ -21,7 +25,7 @@ type S struct {
 }
 
 //go:wasmimport modulename validparam
-func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g string, h *int32, i *S, j *[8]uint8)
+func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g string, h *int32, i *S, j *struct{}, k *[8]uint8)
 
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type [4]uint32
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type []byte
@@ -35,6 +39,12 @@ func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintpt
 //go:wasmimport modulename invalidparam
 func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func(), f int, g uint, h [8]int)
 
+// ERROR: //go:wasmimport modulename invalidparam_no_hostlayout: unsupported parameter type *struct{int}
+// ERROR: //go:wasmimport modulename invalidparam_no_hostlayout: unsupported parameter type *struct{string}
+//
+//go:wasmimport modulename invalidparam_no_hostlayout
+func invalidparam_no_hostlayout(a *struct{ int }, b *struct{ string })
+
 //go:wasmimport modulename validreturn_int32
 func validreturn_int32() int32
 
@@ -46,6 +56,9 @@ func validreturn_ptr_string() *string
 
 //go:wasmimport modulename validreturn_ptr_struct
 func validreturn_ptr_struct() *S
+
+//go:wasmimport modulename validreturn_ptr_struct
+func validreturn_ptr_empty_struct() *struct{}
 
 //go:wasmimport modulename validreturn_ptr_array
 func validreturn_ptr_array() *[8]uint8

--- a/testdata/wasmexport-noscheduler.go
+++ b/testdata/wasmexport-noscheduler.go
@@ -18,16 +18,16 @@ func hello() {
 }
 
 //go:wasmexport add
-func add(a, b int) int {
+func add(a, b int32) int32 {
 	println("called add:", a, b)
 	return a + b
 }
 
 //go:wasmimport tester callOutside
-func callOutside(a, b int) int
+func callOutside(a, b int32) int32
 
 //go:wasmexport reentrantCall
-func reentrantCall(a, b int) int {
+func reentrantCall(a, b int32) int32 {
 	println("reentrantCall:", a, b)
 	result := callOutside(a, b)
 	println("reentrantCall result:", result)

--- a/testdata/wasmexport.go
+++ b/testdata/wasmexport.go
@@ -21,15 +21,15 @@ func hello() {
 }
 
 //go:wasmexport add
-func add(a, b int) int {
+func add(a, b int32) int32 {
 	println("called add:", a, b)
 	addInputs <- a
 	addInputs <- b
 	return <-addOutput
 }
 
-var addInputs = make(chan int)
-var addOutput = make(chan int)
+var addInputs = make(chan int32)
+var addOutput = make(chan int32)
 
 func adder() {
 	for {
@@ -41,10 +41,10 @@ func adder() {
 }
 
 //go:wasmimport tester callOutside
-func callOutside(a, b int) int
+func callOutside(a, b int32) int32
 
 //go:wasmexport reentrantCall
-func reentrantCall(a, b int) int {
+func reentrantCall(a, b int32) int32 {
 	println("reentrantCall:", a, b)
 	result := callOutside(a, b)
 	println("reentrantCall result:", result)


### PR DESCRIPTION
Updates to current version of the wasm types proposal at https://github.com/golang/go/issues/66984. 

Changes include:

- Removal of `int` and `uint` as allowed types.
- Restriction of `int8`, `uint8`, `int16`, and `uint16` to struct fields, arrays, or pointer values.
- Requires `struct` types in wasm params with 1 or more fields to include `structs.HostLayout`. It enforces this for Go 1.23 or later.
    - TODO: revise this to minimum Go 1.24?