### PR TITLE
goenv: parse patch version, add func Compare to compare two Go version strings

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -43,7 +43,7 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	// compiled with the latest Go version.
 	// This may be a bit too aggressive: if the newer version doesn't change the
 	// Go language we will most likely be able to compile it.
-	buildMajor, buildMinor, err := goenv.Parse(runtime.Version())
+	buildMajor, buildMinor, _, err := goenv.Parse(runtime.Version())
 	if err != nil {
 		return nil, err
 	}

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -74,6 +74,28 @@ func WantGoVersion(s string, major, minor int) bool {
 	return ma > major || (ma == major && mi >= minor)
 }
 
+// Compare compares two Go version strings.
+// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
+// If either a or b is not a valid Go version, it is treated as "go0.0"
+// and compared lexicographically.
+// See [Parse] for more information.
+func Compare(a, b string) int {
+	aMajor, aMinor, _ := Parse(a)
+	bMajor, bMinor, _ := Parse(b)
+	switch {
+	case aMajor < bMajor:
+		return -1
+	case aMajor > bMajor:
+		return +1
+	case aMinor < bMinor:
+		return -1
+	case aMinor > bMinor:
+		return +1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
 // GorootVersionString returns the version string as reported by the Go
 // toolchain. It is usually of the form `go1.x.y` but can have some variations
 // (for beta releases, for example).

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -68,16 +68,6 @@ func Parse(version string) (major, minor, patch int, err error) {
 	return major, minor, patch, nil
 }
 
-// WantGoVersion returns true if Go version s is >= major and minor.
-// Returns false if s is not a valid Go version string. See [Parse] for more information.
-func WantGoVersion(s string, major, minor int) bool {
-	ma, mi, _, err := Parse(s)
-	if err != nil {
-		return false
-	}
-	return ma > major || (ma == major && mi >= minor)
-}
-
 // Compare compares two Go version strings.
 // The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
 // If either a or b is not a valid Go version, it is treated as "go0.0"

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -71,7 +71,7 @@ func WantGoVersion(s string, major, minor int) bool {
 	if err != nil {
 		return false
 	}
-	return ma >= major && mi >= minor
+	return ma > major || (ma == major && mi >= minor)
 }
 
 // GorootVersionString returns the version string as reported by the Go

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -60,7 +60,18 @@ func Parse(version string) (major, minor int, err error) {
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to parse version: %s", err)
 	}
-	return
+
+	return major, minor, nil
+}
+
+// WantGoVersion returns true if Go version s is >= major and minor.
+// Returns false if s is not a valid Go version string. See [Parse] for more information.
+func WantGoVersion(s string, major, minor int) bool {
+	ma, mi, err := Parse(s)
+	if err != nil {
+		return false
+	}
+	return ma >= major && mi >= minor
 }
 
 // GorootVersionString returns the version string as reported by the Go

--- a/goenv/version_test.go
+++ b/goenv/version_test.go
@@ -36,3 +36,33 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestWantGoVersion(t *testing.T) {
+	tests := []struct {
+		v     string
+		major int
+		minor int
+		want  bool
+	}{
+		{"", 0, 0, false},
+		{"go", 0, 0, false},
+		{"go1", 0, 0, false},
+		{"go.0", 0, 0, false},
+		{"go1.0", 1, 0, true},
+		{"go1.1", 1, 1, true},
+		{"go1.23", 1, 23, true},
+		{"go1.23.5", 1, 23, true},
+		{"go1.23.5-rc6", 1, 23, true},
+		{"go2.0", 1, 23, true},
+		{"go2.0", 2, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.v, func(t *testing.T) {
+			got := WantGoVersion(tt.v, tt.major, tt.minor)
+			if got != tt.want {
+				t.Errorf("WantGoVersion(%q, %d, %d): expected %t; got %t",
+					tt.v, tt.major, tt.minor, tt.want, got)
+			}
+		})
+	}
+}

--- a/goenv/version_test.go
+++ b/goenv/version_test.go
@@ -39,36 +39,6 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestWantGoVersion(t *testing.T) {
-	tests := []struct {
-		v     string
-		major int
-		minor int
-		want  bool
-	}{
-		{"", 0, 0, false},
-		{"go", 0, 0, false},
-		{"go1", 0, 0, false},
-		{"go.0", 0, 0, false},
-		{"go1.0", 1, 0, true},
-		{"go1.1", 1, 1, true},
-		{"go1.23", 1, 23, true},
-		{"go1.23.5", 1, 23, true},
-		{"go1.23.5-rc6", 1, 23, true},
-		{"go2.0", 1, 23, true},
-		{"go2.0", 2, 0, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.v, func(t *testing.T) {
-			got := WantGoVersion(tt.v, tt.major, tt.minor)
-			if got != tt.want {
-				t.Errorf("WantGoVersion(%q, %d, %d): expected %t; got %t",
-					tt.v, tt.major, tt.minor, tt.want, got)
-			}
-		})
-	}
-}
-
 func TestCompare(t *testing.T) {
 	tests := []struct {
 		a    string

--- a/goenv/version_test.go
+++ b/goenv/version_test.go
@@ -1,0 +1,38 @@
+package goenv
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		v       string
+		major   int
+		minor   int
+		wantErr bool
+	}{
+		{"", 0, 0, true},
+		{"go", 0, 0, true},
+		{"go1", 0, 0, true},
+		{"go.0", 0, 0, true},
+		{"go1.0", 1, 0, false},
+		{"go1.1", 1, 1, false},
+		{"go1.23", 1, 23, false},
+		{"go1.23.5", 1, 23, false},
+		{"go1.23.5-rc6", 1, 23, false},
+		{"go2.0", 2, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.v, func(t *testing.T) {
+			major, minor, err := Parse(tt.v)
+			if err == nil && tt.wantErr {
+				t.Errorf("Parse(%q): expected err != nil", tt.v)
+			}
+			if err != nil && !tt.wantErr {
+				t.Errorf("Parse(%q): expected err == nil", tt.v)
+			}
+			if major != tt.major || minor != tt.minor {
+				t.Errorf("Parse(%q): expected %d, %d, nil; got %d, %d, %v",
+					tt.v, tt.major, tt.minor, major, minor, err)
+			}
+		})
+	}
+}

--- a/goenv/version_test.go
+++ b/goenv/version_test.go
@@ -7,31 +7,33 @@ func TestParse(t *testing.T) {
 		v       string
 		major   int
 		minor   int
+		patch   int
 		wantErr bool
 	}{
-		{"", 0, 0, true},
-		{"go", 0, 0, true},
-		{"go1", 0, 0, true},
-		{"go.0", 0, 0, true},
-		{"go1.0", 1, 0, false},
-		{"go1.1", 1, 1, false},
-		{"go1.23", 1, 23, false},
-		{"go1.23.5", 1, 23, false},
-		{"go1.23.5-rc6", 1, 23, false},
-		{"go2.0", 2, 0, false},
+		{"", 0, 0, 0, true},
+		{"go", 0, 0, 0, true},
+		{"go1", 0, 0, 0, true},
+		{"go.0", 0, 0, 0, true},
+		{"go1.0", 1, 0, 0, false},
+		{"go1.1", 1, 1, 0, false},
+		{"go1.23", 1, 23, 0, false},
+		{"go1.23.5", 1, 23, 5, false},
+		{"go1.23.5-rc6", 1, 23, 5, false},
+		{"go2.0", 2, 0, 0, false},
+		{"go2.0.15", 2, 0, 15, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.v, func(t *testing.T) {
-			major, minor, err := Parse(tt.v)
+			major, minor, patch, err := Parse(tt.v)
 			if err == nil && tt.wantErr {
 				t.Errorf("Parse(%q): expected err != nil", tt.v)
 			}
 			if err != nil && !tt.wantErr {
 				t.Errorf("Parse(%q): expected err == nil", tt.v)
 			}
-			if major != tt.major || minor != tt.minor {
-				t.Errorf("Parse(%q): expected %d, %d, nil; got %d, %d, %v",
-					tt.v, tt.major, tt.minor, major, minor, err)
+			if major != tt.major || minor != tt.minor || patch != tt.patch {
+				t.Errorf("Parse(%q): expected %d, %d, %d, nil; got %d, %d, %d, %v",
+					tt.v, tt.major, tt.minor, tt.patch, major, minor, patch, err)
 			}
 		})
 	}
@@ -84,7 +86,8 @@ func TestCompare(t *testing.T) {
 		{"go1.1.0", "go1.2.0", -1},
 		{"go1.2.0", "go1.1.0", 1},
 		{"go1.2.0", "go2.3.0", -1},
-		// {"go1.23.2", "go1.23.10", -1}, // FIXME: parse patch number
+		{"go1.23.2", "go1.23.10", -1},
+		{"go0.1.22", "go1.23.101", -1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.a+" "+tt.b, func(t *testing.T) {

--- a/goenv/version_test.go
+++ b/goenv/version_test.go
@@ -66,3 +66,33 @@ func TestWantGoVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		a    string
+		b    string
+		want int
+	}{
+		{"", "", 0},
+		{"go0", "go0", 0},
+		{"go0", "go1", -1},
+		{"go1", "go0", 1},
+		{"go1", "go2", -1},
+		{"go2", "go1", 1},
+		{"go1.1", "go1.2", -1},
+		{"go1.2", "go1.1", 1},
+		{"go1.1.0", "go1.2.0", -1},
+		{"go1.2.0", "go1.1.0", 1},
+		{"go1.2.0", "go2.3.0", -1},
+		// {"go1.23.2", "go1.23.10", -1}, // FIXME: parse patch number
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+" "+tt.b, func(t *testing.T) {
+			got := Compare(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("Compare(%q, %q): expected %d; got %d",
+					tt.a, tt.b, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements 3 changes:

- `goenv.Parse` now parses patch version out of a Go version string.
- Adds `goenv.Compare` to compare two Go version strings. This is used in #4501 to enable `structs.HostLayout` enforcement.
- Adds tests for `Parse` and `Compare`.

Extracted from #4501.