### PR TITLE
fix: ensure that tkey target has stubs for runtime/interrupt package

### DIFF
--- a/src/runtime/interrupt/interrupt_none.go
+++ b/src/runtime/interrupt/interrupt_none.go
@@ -1,4 +1,4 @@
-//go:build !baremetal
+//go:build !baremetal || tkey
 
 package interrupt
 

--- a/src/runtime/interrupt/interrupt_tinygoriscv.go
+++ b/src/runtime/interrupt/interrupt_tinygoriscv.go
@@ -1,4 +1,4 @@
-//go:build tinygo.riscv
+//go:build tinygo.riscv && !tkey
 
 package interrupt
 


### PR DESCRIPTION
This PR is add build tags to ensure that tkey target has stubs for `runtime/interrupt` package. That way if that package is included by some other package, it does not try to bring in any standard RISC-V IRQ implementation.

Discovered when working on https://github.com/hybridgroup/tinygo-tkey/pull/2 with solution suggested by @aykevl 