### PR TITLE
compiler: link .syso files found in Go package directories

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -711,6 +711,12 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 			}
 			linkerDependencies = append(linkerDependencies, job)
 		}
+
+		// Add .syso files
+		// TODO: is this the right way to do this?
+		for _, filename := range pkg.SysoFiles {
+			ldflags = append(ldflags, filepath.Join(pkg.Dir, filename))
+		}
 	}
 
 	// Linker flags from CGo lines:

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -350,6 +350,10 @@ func (c *compilerContext) parsePragmas(info *functionInfo, f *ssa.Function) {
 			info.wasmModule = parts[1]
 			info.wasmName = parts[2]
 		case "//go:wasmexport":
+			if c.archFamily() != "wasm32" {
+				// go:wasmimport is ignored on non-wasm architectures
+				continue
+			}
 			if f.Blocks == nil {
 				c.addError(f.Pos(), "can only use //go:wasmexport on definitions")
 				continue
@@ -366,9 +370,6 @@ func (c *compilerContext) parsePragmas(info *functionInfo, f *ssa.Function) {
 			if c.BuildMode != "c-shared" && f.RelString(nil) == "main.main" {
 				c.addError(f.Pos(), fmt.Sprintf("//go:wasmexport does not allow main.main to be exported with -buildmode=%s", c.BuildMode))
 				continue
-			}
-			if c.archFamily() != "wasm32" {
-				c.addError(f.Pos(), "//go:wasmexport is only supported on wasm")
 			}
 			c.checkWasmImportExport(f, comment.Text)
 			info.wasmExport = name

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -60,9 +60,10 @@ type PackageJSON struct {
 	}
 
 	// Source files
-	GoFiles  []string
-	CgoFiles []string
-	CFiles   []string
+	GoFiles   []string
+	CgoFiles  []string
+	CFiles    []string
+	SysoFiles []string
 
 	// Embedded files
 	EmbedFiles []string


### PR DESCRIPTION
This is an experiment, driven by a need to link in custom sections into the resulting .wasm binary. Using a .syso file in a package directory is a well-known way to accomplish this with other architectures in big Go.

We have a POC that proves this works: https://github.com/ydnar/wasi-http-go/pull/13

Another example: https://tip.golang.org/src/crypto/internal/boring/syso/

@dgryski co-authored this live at WasmCon.