### PR TITLE
Binary size report in HTML

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -925,15 +925,16 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 			}
 
 			// Print code size if requested.
-			if config.Options.PrintSizes == "short" || config.Options.PrintSizes == "full" {
+			if config.Options.PrintSizes != "" {
 				sizes, err := loadProgramSize(result.Executable, result.PackagePathMap)
 				if err != nil {
 					return err
 				}
-				if config.Options.PrintSizes == "short" {
+				switch config.Options.PrintSizes {
+				case "short":
 					fmt.Printf("   code    data     bss |   flash     ram\n")
 					fmt.Printf("%7d %7d %7d | %7d %7d\n", sizes.Code+sizes.ROData, sizes.Data, sizes.BSS, sizes.Flash(), sizes.RAM())
-				} else {
+				case "full":
 					if !config.Debug() {
 						fmt.Println("warning: data incomplete, remove the -no-debug flag for more detail")
 					}
@@ -945,6 +946,13 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					}
 					fmt.Printf("------------------------------- | --------------- | -------\n")
 					fmt.Printf("%7d %7d %7d %7d | %7d %7d | total\n", sizes.Code, sizes.ROData, sizes.Data, sizes.BSS, sizes.Code+sizes.ROData+sizes.Data, sizes.Data+sizes.BSS)
+				case "html":
+					const filename = "size-report.html"
+					err := writeSizeReport(sizes, filename, pkgName)
+					if err != nil {
+						return err
+					}
+					fmt.Println("Wrote size report to", filename)
 				}
 			}
 

--- a/builder/size-report.go
+++ b/builder/size-report.go
@@ -1,0 +1,56 @@
+package builder
+
+import (
+	_ "embed"
+	"fmt"
+	"html/template"
+	"os"
+)
+
+//go:embed size-report.html
+var sizeReportBase string
+
+func writeSizeReport(sizes *programSize, filename, pkgName string) error {
+	tmpl, err := template.New("report").Parse(sizeReportBase)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("could not open report file: %w", err)
+	}
+	defer f.Close()
+
+	// Prepare data for the report.
+	type sizeLine struct {
+		Name string
+		Size *packageSize
+	}
+	programData := []sizeLine{}
+	for _, name := range sizes.sortedPackageNames() {
+		pkgSize := sizes.Packages[name]
+		programData = append(programData, sizeLine{
+			Name: name,
+			Size: pkgSize,
+		})
+	}
+	sizeTotal := map[string]uint64{
+		"code":   sizes.Code,
+		"rodata": sizes.ROData,
+		"data":   sizes.Data,
+		"bss":    sizes.BSS,
+		"flash":  sizes.Flash(),
+	}
+
+	// Write the report.
+	err = tmpl.Execute(f, map[string]any{
+		"pkgName":   pkgName,
+		"sizes":     programData,
+		"sizeTotal": sizeTotal,
+	})
+	if err != nil {
+		return fmt.Errorf("could not create report file: %w", err)
+	}
+	return nil
+}

--- a/builder/size-report.html
+++ b/builder/size-report.html
@@ -11,6 +11,12 @@
   border-left: calc(var(--bs-border-width) * 2) solid currentcolor;
 }
 
+/* Hover on only the rows that are clickable. */
+.row-package:hover > * {
+  --bs-table-color-state: var(--bs-table-hover-color);
+  --bs-table-bg-state: var(--bs-table-hover-bg);
+}
+
     </style>
   </head>
   <body>
@@ -29,6 +35,9 @@
       <p>The binary size consists of code, read-only data, and data. On microcontrollers, this is exactly the size of the firmware image. On other systems, there is some extra overhead: binary metadata (headers of the ELF/MachO/COFF file), debug information, exception tables, symbol names, etc. Using <code>-no-debug</code> strips most of those.</p>
 
       <h2>Program breakdown</h2>
+
+      <p>You can click on the rows below to see which files contribute to the binary size.</p>
+
       <div class="table-responsive">
         <table class="table w-auto">
           <thead>
@@ -42,8 +51,8 @@
             </tr>
           </thead>
           <tbody class="table-group-divider">
