### PR TITLE
runtime/trace: stub more functions

### DIFF
--- a/src/runtime/trace/trace.go
+++ b/src/runtime/trace/trace.go
@@ -2,6 +2,7 @@
 package trace
 
 import (
+	"context"
 	"errors"
 	"io"
 )
@@ -11,3 +12,31 @@ func Start(w io.Writer) error {
 }
 
 func Stop() {}
+
+func NewTask(pctx context.Context, taskType string) (ctx context.Context, task *Task) {
+	return context.TODO(), nil
+}
+
+type Task struct{}
+
+func (t *Task) End() {}
+
+func Log(ctx context.Context, category, message string) {}
+
+func Logf(ctx context.Context, category, format string, args ...any) {}
+
+func WithRegion(ctx context.Context, regionType string, fn func()) {
+	fn()
+}
+
+func StartRegion(ctx context.Context, regionType string) *Region {
+	return nil
+}
+
+type Region struct{}
+
+func (r *Region) End() {}
+
+func IsEnabled() bool {
+	return false
+}


### PR DESCRIPTION
I came across the following error while I was looking at using the opentelemetry libraries with TinyGo:
```console
# go.opentelemetry.io/otel/sdk/trace
../../../../pkg/mod/go.opentelemetry.io/otel/sdk@v1.31.0/trace/span.go:820:9: undefined: rt.IsEnabled
../../../../pkg/mod/go.opentelemetry.io/otel/sdk@v1.31.0/trace/span.go:824:19: undefined: rt.NewTask
```

I thought it would be nice to have these functions stubbed out so that it would be possible to get further along with libraries that might try to make use of these `runtime/trace` functions, if for no other reason than to be able to use the `go:linkname` directive to do something else with them.