### PR TITLE
ci: run at least some tests on older Go/LLVM versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ commands:
               name: Check Go code formatting
               command: make fmt-check lint
       - run: make gen-device -j4
+      # TODO: change this to -skip='TestErrors|TestWasm' with Go 1.20
+      - run: go test -tags=llvm<<parameters.llvm>> -short -run='TestBuild|TestTest|TestGetList|TestTraceback'
       - run: make smoketest XTENSA=0
       - save_cache:
           key: go-cache-v4-{{ checksum "go.mod" }}-{{ .Environment.CIRCLE_BUILD_NUM }}

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -517,12 +516,26 @@ func TestWebAssembly(t *testing.T) {
 						}
 					}
 				}
-				if !slices.Equal(imports, tc.imports) {
+				if !stringSlicesEqual(imports, tc.imports) {
 					t.Errorf("import list not as expected!\nexpected: %v\nactual:   %v", tc.imports, imports)
 				}
 			}
 		})
 	}
+}
+
+func stringSlicesEqual(s1, s2 []string) bool {
+	// We can use slices.Equal once we drop support for Go 1.20 (it was added in
+	// Go 1.21).
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i, s := range s1 {
+		if s != s2[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestWasmExport(t *testing.T) {


### PR DESCRIPTION
These should make sure basic functionality is still working. Using the `-short` flag to avoid taking too long to run all tests (and to install all the necessary emulators), and because some targets might not work in older Go/LLVM versions (such as WASI).