-            {{range .sizes}}
-            <tr>
+            {{range $i, $pkg := .sizes}}
+            <tr class="row-package" data-collapse=".collapse-row-{{$i}}">
               <td>{{.Name}}</td>
               <td class="table-vertical-border">{{.Size.Code}}</td>
               <td>{{.Size.ROData}}</td>
@@ -53,6 +62,24 @@
                 {{.Size.Flash}}
               </td>
             </tr>
+            {{range $filename, $sizes := .Size.Sub}}
+            <tr class="table-secondary collapse collapse-row-{{$i}}">
+              <td class="ps-4">
+                {{if eq $filename ""}}
+                  (unknown file)
+                {{else}}
+                  {{$filename}}
+                {{end}}
+              </td>
+              <td class="table-vertical-border">{{$sizes.Code}}</td>
+              <td>{{$sizes.ROData}}</td>
+              <td>{{$sizes.Data}}</td>
+              <td>{{$sizes.BSS}}</td>
+              <td class="table-vertical-border" style="background: linear-gradient(to right, var(--bs-info-bg-subtle) {{$sizes.FlashPercent}}%, var(--bs-table-bg) {{$sizes.FlashPercent}}%)">
+                {{$sizes.Flash}}
+              </td>
+            </tr>
+            {{end}}
             {{end}}
           </tbody>
           <tfoot class="table-group-divider">
@@ -68,5 +95,15 @@
         </table>
       </div>
     </div>
+    <script>
+// Make table rows toggleable to show filenames.
+for (let clickable of document.querySelectorAll('.row-package')) {
+  clickable.addEventListener('click', e => {
+    for (let row of document.querySelectorAll(clickable.dataset.collapse)) {
+      row.classList.toggle('show');
+    }
+  });
+}
+    </script>
   </body>
 </html>

--- a/builder/size-report.html
+++ b/builder/size-report.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Size Report for {{.pkgName}}</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <style>
+
+.table-vertical-border {
+  border-left: calc(var(--bs-border-width) * 2) solid currentcolor;
+}
+
+    </style>
+  </head>
+  <body>
+    <div class="container-xxl">
+      <h1>Size Report for {{.pkgName}}</h1>
+
+      <p>How much space is used by Go packages, C libraries, and other bits to set up the program environment.</p>
+
+      <ul>
+        <li><strong>Code</strong> is the actual program code (machine code instructions).</li>
+        <li><strong>Read-only data</strong> are read-only global variables. On most microcontrollers, these are stored in flash and do not take up any RAM.</li>
+        <li><strong>Data</strong> are writable global variables with a non-zero initializer. On microcontrollers, they are copied from flash to RAM on reset.</li>
+        <li><strong>BSS</strong> are writable global variables that are zero initialized. They do not take up any space in the binary, but do take up RAM. On microcontrollers, this area is zeroed on reset.</li>
+      </ul>
+
+      <p>The binary size consists of code, read-only data, and data. On microcontrollers, this is exactly the size of the firmware image. On other systems, there is some extra overhead: binary metadata (headers of the ELF/MachO/COFF file), debug information, exception tables, symbol names, etc. Using <code>-no-debug</code> strips most of those.</p>
+
+      <h2>Program breakdown</h2>
+      <div class="table-responsive">
+        <table class="table w-auto">
+          <thead>
+            <tr>
+              <th>Package</th>
+              <th class="table-vertical-border">Code</th>
+              <th>Read-only data</th>
+              <th>Data</th>
+              <th title="zero-initialized data">BSS</th>
+              <th class="table-vertical-border" style="min-width: 16em">Binary size</th>
+            </tr>
+          </thead>
+          <tbody class="table-group-divider">
+            {{range .sizes}}
+            <tr>
+              <td>{{.Name}}</td>
+              <td class="table-vertical-border">{{.Size.Code}}</td>
+              <td>{{.Size.ROData}}</td>
+              <td>{{.Size.Data}}</td>
+              <td>{{.Size.BSS}}</td>
+              <td class="table-vertical-border" style="background: linear-gradient(to right, var(--bs-info-bg-subtle) {{.Size.FlashPercent}}%, var(--bs-table-bg) {{.Size.FlashPercent}}%)">
+                {{.Size.Flash}}
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+          <tfoot class="table-group-divider">
+            <tr>
+              <th>Total</th>
+              <td class="table-vertical-border">{{.sizeTotal.code}}</td>
+              <td>{{.sizeTotal.rodata}}</td>
+              <td>{{.sizeTotal.data}}</td>
+              <td>{{.sizeTotal.bss}}</td>
+              <td class="table-vertical-border">{{.sizeTotal.flash}}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -53,6 +53,20 @@ func (ps *programSize) RAM() uint64 {
 	return ps.Data + ps.BSS
 }
 
