### PR TITLE
test: show output even when a test binary didn't exit cleanly

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -429,6 +429,9 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		for _, line := range strings.Split(strings.TrimRight(w.String(), "\n"), "\n") {
 			t.Log(line)
 		}
+		if stdout.Len() != 0 {
+			t.Logf("output:\n%s", stdout.String())
+		}
 		t.Fail()
 		return
 	}


### PR DESCRIPTION
This was a problem on wasm, where `node` would exit with a non-zero exit code when there was a panic.