### PR TITLE
Windows: add i386 (windows/386) support

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -92,7 +92,7 @@ jobs:
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo
-        run: make test GOTESTFLAGS="-short"
+        run: make test GOTESTFLAGS="-only-current-os"
       - name: Build TinyGo release tarball
         run: make release -j3
       - name: Test stdlib packages

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
         run: make -j3 gen-device
       - name: Test TinyGo
         shell: bash
-        run: make test GOTESTFLAGS="-short"
+        run: make test GOTESTFLAGS="-only-current-os"
       - name: Build TinyGo release tarball
         shell: bash
         run: make build/release -j4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -940,8 +940,9 @@ build/release: tinygo gen-device $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binary
 	@mkdir -p build/release/tinygo/lib/clang/include
 	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
 	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
+	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/crt
+	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/math
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/stdio
 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-headers/defaults
 	@mkdir -p build/release/tinygo/lib/musl/arch
 	@mkdir -p build/release/tinygo/lib/musl/crt
@@ -997,10 +998,17 @@ endif
 	@cp -rp lib/musl/src/time            build/release/tinygo/lib/musl/src
 	@cp -rp lib/musl/src/unistd          build/release/tinygo/lib/musl/src
 	@cp -rp lib/musl/src/process         build/release/tinygo/lib/musl/src
+	@cp -rp lib/mingw-w64/mingw-w64-crt/crt/pseudo-reloc.c          build/release/tinygo/lib/mingw-w64/mingw-w64-crt/crt
 	@cp -rp lib/mingw-w64/mingw-w64-crt/def-include                 build/release/tinygo/lib/mingw-w64/mingw-w64-crt
+	@cp -rp lib/mingw-w64/mingw-w64-crt/gdtoa                       build/release/tinygo/lib/mingw-w64/mingw-w64-crt
+	@cp -rp lib/mingw-w64/mingw-w64-crt/include                     build/release/tinygo/lib/mingw-w64/mingw-w64-crt
 	@cp -rp lib/mingw-w64/mingw-w64-crt/lib-common/api-ms-win-crt-* build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
+	@cp -rp lib/mingw-w64/mingw-w64-crt/lib-common/advapi32.def.in  build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
 	@cp -rp lib/mingw-w64/mingw-w64-crt/lib-common/kernel32.def.in  build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-	@cp -rp lib/mingw-w64/mingw-w64-crt/stdio/ucrt_*                build/release/tinygo/lib/mingw-w64/mingw-w64-crt/stdio
+	@cp -rp lib/mingw-w64/mingw-w64-crt/lib-common/msvcrt.def.in    build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
+	@cp -rp lib/mingw-w64/mingw-w64-crt/math/x86                    build/release/tinygo/lib/mingw-w64/mingw-w64-crt/math
+	@cp -rp lib/mingw-w64/mingw-w64-crt/misc                        build/release/tinygo/lib/mingw-w64/mingw-w64-crt
+	@cp -rp lib/mingw-w64/mingw-w64-crt/stdio                       build/release/tinygo/lib/mingw-w64/mingw-w64-crt
 	@cp -rp lib/mingw-w64/mingw-w64-headers/crt/                    build/release/tinygo/lib/mingw-w64/mingw-w64-headers
 	@cp -rp lib/mingw-w64/mingw-w64-headers/defaults/include        build/release/tinygo/lib/mingw-w64/mingw-w64-headers/defaults
 	@cp -rp lib/mingw-w64/mingw-w64-headers/include                 build/release/tinygo/lib/mingw-w64/mingw-w64-headers

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -67,6 +67,7 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "linux", GOARCH: "mipsle", GOMIPS: "softfloat"},
 		{GOOS: "darwin", GOARCH: "amd64"},
 		{GOOS: "darwin", GOARCH: "arm64"},
