### PR TITLE
fix: allow nintendoswitch target to compile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -867,7 +867,7 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -serial=rtt examples/echo
 	@$(MD5SUM) test.hex
-	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/serial
+	$(TINYGO) build             -o test.nro -target=nintendoswitch      examples/echo2
 	@$(MD5SUM) test.nro
 	$(TINYGO) build -size short -o test.hex -target=pca10040 -opt=0     ./testdata/stdlib.go
 	@$(MD5SUM) test.hex

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows || wasm_unknown
+//go:build baremetal || js || windows || wasm_unknown || nintendoswitch
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasip1 && !wasip2 && !wasm_unknown
+//go:build linux && !baremetal && !wasip1 && !wasip2 && !wasm_unknown && !nintendoswitch
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasip1 && !wasip2 && !wasm_unknown
+//go:build !baremetal && !js && !wasip1 && !wasip2 && !wasm_unknown && !nintendoswitch
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/exec_linux.go
+++ b/src/os/exec_linux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !tinygo.wasm
+//go:build linux && !baremetal && !tinygo.wasm && !nintendoswitch
 
 package os
 

--- a/src/os/exec_other.go
+++ b/src/os/exec_other.go
@@ -1,4 +1,4 @@
-//go:build (!aix && !android && !freebsd && !linux && !netbsd && !openbsd && !plan9 && !solaris) || baremetal || tinygo.wasm
+//go:build (!aix && !android && !freebsd && !linux && !netbsd && !openbsd && !plan9 && !solaris) || baremetal || tinygo.wasm || nintendoswitch
 
 package os
 

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasm_unknown
+//go:build !baremetal && !js && !wasm_unknown && !nintendoswitch
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (tinygo.wasm && !wasip1 && !wasip2)
+//go:build baremetal || (tinygo.wasm && !wasip1 && !wasip2) || nintendoswitch
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1 || wasip2
+//go:build darwin || (linux && !baremetal && !wasm_unknown && !nintendoswitch) || wasip1 || wasip2
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/osexec.go
+++ b/src/os/osexec.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal && !tinygo.wasm
+//go:build linux && !baremetal && !tinygo.wasm && !nintendoswitch
 
 package os
 

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasip1 && !wasip2 && !wasm_unknown
+//go:build !baremetal && !js && !wasip1 && !wasip2 && !wasm_unknown && !nintendoswitch
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasip1 || wasip2 || wasm_unknown
+//go:build baremetal || js || wasip1 || wasip2 || wasm_unknown || nintendoswitch
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_linuxlike.go
+++ b/src/os/stat_linuxlike.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal && !wasm_unknown) || wasip1 || wasip2
+//go:build (linux && !baremetal && !wasm_unknown && !nintendoswitch) || wasip1 || wasip2
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (tinygo.wasm && !wasip1 && !wasip2)
+//go:build baremetal || (tinygo.wasm && !wasip1 && !wasip2) || nintendoswitch
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1 || wasip2
+//go:build darwin || (linux && !baremetal && !wasm_unknown && !nintendoswitch) || wasip1 || wasip2
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasm_unknown
+//go:build !baremetal && !js && !wasm_unknown && !nintendoswitch
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !wasm_unknown) || wasip1 || wasip2
+//go:build darwin || (linux && !baremetal && !wasm_unknown && !nintendoswitch) || wasip1 || wasip2
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/nonhosted.go
+++ b/src/runtime/nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasm_unknown
+//go:build baremetal || js || wasm_unknown || nintendoswitch
 
 package runtime
 

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -84,6 +84,19 @@ func ticks() timeUnit {
 	return timeUnit(ticksToNanoseconds(timeUnit(getArmSystemTick())))
 }
 
+// timeOffset is how long the monotonic clock started after the Unix epoch. It
+// should be a positive integer under normal operation or zero when it has not
+// been set.
+var timeOffset int64
+
+//go:linkname now time.now
+func now() (sec int64, nsec int32, mono int64) {
+	mono = nanotime()
+	sec = (mono + timeOffset) / (1000 * 1000 * 1000)
+	nsec = int32((mono + timeOffset) - sec*(1000*1000*1000))
+	return
+}
+
 var stdoutBuffer = make([]byte, 120)
 var position = 0
 
@@ -96,6 +109,14 @@ func putchar(c byte) {
 
 	stdoutBuffer[position] = c
 	position++
+}
+
+func buffered() int {
+	return 0
+}
+
+func getchar() byte {
+	return 0
 }
 
 func abort() {

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || (linux && !baremetal && !wasip1 && !wasm_unknown && !wasip2)) && !nintendoswitch
+//go:build darwin || (linux && !baremetal && !wasip1 && !wasm_unknown && !wasip2 && !nintendoswitch)
 
 package runtime
 

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || tinygo.wasm
+//go:build baremetal || tinygo.wasm || nintendoswitch
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !tinygo.wasm
+//go:build !baremetal && !tinygo.wasm && !nintendoswitch
 
 // This file assumes there is a libc available that runs on a real operating
 // system.


### PR DESCRIPTION
This PR is to fix the build errors for the `nintendoswitch` target as mentioned in #2530 