### PR TITLE
Various improved error checks

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -25,6 +25,7 @@ func TestErrors(t *testing.T) {
 		{name: "compiler"},
 		{name: "interp"},
 		{name: "invalidmain"},
+		{name: "invalidname"},
 		{name: "linker-flashoverflow", target: "cortex-m-qemu"},
 		{name: "linker-ramoverflow", target: "cortex-m-qemu"},
 		{name: "linker-undefined", target: "darwin/arm64"},

--- a/errors_test.go
+++ b/errors_test.go
@@ -24,6 +24,7 @@ func TestErrors(t *testing.T) {
 		{name: "cgo"},
 		{name: "compiler"},
 		{name: "interp"},
+		{name: "invalidmain"},
 		{name: "linker-flashoverflow", target: "cortex-m-qemu"},
 		{name: "linker-ramoverflow", target: "cortex-m-qemu"},
 		{name: "linker-undefined", target: "darwin/arm64"},

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -34,19 +34,25 @@ func GetGorootVersion() (major, minor int, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	return Parse(s)
+}
 
-	if s == "" || s[:2] != "go" {
+// Parse parses the Go version (like "go1.3.2") in the parameter and return the
+// major and minor version: 1 and 3 in this example. If there is an error, (0,
+// 0) and an error will be returned.
+func Parse(version string) (major, minor int, err error) {
+	if version == "" || version[:2] != "go" {
 		return 0, 0, errors.New("could not parse Go version: version does not start with 'go' prefix")
 	}
 
-	parts := strings.Split(s[2:], ".")
+	parts := strings.Split(version[2:], ".")
 	if len(parts) < 2 {
 		return 0, 0, errors.New("could not parse Go version: version has less than two parts")
 	}
 
 	// Ignore the errors, we don't really handle errors here anyway.
 	var trailing string
-	n, err := fmt.Sscanf(s, "go%d.%d%s", &major, &minor, &trailing)
+	n, err := fmt.Sscanf(version, "go%d.%d%s", &major, &minor, &trailing)
 	if n == 2 && err == io.EOF {
 		// Means there were no trailing characters (i.e., not an alpha/beta)
 		err = nil

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -418,8 +418,12 @@ func (p *Package) Check() error {
 	packageName := p.ImportPath
 	if p == p.program.MainPkg() {
 		if p.Name != "main" {
-			// Sanity check. Should not ever trigger.
-			panic("expected main package to have name 'main'")
+			return Errors{p, []error{
+				scanner.Error{
+					Pos: p.program.fset.Position(p.Files[0].Name.Pos()),
+					Msg: fmt.Sprintf("expected main package to have name \"main\", not %#v", p.Name),
+				},
+			}}
 		}
 		packageName = "main"
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -432,7 +432,15 @@ func (p *Package) Check() error {
 		if err, ok := err.(Errors); ok {
 			return err
 		}
-		return Errors{p, typeErrors}
+		if len(typeErrors) != 0 {
+			// Got type errors, so return them.
+			return Errors{p, typeErrors}
+		}
+		// This can happen in some weird cases.
+		// The only case I know is when compiling a Go 1.23 program, with a
+		// TinyGo version that supports Go 1.23 but is compiled using Go 1.22.
+		// So this should be pretty rare.
+		return Errors{p, []error{err}}
 	}
 	p.Pkg = typesPkg
 

--- a/testdata/errors/invalidmain.go
+++ b/testdata/errors/invalidmain.go
@@ -1,0 +1,6 @@
+// some comment to move the first line
+
+package foobar
+
+// ERROR: # command-line-arguments
+// ERROR: invalidmain.go:3:9: expected main package to have name "main", not "foobar"

--- a/testdata/errors/invalidname.go
+++ b/testdata/errors/invalidname.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "github.com/tinygo-org/tinygo/testdata/errors/invalidname"
+
+// ERROR: # github.com/tinygo-org/tinygo/testdata/errors/invalidname
+// ERROR: invalidname{{[\\/]}}invalidname.go:3:9: invalid package name _

--- a/testdata/errors/invalidname/invalidname.go
+++ b/testdata/errors/invalidname/invalidname.go
@@ -1,0 +1,3 @@
+// some comment to move the 'package' line
+
+package _


### PR DESCRIPTION
This is a bunch of small error checking and reporting changes.

Most importantly, it will now check whether TinyGo has been compiled with a too-old Go toolchain version. This should make issues like the following much clearer: https://github.com/NixOS/nixpkgs/pull/341170#issuecomment-2359237471
It may be overly aggressive though: compiling a package that specifies a newer Go version than the one TinyGo was compiled with may still work if there weren't any language changes. But in that case, the real issue is probably packaging: TinyGo should have been compiled with the newest Go version that it supports.