+// Return the package size information for a given package path, creating it if
+// it doesn't exist yet.
+func (ps *programSize) getPackage(path string) *packageSize {
+	if field, ok := ps.Packages[path]; ok {
+		return field
+	}
+	field := &packageSize{
+		Program: ps,
+		Sub:     map[string]*packageSize{},
+	}
+	ps.Packages[path] = field
+	return field
+}
+
 // packageSize contains the size of a package, calculated from the linked object
 // file.
 type packageSize struct {
@@ -61,6 +75,7 @@ type packageSize struct {
 	ROData  uint64
 	Data    uint64
 	BSS     uint64
+	Sub     map[string]*packageSize
 }
 
 // Flash usage in regular microcontrollers.
@@ -77,6 +92,25 @@ func (ps *packageSize) RAM() uint64 {
 // usage of the program.
 func (ps *packageSize) FlashPercent() float64 {
 	return float64(ps.Flash()) / float64(ps.Program.Flash()) * 100
+}
+
+// Add a single size data point to this package.
+// This must only be called while calculating package size, not afterwards.
+func (ps *packageSize) addSize(getField func(*packageSize, bool) *uint64, filename string, size uint64, isVariable bool) {
+	if size == 0 {
+		return
+	}
+
+	// Add size for the package.
+	*getField(ps, isVariable) += size
+
+	// Add size for file inside package.
+	sub, ok := ps.Sub[filename]
+	if !ok {
+		sub = &packageSize{Program: ps.Program}
+		ps.Sub[filename] = sub
+	}
+	*getField(sub, isVariable) += size
 }
 
 // A mapping of a single chunk of code or data to a file path.
@@ -796,40 +830,32 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 	program := &programSize{
 		Packages: sizes,
 	}
-	getSize := func(path string) *packageSize {
-		if field, ok := sizes[path]; ok {
-			return field
-		}
-		field := &packageSize{Program: program}
-		sizes[path] = field
-		return field
-	}
 	for _, section := range sections {
 		switch section.Type {
 		case memoryCode:
-			readSection(section, addresses, func(path string, size uint64, isVariable bool) {
-				field := getSize(path)
+			readSection(section, addresses, program, func(ps *packageSize, isVariable bool) *uint64 {
 				if isVariable {
-					field.ROData += size
-				} else {
-					field.Code += size
+					return &ps.ROData
 				}
+				return &ps.Code
 			}, packagePathMap)
 		case memoryROData:
-			readSection(section, addresses, func(path string, size uint64, isVariable bool) {
-				getSize(path).ROData += size
+			readSection(section, addresses, program, func(ps *packageSize, isVariable bool) *uint64 {
+				return &ps.ROData
 			}, packagePathMap)
 		case memoryData:
-			readSection(section, addresses, func(path string, size uint64, isVariable bool) {
-				getSize(path).Data += size
+			readSection(section, addresses, program, func(ps *packageSize, isVariable bool) *uint64 {
+				return &ps.Data
 			}, packagePathMap)
 		case memoryBSS:
-			readSection(section, addresses, func(path string, size uint64, isVariable bool) {
-				getSize(path).BSS += size
+			readSection(section, addresses, program, func(ps *packageSize, isVariable bool) *uint64 {
+				return &ps.BSS
 			}, packagePathMap)
 		case memoryStack:
 			// We store the C stack as a pseudo-package.
-			getSize("C stack").BSS += section.Size
+			program.getPackage("C stack").addSize(func(ps *packageSize, isVariable bool) *uint64 {
+				return &ps.BSS
+			}, "", section.Size, false)
 		}
 	}
 
@@ -844,8 +870,8 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 }
 
 // readSection determines for each byte in this section to which package it
-// belongs. It reports this usage through the addSize callback.
-func readSection(section memorySection, addresses []addressLine, addSize func(string, uint64, bool), packagePathMap map[string]string) {
+// belongs.
+func readSection(section memorySection, addresses []addressLine, program *programSize, getField func(*packageSize, bool) *uint64, packagePathMap map[string]string) {
 	// The addr variable tracks at which address we are while going through this
 	// section. We start at the beginning.
 	addr := section.Address
@@ -867,9 +893,9 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 			addrAligned := (addr + line.Align - 1) &^ (line.Align - 1)
 			if line.Align > 1 && addrAligned >= line.Address {
 				// It is, assume that's what causes the gap.
-				addSize("(padding)", line.Address-addr, true)
+				program.getPackage("(padding)").addSize(getField, "", line.Address-addr, true)
 			} else {
-				addSize("(unknown)", line.Address-addr, false)
+				program.getPackage("(unknown)").addSize(getField, "", line.Address-addr, false)
 				if sizesDebug {
 					fmt.Printf("%08x..%08x %5d:  unknown (gap), alignment=%d\n", addr, line.Address, line.Address-addr, line.Align)
 				}
@@ -891,7 +917,8 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 			length = line.Length - (addr - line.Address)
 		}
 		// Finally, mark this chunk of memory as used by the given package.
-		addSize(findPackagePath(line.File, packagePathMap), length, line.IsVariable)
+		packagePath, filename := findPackagePath(line.File, packagePathMap)
+		program.getPackage(packagePath).addSize(getField, filename, length, line.IsVariable)
 		addr = line.Address + line.Length
 	}
 	if addr < sectionEnd {
@@ -900,9 +927,9 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 		if section.Align > 1 && addrAligned >= sectionEnd {
 			// The gap is caused by the section alignment.
 			// For example, if a .rodata section ends with a non-aligned string.
-			addSize("(padding)", sectionEnd-addr, true)
+			program.getPackage("(padding)").addSize(getField, "", sectionEnd-addr, true)
 		} else {
-			addSize("(unknown)", sectionEnd-addr, false)
+			program.getPackage("(unknown)").addSize(getField, "", sectionEnd-addr, false)
 			if sizesDebug {
 				fmt.Printf("%08x..%08x %5d:  unknown (end), alignment=%d\n", addr, sectionEnd, sectionEnd-addr, section.Align)
 			}
@@ -912,17 +939,25 @@ func readSection(section memorySection, addresses []addressLine, addSize func(st
 
 // findPackagePath returns the Go package (or a pseudo package) for the given
 // path. It uses some heuristics, for example for some C libraries.
-func findPackagePath(path string, packagePathMap map[string]string) string {
+func findPackagePath(path string, packagePathMap map[string]string) (packagePath, filename string) {
 	// Check whether this path is part of one of the compiled packages.
 	packagePath, ok := packagePathMap[filepath.Dir(path)]
-	if !ok {
+	if ok {
+		// Directory is known as a Go package.
+		// Add the file itself as well.
+		filename = filepath.Base(path)
+	} else {
 		if strings.HasPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "lib")) {
 			// Emit C libraries (in the lib subdirectory of TinyGo) as a single
-			// package, with a "C" prefix. For example: "C compiler-rt" for the
-			// compiler runtime library from LLVM.
-			packagePath = "C " + strings.Split(strings.TrimPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "lib")), string(os.PathSeparator))[1]
-		} else if strings.HasPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project")) {
+			// package, with a "C" prefix. For example: "C picolibc" for the
+			// baremetal libc.
+			libPath := strings.TrimPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "lib")+string(os.PathSeparator))
+			parts := strings.SplitN(libPath, string(os.PathSeparator), 2)
+			packagePath = "C " + parts[0]
+			filename = parts[1]
+		} else if prefix := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project", "compiler-rt"); strings.HasPrefix(path, prefix) {
 			packagePath = "C compiler-rt"
+			filename = strings.TrimPrefix(path, prefix+string(os.PathSeparator))
 		} else if packageSymbolRegexp.MatchString(path) {
 			// Parse symbol names like main$alloc or runtime$string.
 			packagePath = path[:strings.LastIndex(path, "$")]
@@ -945,9 +980,11 @@ func findPackagePath(path string, packagePathMap map[string]string) string {
 			// fixed in the compiler.
 			packagePath = "-"
 		} else {
-			// This is some other path. Not sure what it is, so just emit its directory.
-			packagePath = filepath.Dir(path) // fallback
+			// This is some other path. Not sure what it is, so just emit its
+			// directory as a fallback.
+			packagePath = filepath.Dir(path)
+			filename = filepath.Base(path)
 		}
 	}
-	return packagePath
+	return
 }

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -12,7 +12,7 @@ var (
 	validGCOptions            = []string{"none", "leaking", "conservative", "custom", "precise"}
 	validSchedulerOptions     = []string{"none", "tasks", "asyncify"}
 	validSerialOptions        = []string{"none", "uart", "usb", "rtt"}
-	validPrintSizeOptions     = []string{"none", "short", "full"}
+	validPrintSizeOptions     = []string{"none", "short", "full", "html"}
 	validPanicStrategyOptions = []string{"print", "trap"}
 	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
 )

--- a/compileopts/options_test.go
+++ b/compileopts/options_test.go
@@ -11,7 +11,7 @@ func TestVerifyOptions(t *testing.T) {
 
 	expectedGCError := errors.New(`invalid gc option 'incorrect': valid values are none, leaking, conservative, custom, precise`)
 	expectedSchedulerError := errors.New(`invalid scheduler option 'incorrect': valid values are none, tasks, asyncify`)
-	expectedPrintSizeError := errors.New(`invalid size option 'incorrect': valid values are none, short, full`)
+	expectedPrintSizeError := errors.New(`invalid size option 'incorrect': valid values are none, short, full, html`)
 	expectedPanicStrategyError := errors.New(`invalid panic option 'incorrect': valid values are print, trap`)
 
 	testCases := []struct {

--- a/main.go
+++ b/main.go
@@ -1509,7 +1509,7 @@ func main() {
 		stackSize = uint64(size)
 		return err
 	})
-	printSize := flag.String("size", "", "print sizes (none, short, full)")
+	printSize := flag.String("size", "", "print sizes (none, short, full, html)")
 	printStacks := flag.Bool("print-stacks", false, "print stack sizes of goroutines")
 	printAllocsString := flag.String("print-allocs", "", "regular expression of functions for which heap allocations should be printed")
 	printCommands := flag.Bool("x", false, "Print commands")


### PR DESCRIPTION
This adds a `-size-report` flag that writes a HTML file with more detailed information on the binary size. This is similar to `-size=full` but also adds file level size usage.
Here is an example, with "C compiler-rt" expanded:
![Screenshot_20241217_114048](https://github.com/user-attachments/assets/8ce3d3c7-0ba4-4391-ab08-97d0a4f4d17a)

Here you can see that 28 bytes go to `memset`, 92 bytes go to the count-leading-zeroes builtin (clzsi3), and the remaining bytes (92+14 = 106) go to an unsigned 32-bit divide builtin. This makes sense: the chip I used for testing is the nrf51 (in the microbit) which doesn't support clz or division so these need to be done in software.

If you expand the runtime package, you can also see that around 1kB of binary size is taken up by the GC, the rest is for various other runtime features like initialization and the scheduler.

I intend to add more to this size report in the future. Most importantly, a way to answer the question "why does my binary take up so much space, I didn't import that many packages!". Basically, a way to trace from the main package where all the binary size goes and how much a given package is responsible for the binary size of the program. While this could in theory all be done on the command line, doing this in HTML/CSS/JS makes the UX a whole lot better and more intuitive.