### PR TITLE
targets/wasm_exec: call process.exit() when go.run() returns

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -531,7 +531,10 @@
 
 		const go = new Go();
 		WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then((result) => {
-			return go.run(result.instance);
+			go.run(result.instance).then((result) => {
+                            process.exit(result);
+                        }).
+                        catch((e) => { throw e });
 		}).catch((err) => {
 			console.error(err);
 			process.exit(1);


### PR DESCRIPTION
`TestTest/WASM/Fail` started failing with the last patch to this file.  This (I hope) restores the correct behaviour.