### PR TITLE
cgo: support second return value (errno)

### DIFF
--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -34,6 +34,7 @@ var libPicolibc = Library{
 			"-D__OBSOLETE_MATH_FLOAT=1", // use old math code that doesn't expect a FPU
 			"-D__OBSOLETE_MATH_DOUBLE=0",
 			"-D_WANT_IO_C99_FORMATS",
+			"-D__PICOLIBC_ERRNO_FUNCTION=__errno_location",
 			"-nostdlibinc",
 			"-isystem", newlibDir + "/libc/include",
 			"-I" + newlibDir + "/libc/tinystdio",

--- a/cgo/testdata/basic.out.go
+++ b/cgo/testdata/basic.out.go
@@ -1,5 +1,6 @@
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -29,6 +30,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/cgo/testdata/const.out.go
+++ b/cgo/testdata/const.out.go
@@ -1,5 +1,6 @@
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -29,6 +30,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -24,6 +24,7 @@
 
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -53,6 +54,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/cgo/testdata/flags.out.go
+++ b/cgo/testdata/flags.out.go
@@ -5,6 +5,7 @@
 
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -34,6 +35,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/cgo/testdata/symbols.out.go
+++ b/cgo/testdata/symbols.out.go
@@ -1,5 +1,6 @@
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -29,6 +30,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/cgo/testdata/types.out.go
+++ b/cgo/testdata/types.out.go
@@ -1,5 +1,6 @@
 package main
 
+import "syscall"
 import "unsafe"
 
 var _ unsafe.Pointer
@@ -29,6 +30,13 @@ func C.__CBytes([]byte) unsafe.Pointer
 
 func C.CBytes(b []byte) unsafe.Pointer {
 	return C.__CBytes(b)
+}
+
+//go:linkname C.__get_errno_num runtime.cgo_errno
+func C.__get_errno_num() uintptr
+
+func C.__get_errno() error {
+	return syscall.Errno(C.__get_errno_num())
 }
 
 type (

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -331,6 +331,7 @@ func (c *Config) CFlags(libclang bool) []string {
 			"-isystem", filepath.Join(path, "include"),
 			"-isystem", filepath.Join(picolibcDir, "include"),
 			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
+			"-D__PICOLIBC_ERRNO_FUNCTION=__errno_location",
 		)
 	case "musl":
 		root := goenv.Get("TINYGOROOT")
@@ -340,6 +341,7 @@ func (c *Config) CFlags(libclang bool) []string {
 			"-nostdlibinc",
 			"-isystem", filepath.Join(path, "include"),
 			"-isystem", filepath.Join(root, "lib", "musl", "arch", arch),
+			"-isystem", filepath.Join(root, "lib", "musl", "arch", "generic"),
 			"-isystem", filepath.Join(root, "lib", "musl", "include"),
 		)
 	case "wasi-libc":

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -485,7 +485,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags(true)...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
-		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags)
+		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.config.GOOS())
 		p.CFlags = append(initialCFlags, cflags...)
 		p.CGoHeaders = headerCode
 		for path, hash := range accessedFiles {

--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -86,3 +86,16 @@ func AdjustTimeOffset(offset int64) {
 	// TODO: do this atomically?
 	timeOffset += offset
 }
+
+// Picolibc is not configured to define its own errno value, instead it calls
+// __errno_location.
+// TODO: a global works well enough for now (same as errno on Linux with
+// -scheduler=tasks), but this should ideally be a thread-local variable stored
+// in task.Task.
+// Especially when we add multicore support for microcontrollers.
+var errno int32
+
+//export __errno_location
+func libc_errno_location() *int32 {
+	return &errno
+}

--- a/src/runtime/os_darwin.go
+++ b/src/runtime/os_darwin.go
@@ -151,7 +151,7 @@ func syscall_rawSyscall(fn, a1, a2, a3 uintptr) (r1, r2, err uintptr) {
 	r1 = uintptr(result)
 	if result == -1 {
 		// Syscall returns -1 on failure.
-		err = uintptr(*libc___error())
+		err = uintptr(*libc_errno_location())
 	}
 	return
 }
@@ -161,7 +161,7 @@ func syscall_syscallX(fn, a1, a2, a3 uintptr) (r1, r2, err uintptr) {
 	r1 = call_syscallX(fn, a1, a2, a3)
 	if int64(r1) == -1 {
 		// Syscall returns -1 on failure.
-		err = uintptr(*libc___error())
+		err = uintptr(*libc_errno_location())
 	}
 	return
 }
@@ -171,7 +171,7 @@ func syscall_syscallPtr(fn, a1, a2, a3 uintptr) (r1, r2, err uintptr) {
 	r1 = call_syscallX(fn, a1, a2, a3)
 	if r1 == 0 {
 		// Syscall returns a pointer on success, or NULL on failure.
-		err = uintptr(*libc___error())
+		err = uintptr(*libc_errno_location())
 	}
 	return
 }
@@ -182,7 +182,7 @@ func syscall_syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr) 
 	r1 = uintptr(result)
 	if result == -1 {
 		// Syscall returns -1 on failure.
-		err = uintptr(*libc___error())
+		err = uintptr(*libc_errno_location())
 	}
 	return
 }
@@ -192,7 +192,7 @@ func syscall_syscall6X(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr)
 	r1 = call_syscall6X(fn, a1, a2, a3, a4, a5, a6)
 	if int64(r1) == -1 {
 		// Syscall returns -1 on failure.
-		err = uintptr(*libc___error())
+		err = uintptr(*libc_errno_location())
 	}
 	return
 }
