### PR TITLE
feature: make RNG implementation shared for rp2040/rp2350

### DIFF
--- a/src/machine/machine_rp2_rng.go
+++ b/src/machine/machine_rp2_rng.go
@@ -1,4 +1,4 @@
-//go:build rp2040
+//go:build rp2040 || rp2350
 
 // Implementation based on code located here:
 // https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_lwip/random.c


### PR DESCRIPTION
This PR makes the RNG implementation shared between the rp2040 and the rp2350.

Worth noting that it is not a true RNG so is not enabled by default on rp2040 or rp2350.

I did test on real hardware with my usual insecure hackaround. Works as expected.