### PR TITLE
ci: use macos-13 instead of macos-12 for amd64 builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,11 +16,11 @@ jobs:
     name: build-macos
     strategy:
       matrix:
-        # macos-12: amd64 (oldest supported version as of 05-02-2024)
+        # macos-13: amd64 (oldest supported version as of 18-10-2024)
         # macos-14: arm64 (oldest arm64 version)
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
         include:
-          - os: macos-12
+          - os: macos-13
             goarch: amd64
           - os: macos-14
             goarch: arm64


### PR DESCRIPTION
The macos-12 runner is being deprecated, so we have to switch to a new runner: https://github.com/actions/runner-images/issues/10721

The next one is macos-13, which is still amd64.