@@ -216,7 +216,7 @@ func libc_getpagesize() int32
 //	}
 //
 //export __error
-func libc___error() *int32
+func libc_errno_location() *int32
 
 //export tinygo_syscall
 func call_syscall(fn, a1, a2, a3 uintptr) int32

--- a/src/runtime/os_windows.go
+++ b/src/runtime/os_windows.go
@@ -113,3 +113,6 @@ func syscall_Getpagesize() int {
 	_GetSystemInfo(unsafe.Pointer(&info))
 	return int(info.dwpagesize)
 }
+
+//export _errno
+func libc_errno_location() *int32

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -127,3 +127,8 @@ func write(fd uintptr, p unsafe.Pointer, n int32) int32 {
 func getAuxv() []uintptr {
 	return nil
 }
+
+// Called from cgo to obtain the errno value.
+func cgo_errno() uintptr {
+	return uintptr(*libc_errno_location())
+}

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -313,3 +313,9 @@ func hardwareRand() (n uint64, ok bool) {
 	// TODO: see whether there is a RNG and use it.
 	return 0, false
 }
+
+func libc_errno_location() *int32 {
+	// CGo is unavailable, so this function should be unreachable.
+	runtimePanic("runtime: no cgo errno")
+	return nil
+}

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -112,3 +112,8 @@ func hardwareRand() (n uint64, ok bool) {
 //
 //export arc4random
 func libc_arc4random() uint32
+
+// int *__errno_location(void);
+//
+//export __errno_location
+func libc_errno_location() *int32

--- a/src/runtime/runtime_tinygowasm_unknown.go
+++ b/src/runtime/runtime_tinygowasm_unknown.go
@@ -51,3 +51,9 @@ func procUnpin() {
 func hardwareRand() (n uint64, ok bool) {
 	return 0, false
 }
+
+func libc_errno_location() *int32 {
+	// CGo is unavailable, so this function should be unreachable.
+	runtimePanic("runtime: no cgo errno")
+	return nil
+}

--- a/src/runtime/runtime_tinygowasmp2.go
+++ b/src/runtime/runtime_tinygowasmp2.go
@@ -81,3 +81,9 @@ func procUnpin() {
 func hardwareRand() (n uint64, ok bool) {
 	return random.GetRandomU64(), true
 }
+
+func libc_errno_location() *int32 {
+	// CGo is unavailable, so this function should be unreachable.
+	runtimePanic("runtime: no cgo errno")
+	return nil
+}

--- a/testdata/cgo/main.c
+++ b/testdata/cgo/main.c
@@ -77,3 +77,8 @@ double doSqrt(double x) {
 void printf_single_int(char *format, int arg) {
 	printf(format, arg);
 }
+
+int set_errno(int err) {
+	errno = err;
+	return -1;
+}

--- a/testdata/cgo/main.go
+++ b/testdata/cgo/main.go
@@ -18,7 +18,10 @@ import "C"
 // static int headerfunc_static(int a) { return a - 1; }
 import "C"
 
-import "unsafe"
+import (
+	"syscall"
+	"unsafe"
+)
 
 func main() {
 	println("fortytwo:", C.fortytwo())
@@ -167,6 +170,13 @@ func main() {
 	println("len(C.GoBytes(nil, 0)):", len(C.GoBytes(nil, 0)))
 	println("len(C.GoBytes(C.CBytes(nil),0)):", len(C.GoBytes(C.CBytes(nil), 0)))
 	println(`rountrip CBytes:`, C.GoString((*C.char)(C.CBytes([]byte("hello\000")))))
+
+	// Check that errno is returned from the second return value, and that it
+	// matches the errno value that was just set.
+	_, errno := C.set_errno(C.EINVAL)
+	println("EINVAL:", errno == syscall.EINVAL)
+	_, errno = C.set_errno(C.EAGAIN)
+	println("EAGAIN:", errno == syscall.EAGAIN)
 
 	// libc: test whether C functions work at all.
 	buf1 := []byte("foobar\x00")

--- a/testdata/cgo/main.h
+++ b/testdata/cgo/main.h
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdint.h>
+#include <errno.h>
 
 typedef short myint;
 typedef short unusedTypedef;
@@ -154,3 +155,5 @@ void arraydecay(int buf1[5], int buf2[3][8], arraydecay_buf3 buf3);
 double doSqrt(double);
 
 void printf_single_int(char *format, int arg);
+
+int set_errno(int err);

--- a/testdata/cgo/out.txt
+++ b/testdata/cgo/out.txt
@@ -75,6 +75,8 @@ len(C.GoStringN(nil, 0)): 0
 len(C.GoBytes(nil, 0)): 0
 len(C.GoBytes(C.CBytes(nil),0)): 0
 rountrip CBytes: hello
+EINVAL: true
+EAGAIN: true
 copied string: foobar
 CGo sqrt(3): +1.732051e+000
 C   sqrt(3): +1.732051e+000


### PR DESCRIPTION
This adds support for code like this:

```go
val, err := C.some_func()
if val == -1 {
    println("failed:", err.Error())
}
```

That is, the second return value is the errno value (a `syscall.Errno` value) after the call. Because of how C errno works, you can't just check errno: you have to check the normal return value to know whether the call succeeded or not, and only use errno when you know it failed and was therefore set by the call.

To make this work, I also had to implement some CGo features that weren't implemented yet (mainly for WASI which likes to use rather indirect errno values). I also changed the syscall package for wasm/js because the errno values in there didn't actually match the values in wasi-libc.

The reason I did this was to be able to run `tinygo test os/syscall`. That test needs some more CGo stuff but this is one of the prerequisites.