### PR TITLE
interp: align created globals

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,7 +43,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4600, 280, 0, 2268},
 		{"microbit", "examples/serial", 2908, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 6140, 1484, 116, 6832},
+		{"wioterminal", "examples/pininterrupt", 6140, 1484, 116, 6824},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the


### PR DESCRIPTION
Use the alignment from the align attribute of the runtime.alloc call. This is going to be a more accurate alignment, and is typically smaller than the default.

This also reduces binary size and static RAM usage slightly in some cases.