### PR TITLE
Prepare channels for parallelism

### DIFF
--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -27,7 +27,7 @@ type Task struct {
 }
 
 // DataUint32 returns the Data field as a uint32. The value is only valid after
-// setting it through SetDataUint32.
+// setting it through SetDataUint32 or by storing to it using DataAtomicUint32.
 func (t *Task) DataUint32() uint32 {
 	return *(*uint32)(unsafe.Pointer(&t.Data))
 }
@@ -36,6 +36,11 @@ func (t *Task) DataUint32() uint32 {
 // the first 4 or last 4 bytes depending on the architecture endianness).
 func (t *Task) SetDataUint32(val uint32) {
 	*(*uint32)(unsafe.Pointer(&t.Data)) = val
+}
+
+// DataAtomicUint32 returns the Data field as an atomic-if-needed Uint32 value.
+func (t *Task) DataAtomicUint32() *Uint32 {
+	return (*Uint32)(unsafe.Pointer(&t.Data))
 }
 
 // getGoroutineStackSize is a compiler intrinsic that returns the stack size for

--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -21,6 +21,12 @@ import (
 // queue a new scheduler invocation using setTimeout.
 const asyncScheduler = GOOS == "js"
 
+const hasScheduler = true
+
+// Concurrency is not parallelism. While the cooperative scheduler has
+// concurrency, it does not have parallelism.
+const hasParallelism = false
+
 // Queues used by the scheduler.
 var (
 	runqueue           task.Queue
@@ -248,5 +254,3 @@ func run() {
 	}()
 	scheduler(false)
 }
-
-const hasScheduler = true

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -6,6 +6,9 @@ import "internal/task"
 
 const hasScheduler = false
 
+// No goroutines are allowed, so there's no parallelism anywhere.
+const hasParallelism = false
+
 // run is called by the program entry point to execute the go program.
 // With the "none" scheduler, init and the main function are invoked directly.
 func run() {


### PR DESCRIPTION
This is part of #4559 but extracted for easier review.
In theory this should not change the binary size of any existing code, since all the new synchronisation should be no-ops when there are no threads involved.