### PR TITLE
examples: use default UART settings in echo example

### DIFF
--- a/src/examples/echo/echo.go
+++ b/src/examples/echo/echo.go
@@ -7,15 +7,13 @@ import (
 	"time"
 )
 
-// change these to test a different UART or pins if available
 var (
 	uart = machine.Serial
-	tx   = machine.UART_TX_PIN
-	rx   = machine.UART_RX_PIN
 )
 
 func main() {
-	uart.Configure(machine.UARTConfig{TX: tx, RX: rx})
+	// use default settings for UART
+	uart.Configure(machine.UARTConfig{})
 	uart.Write([]byte("Echo console enabled. Type something then press enter:\r\n"))
 
 	input := make([]byte, 64)


### PR DESCRIPTION
This PR modifies the `echo` example to use the default UART settings now that they work on all supported platforms.