### PR TITLE
reflect: fix incorrect comment on elemType

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -424,8 +424,8 @@ type rawType struct {
 	meta uint8 // metadata byte, contains kind and flags (see constants above)
 }
 
-// All types that have an element type: named, chan, slice, array, map, interface
-// (but not pointer because it doesn't have ptrTo).
+// All types that have an element type: named, chan, slice, array, map (but not
+// pointer because it doesn't have ptrTo).
 type elemType struct {
 	rawType
 	numMethod uint16


### PR DESCRIPTION
PR that introduced this: https://github.com/tinygo-org/tinygo/pull/4543

`elemType` has a different set of fields than `interfaceType`, but the comment says something else.