### PR TITLE
runtime: use uint32 for the channel state and select index

### DIFF
--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -26,6 +26,18 @@ type Task struct {
 	DeferFrame unsafe.Pointer
 }
 
+// DataUint32 returns the Data field as a uint32. The value is only valid after
+// setting it through SetDataUint32.
+func (t *Task) DataUint32() uint32 {
+	return *(*uint32)(unsafe.Pointer(&t.Data))
+}
+
+// SetDataUint32 updates the uint32 portion of the Data field (which could be
+// the first 4 or last 4 bytes depending on the architecture endianness).
+func (t *Task) SetDataUint32(val uint32) {
+	*(*uint32)(unsafe.Pointer(&t.Data)) = val
+}
+
 // getGoroutineStackSize is a compiler intrinsic that returns the stack size for
 // the given function and falls back to the default stack size. It is replaced
 // with a load from a special section just before codegen.


### PR DESCRIPTION
This uses uint32 instead of uint64. The reason for this is that uint64 atomic operations aren't universally available (especially on 32-bit architectures). We could also use uintptr, but that seems needlessly complicated: it's unlikely real-world programs will use more than a billion select states (2^30).

(This could also reduce code size slightly, but I didn't test that).