### PR TITLE
builder: remove environment variables when invoking Clang

### DIFF
--- a/builder/commands.go
+++ b/builder/commands.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -75,15 +74,4 @@ func LookupCommand(name string) (string, error) {
 		return cmdName, nil
 	}
 	return "", errors.New("none of these commands were found in your $PATH: " + strings.Join(commands[name], " "))
-}
-
-func execCommand(name string, args ...string) error {
-	name, err := LookupCommand(name)
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }


### PR DESCRIPTION
This is a problem on Guix, which sets `C_INCLUDE_PATH` that is not affected by `-nostdlibinc`. And therefore it affects the build in unintended ways.

Removing all environmental variables fixes this issue, and perhaps also other issues caused by Clang being affected by environment variables.

This PR also refactors the code a bit, basically inlining `execCommand` into `runCCompiler`. The only actual change is:

```go
cmd.Env = []string{}
```