### PR TITLE
interrupt: fix bug in interrupt lowering

### DIFF
--- a/compiler/interrupt.go
+++ b/compiler/interrupt.go
@@ -41,6 +41,8 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 
 	// Create a new global of type runtime/interrupt.handle. Globals of this
 	// type are lowered in the interrupt lowering pass.
+	// It must have an alignment of 1, otherwise LLVM thinks a ptrtoint of the
+	// global has the lower bits unset.
 	globalType := b.program.ImportedPackage("runtime/interrupt").Type("handle").Type()
 	globalLLVMType := b.getLLVMType(globalType)
 	globalName := b.fn.Package().Pkg.Path() + "$interrupt" + strconv.FormatInt(id.Int64(), 10)
@@ -48,6 +50,7 @@ func (b *builder) createInterruptGlobal(instr *ssa.CallCommon) (llvm.Value, erro
 	global.SetVisibility(llvm.HiddenVisibility)
 	global.SetGlobalConstant(true)
 	global.SetUnnamedAddr(true)
+	global.SetAlignment(1)
 	initializer := llvm.ConstNull(globalLLVMType)
 	initializer = b.CreateInsertValue(initializer, funcContext, 0, "")
 	initializer = b.CreateInsertValue(initializer, funcPtr, 1, "")


### PR DESCRIPTION
The alignment wasn't set, so defaulted to 4 (for a 32-bit int). LLVM saw this, and therefore assumed that a ptrtoint of the pointer would have had the lowest bits unset. That's an entirely valid optimization, except that we are using these globals for arbitrary values (and aren't actually using these globals).

Fixed by setting alignment to 1. It works, though long-term we should maybe find a different solution for this.

This is the root cause of https://github.com/tinygo-org/tinygo/issues/4527, which I finally found after some extensive debugging why a single constant would change whether I called `arm.EnableIRQ` with an arbitrary value or not.