### PR TITLE
wasm: use precise GC for WebAssembly (including WASI)

### DIFF
--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -30,3 +30,6 @@ type Task struct {
 // the given function and falls back to the default stack size. It is replaced
 // with a load from a special section just before codegen.
 func getGoroutineStackSize(fn uintptr) uintptr
+
+//go:linkname runtime_alloc runtime.alloc
+func runtime_alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer

--- a/src/internal/task/task_stack.go
+++ b/src/internal/task/task_stack.go
@@ -104,9 +104,6 @@ var startTask [0]uint8
 //go:linkname runqueuePushBack runtime.runqueuePushBack
 func runqueuePushBack(*Task)
 
-//go:linkname runtime_alloc runtime.alloc
-func runtime_alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
-
 // start creates and starts a new goroutine with the given function and arguments.
 // The new goroutine is scheduled to run later.
 func start(fn uintptr, args unsafe.Pointer, stackSize uintptr) {

--- a/targets/wasip1.json
+++ b/targets/wasip1.json
@@ -8,6 +8,7 @@
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"rtlib":         "compiler-rt",
+	"gc":            "precise",
 	"scheduler":     "asyncify",
 	"default-stack-size": 65536,
 	"cflags": [

--- a/targets/wasip2.json
+++ b/targets/wasip2.json
@@ -9,6 +9,7 @@
 	"linker":        "wasm-ld",
 	"libc":          "wasmbuiltins",
 	"rtlib":         "compiler-rt",
+	"gc":            "precise",
 	"scheduler":     "asyncify",
 	"default-stack-size": 65536,
 	"cflags": [

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -8,6 +8,7 @@
 	"linker":        "wasm-ld",
 	"libc":          "wasi-libc",
 	"rtlib":         "compiler-rt",
+	"gc":            "precise",
 	"scheduler":     "asyncify",
 	"default-stack-size": 65536,
 	"cflags": [


### PR DESCRIPTION
With a few small modifications, all the problems with `-gc=precise` in WebAssembly seem to have been fixed.

I didn't do any performance measurements, but this is supposed to improve GC performance.

One issue was that it was allocating a `[]uintptr` for the stack, even though the stack can contain pointers. Another issue was a bad check for stack overflows that triggered when it should not.