### PR TITLE
fe310: support GPIO PinInput

### DIFF
--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -26,6 +26,8 @@ const (
 func (p Pin) Configure(config PinConfig) {
 	sifive.GPIO0.INPUT_EN.SetBits(1 << uint8(p))
 	switch config.Mode {
+	case PinInput:
+		sifive.GPIO0.OUTPUT_EN.ClearBits(1 << uint8(p))
 	case PinOutput:
 		sifive.GPIO0.OUTPUT_EN.SetBits(1 << uint8(p))
 	case PinPWM:


### PR DESCRIPTION
This is needed to support switching between input and output.