### PR TITLE
sync: only use a real lock in `sync.Map` when needed

### DIFF
--- a/src/sync/map.go
+++ b/src/sync/map.go
@@ -1,10 +1,12 @@
 package sync
 
+import "internal/task"
+
 // This file implements just enough of sync.Map to get packages to compile. It
 // is no more efficient than a map with a lock.
 
 type Map struct {
-	lock Mutex
+	lock task.PMutex
 	m    map[interface{}]interface{}
 }
 


### PR DESCRIPTION
There's no need for a real mutex with a cooperative scheduler (like `-scheduler=tasks`). So we can use a fake one instead.

This is a small PR mainly to show/implement `task.PMutex` which I'm going to use in other PRs.