### PR TITLE
Prepare `sync.Pool` for parallelism

### DIFF
--- a/src/sync/pool.go
+++ b/src/sync/pool.go
@@ -1,18 +1,24 @@
 package sync
 
+import "internal/task"
+
 // Pool is a very simple implementation of sync.Pool.
 type Pool struct {
+	lock  task.PMutex
 	New   func() interface{}
 	items []interface{}
 }
 
 // Get returns an item in the pool, or the value of calling Pool.New() if there are no items.
 func (p *Pool) Get() interface{} {
+	p.lock.Lock()
 	if len(p.items) > 0 {
 		x := p.items[len(p.items)-1]
 		p.items = p.items[:len(p.items)-1]
+		p.lock.Unlock()
 		return x
 	}
+	p.lock.Unlock()
 	if p.New == nil {
 		return nil
 	}
@@ -21,5 +27,7 @@ func (p *Pool) Get() interface{} {
 
 // Put adds a value back into the pool.
 func (p *Pool) Put(x interface{}) {
+	p.lock.Lock()
 	p.items = append(p.items, x)
+	p.lock.Unlock()
 }


### PR DESCRIPTION
Use the same `sync.PMutex` that is a dummy lock on non-parallel systems also used in #4619.