### PR TITLE
mips: fix a bug when scanning the stack

### DIFF
--- a/src/internal/task/task_stack_mipsx.S
+++ b/src/internal/task/task_stack_mipsx.S
@@ -1,3 +1,7 @@
+// Do not reorder instructions to insert a branch delay slot.
+// We know what we're doing, and will manually fill the branch delay slot.
+.set noreorder
+
 .section .text.tinygo_startTask
 .global  tinygo_startTask
 .type    tinygo_startTask, %function

--- a/src/runtime/asm_mipsx.S
+++ b/src/runtime/asm_mipsx.S
@@ -1,3 +1,7 @@
+// Do not reorder instructions to insert a branch delay slot.
+// We know what we're doing, and will manually fill the branch delay slot.
+.set noreorder
+
 .section .text.tinygo_scanCurrentStack
 .global  tinygo_scanCurrentStack
 .type    tinygo_scanCurrentStack, %function


### PR DESCRIPTION
Previously the assembler was changing this code:

    jal tinygo_scanstack
    move $a0, $sp

Into this:

    jal tinygo_scanstack
    nop
    move $a0, $sp

So it was "helpfully" inserting a branch delay slot, even though this was already being taken care of.
Somehow this didn't lead to a crash before, but it does break in the WIP threading branch (https://github.com/tinygo-org/tinygo/pull/4559).

The `.set noreorder` avoids the extra inserted nop, fixing this issue.