### PR TITLE
Prepare leaking GC for multithreading

### DIFF
--- a/src/internal/task/pmutex-cooperative.go
+++ b/src/internal/task/pmutex-cooperative.go
@@ -1,0 +1,16 @@
+package task
+
+// PMutex is a real mutex on systems that can be either preemptive or threaded,
+// and a dummy lock on other (purely cooperative) systems.
+//
+// It is mainly useful for short operations that need a lock when threading may
+// be involved, but which do not need a lock with a purely cooperative
+// scheduler.
+type PMutex struct {
+}
+
+func (m *PMutex) Lock() {
+}
+
+func (m *PMutex) Unlock() {
+}


### PR DESCRIPTION
This makes the leaking GC (`-gc=leaking`) ready for multithreading. The leaking GC is the easiest real heap allocator to add support for, since it can increment the heap pointer with a simple atomic add operation.
This PR does not actually make the leaking GC support multithreading, but it makes it very easy to do so in the future simply by changing the new llsync package (see https://github.com/tinygo-org/tinygo/pull/4559).

This is the first PR of (hopefully) a bunch to follow that will gradually add support for multithreading to various parts of TinyGo. I split it in many pieces to make it hopefully easier to review.

This PR is intended to be merged by rebasing.