### PR TITLE
ci: remove 'shell: bash' lines from MacOS build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Dependencies
-        shell: bash
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu binaryen
       - name: Checkout
@@ -72,7 +71,6 @@ jobs:
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
-        shell: bash
         run: |
           # fetch LLVM source
           rm -rf llvm-project
@@ -100,14 +98,12 @@ jobs:
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo
-        shell: bash
         run: make test GOTESTFLAGS="-short"
       - name: Build TinyGo release tarball
         run: make release -j3
       - name: Test stdlib packages
         run: make tinygo-test
       - name: Make release artifact
-        shell: bash
         run: cp -p build/release.tar.gz build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
         # Note: this release artifact is double-zipped, see:
@@ -121,7 +117,6 @@ jobs:
           name: darwin-${{ matrix.goarch }}-double-zipped
           path: build/tinygo.darwin-${{ matrix.goarch }}.tar.gz
       - name: Smoke tests
-        shell: bash
         run: make smoketest TINYGO=$(PWD)/build/tinygo
   test-macos-homebrew:
     name: homebrew-install


### PR DESCRIPTION
Unlike Windows, we can just use the default shell here.