### PR TITLE
wasm: use wasip1 API for parameter/env passing

### DIFF
--- a/main.go
+++ b/main.go
@@ -770,12 +770,11 @@ func Run(pkgName string, options *compileopts.Options, cmdArgs []string) error {
 // for the given emulator.
 func buildAndRun(pkgName string, config *compileopts.Config, stdout io.Writer, cmdArgs, environmentVars []string, timeout time.Duration, run func(cmd *exec.Cmd, result builder.BuildResult) error) (builder.BuildResult, error) {
 	// Determine whether we're on a system that supports environment variables
-	// and command line parameters (operating systems, WASI) or not (baremetal,
-	// WebAssembly in the browser). If we're on a system without an environment,
-	// we need to pass command line arguments and environment variables through
-	// global variables (built into the binary directly) instead of the
-	// conventional way.
-	needsEnvInVars := config.GOOS() == "js"
+	// and command line parameters (operating systems, WASI) or not (baremetal).
+	// If we're on a system without an environment, we need to pass command line
+	// arguments and environment variables through global variables (built into
+	// the binary directly) instead of the conventional way.
+	needsEnvInVars := false
 	for _, tag := range config.BuildTags() {
 		if tag == "baremetal" {
 			needsEnvInVars = true

--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasm_unknown
+//go:build baremetal || wasm_unknown
 
 package runtime
 

--- a/src/syscall/env_libc.go
+++ b/src/syscall/env_libc.go
@@ -1,4 +1,4 @@
-//go:build nintendoswitch || wasip1
+//go:build js || nintendoswitch || wasip1
 
 package syscall
 

--- a/src/syscall/errno_other.go
+++ b/src/syscall/errno_other.go
@@ -1,4 +1,4 @@
-//go:build !wasip1 && !wasip2
+//go:build !js && !wasip1 && !wasip2
 
 package syscall
 

--- a/src/syscall/errno_wasmlibc.go
+++ b/src/syscall/errno_wasmlibc.go
@@ -1,4 +1,4 @@
-//go:build wasip1
+//go:build js || wasip1
 
 package syscall
 

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -1,4 +1,4 @@
-//go:build nintendoswitch || wasip1 || wasip2
+//go:build js || nintendoswitch || wasip1 || wasip2
 
 package syscall
 

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -1,4 +1,4 @@
-//go:build wasip1 || wasip2
+//go:build js || wasip1 || wasip2
 
 package syscall
 

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasm_unknown
+//go:build baremetal || wasm_unknown
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js || wasm_unknown
+//go:build baremetal || nintendoswitch || wasm_unknown
 
 package syscall
 


### PR DESCRIPTION
Instead of hardcoding the command line parameters and the environment variables in the binary, pass them at runtime to Node.js and use the WASIp1 API to retrieve them in wasm_exec.js.

The only real benefit right now is that it becomes possible to change `go.argv` and `go.env` before running a wasm binary.

This also changes the syscall package for GOOS=js: it now becomes more like a libc (using wasi-libc), which means error values like `syscall.EEXIST` will actually match the one returned by the relevant libc function.

Wasm binary size for packages that import the os package will be increased somewhat.

---

Now that I've written it, I realized I don't need it after all. So I'm not sure whether this change is a good idea: I haven't seen anybody request support for `go.argv` or `go.env` yet and it does increase binary size for wasm binaries in many cases. Leaving it as a draft for now, we can merge it if there's demand for it I guess. Or close it if not.