### PR TITLE
Fix two wasm bugs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/sys"
 	"github.com/tinygo-org/tinygo/builder"
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/diagnostics"
@@ -683,7 +684,14 @@ func TestWasmExport(t *testing.T) {
 			if tc.command {
 				// Call _start (the entry point), which calls
 				// tester.callTestMain, which then runs all the tests.
-				mustCall(mod.ExportedFunction("_start").Call(ctx))
+				_, err := mod.ExportedFunction("_start").Call(ctx)
+				if err != nil {
+					if exitErr, ok := err.(*sys.ExitError); ok && exitErr.ExitCode() == 0 {
+						// Exited with code 0. Nothing to worry about.
+					} else {
+						t.Error("failed to run _start:", err)
+					}
+				}
 			} else {
 				// Run the _initialize call, because this is reactor mode wasm.
 				mustCall(mod.ExportedFunction("_initialize").Call(ctx))
@@ -766,12 +774,56 @@ func TestWasmExportJS(t *testing.T) {
 	}
 }
 
+// Test whether Go.run() (in wasm_exec.js) normally returns and returns the
+// right exit code.
+func TestWasmExit(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name   string
+		output string
+	}
+
+	tests := []testCase{
+		{name: "normal", output: "exit code: 0\n"},
+		{name: "exit-0", output: "exit code: 0\n"},
+		{name: "exit-0-sleep", output: "slept\nexit code: 0\n"},
+		{name: "exit-1", output: "exit code: 1\n"},
+		{name: "exit-1-sleep", output: "slept\nexit code: 1\n"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			options := optionsFromTarget("wasm", sema)
+			buildConfig, err := builder.NewConfig(&options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			buildConfig.Target.Emulator = "node testdata/wasmexit.js {}"
+			output := &bytes.Buffer{}
+			_, err = buildAndRun("testdata/wasmexit.go", buildConfig, output, []string{tc.name}, nil, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+				return cmd.Run()
+			})
+			if err != nil {
+				t.Error(err)
+			}
+			expected := "wasmexit test: " + tc.name + "\n" + tc.output
+			checkOutputData(t, []byte(expected), output.Bytes())
+		})
+	}
+}
+
 // Check whether the output of a test equals the expected output.
 func checkOutput(t *testing.T, filename string, actual []byte) {
 	expectedOutput, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal("could not read output file:", err)
 	}
