### PR TITLE
feature: make i2c implementation shared for rp2040/rp2350

### DIFF
--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || mimxrt1062 || (esp32c3 && !m5stamp_c3) || esp32
+//go:build !baremetal || atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || rp2350 || mimxrt1062 || (esp32c3 && !m5stamp_c3) || esp32
 
 package machine
 

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -1,4 +1,4 @@
-//go:build rp2040
+//go:build rp2040 || rp2350
 
 package machine
 
@@ -8,7 +8,7 @@ import (
 	"internal/itoa"
 )
 
-// I2C on the RP2040.
+// I2C on the RP2040/RP2350
 var (
 	I2C0  = &_I2C0
 	_I2C0 = I2C{


### PR DESCRIPTION
This PR makes the i2c implementation shared between the `rp2040` and the `rp2350`. 

It works on the real hardware, just tested on my Pico2 with an ssd1306 display. :smiley_cat:
![PXL_20241217_194237882](https://github.com/user-attachments/assets/83a20267-0699-4989-b83d-1750bbf6c16f)