### PR TITLE
runtime: don't call `sleepTicks` with a negative duration

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -41,9 +41,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 4568, 280, 0, 2268},
-		{"microbit", "examples/serial", 2868, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 6104, 1484, 116, 6832},
+		{"hifive1b", "examples/echo", 4580, 280, 0, 2268},
+		{"microbit", "examples/serial", 2888, 388, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 6124, 1484, 116, 6832},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/runtime/runtime_mimxrt1062_time.go
+++ b/src/runtime/runtime_mimxrt1062_time.go
@@ -119,19 +119,17 @@ func ticks() timeUnit {
 }
 
 func sleepTicks(duration timeUnit) {
-	if duration >= 0 {
-		curr := ticks()
-		last := curr + duration // 64-bit overflow unlikely
-		for curr < last {
-			cycles := timeUnit((last - curr) / pitCyclesPerMicro)
-			if cycles > 0xFFFFFFFF {
-				cycles = 0xFFFFFFFF
-			}
-			if !timerSleep(uint32(cycles)) {
-				return // return early due to interrupt
-			}
-			curr = ticks()
+	curr := ticks()
+	last := curr + duration // 64-bit overflow unlikely
+	for curr < last {
+		cycles := timeUnit((last - curr) / pitCyclesPerMicro)
+		if cycles > 0xFFFFFFFF {
+			cycles = 0xFFFFFFFF
 		}
+		if !timerSleep(uint32(cycles)) {
+			return // return early due to interrupt
+		}
+		curr = ticks()
 	}
 }
 

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -31,10 +31,6 @@ func nanosecondsToTicks(ns int64) timeUnit {
 }
 
 func sleepTicks(d timeUnit) {
-	if d <= 0 {
-		return
-	}
-
 	if hasScheduler {
 		// With scheduler, sleepTicks may return early if an interrupt or
 		// event fires - so scheduler can schedule any go routines now

--- a/src/runtime/scheduler.go
+++ b/src/runtime/scheduler.go
@@ -230,13 +230,15 @@ func scheduler(returnAtDeadlock bool) {
 					println("---   timer waiting:", tim, tim.whenTicks())
 				}
 			}
-			sleepTicks(timeLeft)
-			if asyncScheduler {
-				// The sleepTicks function above only sets a timeout at which
-				// point the scheduler will be called again. It does not really
-				// sleep. So instead of sleeping, we return and expect to be
-				// called again.
-				break
+			if timeLeft > 0 {
+				sleepTicks(timeLeft)
+				if asyncScheduler {
+					// The sleepTicks function above only sets a timeout at
+					// which point the scheduler will be called again. It does
+					// not really sleep. So instead of sleeping, we return and
+					// expect to be called again.
+					break
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
There are rare cases where this can happen, see for example https://github.com/tinygo-org/tinygo/issues/4568.

Also removed some of these checks from specific runtime files, now that it is done in a central place.