### PR TITLE
properly handle unix read on directory

### DIFF
--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,6 +1,6 @@
 //go:build !baremetal && !js && !wasm_unknown
 
-// Portions copyright 2009 The Go Authors. All rights reserved.
+// Portions copyright 2009-2024 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -97,6 +97,11 @@ type unixFileHandle uintptr
 // read and any error encountered. At end of file, Read returns 0, io.EOF.
 func (f unixFileHandle) Read(b []byte) (n int, err error) {
 	n, err = syscall.Read(syscallFd(f), b)
+	// In case of EISDIR, n == -1.
+	// This breaks the assumption that n always represent the number of read bytes.
+	if err == syscall.EISDIR {
+		n = 0
+	}
 	err = handleSyscallError(err)
 	if n == 0 && len(b) > 0 && err == nil {
 		err = io.EOF

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -185,3 +185,22 @@ func TestClose(t *testing.T) {
 		}
 	}
 }
+
+func TestReadOnDir(t *testing.T) {
+	name := TempDir() + "/_os_test_TestReadOnDir"
+	defer Remove(name)
+	f, err := OpenFile(name, O_RDWR|O_CREATE, 0644)
+	if err != nil {
+		t.Errorf("OpenFile %s: %s", name, err)
+		return
+	}
+	var buf [32]byte
+	n, err := f.Read(buf[:])
+	if err == nil {
+		t.Errorf("Error expected")
+		return
+	}
+	if n != 0 {
+		t.Errorf("Wrong read bytes: %s", err)
+	}
+}


### PR DESCRIPTION
On linux systems the `syscall.Read` returns -1 in case the read is being performed on a directory.
This does not play well with the documentation of this function which states that `n` matches the number of bytes count being read. As a result, other code parts may panic, like here:
https://github.com/noboruma/tinygo/blob/fix-os-unix-read/src/os/file.go#L471

The proposition here is to simply set `n` to 0 in case of directory `EISDIR` error.