### PR TITLE
fix: add updated test output to match recent changes

### DIFF
--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -85,10 +85,10 @@ entry:
 
 declare void @main.undefinedFunctionNotInSection(ptr) #1
 
-declare void @main.doesNotEscapeParam(ptr nocapture dereferenceable_or_null(4), ptr nocapture, i32, i32, ptr nocapture dereferenceable_or_null(32), ptr nocapture, ptr) #1
+declare void @main.doesNotEscapeParam(ptr nocapture dereferenceable_or_null(4), ptr nocapture, i32, i32, ptr nocapture dereferenceable_or_null(36), ptr nocapture, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.stillEscapes(ptr dereferenceable_or_null(4) %a, ptr %b.data, i32 %b.len, i32 %b.cap, ptr dereferenceable_or_null(32) %c, ptr %d, ptr %context) unnamed_addr #2 {
+define hidden void @main.stillEscapes(ptr dereferenceable_or_null(4) %a, ptr %b.data, i32 %b.len, i32 %b.cap, ptr dereferenceable_or_null(36) %c, ptr %d, ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }


### PR DESCRIPTION
This PR is to correct test fails from recent changes to runtime channel implementation in #5874
