### PR TITLE
os: net.newUnixFile

### DIFF
--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -12,6 +12,7 @@ package os
 import (
 	"io"
 	"syscall"
+	_ "unsafe"
 )
 
 const DevNull = "/dev/null"
@@ -222,4 +223,18 @@ func newUnixDirent(parent, name string, typ FileMode) (DirEntry, error) {
 	ude.typ = info.Mode().Type()
 	ude.info = info
 	return ude, nil
+}
+
+// Since internal/poll is not available, we need to stub this out.
+// Big go requires the option to add the fd to the polling system.
+//
+//go:linkname net_newUnixFile net.newUnixFile
+func net_newUnixFile(fd int, name string) *File {
+	if fd < 0 {
+		panic("invalid FD")
+	}
+
+	// see src/os/file_unix.go:162 newFile for the original implementation.
+	// return newFile(fd, name, kindSock, true)
+	return NewFile(uintptr(fd), name)
 }


### PR DESCRIPTION
Building the u-root cmdlet `sluinit` with my experimental `net` PR #4498 following error occurs:

```
/usr/local/go/src/net/fd_unix.go:205: linker could not find symbol net.newUnixFile
``` 

This PR resolves the issue of the missing function `net_newUnixFile` and links it into the net package.

Since this package implements functionality for the linux net package, this code can currently not really be tested (see #4498).