### PR TITLE
main: parse extldflags early so we can report the error message

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -406,15 +406,7 @@ func (c *Config) LDFlags() []string {
 	if c.Target.LinkerScript != "" {
 		ldflags = append(ldflags, "-T", c.Target.LinkerScript)
 	}
-
-	if c.Options.ExtLDFlags != "" {
-		ext, err := shlex.Split(c.Options.ExtLDFlags)
-		if err != nil {
-			// if shlex can't split it, pass it as-is and let the external linker complain
-			ext = []string{c.Options.ExtLDFlags}
-		}
-		ldflags = append(ldflags, ext...)
-	}
+	ldflags = append(ldflags, c.Options.ExtLDFlags...)
 
 	return ldflags
 }

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -58,7 +58,7 @@ type Options struct {
 	Timeout         time.Duration
 	WITPackage      string // pass through to wasm-tools component embed invocation
 	WITWorld        string // pass through to wasm-tools component embed -w option
-	ExtLDFlags      string
+	ExtLDFlags      []string
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/main.go
+++ b/main.go
@@ -1639,10 +1639,17 @@ func main() {
 		Timeout:         *timeout,
 		WITPackage:      witPackage,
 		WITWorld:        witWorld,
-		ExtLDFlags:      extLDFlags,
 	}
 	if *printCommands {
 		options.PrintCommands = printCommand
+	}
+
+	if extLDFlags != "" {
+		options.ExtLDFlags, err = shlex.Split(extLDFlags)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "could not parse -extldflags:", err)
+			os.Exit(1)
+		}
 	}
 
 	err = options.Verify()


### PR DESCRIPTION
This avoids some weird behavior when the -extldflags flag cannot be parsed by TinyGo.