### PR TITLE
builder: fix cache paths in `-size=full` output

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -690,7 +690,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 	for _, pkg := range lprogram.Sorted() {
 		pkg := pkg
 		for _, filename := range pkg.CFiles {
-			abspath := filepath.Join(pkg.Dir, filename)
+			abspath := filepath.Join(pkg.OriginalDir(), filename)
 			job := &compileJob{
 				description: "compile CGo file " + abspath,
 				run: func(job *compileJob) error {

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -200,6 +200,11 @@ func readProgramSizeFromDWARF(data *dwarf.Data, codeOffset, codeAlignment uint64
 						// Work around a Clang bug on Windows:
 						// https://github.com/llvm/llvm-project/issues/117317
 						path = strings.ReplaceAll(path, "\\\\", "\\")
+
+						// wasi-libc likes to use forward slashes, but we
+						// canonicalize everything to use backwards slashes as
+						// is common on Windows.
+						path = strings.ReplaceAll(path, "/", "\\")
 					}
 					line := addressLine{
 						Address: prevLineEntry.Address + codeOffset,

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -194,11 +195,17 @@ func readProgramSizeFromDWARF(data *dwarf.Data, codeOffset, codeAlignment uint64
 				if !prevLineEntry.EndSequence {
 					// The chunk describes the code from prevLineEntry to
 					// lineEntry.
+					path := prevLineEntry.File.Name
+					if runtime.GOOS == "windows" {
+						// Work around a Clang bug on Windows:
+						// https://github.com/llvm/llvm-project/issues/117317
+						path = strings.ReplaceAll(path, "\\\\", "\\")
+					}
 					line := addressLine{
 						Address: prevLineEntry.Address + codeOffset,
 						Length:  lineEntry.Address - prevLineEntry.Address,
 						Align:   codeAlignment,
-						File:    prevLineEntry.File.Name,
+						File:    path,
 					}
 					if line.Length != 0 {
 						addresses = append(addresses, line)


### PR DESCRIPTION
This fixes long paths from the TinyGo cached GOROOT, as can be seen here in the `-size=full` output:

```
   code  rodata    data     bss |   flash     ram | package
------------------------------- | --------------- | -------
      0       5       0       5 |       5       5 | (padding)
    148       0       0       5 |     148       5 | (unknown)
     76       0       0       0 |      76       0 | /home/ayke/.cache/tinygo/goroot-ce8827882be9dc201bed279a631881177ae124ea064510684a3cf4bb66436e1a/src/device/arm
      4       0       0       0 |       4       0 | /home/ayke/.cache/tinygo/goroot-ce8827882be9dc201bed279a631881177ae124ea064510684a3cf4bb66436e1a/src/internal/task
```

They're now attributed to the correct package instead (device/arm and internal/task).

I've also added a test to make sure this doesn't happen again (at least not for a small `-target=microbit` binary).