### PR TITLE
feature: make SPI implementation shared for rp2040/rp2350

### DIFF
--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -1,4 +1,4 @@
-//go:build rp2040
+//go:build rp2040 || rp2350
 
 package machine
 
@@ -207,7 +207,7 @@ func (spi SPI) initSPI(config SPIConfig) (err error) {
 	}
 	err = spi.SetBaudRate(config.Frequency)
 	// Set SPI Format (CPHA and CPOL) and frame format (default is Motorola)
-	spi.setFormat(config.Mode, rp.XIP_SSI_CTRLR0_SPI_FRF_STD)
+	spi.setFormat(config.Mode)
 
 	// Always enable DREQ signals -- harmless if DMA is not listening
 	spi.Bus.SSPDMACR.SetBits(rp.SPI0_SSPDMACR_TXDMAE | rp.SPI0_SSPDMACR_RXDMAE)
@@ -217,14 +217,13 @@ func (spi SPI) initSPI(config SPIConfig) (err error) {
 }
 
 //go:inline
-func (spi SPI) setFormat(mode uint8, frameFormat uint32) {
+func (spi SPI) setFormat(mode uint8) {
 	cpha := uint32(mode) & 1
 	cpol := uint32(mode>>1) & 1
 	spi.Bus.SSPCR0.ReplaceBits(
 		(cpha<<rp.SPI0_SSPCR0_SPH_Pos)|
 			(cpol<<rp.SPI0_SSPCR0_SPO_Pos)|
-			(uint32(7)<<rp.SPI0_SSPCR0_DSS_Pos)| // Set databits (SPI word length) to 8 bits.
-			(frameFormat&0b11)<<rp.SPI0_SSPCR0_FRF_Pos, // Frame format bits 4:5
+			(uint32(7)<<rp.SPI0_SSPCR0_DSS_Pos), // Set databits (SPI word length) to 8 bits.
 		rp.SPI0_SSPCR0_SPH_Msk|rp.SPI0_SSPCR0_SPO_Msk|rp.SPI0_SSPCR0_DSS_Msk|rp.SPI0_SSPCR0_FRF_Msk, 0)
 }
 

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || rp2350 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 package machine
 


### PR DESCRIPTION
This PR makes the SPI implementation shared between the rp2040 and the rp2350.

Tested on real hardware on my Pico2 with an mcp3008 ADC.

I simplified the `setFormat()` function becuase the additional param was not actually doing anything (`rp.XIP_SSI_CTRLR0_SPI_FRF_STD = 0`)
 