### PR TITLE
runtime: rewrite channel implementation

### DIFF
--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -3,7 +3,7 @@ source_filename = "channel.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-%runtime.channelBlockedList = type { ptr, ptr, ptr, { ptr, i32, i32 } }
+%runtime.channelOp = type { ptr, ptr, i32, ptr }
 %runtime.chanSelectState = type { ptr, ptr }
 
 ; Function Attrs: allockind("alloc,zeroed") allocsize(0)
@@ -18,15 +18,15 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
+define hidden void @main.chanIntSend(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  %chan.blockedList = alloca %runtime.channelBlockedList, align 8
+  %chan.op = alloca %runtime.channelOp, align 8
   %chan.value = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
   store i32 3, ptr %chan.value, align 4
-  call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  call void @runtime.chanSend(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #4
-  call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
+  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @runtime.chanSend(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.op, ptr undef) #4
+  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
   ret void
 }
@@ -34,48 +34,48 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3
 
-declare void @runtime.chanSend(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #1
+declare void @runtime.chanSend(ptr dereferenceable_or_null(36), ptr, ptr dereferenceable_or_null(16), ptr) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3
 
 ; Function Attrs: nounwind
-define hidden void @main.chanIntRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
+define hidden void @main.chanIntRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  %chan.blockedList = alloca %runtime.channelBlockedList, align 8
+  %chan.op = alloca %runtime.channelOp, align 8
   %chan.value = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
-  call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.blockedList, ptr undef) #4
+  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.op, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
-  call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
+  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
   ret void
 }
 
-declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(32), ptr, ptr dereferenceable_or_null(24), ptr) #1
+declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(36), ptr, ptr dereferenceable_or_null(16), ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
+define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  %chan.blockedList = alloca %runtime.channelBlockedList, align 8
-  call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #4
-  call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
+  %chan.op = alloca %runtime.channelOp, align 8
+  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.op, ptr undef) #4
+  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.chanZeroRecv(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
+define hidden void @main.chanZeroRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #2 {
 entry:
-  %chan.blockedList = alloca %runtime.channelBlockedList, align 8
-  call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %chan.blockedList)
-  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr null, ptr nonnull %chan.blockedList, ptr undef) #4
-  call void @llvm.lifetime.end.p0(i64 24, ptr nonnull %chan.blockedList)
+  %chan.op = alloca %runtime.channelOp, align 8
+  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  %0 = call i1 @runtime.chanRecv(ptr %ch, ptr null, ptr nonnull %chan.op, ptr undef) #4
+  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.selectZeroRecv(ptr dereferenceable_or_null(32) %ch1, ptr dereferenceable_or_null(32) %ch2, ptr %context) unnamed_addr #2 {
+define hidden void @main.selectZeroRecv(ptr dereferenceable_or_null(36) %ch1, ptr dereferenceable_or_null(36) %ch2, ptr %context) unnamed_addr #2 {
 entry:
   %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
   %select.send.value = alloca i32, align 4
@@ -88,7 +88,7 @@ entry:
   store ptr %ch2, ptr %0, align 4
   %.repack3 = getelementptr inbounds [2 x %runtime.chanSelectState], ptr %select.states.alloca, i32 0, i32 1, i32 1
   store ptr null, ptr %.repack3, align 4
-  %select.result = call { i32, i1 } @runtime.tryChanSelect(ptr undef, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr undef) #4
+  %select.result = call { i32, i1 } @runtime.chanSelect(ptr undef, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr null, i32 0, i32 0, ptr undef) #4
   call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %select.states.alloca)
   %1 = extractvalue { i32, i1 } %select.result, 0
   %2 = icmp eq i32 %1, 0
@@ -105,7 +105,7 @@ select.body:                                      ; preds = %select.next
   br label %select.done
 }
 
-declare { i32, i1 } @runtime.tryChanSelect(ptr, ptr, i32, i32, ptr) #1
+declare { i32, i1 } @runtime.chanSelect(ptr, ptr, i32, i32, ptr, i32, i32, ptr) #1
 
 attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }
 attributes #1 = { "target-features"="+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext" }

--- a/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
@@ -135,13 +135,13 @@ entry:
 declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #2
 
 ; Function Attrs: nounwind
-define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #1 {
+define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
 entry:
   call void @runtime.chanClose(ptr %ch, ptr undef) #9
   ret void
 }
 
-declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #2
+declare void @runtime.chanClose(ptr dereferenceable_or_null(36), ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.startInterfaceMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #1 {

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -144,13 +144,13 @@ entry:
 declare i32 @runtime.sliceCopy(ptr nocapture writeonly, ptr nocapture readonly, i32, i32, i32, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(32) %ch, ptr %context) unnamed_addr #2 {
+define hidden void @main.closeBuiltinGoroutine(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #2 {
 entry:
   call void @runtime.chanClose(ptr %ch, ptr undef) #9
   ret void
 }
 
-declare void @runtime.chanClose(ptr dereferenceable_or_null(32), ptr) #1
+declare void @runtime.chanClose(ptr dereferenceable_or_null(36), ptr) #1
 
 ; Function Attrs: nounwind
 define hidden void @main.startInterfaceMethod(ptr %itf.typecode, ptr %itf.value, ptr %context) unnamed_addr #2 {


### PR DESCRIPTION
This rewrite simplifies the channel implementation considerably, with 34% fewer LOC. Perhaps the most important change is the removal of the channel state, which made sense when we had only send and receive operations but only makes things more compliated when multiple select operations can be pending on a single channel.

I did this rewrite originally to make it possible to make channels parallelism-safe (see https://github.com/tinygo-org/tinygo/issues/2446). The current implementation is not parallelism-safe, but it will be easy to make it so (the main additions will be a channel lock, a global select lock, and an atomic compare-and-swap in chanQueue.pop).

This change also reduces binary size: for the driver examples that do change (presumably the ones that use a channel), the code size is reduced by around 400 bytes.