### PR TITLE
compiler: allow deferred panic

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1680,6 +1680,10 @@ func (b *builder) createBuiltin(argTypes []types.Type, argValues []llvm.Value, c
 			result = b.CreateSelect(cmp, result, arg, "")
 		}
 		return result, nil
+	case "panic":
+		// This is rare, but happens in "defer panic()".
+		b.createRuntimeInvoke("_panic", argValues, "")
+		return llvm.Value{}, nil
 	case "print", "println":
 		for i, value := range argValues {
 			if i >= 1 && callName == "println" {

--- a/testdata/recover.go
+++ b/testdata/recover.go
@@ -19,6 +19,9 @@ func main() {
 
 	println("\n# panic replace")
 	panicReplace()
+
+	println("\n# defer panic")
+	deferPanic()
 }
 
 func recoverSimple() {
@@ -87,6 +90,18 @@ func panicReplace() {
 	}()
 	println("panic 1")
 	panic("panic 1")
+}
+
+func deferPanic() {
+	defer func() {
+		printitf("recovered from deferred call:", recover())
+	}()
+
+	// This recover should not do anything.
+	defer recover()
+
+	defer panic("deferred panic")
+	println("defer panic")
 }
 
 func printitf(msg string, itf interface{}) {

--- a/testdata/recover.txt
+++ b/testdata/recover.txt
@@ -23,3 +23,7 @@ recovered: panic
 panic 1
 panic 2
 recovered: panic 2
+
+# defer panic
+defer panic
+recovered from deferred call: deferred panic


### PR DESCRIPTION
This is rare, but apparently some programs do this:

    defer panic("...")

This is emitted in the IR as a builtin function.

See: https://github.com/tinygo-org/tinygo/issues/3731