### PR TITLE
ci: use TinyGo version in artifact files

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Extract TinyGo version
+        id: version
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -104,7 +107,7 @@ jobs:
       - name: Test stdlib packages
         run: make tinygo-test
       - name: Make release artifact
-        run: cp -p build/release.tar.gz build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
+        run: cp -p build/release.tar.gz build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
         # Note: this release artifact is double-zipped, see:
         # https://github.com/actions/upload-artifact/issues/39
@@ -114,8 +117,8 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v4
         with:
-          name: darwin-${{ matrix.goarch }}-double-zipped
-          path: build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
+          name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
+          path: build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Smoke tests
         run: make smoketest TINYGO=$(PWD)/build/tinygo
   test-macos-homebrew:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.23-alpine
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Install apk dependencies
         # tar: needed for actions/cache@v4
@@ -32,6 +34,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Extract TinyGo version
+        id: version
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
       - name: Cache Go
         uses: actions/cache@v4
         with:
@@ -120,15 +125,15 @@ jobs:
       - name: Build TinyGo release
         run: |
           make release deb -j3 STATIC=1
-          cp -p build/release.tar.gz /tmp/tinygo.linux-amd64.tar.gz
-          cp -p build/release.deb    /tmp/tinygo_amd64.deb
+          cp -p build/release.tar.gz /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
+          cp -p build/release.deb    /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
       - name: Publish release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-amd64-double-zipped
+          name: linux-amd64-double-zipped-${{ steps.version.outputs.version }}
           path: |
-            /tmp/tinygo.linux-amd64.tar.gz
-            /tmp/tinygo_amd64.deb
+            /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
+            /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
   test-linux-build:
     # Test the binaries built in the build-linux job by running the smoke tests.
     runs-on: ubuntu-latest
@@ -152,11 +157,11 @@ jobs:
       - name: Download release artifact
         uses: actions/download-artifact@v4
         with:
-          name: linux-amd64-double-zipped
+          name: linux-amd64-double-zipped-${{ needs.build-linux.outputs.version }}
       - name: Extract release tarball
         run: |
           mkdir -p ~/lib
-          tar -C ~/lib -xf tinygo.linux-amd64.tar.gz
+          tar -C ~/lib -xf tinygo${{ needs.build-linux.outputs.version }}.linux-amd64.tar.gz
           ln -s ~/lib/tinygo/bin/tinygo ~/go/bin/tinygo
       - run: make tinygo-test-wasip1-fast
       - run: make tinygo-test-wasip2-fast
@@ -297,6 +302,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Get TinyGo version
+        id: version
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
       - name: Install apt dependencies
         run: |
           sudo apt-get update
@@ -381,11 +389,11 @@ jobs:
       - name: Download amd64 release
         uses: actions/download-artifact@v4
         with:
-          name: linux-amd64-double-zipped
+          name: linux-amd64-double-zipped-${{ needs.build-linux.outputs.version }}
       - name: Extract amd64 release
         run: |
           mkdir -p build/release
-          tar -xf tinygo.linux-amd64.tar.gz -C build/release tinygo
+          tar -xf tinygo${{ needs.build-linux.outputs.version }}.linux-amd64.tar.gz -C build/release tinygo
       - name: Modify release
         run: |
           cp -p build/tinygo   build/release/tinygo/bin
@@ -393,12 +401,12 @@ jobs:
       - name: Create ${{ matrix.goarch }} release
         run: |
           make release deb RELEASEONLY=1 DEB_ARCH=${{ matrix.libc }}
-          cp -p build/release.tar.gz /tmp/tinygo.linux-${{ matrix.goarch }}.tar.gz
-          cp -p build/release.deb    /tmp/tinygo_${{ matrix.libc }}.deb
+          cp -p build/release.tar.gz /tmp/tinygo${{ steps.version.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
+          cp -p build/release.deb    /tmp/tinygo_${{ steps.version.outputs.version }}_${{ matrix.libc }}.deb
       - name: Publish release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.goarch }}-double-zipped
+          name: linux-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
           path: |
-            /tmp/tinygo.linux-${{ matrix.goarch }}.tar.gz
-            /tmp/tinygo_${{ matrix.libc }}.deb
+            /tmp/tinygo${{ steps.version.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
+            /tmp/tinygo_${{ steps.version.outputs.version }}_${{ matrix.libc }}.deb

--- a/.github/workflows/tinygo-extract-version.sh
+++ b/.github/workflows/tinygo-extract-version.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Extract the version string from the source code, to be stored in a variable.
+grep 'const version' goenv/version.go | sed 's/^const version = "\(.*\)"$/version=\1/g'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   build-windows:
     runs-on: windows-2022
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Configure pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
@@ -32,6 +34,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Extract TinyGo version
+        id: version
+        shell: bash
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -108,7 +114,7 @@ jobs:
       - name: Make release artifact
         shell: bash
         working-directory: build/release
-        run: 7z -tzip a release.zip tinygo
+        run: 7z -tzip a tinygo${{ steps.version.outputs.version }}.windows-amd64.zip tinygo
       - name: Publish release artifact
         # Note: this release artifact is double-zipped, see:
         # https://github.com/actions/upload-artifact/issues/39
@@ -118,8 +124,8 @@ jobs:
         # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v4
         with:
-          name: windows-amd64-double-zipped
-          path: build/release/release.zip
+          name: windows-amd64-double-zipped-${{ steps.version.outputs.version }}
+          path: build/release/tinygo${{ steps.version.outputs.version }}.windows-amd64.zip
 
   smoke-test-windows:
     runs-on: windows-2022
@@ -148,12 +154,12 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
         with:
-          name: windows-amd64-double-zipped
+          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
           path: build/
       - name: Unzip TinyGo build
         shell: bash
         working-directory: build
-        run: 7z x release.zip -r
+        run: 7z x tinygo*.windows-amd64.zip -r
       - name: Smoke tests
         shell: bash
         run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo
@@ -178,12 +184,12 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
         with:
-          name: windows-amd64-double-zipped
+          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
           path: build/
       - name: Unzip TinyGo build
         shell: bash
         working-directory: build
-        run: 7z x release.zip -r
+        run: 7z x tinygo*.windows-amd64.zip -r
       - name: Test stdlib packages
         run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
@@ -214,11 +220,11 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
         with:
-          name: windows-amd64-double-zipped
+          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
           path: build/
       - name: Unzip TinyGo build
         shell: bash
         working-directory: build
-        run: 7z x release.zip -r
+        run: 7z x tinygo*.windows-amd64.zip -r
       - name: Test stdlib packages on wasip1
         run: make tinygo-test-wasip1-fast TINYGO=$(PWD)/build/tinygo/bin/tinygo


### PR DESCRIPTION
This avoids needing to rename them ourselves (which is kinda annoying) and also avoids mistakes in the process.