### PR TITLE
runtime: lock output in print/println

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1686,6 +1686,7 @@ func (b *builder) createBuiltin(argTypes []types.Type, argValues []llvm.Value, c
 		b.createRuntimeInvoke("_panic", argValues, "")
 		return llvm.Value{}, nil
 	case "print", "println":
+		b.createRuntimeCall("printlock", nil, "")
 		for i, value := range argValues {
 			if i >= 1 && callName == "println" {
 				b.createRuntimeCall("printspace", nil, "")
@@ -1746,6 +1747,7 @@ func (b *builder) createBuiltin(argTypes []types.Type, argValues []llvm.Value, c
 		if callName == "println" {
 			b.createRuntimeCall("printnl", nil, "")
 		}
+		b.createRuntimeCall("printunlock", nil, "")
 		return llvm.Value{}, nil // print() or println() returns void
 	case "real":
 		cplx := argValues[0]

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -122,11 +122,17 @@ declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(24), ptr) #2
 ; Function Attrs: nounwind
 define internal void @"main.deferSimple$1"(ptr %context) unnamed_addr #1 {
 entry:
+  call void @runtime.printlock(ptr undef) #4
   call void @runtime.printint32(i32 3, ptr undef) #4
+  call void @runtime.printunlock(ptr undef) #4
   ret void
 }
 
+declare void @runtime.printlock(ptr) #2
+
 declare void @runtime.printint32(i32, ptr) #2
+
+declare void @runtime.printunlock(ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.deferMultiple(ptr %context) unnamed_addr #1 {
@@ -250,14 +256,18 @@ rundefers.end7:                                   ; preds = %rundefers.loophead1
 ; Function Attrs: nounwind
 define internal void @"main.deferMultiple$1"(ptr %context) unnamed_addr #1 {
 entry:
+  call void @runtime.printlock(ptr undef) #4
   call void @runtime.printint32(i32 3, ptr undef) #4
+  call void @runtime.printunlock(ptr undef) #4
   ret void
 }
 
 ; Function Attrs: nounwind
 define internal void @"main.deferMultiple$2"(ptr %context) unnamed_addr #1 {
 entry:
+  call void @runtime.printlock(ptr undef) #4
   call void @runtime.printint32(i32 5, ptr undef) #4
+  call void @runtime.printunlock(ptr undef) #4
   ret void
 }
 

--- a/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
+++ b/compiler/testdata/goroutine-cortex-m-qemu-tasks.ll
@@ -70,7 +70,9 @@ entry:
   %stacksize = call i32 @"internal/task.getGoroutineStackSize"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr undef) #9
   call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 %stacksize, ptr undef) #9
   %2 = load i32, ptr %n, align 4
+  call void @runtime.printlock(ptr undef) #9
   call void @runtime.printint32(i32 %2, ptr undef) #9
+  call void @runtime.printunlock(ptr undef) #9
   ret void
 }
 
@@ -91,7 +93,11 @@ entry:
   ret void
 }
 
+declare void @runtime.printlock(ptr) #2
+
 declare void @runtime.printint32(i32, ptr) #2
+
+declare void @runtime.printunlock(ptr) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.funcGoroutine(ptr %fn.context, ptr %fn.funcptr, ptr %context) unnamed_addr #1 {

--- a/compiler/testdata/goroutine-wasm-asyncify.ll
+++ b/compiler/testdata/goroutine-wasm-asyncify.ll
@@ -76,7 +76,9 @@ entry:
   store ptr %n, ptr %1, align 4
   call void @"internal/task.start"(i32 ptrtoint (ptr @"main.closureFunctionGoroutine$1$gowrapper" to i32), ptr nonnull %0, i32 65536, ptr undef) #9
   %2 = load i32, ptr %n, align 4
+  call void @runtime.printlock(ptr undef) #9
   call void @runtime.printint32(i32 %2, ptr undef) #9
+  call void @runtime.printunlock(ptr undef) #9
   ret void
 }
 
@@ -98,7 +100,11 @@ entry:
   unreachable
 }
 
+declare void @runtime.printlock(ptr) #1
+
 declare void @runtime.printint32(i32, ptr) #1
+
+declare void @runtime.printunlock(ptr) #1
 
 ; Function Attrs: nounwind
 define hidden void @main.funcGoroutine(ptr %fn.context, ptr %fn.funcptr, ptr %context) unnamed_addr #2 {

--- a/testdata/print.go
+++ b/testdata/print.go
@@ -37,6 +37,12 @@ func main() {
 
 	// print interface
 	println(interface{}(nil))
+	println(interface{}(true))
+	println(interface{}("foobar"))
+	println(interface{}(int64(-3)))
+	println(interface{}(uint64(3)))
+	println(interface{}(int(-3)))
+	println(interface{}(uint(3)))
 
 	// print map
 	println(map[string]int{"three": 3, "five": 5})

--- a/testdata/print.txt
+++ b/testdata/print.txt
@@ -19,6 +19,12 @@ a b c
 +3.140000e+000
 (+5.000000e+000+1.234500e+000i)
 (0:nil)
+true
+foobar
+-3
+3
+-3
+3
 map[2]
 true false
 [0/0]nil


### PR DESCRIPTION
This ensures that calls to print/println happening in different threads are not interleaved. It's a `task.PMutex`, so this should only change things when threading is used.

This matches the Go compiler, which does the same thing: https://godbolt.org/z/na5KzE7en

The locks are not recursive, which means that we need to be careful to not call `print` or `println` inside a runtime.print* implementation, inside putchar (recursively), and inside signal handlers. Making them recursive might be useful to do in the future, but it's not really necessary.

Extracted from #4559 to make reviewing easier.