### PR TITLE
windows: don't return in mainCRTStartup, exit via `exit(0)` instead

### DIFF
--- a/src/runtime/runtime_windows.go
+++ b/src/runtime/runtime_windows.go
@@ -52,7 +52,16 @@ func mainCRTStartup() int {
 	stackTop = getCurrentStackPointer()
 	runMain()
 
-	// For libc compatibility.
+	// Exit via exit(0) instead of returning. This matches
+	// mingw-w64-crt/crt/crtexe.c, which exits using exit(0) instead of
+	// returning the return value.
+	// Exiting this way (instead of returning) also fixes an issue where not all
+	// output would be sent to stdout before exit.
+	// See: https://github.com/tinygo-org/tinygo/pull/4589
+	libc_exit(0)
+
+	// Unreachable, since we've already exited. But we need to return something
+	// here to make this valid Go code.
 	return 0
 }
 


### PR DESCRIPTION
This fixes a bug where output would not actually be written to stdout before exiting the process, leading to a flaky Windows CI. Exiting using `exit(0)` appears to fix this.

For some background, see: https://github.com/tinygo-org/tinygo/pull/4589