+	checkOutputData(t, expectedOutput, actual)
+}
+
+func checkOutputData(t *testing.T, expectedOutput, actual []byte) {
 	expectedOutput = bytes.ReplaceAll(expectedOutput, []byte("\r\n"), []byte("\n"))
 	actual = bytes.ReplaceAll(actual, []byte("\r\n"), []byte("\n"))
 

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -80,10 +80,15 @@ func abort() {
 
 //go:linkname syscall_Exit syscall.Exit
 func syscall_Exit(code int) {
-	// TODO: should we call __stdio_exit here?
-	// It's a low-level exit (syscall.Exit) so doing any libc stuff seems
-	// unexpected, but then where else should stdio buffers be flushed?
+	// Flush stdio buffers.
+	__stdio_exit()
+
+	// Exit the program.
 	proc_exit(uint32(code))
+}
+
+func mainReturnExit() {
+	syscall_Exit(0)
 }
 
 // TinyGo does not yet support any form of parallelism on WebAssembly, so these

--- a/src/runtime/runtime_tinygowasm_unknown.go
+++ b/src/runtime/runtime_tinygowasm_unknown.go
@@ -31,6 +31,10 @@ func abort() {
 
 //go:linkname syscall_Exit syscall.Exit
 func syscall_Exit(code int) {
+	// Because this is the "unknown" target we can't call an exit function.
+	// But we also can't just return since the program will likely expect this
+	// function to never return. So we panic instead.
+	runtimePanic("unsupported: syscall.Exit")
 }
 
 // There is not yet any support for any form of parallelism on WebAssembly, so these

--- a/src/runtime/runtime_tinygowasmp2.go
+++ b/src/runtime/runtime_tinygowasmp2.go
@@ -60,6 +60,13 @@ func syscall_Exit(code int) {
 	exit.Exit(code != 0)
 }
 
+func mainReturnExit() {
+	// WASIp2 does not use _start, instead it uses _initialize and a custom
+	// WASIp2-specific main function. So this should never be called in
+	// practice.
+	runtimePanic("unreachable: _start was called")
+}
+
 // TinyGo does not yet support any form of parallelism on WebAssembly, so these
 // can be left empty.
 

--- a/src/runtime/runtime_wasip1.go
+++ b/src/runtime/runtime_wasip1.go
@@ -91,10 +91,6 @@ func ticks() timeUnit {
 	return timeUnit(nano)
 }
 
-func beforeExit() {
-	__stdio_exit()
-}
-
 // Implementations of WASI APIs
 
 //go:wasmimport wasi_snapshot_preview1 args_get

--- a/src/runtime/runtime_wasip2.go
+++ b/src/runtime/runtime_wasip2.go
@@ -52,6 +52,3 @@ func sleepTicks(d timeUnit) {
 func ticks() timeUnit {
 	return timeUnit(monotonicclock.Now())
 }
-
-func beforeExit() {
-}

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -32,7 +32,3 @@ func sleepTicks(d timeUnit)
 
 //go:wasmimport gojs runtime.ticks
 func ticks() timeUnit
-
-func beforeExit() {
-	__stdio_exit()
-}

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -34,5 +34,8 @@ func ticks() timeUnit {
 	return timeUnit(0)
 }
 
-func beforeExit() {
+func mainReturnExit() {
+	// Don't exit explicitly here. We can't (there is no environment with an
+	// exit call) but also it's not needed. We can just let _start and main.main
+	// return to the caller.
 }

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -19,7 +19,8 @@ func wasmEntryCommand() {
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
 	run()
 	if mainExited {
-		beforeExit()
+		// To make sure wasm_exec.js knows that we've exited, exit explicitly.
+		mainReturnExit()
 	}
 }
 

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -21,7 +21,7 @@ const schedulerDebug = false
 // queue a new scheduler invocation using setTimeout.
 const asyncScheduler = GOOS == "js"
 
-var schedulerDone bool
+var mainExited bool
 
 // Queues used by the scheduler.
 var (
@@ -166,7 +166,7 @@ func removeTimer(tim *timer) bool {
 func scheduler(returnAtDeadlock bool) {
 	// Main scheduler loop.
 	var now timeUnit
-	for !schedulerDone {
+	for !mainExited {
 		scheduleLog("")
 		scheduleLog("  schedule")
 		if sleepQueue != nil || timerQueue != nil {

--- a/src/runtime/scheduler_any.go
+++ b/src/runtime/scheduler_any.go
@@ -23,7 +23,7 @@ func run() {
 	go func() {
 		initAll()
 		callMain()
-		schedulerDone = true
+		mainExited = true
 	}()
 	scheduler(false)
 }

--- a/testdata/wasmexit.go
+++ b/testdata/wasmexit.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+func main() {
+	println("wasmexit test:", os.Args[1])
+	switch os.Args[1] {
+	case "normal":
+		return
+	case "exit-0":
+		os.Exit(0)
+	case "exit-0-sleep":
+		time.Sleep(time.Millisecond)
+		println("slept")
+		os.Exit(0)
+	case "exit-1":
+		os.Exit(1)
+	case "exit-1-sleep":
+		time.Sleep(time.Millisecond)
+		println("slept")
+		os.Exit(1)
+	}
+	println("unknown wasmexit test")
+}

--- a/testdata/wasmexit.js
+++ b/testdata/wasmexit.js
@@ -1,0 +1,35 @@
+require('../targets/wasm_exec.js');
+
+function runTests() {
+    let testCall = (name, params, expected) => {
+        let result = go._inst.exports[name].apply(null, params);
+        if (result !== expected) {
+            console.error(`${name}(...${params}): expected result ${expected}, got ${result}`);
+        }
+    }
+
+    // These are the same tests as in TestWasmExport.
+    testCall('hello', [], undefined);
+    testCall('add', [3, 5], 8);
+    testCall('add', [7, 9], 16);
+    testCall('add', [6, 1], 7);
+    testCall('reentrantCall', [2, 3], 5);
+    testCall('reentrantCall', [1, 8], 9);
+}
+
+let go = new Go();
+go.importObject.tester = {
+    callOutside: (a, b) => {
+        return go._inst.exports.add(a, b);
+    },
+    callTestMain: () => {
+        runTests();
+    },
+};
+WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then(async (result) => {
+    let value = await go.run(result.instance);
+    console.log('exit code:', value);
+}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/testdata/wasmexport-noscheduler.go
+++ b/testdata/wasmexport-noscheduler.go
@@ -1,5 +1,7 @@
 package main
 
+import "time"
+
 func init() {
 	println("called init")
 }
@@ -8,6 +10,10 @@ func init() {
 func callTestMain()
 
 func main() {
+	// Check that exported functions can still be called after calling
+	// time.Sleep.
+	time.Sleep(time.Millisecond)
+
 	// main.main is not used when using -buildmode=c-shared.
 	callTestMain()
 }


### PR DESCRIPTION
Fix two related bugs:

 1. `time.Sleep` in a normal (non-reactor) browser wasm binary would cause every subsequent exported function (`//go:wasmexport`) to fail.
 2. https://github.com/tinygo-org/tinygo/issues/4563