### PR TITLE
syscall: refactor wasm environment variables and constants

### DIFF
--- a/src/syscall/env_nonhosted.go
+++ b/src/syscall/env_nonhosted.go
@@ -1,0 +1,45 @@
+//go:build baremetal || js || wasm_unknown
+
+package syscall
+
+func Environ() []string {
+	env := runtime_envs()
+	envCopy := make([]string, len(env))
+	copy(envCopy, env)
+	return envCopy
+}
+
+func Getenv(key string) (value string, found bool) {
+	env := runtime_envs()
+	for _, keyval := range env {
+		// Split at '=' character.
+		var k, v string
+		for i := 0; i < len(keyval); i++ {
+			if keyval[i] == '=' {
+				k = keyval[:i]
+				v = keyval[i+1:]
+			}
+		}
+		if k == key {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func Setenv(key, val string) (err error) {
+	// stub for now
+	return ENOSYS
+}
+
+func Unsetenv(key string) (err error) {
+	// stub for now
+	return ENOSYS
+}
+
+func Clearenv() (err error) {
+	// stub for now
+	return ENOSYS
+}
+
+func runtime_envs() []string

--- a/src/syscall/env_wasip2.go
+++ b/src/syscall/env_wasip2.go
@@ -2,10 +2,55 @@
 
 package syscall
 
+import (
+	"internal/wasi/cli/v0.2.0/environment"
+)
+
+var libc_envs map[string]string
+
+func populateEnvironment() {
+	libc_envs = make(map[string]string)
+	for _, kv := range environment.GetEnvironment().Slice() {
+		libc_envs[kv[0]] = kv[1]
+	}
+}
+
 func Environ() []string {
 	var env []string
 	for k, v := range libc_envs {
 		env = append(env, k+"="+v)
 	}
 	return env
+}
+
+func Getenv(key string) (value string, found bool) {
+	value, found = libc_envs[key]
+	return
+}
+
+func Setenv(key, val string) (err error) {
+	if len(key) == 0 {
+		return EINVAL
+	}
+	for i := 0; i < len(key); i++ {
+		if key[i] == '=' || key[i] == 0 {
+			return EINVAL
+		}
+	}
+	for i := 0; i < len(val); i++ {
+		if val[i] == 0 {
+			return EINVAL
+		}
+	}
+	libc_envs[key] = val
+	return nil
+}
+
+func Unsetenv(key string) (err error) {
+	delete(libc_envs, key)
+	return nil
+}
+
+func Clearenv() {
+	clear(libc_envs)
 }

--- a/src/syscall/errno_other.go
+++ b/src/syscall/errno_other.go
@@ -1,4 +1,4 @@
-//go:build !wasip1 && !wasip2
+//go:build !js && !wasip1 && !wasip2
 
 package syscall
 

--- a/src/syscall/errno_wasilibc.go
+++ b/src/syscall/errno_wasilibc.go
@@ -1,4 +1,4 @@
-//go:build wasip1
+//go:build wasip1 || js
 
 package syscall
 

--- a/src/syscall/libc_wasip2.go
+++ b/src/syscall/libc_wasip2.go
@@ -1227,58 +1227,6 @@ func p2fileTypeToStatType(t types.DescriptorType) uint32 {
 	return 0
 }
 
-var libc_envs map[string]string
-
-func populateEnvironment() {
-	libc_envs = make(map[string]string)
-	for _, kv := range environment.GetEnvironment().Slice() {
-		libc_envs[kv[0]] = kv[1]
-	}
-}
-
-// char * getenv(const char *name);
-//
-//export getenv
-func getenv(key *byte) *byte {
-	k := goString(key)
-
-	v, ok := libc_envs[k]
-	if !ok {
-		return nil
-	}
-
-	// The new allocation is zero-filled; allocating an extra byte and then
-	// copying the data over will leave the last byte untouched,
-	// null-terminating the string.
-	vbytes := make([]byte, len(v)+1)
-	copy(vbytes, v)
-	return unsafe.SliceData(vbytes)
-}
-
-// int setenv(const char *name, const char *value, int overwrite);
-//
-//export setenv
-func setenv(key, value *byte, overwrite int) int {
-	k := goString(key)
-	if _, ok := libc_envs[k]; ok && overwrite == 0 {
-		return 0
-	}
-
-	v := goString(value)
-	libc_envs[k] = v
-
-	return 0
-}
-
-// int unsetenv(const char *name);
-//
-//export unsetenv
-func unsetenv(key *byte) int {
-	k := goString(key)
-	delete(libc_envs, k)
-	return 0
-}
-
 // void arc4random_buf (void *, size_t);
 //
 //export arc4random_buf

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -1,4 +1,4 @@
-//go:build nintendoswitch || wasip1 || wasip2
+//go:build js || nintendoswitch || wasip1 || wasip2
 
 package syscall
 

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -238,58 +238,6 @@ func Wait4(pid int, wstatus *WaitStatus, options int, rusage uintptr) (wpid int,
 	return 0, ENOSYS // TODO
 }
 
-func Getenv(key string) (value string, found bool) {
-	data := cstring(key)
-	raw := libc_getenv(&data[0])
-	if raw == nil {
-		return "", false
-	}
-
-	ptr := uintptr(unsafe.Pointer(raw))
-	for size := uintptr(0); ; size++ {
-		v := *(*byte)(unsafe.Pointer(ptr))
-		if v == 0 {
-			src := *(*[]byte)(unsafe.Pointer(&sliceHeader{buf: raw, len: size, cap: size}))
-			return string(src), true
-		}
-		ptr += unsafe.Sizeof(byte(0))
-	}
-}
-
-func Setenv(key, val string) (err error) {
-	if len(key) == 0 {
-		return EINVAL
-	}
-	for i := 0; i < len(key); i++ {
-		if key[i] == '=' || key[i] == 0 {
-			return EINVAL
-		}
-	}
-	for i := 0; i < len(val); i++ {
-		if val[i] == 0 {
-			return EINVAL
-		}
-	}
-	runtimeSetenv(key, val)
-	return
-}
-
-func Unsetenv(key string) (err error) {
-	runtimeUnsetenv(key)
-	return
-}
-
-func Clearenv() {
-	for _, s := range Environ() {
-		for j := 0; j < len(s); j++ {
-			if s[j] == '=' {
-				Unsetenv(s[0:j])
-				break
-			}
-		}
-	}
-}
-
 func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
 	addr := libc_mmap(nil, uintptr(length), int32(prot), int32(flags), int32(fd), uintptr(offset))
 	if addr == unsafe.Pointer(^uintptr(0)) {

--- a/src/syscall/syscall_libc_wasi.go
+++ b/src/syscall/syscall_libc_wasi.go
@@ -1,4 +1,6 @@
-//go:build wasip1 || wasip2
+//go:build js || wasip1 || wasip2
+
+// Note: also including js in here because it also uses wasi-libc.
 
 package syscall
 

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasm_unknown
+//go:build baremetal || wasm_unknown
 
 package syscall
 

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -87,48 +87,6 @@ const (
 	MAP_ANONYMOUS = MAP_ANON
 )
 
-func runtime_envs() []string
-
-func Getenv(key string) (value string, found bool) {
-	env := runtime_envs()
-	for _, keyval := range env {
-		// Split at '=' character.
-		var k, v string
-		for i := 0; i < len(keyval); i++ {
-			if keyval[i] == '=' {
-				k = keyval[:i]
-				v = keyval[i+1:]
-			}
-		}
-		if k == key {
-			return v, true
-		}
-	}
-	return "", false
-}
-
-func Setenv(key, val string) (err error) {
-	// stub for now
-	return ENOSYS
-}
-
-func Unsetenv(key string) (err error) {
-	// stub for now
-	return ENOSYS
-}
-
-func Clearenv() (err error) {
-	// stub for now
-	return ENOSYS
-}
-
-func Environ() []string {
-	env := runtime_envs()
-	envCopy := make([]string, len(env))
-	copy(envCopy, env)
-	return envCopy
-}
-
 func Open(path string, mode int, perm uint32) (fd int, err error) {
 	return 0, ENOSYS
 }

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js || wasm_unknown
+//go:build baremetal || nintendoswitch || wasm_unknown
 
 package syscall
 


### PR DESCRIPTION
Two changes for WebAssembly:
1. Move environment variables into their own files, and refactor WASIp2 environment variables to be a lot simpler (not going through the C API).
2. Use the correct constants for `-target=wasm`. Instead of using fake constants, use the ones that match wasi-libc.

This PR is extracted from #4585 because it's a bit more tricky than it initially seemed.