### PR TITLE
cgo: support more macros

### DIFF
--- a/cgo/cgo.go
+++ b/cgo/cgo.go
@@ -1148,7 +1148,7 @@ func (f *cgoFile) getASTDeclName(name string, found clangCursor, iscall bool) st
 	if alias := cgoAliases["C."+name]; alias != "" {
 		return alias
 	}
-	node := f.getASTDeclNode(name, found, iscall)
+	node := f.getASTDeclNode(name, found)
 	if node, ok := node.(*ast.FuncDecl); ok {
 		if !iscall {
 			return node.Name.Name + "$funcaddr"
@@ -1160,7 +1160,7 @@ func (f *cgoFile) getASTDeclName(name string, found clangCursor, iscall bool) st
 
 // getASTDeclNode will declare the given C AST node (if not already defined) and
 // returns it.
-func (f *cgoFile) getASTDeclNode(name string, found clangCursor, iscall bool) ast.Node {
+func (f *cgoFile) getASTDeclNode(name string, found clangCursor) ast.Node {
 	if node, ok := f.defined[name]; ok {
 		// Declaration was found in the current file, so return it immediately.
 		return node

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -59,7 +59,7 @@ func TestParseConst(t *testing.T) {
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)
-		expr, err := parseConst(startPos, fset, tc.C, nil)
+		expr, err := parseConst(startPos, fset, tc.C, nil, token.NoPos, nil)
 		s := "<invalid>"
 		if err != nil {
 			if !strings.HasPrefix(tc.Go, "error: ") {

--- a/cgo/const_test.go
+++ b/cgo/const_test.go
@@ -59,7 +59,7 @@ func TestParseConst(t *testing.T) {
 	} {
 		fset := token.NewFileSet()
 		startPos := fset.AddFile("", -1, 1000).Pos(0)
-		expr, err := parseConst(startPos, fset, tc.C)
+		expr, err := parseConst(startPos, fset, tc.C, nil)
 		s := "<invalid>"
 		if err != nil {
 			if !strings.HasPrefix(tc.Go, "error: ") {

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -408,7 +408,7 @@ func (f *cgoFile) createASTNode(name string, c clangCursor) (ast.Node, any) {
 		if pos != token.NoPos {
 			tokenPos = pos + token.Pos(len(name))
 		}
-		expr, scannerError := parseConst(tokenPos, f.fset, value)
+		expr, scannerError := parseConst(tokenPos, f.fset, value, f)
 		if scannerError != nil {
 			f.errors = append(f.errors, *scannerError)
 			return nil, nil

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -63,6 +63,7 @@ long long tinygo_clang_getEnumConstantDeclValue(GoCXCursor c);
 CXType tinygo_clang_getEnumDeclIntegerType(GoCXCursor c);
 unsigned tinygo_clang_Cursor_isAnonymous(GoCXCursor c);
 unsigned tinygo_clang_Cursor_isBitField(GoCXCursor c);
+unsigned tinygo_clang_Cursor_isMacroFunctionLike(GoCXCursor c);
 
 int tinygo_clang_globals_visitor(GoCXCursor c, GoCXCursor parent, CXClientData client_data);
 int tinygo_clang_struct_visitor(GoCXCursor c, GoCXCursor parent, CXClientData client_data);
@@ -370,45 +371,8 @@ func (f *cgoFile) createASTNode(name string, c clangCursor) (ast.Node, any) {
 		gen.Specs = append(gen.Specs, valueSpec)
 		return gen, nil
 	case C.CXCursor_MacroDefinition:
-		// Extract tokens from the Clang tokenizer.
-		// See: https://stackoverflow.com/a/19074846/559350
-		sourceRange := C.tinygo_clang_getCursorExtent(c)
-		tu := C.tinygo_clang_Cursor_getTranslationUnit(c)
-		var rawTokens *C.CXToken
-		var numTokens C.unsigned
-		C.clang_tokenize(tu, sourceRange, &rawTokens, &numTokens)
-		tokens := unsafe.Slice(rawTokens, numTokens)
-		// Convert this range of tokens back to source text.
-		// Ugly, but it works well enough.
-		sourceBuf := &bytes.Buffer{}
-		var startOffset int
-		for i, token := range tokens {
-			spelling := getString(C.clang_getTokenSpelling(tu, token))
-			location := C.clang_getTokenLocation(tu, token)
-			var tokenOffset C.unsigned
-			C.clang_getExpansionLocation(location, nil, nil, nil, &tokenOffset)
-			if i == 0 {
-				// The first token is the macro name itself.
-				// Skip it (after using its location).
-				startOffset = int(tokenOffset) + len(name)
-			} else {
-				// Later tokens are the macro contents.
-				for int(tokenOffset) > (startOffset + sourceBuf.Len()) {
-					// Pad the source text with whitespace (that must have been
-					// present in the original source as well).
-					sourceBuf.WriteByte(' ')
-				}
-				sourceBuf.WriteString(spelling)
-			}
-		}
-		C.clang_disposeTokens(tu, rawTokens, numTokens)
-		value := sourceBuf.String()
-		// Try to convert this #define into a Go constant expression.
-		tokenPos := token.NoPos
-		if pos != token.NoPos {
-			tokenPos = pos + token.Pos(len(name))
-		}
-		expr, scannerError := parseConst(tokenPos, f.fset, value, f)
+		tokenPos, value := f.getMacro(c)
+		expr, scannerError := parseConst(tokenPos, f.fset, value, nil, token.NoPos, f)
 		if scannerError != nil {
 			f.errors = append(f.errors, *scannerError)
 			return nil, nil
@@ -486,6 +450,62 @@ func (f *cgoFile) createASTNode(name string, c clangCursor) (ast.Node, any) {
 		f.addError(pos, fmt.Sprintf("internal error: unknown cursor type: %d", kind))
 		return nil, nil
 	}
+}
+
+// Return whether this is a macro that's also function-like, like this:
+//
+//	#define add(a, b) (a+b)
+func (f *cgoFile) isFunctionLikeMacro(c clangCursor) bool {
+	if C.tinygo_clang_getCursorKind(c) != C.CXCursor_MacroDefinition {
+		return false
+	}
+	return C.tinygo_clang_Cursor_isMacroFunctionLike(c) != 0
+}
+
+// Get the macro value: the position in the source file and the string value of
+// the macro.
+func (f *cgoFile) getMacro(c clangCursor) (pos token.Pos, value string) {
+	// Extract tokens from the Clang tokenizer.
+	// See: https://stackoverflow.com/a/19074846/559350
+	sourceRange := C.tinygo_clang_getCursorExtent(c)
+	tu := C.tinygo_clang_Cursor_getTranslationUnit(c)
+	var rawTokens *C.CXToken
+	var numTokens C.unsigned
+	C.clang_tokenize(tu, sourceRange, &rawTokens, &numTokens)
+	tokens := unsafe.Slice(rawTokens, numTokens)
+	defer C.clang_disposeTokens(tu, rawTokens, numTokens)
+
+	// Convert this range of tokens back to source text.
+	// Ugly, but it works well enough.
+	sourceBuf := &bytes.Buffer{}
+	var startOffset int
+	for i, token := range tokens {
+		spelling := getString(C.clang_getTokenSpelling(tu, token))
+		location := C.clang_getTokenLocation(tu, token)
+		var tokenOffset C.unsigned
+		C.clang_getExpansionLocation(location, nil, nil, nil, &tokenOffset)
+		if i == 0 {
+			// The first token is the macro name itself.
+			// Skip it (after using its location).
+			startOffset = int(tokenOffset)
+		} else {
+			// Later tokens are the macro contents.
+			for int(tokenOffset) > (startOffset + sourceBuf.Len()) {
+				// Pad the source text with whitespace (that must have been
+				// present in the original source as well).
+				sourceBuf.WriteByte(' ')
+			}
+			sourceBuf.WriteString(spelling)
+		}
+	}
+	value = sourceBuf.String()
+
+	// Obtain the position of this token. This is the position of the first
+	// character in the 'value' string and is used to report errors at the
+	// correct location in the source file.
+	pos = f.getCursorPosition(c)
+
+	return
 }
 
 func getString(clangString C.CXString) (s string) {

--- a/cgo/libclang_stubs.c
+++ b/cgo/libclang_stubs.c
@@ -84,3 +84,7 @@ unsigned tinygo_clang_Cursor_isAnonymous(CXCursor c) {
 unsigned tinygo_clang_Cursor_isBitField(CXCursor c) {
 	return clang_Cursor_isBitField(c);
 }
+
+unsigned tinygo_clang_Cursor_isMacroFunctionLike(CXCursor c) {
+	return clang_Cursor_isMacroFunctionLike(c);
+}

--- a/cgo/testdata/const.go
+++ b/cgo/testdata/const.go
@@ -3,13 +3,26 @@ package main
 /*
 #define foo 3
 #define bar foo
+
 #define unreferenced 4
 #define referenced unreferenced
+
+#define fnlike() 5
+#define fnlike_val fnlike()
+#define square(n) (n*n)
+#define square_val square(20)
+#define add(a, b) (a + b)
+#define add_val add(3, 5)
 */
 import "C"
 
 const (
 	Foo = C.foo
 	Bar = C.bar
+
 	Baz = C.referenced
+
+	fnlike = C.fnlike_val
+	square = C.square_val
+	add    = C.add_val
 )

--- a/cgo/testdata/const.go
+++ b/cgo/testdata/const.go
@@ -3,10 +3,13 @@ package main
 /*
 #define foo 3
 #define bar foo
+#define unreferenced 4
+#define referenced unreferenced
 */
 import "C"
 
 const (
 	Foo = C.foo
 	Bar = C.bar
+	Baz = C.referenced
 )

--- a/cgo/testdata/const.out.go
+++ b/cgo/testdata/const.out.go
@@ -47,3 +47,5 @@ type (
 
 const C.foo = 3
 const C.bar = C.foo
+const C.unreferenced = 4
+const C.referenced = C.unreferenced

--- a/cgo/testdata/const.out.go
+++ b/cgo/testdata/const.out.go
@@ -49,3 +49,6 @@ const C.foo = 3
 const C.bar = C.foo
 const C.unreferenced = 4
 const C.referenced = C.unreferenced
+const C.fnlike_val = 5
+const C.square_val = (20 * 20)
+const C.add_val = (3 + 5)

--- a/cgo/testdata/errors.go
+++ b/cgo/testdata/errors.go
@@ -26,6 +26,11 @@ import "C"
 // #warning another warning
 import "C"
 
+// #define add(a, b) (a+b)
+// #define add_toomuch add(1, 2, 3)
+// #define add_toolittle add(1)
+import "C"
+
 // Make sure that errors for the following lines won't change with future
 // additions to the CGo preamble.
 //
@@ -51,4 +56,7 @@ var (
 	// constants passed by a command line parameter
 	_ = C.SOME_PARAM_CONST_invalid
 	_ = C.SOME_PARAM_CONST_valid
+
+	_ = C.add_toomuch
+	_ = C.add_toolittle
 )

--- a/cgo/testdata/errors.out.go
+++ b/cgo/testdata/errors.out.go
@@ -7,6 +7,8 @@
 //     testdata/errors.go:16:33: unexpected token ), expected end of expression
 //     testdata/errors.go:17:34: unexpected token ), expected end of expression
 //     -: unexpected token INT, expected end of expression
+//     testdata/errors.go:30:35: unexpected number of parameters: expected 2, got 3
+//     testdata/errors.go:31:31: unexpected number of parameters: expected 2, got 1
 
 // Type checking errors after CGo processing:
 //     testdata/errors.go:102: cannot use 2 << 10 (untyped int constant 2048) as C.char value in variable declaration (overflows)
@@ -17,6 +19,8 @@
 //     testdata/errors.go:114: undefined: C.SOME_CONST_b
 //     testdata/errors.go:116: undefined: C.SOME_CONST_startspace
 //     testdata/errors.go:119: undefined: C.SOME_PARAM_CONST_invalid
+//     testdata/errors.go:122: undefined: C.add_toomuch
+//     testdata/errors.go:123: undefined: C.add_toolittle
 
 package main
 


### PR DESCRIPTION
This PR adds better support for C macros (`#define`) in CGo.

1. It makes sure that if a macro contains another macro (such as `#define foo (bar+1)`) the referenced macro is also defined on the Go side, to avoid errors (`undefined: C.something`).
2. It supports function-like macros inside macros. For example, `#define add(a, b) (a+b)` that can be used like `#define added add(3, 5)`.

Both of these will be necessary to fully support CGo errno values with wasi-libc.

I extracted these two from #4585 because these seem like relatively simple changes, to make the other PR smaller.