### PR TITLE
fix: specify ubuntu-22.04 during GH actions transition period

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,7 +169,7 @@ jobs:
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch
     # potential bugs.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is to address recent build failures.

See for example https://github.com/tinygo-org/tinygo/actions/runs/12224188478/job/34096630914#step:23:24

The solution for the moment is by specifying `ubuntu-22.04` during GH actions transition period to ubuntu-24.04

See https://github.com/actions/runner-images/issues/10636 for the backstory.

We will want to update to ubuntu 24.04 but will need to address the testing with headless Chrome first.