### PR TITLE
esp32c3: add smoke tests for a few boards

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -841,6 +841,12 @@ endif
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=xiao-esp32c3        examples/machinetest
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=esp32-c3-devkit-rust-1 examples/blinky1
+	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=esp32c3-12f         examples/blinky1
+	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=makerfabs-esp32c3spi35 examples/machinetest
+	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.hex -target=hifive1b            examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=maixbit             examples/blinky1

--- a/src/machine/board_esp32-c3-devkit-rust-1.go
+++ b/src/machine/board_esp32-c3-devkit-rust-1.go
@@ -64,8 +64,8 @@ const (
 
 // I2C pins
 const (
-	I2C_SCL_PIN = D8
-	I2C_SDA_PIN = D10
+	SCL_PIN = D8
+	SDA_PIN = D10
 )
 
 // USBCDC pins

--- a/src/machine/board_esp32c3-12f.go
+++ b/src/machine/board_esp32c3-12f.go
@@ -46,3 +46,9 @@ const (
 	UART_TX_PIN = TXD
 	UART_RX_PIN = RXD
 )
+
+// I2C pins
+const (
+	SCL_PIN = NoPin
+	SDA_PIN = NoPin
+)

--- a/src/machine/board_makerfabs-esp32c3spi35.go
+++ b/src/machine/board_makerfabs-esp32c3spi35.go
@@ -64,8 +64,8 @@ const (
 // Touchscreen pins
 const (
 	TS_CS_PIN  = D0
-	TS_SDA_PIN = I2C_SDA_PIN
-	TS_SCL_PIN = I2C_SCL_PIN
+	TS_SDA_PIN = SDA_PIN
+	TS_SCL_PIN = SCL_PIN
 )
 
 // MicroSD pins
@@ -90,8 +90,8 @@ const (
 
 // I2C pins
 const (
-	I2C_SDA_PIN = D2
-	I2C_SCL_PIN = D3
+	SDA_PIN = D2
+	SCL_PIN = D3
 )
 
 // SPI pins


### PR DESCRIPTION
These boards probably haven't been working since the addition of I2C, because they were missing some constants in the machine package.