### PR TITLE
nix: use LLVM 18 instead of LLVM 17

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,6 +15,11 @@ jobs:
   nix-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Uninstall system LLVM
+        # Hack to work around issue where we still include system headers for
+        # some reason.
+        # See: https://github.com/tinygo-org/tinygo/pull/4516#issuecomment-2416363668
+        run: sudo apt-get remove llvm-18
       - name: Checkout
         uses: actions/checkout@v4
       - name: Pull musl

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703068421,
-        "narHash": "sha256-WSw5Faqlw75McIflnl5v7qVD/B3S2sLh+968bpOGrWA=",
+        "lastModified": 1728500571,
+        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d65bceaee0fb1e64363f7871bc43dc1c6ecad99f",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
   inputs = {
     # Use a recent stable release, but fix the version to make it reproducible.
     # This version should be updated from time to time.
-    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:
@@ -49,11 +49,11 @@
           buildInputs = [
             # These dependencies are required for building tinygo (go install).
             go
-            llvmPackages_17.llvm
-            llvmPackages_17.libclang
+            llvmPackages_18.llvm
+            llvmPackages_18.libclang
             # Additional dependencies needed at runtime, for building and/or
             # flashing.
-            llvmPackages_17.lld
+            llvmPackages_18.lld
             avrdude
             binaryen
             # Additional dependencies needed for on-chip debugging.
@@ -68,7 +68,7 @@
             # Without setting these explicitly, Homebrew versions might be used
             # or the default `ar` and `nm` tools might be used (which don't
             # support wasi).
-            export CLANG="clang-17 -resource-dir ${llvmPackages_17.clang.cc.lib}/lib/clang/17"
+            export CLANG="clang-18 -resource-dir ${llvmPackages_18.clang.cc.lib}/lib/clang/18"
             export LLVM_AR=llvm-ar
             export LLVM_NM=llvm-nm
 
@@ -77,7 +77,7 @@
             export MD5SUM=md5sum
 
             # Ugly hack to make the Clang resources directory available.
-            export GOFLAGS="\"-ldflags=-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${llvmPackages_17.clang.cc.lib}/lib/clang/17\" -tags=llvm17"
+            export GOFLAGS="\"-ldflags=-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${llvmPackages_18.clang.cc.lib}/lib/clang/18\" -tags=llvm18"
           '';
         };
       }


### PR DESCRIPTION
This should hopefully fix some CI issues we're currently having: https://github.com/tinygo-org/tinygo/issues/4515