+		{GOOS: "windows", GOARCH: "386"},
 		{GOOS: "windows", GOARCH: "amd64"},
 		{GOOS: "windows", GOARCH: "arm64"},
 	} {

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
@@ -201,6 +202,11 @@ var avrBuiltins = []string{
 	"avr/udivmodqi4.S",
 }
 
+// Builtins needed specifically for windows/386.
+var windowsI386Builtins = []string{
+	"i386/chkstk.S", // also _alloca
+}
+
 // libCompilerRT is a library with symbols required by programs compiled with
 // LLVM. These symbols are for operations that cannot be emitted with a single
 // instruction or a short sequence of instructions for that target.
@@ -229,6 +235,10 @@ var libCompilerRT = Library{
 			builtins = append(builtins, avrBuiltins...)
 		case "x86_64", "aarch64", "riscv64": // any 64-bit arch
 			builtins = append(builtins, genericBuiltins128...)
+		case "i386":
+			if strings.Split(target, "-")[2] == "windows" {
+				builtins = append(builtins, windowsI386Builtins...)
+			}
 		}
 		return builtins, nil
 	},

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -93,6 +93,9 @@ func makeMinGWExtraLibs(tmpdir, goarch string) []*compileJob {
 				defpath := inpath
 				var archDef, emulation string
 				switch goarch {
+				case "386":
+					archDef = "-DDEF_I386"
+					emulation = "i386pe"
 				case "amd64":
 					archDef = "-DDEF_X64"
 					emulation = "i386pep"

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -30,25 +30,62 @@ var libMinGW = Library{
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/mingw-w64") },
 	cflags: func(target, headerPath string) []string {
 		mingwDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/mingw-w64")
-		return []string{
+		flags := []string{
 			"-nostdlibinc",
+			"-isystem", mingwDir + "/mingw-w64-crt/include",
 			"-isystem", mingwDir + "/mingw-w64-headers/crt",
+			"-isystem", mingwDir + "/mingw-w64-headers/include",
 			"-I", mingwDir + "/mingw-w64-headers/defaults/include",
 			"-I" + headerPath,
 		}
+		if strings.Split(target, "-")[0] == "i386" {
+			flags = append(flags,
+				"-D__MSVCRT_VERSION__=0x700", // Microsoft Visual C++ .NET 2002
+				"-D_WIN32_WINNT=0x0501",      // target Windows XP
+				"-D_CRTBLD",
+				"-Wno-pragma-pack",
+			)
+		}
+		return flags
 	},
 	librarySources: func(target string) ([]string, error) {
 		// These files are needed so that printf and the like are supported.
-		sources := []string{
-			"mingw-w64-crt/stdio/ucrt_fprintf.c",
-			"mingw-w64-crt/stdio/ucrt_fwprintf.c",
-			"mingw-w64-crt/stdio/ucrt_printf.c",
-			"mingw-w64-crt/stdio/ucrt_snprintf.c",
-			"mingw-w64-crt/stdio/ucrt_sprintf.c",
-			"mingw-w64-crt/stdio/ucrt_vfprintf.c",
-			"mingw-w64-crt/stdio/ucrt_vprintf.c",
-			"mingw-w64-crt/stdio/ucrt_vsnprintf.c",
-			"mingw-w64-crt/stdio/ucrt_vsprintf.c",
+		var sources []string
+		if strings.Split(target, "-")[0] == "i386" {
+			// Old 32-bit x86 systems use msvcrt.dll.
+			sources = []string{
+				"mingw-w64-crt/crt/pseudo-reloc.c",
+				"mingw-w64-crt/gdtoa/dmisc.c",
+				"mingw-w64-crt/gdtoa/gdtoa.c",
+				"mingw-w64-crt/gdtoa/gmisc.c",
+				"mingw-w64-crt/gdtoa/misc.c",
+				"mingw-w64-crt/math/x86/exp2.S",
+				"mingw-w64-crt/math/x86/trunc.S",
+				"mingw-w64-crt/misc/___mb_cur_max_func.c",
+				"mingw-w64-crt/misc/lc_locale_func.c",
+				"mingw-w64-crt/misc/mbrtowc.c",
+				"mingw-w64-crt/misc/strnlen.c",
+				"mingw-w64-crt/misc/wcrtomb.c",
+				"mingw-w64-crt/misc/wcsnlen.c",
+				"mingw-w64-crt/stdio/acrt_iob_func.c",
+				"mingw-w64-crt/stdio/mingw_lock.c",
+				"mingw-w64-crt/stdio/mingw_pformat.c",
+				"mingw-w64-crt/stdio/mingw_vfprintf.c",
+				"mingw-w64-crt/stdio/mingw_vsnprintf.c",
+			}
+		} else {
+			// Anything somewhat modern (amd64, arm64) uses UCRT.
+			sources = []string{
+				"mingw-w64-crt/stdio/ucrt_fprintf.c",
+				"mingw-w64-crt/stdio/ucrt_fwprintf.c",
+				"mingw-w64-crt/stdio/ucrt_printf.c",
+				"mingw-w64-crt/stdio/ucrt_snprintf.c",
+				"mingw-w64-crt/stdio/ucrt_sprintf.c",
+				"mingw-w64-crt/stdio/ucrt_vfprintf.c",
+				"mingw-w64-crt/stdio/ucrt_vprintf.c",
+				"mingw-w64-crt/stdio/ucrt_vsnprintf.c",
+				"mingw-w64-crt/stdio/ucrt_vsprintf.c",
+			}
 		}
 		return sources, nil
 	},
@@ -63,27 +100,41 @@ var libMinGW = Library{
 func makeMinGWExtraLibs(tmpdir, goarch string) []*compileJob {
 	var jobs []*compileJob
 	root := goenv.Get("TINYGOROOT")
-	// Normally all the api-ms-win-crt-*.def files are all compiled to a single
-	// .lib file. But to simplify things, we're going to leave them as separate
-	// files.
-	for _, name := range []string{
-		"kernel32.def.in",
-		"api-ms-win-crt-conio-l1-1-0.def",
-		"api-ms-win-crt-convert-l1-1-0.def.in",
-		"api-ms-win-crt-environment-l1-1-0.def",
-		"api-ms-win-crt-filesystem-l1-1-0.def",
-		"api-ms-win-crt-heap-l1-1-0.def",
-		"api-ms-win-crt-locale-l1-1-0.def",
-		"api-ms-win-crt-math-l1-1-0.def.in",
-		"api-ms-win-crt-multibyte-l1-1-0.def",
-		"api-ms-win-crt-private-l1-1-0.def.in",
-		"api-ms-win-crt-process-l1-1-0.def",
-		"api-ms-win-crt-runtime-l1-1-0.def.in",
-		"api-ms-win-crt-stdio-l1-1-0.def",
-		"api-ms-win-crt-string-l1-1-0.def",
-		"api-ms-win-crt-time-l1-1-0.def",
-		"api-ms-win-crt-utility-l1-1-0.def",
-	} {
+	var libs []string
+	if goarch == "386" {
+		libs = []string{
+			// x86 uses msvcrt.dll instead of UCRT for compatibility with old
+			// Windows versions.
+			"advapi32.def.in",
+			"kernel32.def.in",
+			"msvcrt.def.in",
+		}
+	} else {
+		// Use the modernized UCRT on new systems.
+		// Normally all the api-ms-win-crt-*.def files are all compiled to a
+		// single .lib file. But to simplify things, we're going to leave them
+		// as separate files.
+		libs = []string{
+			"advapi32.def.in",
+			"kernel32.def.in",
+			"api-ms-win-crt-conio-l1-1-0.def",
+			"api-ms-win-crt-convert-l1-1-0.def.in",
+			"api-ms-win-crt-environment-l1-1-0.def",
+			"api-ms-win-crt-filesystem-l1-1-0.def",
+			"api-ms-win-crt-heap-l1-1-0.def",
+			"api-ms-win-crt-locale-l1-1-0.def",
+			"api-ms-win-crt-math-l1-1-0.def.in",
+			"api-ms-win-crt-multibyte-l1-1-0.def",
+			"api-ms-win-crt-private-l1-1-0.def.in",
+			"api-ms-win-crt-process-l1-1-0.def",
+			"api-ms-win-crt-runtime-l1-1-0.def.in",
+			"api-ms-win-crt-stdio-l1-1-0.def",
+			"api-ms-win-crt-string-l1-1-0.def",
+			"api-ms-win-crt-time-l1-1-0.def",
+			"api-ms-win-crt-utility-l1-1-0.def",
+		}
+	}
+	for _, name := range libs {
 		outpath := filepath.Join(tmpdir, filepath.Base(name)+".lib")
 		inpath := filepath.Join(root, "lib/mingw-w64/mingw-w64-crt/lib-common/"+name)
 		job := &compileJob{

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -398,15 +398,25 @@ func (c *Config) LibcCFlags() []string {
 	case "mingw-w64":
 		root := goenv.Get("TINYGOROOT")
 		path := c.LibraryPath("mingw-w64")
-		return []string{
+		cflags := []string{
 			"-nostdlibinc",
 			"-isystem", filepath.Join(path, "include"),
 			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "crt"),
 			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "include"),
 			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "defaults", "include"),
-			"-D_UCRT",
-			"-D_WIN32_WINNT=0x0a00", // target Windows 10
 		}
+		if c.GOARCH() == "386" {
+			cflags = append(cflags,
+				"-D__MSVCRT_VERSION__=0x700", // Microsoft Visual C++ .NET 2002
+				"-D_WIN32_WINNT=0x0501",      // target Windows XP
+			)
+		} else {
+			cflags = append(cflags,
+				"-D_UCRT",
+				"-D_WIN32_WINNT=0x0a00", // target Windows 10
+			)
+		}
+		return cflags
 	case "":
 		// No libc specified, nothing to add.
 		return nil

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -437,6 +437,8 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 		case "386":
 			spec.LDFlags = append(spec.LDFlags,
 				"-m", "i386pe",
+				"--major-os-version", "4",
+				"--major-subsystem-version", "4",
 			)
 			// __udivdi3 is not present in ucrt it seems.
 			spec.RTLib = "compiler-rt"

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -433,14 +433,20 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 		spec.Scheduler = "tasks"
 		spec.Linker = "ld.lld"
 		spec.Libc = "mingw-w64"
-		// Note: using a medium code model, low image base and no ASLR
-		// because Go doesn't really need those features. ASLR patches
-		// around issues for unsafe languages like C/C++ that are not
-		// normally present in Go (without explicitly opting in).
-		// For more discussion:
-		// https://groups.google.com/g/Golang-nuts/c/Jd9tlNc6jUE/m/Zo-7zIP_m3MJ?pli=1
 		switch options.GOARCH {
+		case "386":
+			spec.LDFlags = append(spec.LDFlags,
+				"-m", "i386pe",
+			)
+			// __udivdi3 is not present in ucrt it seems.
+			spec.RTLib = "compiler-rt"
 		case "amd64":
+			// Note: using a medium code model, low image base and no ASLR
+			// because Go doesn't really need those features. ASLR patches
+			// around issues for unsafe languages like C/C++ that are not
+			// normally present in Go (without explicitly opting in).
+			// For more discussion:
+			// https://groups.google.com/g/Golang-nuts/c/Jd9tlNc6jUE/m/Zo-7zIP_m3MJ?pli=1
 			spec.LDFlags = append(spec.LDFlags,
 				"-m", "i386pep",
 				"--image-base", "0x400000",

--- a/compiler/calls.go
+++ b/compiler/calls.go
@@ -76,7 +76,15 @@ func (b *builder) createCall(fnType llvm.Type, fn llvm.Value, args []llvm.Value,
 		fragments := b.expandFormalParam(arg)
 		expanded = append(expanded, fragments...)
 	}
-	return b.CreateCall(fnType, fn, expanded, name)
+	call := b.CreateCall(fnType, fn, expanded, name)
+	if !fn.IsAFunction().IsNil() {
+		if cc := fn.FunctionCallConv(); cc != llvm.CCallConv {
+			// Set a different calling convention if needed.
+			// This is needed for GetModuleHandleExA on Windows, for example.
+			call.SetInstructionCallConv(cc)
+		}
+	}
+	return call
 }
 
 // createInvoke is like createCall but continues execution at the landing pad if

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -208,6 +208,12 @@ func (c *compilerContext) getFunction(fn *ssa.Function) (llvm.Type, llvm.Value) 
 			// > circumstances, and should not be exposed to source languages.
 			llvmutil.AppendToGlobal(c.mod, "llvm.compiler.used", llvmFn)
 		}
+	case "GetModuleHandleExA", "GetProcAddress", "GetSystemInfo", "GetSystemTimeAsFileTime", "LoadLibraryExW", "QueryUnbiasedInterruptTime", "SetEnvironmentVariableA", "Sleep", "VirtualAlloc":
+		// On Windows we need to use a special calling convention for some
+		// external calls.
+		if c.GOOS == "windows" && c.GOARCH == "386" {
+			llvmFn.SetFunctionCallConv(llvm.X86StdcallCallConv)
+		}
 	}
 
 	// External/exported functions may not retain pointer values.

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -208,7 +208,7 @@ func (c *compilerContext) getFunction(fn *ssa.Function) (llvm.Type, llvm.Value) 
 			// > circumstances, and should not be exposed to source languages.
 			llvmutil.AppendToGlobal(c.mod, "llvm.compiler.used", llvmFn)
 		}
-	case "GetModuleHandleExA", "GetProcAddress", "GetSystemInfo", "GetSystemTimeAsFileTime", "LoadLibraryExW", "QueryUnbiasedInterruptTime", "SetEnvironmentVariableA", "Sleep", "VirtualAlloc":
+	case "GetModuleHandleExA", "GetProcAddress", "GetSystemInfo", "GetSystemTimeAsFileTime", "LoadLibraryExW", "QueryPerformanceCounter", "QueryPerformanceFrequency", "QueryUnbiasedInterruptTime", "SetEnvironmentVariableA", "Sleep", "SystemFunction036", "VirtualAlloc":
 		// On Windows we need to use a special calling convention for some
 		// external calls.
 		if c.GOOS == "windows" && c.GOARCH == "386" {

--- a/src/internal/task/task_stack_386.S
+++ b/src/internal/task/task_stack_386.S
@@ -1,7 +1,12 @@
+#ifdef _WIN32
+.global  _tinygo_startTask
+_tinygo_startTask:
+#else // Linux etc
 .section .text.tinygo_startTask
 .global  tinygo_startTask
 .type    tinygo_startTask, %function
 tinygo_startTask:
+#endif
     .cfi_startproc
     // Small assembly stub for starting a goroutine. This is already run on the
     // new stack, with the callee-saved registers already loaded.
@@ -24,12 +29,21 @@ tinygo_startTask:
     addl $4, %esp
 
     // After return, exit this goroutine. This is a tail call.
+    #ifdef _WIN32
+    jmp _tinygo_task_exit
+    #else
     jmp tinygo_task_exit
+    #endif
     .cfi_endproc
 
+#ifdef _WIN32
+.global _tinygo_swapTask
+_tinygo_swapTask:
+#else
 .global tinygo_swapTask
 .type tinygo_swapTask, %function
 tinygo_swapTask:
+#endif
     // This function gets the following parameters:
     movl 4(%esp), %eax // newStack uintptr
     movl 8(%esp), %ecx // oldStack *uintptr

--- a/src/runtime/asm_386.S
+++ b/src/runtime/asm_386.S
@@ -1,7 +1,12 @@
+#ifdef _WIN32
+.global _tinygo_scanCurrentStack
+_tinygo_scanCurrentStack:
+#else
 .section .text.tinygo_scanCurrentStack
 .global tinygo_scanCurrentStack
 .type tinygo_scanCurrentStack, %function
 tinygo_scanCurrentStack:
+#endif
     // Sources:
     //   * https://stackoverflow.com/questions/18024672/what-registers-are-preserved-through-a-linux-x86-64-function-call
     //   * https://godbolt.org/z/q7e8dn
@@ -15,7 +20,11 @@ tinygo_scanCurrentStack:
     // Scan the stack.
     subl $8, %esp // adjust the stack before the call to maintain 16-byte alignment
     pushl %esp
+    #ifdef _WIN32
+    calll _tinygo_scanstack
+    #else
     calll tinygo_scanstack
+    #endif
 
     // Restore the stack pointer. Registers do not need to be restored as they
     // were only pushed to be discoverable by the GC.
@@ -23,9 +32,14 @@ tinygo_scanCurrentStack:
     retl
 
 
+#ifdef _WIN32
+.global _tinygo_longjmp
+_tinygo_longjmp:
+#else
 .section .text.tinygo_longjmp
 .global tinygo_longjmp
 tinygo_longjmp:
+#endif
     // Note: the code we jump to assumes eax is set to a non-zero value if we
     // jump from here.
     movl 4(%esp), %eax


### PR DESCRIPTION
This is not fully working, but very simple programs do work.

The issue I'm currently hitting is that `syscall.loadsystemlibrary` (defined in src/runtime/runtime_windows.go) appears to be corrupting memory. Or maybe it just overwrites registers, I'm not sure.

See: #3353