### PR TITLE
compiler, runtime: move constants into shared package

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tinygo-org/tinygo/compiler/llvmutil"
 	"github.com/tinygo-org/tinygo/loader"
+	"github.com/tinygo-org/tinygo/src/tinygo"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/types/typeutil"
 	"tinygo.org/x/go-llvm"
@@ -1869,10 +1870,9 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 			}
 			return llvm.ConstInt(b.ctx.Int1Type(), supportsRecover, false), nil
 		case name == "runtime.panicStrategy":
-			// These constants are defined in src/runtime/panic.go.
 			panicStrategy := map[string]uint64{
-				"print": 1, // panicStrategyPrint
-				"trap":  2, // panicStrategyTrap
+				"print": tinygo.PanicStrategyPrint,
+				"trap":  tinygo.PanicStrategyTrap,
 			}[b.Config.PanicStrategy]
 			return llvm.ConstInt(b.ctx.Int8Type(), panicStrategy, false), nil
 		case name == "runtime/interrupt.New":

--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -256,6 +256,7 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"runtime/":                    false,
 		"sync/":                       true,
 		"testing/":                    true,
+		"tinygo/":                     false,
 		"unique/":                     false,
 	}
 

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"internal/task"
 	"runtime/interrupt"
+	"tinygo"
 	"unsafe"
 )
 
@@ -21,11 +22,6 @@ func tinygo_longjmp(frame *deferFrame)
 // Compiler intrinsic.
 // Returns whether recover is supported on the current architecture.
 func supportsRecover() bool
-
-const (
-	panicStrategyPrint = 1
-	panicStrategyTrap  = 2
-)
 
 // Compile intrinsic.
 // Returns which strategy is used. This is usually "print" but can be changed
@@ -48,7 +44,7 @@ type deferFrame struct {
 
 // Builtin function panic(msg), used as a compiler intrinsic.
 func _panic(message interface{}) {
-	if panicStrategy() == panicStrategyTrap {
+	if panicStrategy() == tinygo.PanicStrategyTrap {
 		trap()
 	}
 	// Note: recover is not supported inside interrupts.
@@ -76,7 +72,7 @@ func runtimePanic(msg string) {
 }
 
 func runtimePanicAt(addr unsafe.Pointer, msg string) {
-	if panicStrategy() == panicStrategyTrap {
+	if panicStrategy() == tinygo.PanicStrategyTrap {
 		trap()
 	}
 	if hasReturnAddr {

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"math/bits"
 	"sync/atomic"
+	"tinygo"
 	"unsafe"
 )
 
@@ -141,7 +142,7 @@ func tinygo_register_fatal_signals()
 //
 //export tinygo_handle_fatal_signal
 func tinygo_handle_fatal_signal(sig int32, addr uintptr) {
-	if panicStrategy() == panicStrategyTrap {
+	if panicStrategy() == tinygo.PanicStrategyTrap {
 		trap()
 	}
 

--- a/src/tinygo/runtime.go
+++ b/src/tinygo/runtime.go
@@ -1,0 +1,17 @@
+// Package tinygo contains constants used between the TinyGo compiler and
+// runtime.
+package tinygo
+
+const (
+	PanicStrategyPrint = iota + 1
+	PanicStrategyTrap
+)
+
+type HashmapAlgorithm uint8
+
+// Constants for hashmap algorithms.
+const (
+	HashmapAlgorithmBinary HashmapAlgorithm = iota
+	HashmapAlgorithmString
+	HashmapAlgorithmInterface
+)


### PR DESCRIPTION
Use a single package for certain constants that must be the same between the compiler and the runtime.

While just using the same values in both places works, this is much more obvious and harder to mess up. It also avoids the need for comments pointing to the other location the constant is defined. And having it in code makes it possible for IDEs to analyze the source.

In the future, more such constants and maybe algorithms can be added. For example: constants for the reflect package.

---

Fee free to bikeshed about the package name. I can't put it under `internal/` (the compiler won't let me) so that's why it is top level.

The direct reason why I want to have this package is because I'd like to use this for a GC optimization I'm working on that's kinda tricky (reusing the remaining stack for the GC mark stack). For that, some constants really do need to be the same that may look like tunable constants.