### PR TITLE
RP2350 machine package unexports

### DIFF
--- a/src/machine/machine_rp2040_rtc.go
+++ b/src/machine/machine_rp2040_rtc.go
@@ -97,7 +97,7 @@ func toAlarmTime(delay uint32) rtcTime {
 
 func (rtc *rtcType) setDivider() {
 	// Get clk_rtc freq and make sure it is running
-	rtcFreq := configuredFreq[ClkRTC]
+	rtcFreq := configuredFreq[clkRTC]
 	if rtcFreq == 0 {
 		panic("can not set RTC divider, clock is not running")
 	}

--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -25,7 +25,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	unresetBlockWait(rp.RESETS_RESET_USBCTRL)
 
 	// Clear any previous state in dpram just in case
-	usbDPSRAM.clear()
+	_usbDPSRAM.clear()
 
 	// Enable USB interrupt at processor
 	rp.USBCTRL_REGS.INTE.Set(0)
@@ -62,7 +62,7 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 	// Setup packet received
 	if (status & rp.USBCTRL_REGS_INTS_SETUP_REQ) > 0 {
 		rp.USBCTRL_REGS.SIE_STATUS.Set(rp.USBCTRL_REGS_SIE_STATUS_SETUP_REC)
-		setup := usb.NewSetup(usbDPSRAM.setupBytes())
+		setup := usb.NewSetup(_usbDPSRAM.setupBytes())
 
 		ok := false
 		if (setup.BmRequestType & usb.REQUEST_TYPE) == usb.REQUEST_STANDARD {
@@ -136,34 +136,34 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 
 func initEndpoint(ep, config uint32) {
 	val := uint32(usbEpControlEnable) | uint32(usbEpControlInterruptPerBuff)
-	offset := ep*2*USBBufferLen + 0x100
+	offset := ep*2*usbBufferLen + 0x100
 	val |= offset
 
 	switch config {
 	case usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointIn:
 		val |= usbEpControlEndpointTypeInterrupt
-		usbDPSRAM.EPxControl[ep].In.Set(val)
+		_usbDPSRAM.EPxControl[ep].In.Set(val)
 
 	case usb.ENDPOINT_TYPE_BULK | usb.EndpointOut:
 		val |= usbEpControlEndpointTypeBulk
-		usbDPSRAM.EPxControl[ep].Out.Set(val)
-		usbDPSRAM.EPxBufferControl[ep].Out.Set(USBBufferLen & usbBuf0CtrlLenMask)
-		usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
+		_usbDPSRAM.EPxControl[ep].Out.Set(val)
+		_usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBufferLen & usbBuf0CtrlLenMask)
+		_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
 
 	case usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointOut:
 		val |= usbEpControlEndpointTypeInterrupt
-		usbDPSRAM.EPxControl[ep].Out.Set(val)
-		usbDPSRAM.EPxBufferControl[ep].Out.Set(USBBufferLen & usbBuf0CtrlLenMask)
-		usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
+		_usbDPSRAM.EPxControl[ep].Out.Set(val)
+		_usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBufferLen & usbBuf0CtrlLenMask)
+		_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
 
 	case usb.ENDPOINT_TYPE_BULK | usb.EndpointIn:
 		val |= usbEpControlEndpointTypeBulk
-		usbDPSRAM.EPxControl[ep].In.Set(val)
+		_usbDPSRAM.EPxControl[ep].In.Set(val)
 
 	case usb.ENDPOINT_TYPE_CONTROL:
 		val |= usbEpControlEndpointTypeControl
-		usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBuf0CtrlData1Pid)
-		usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
+		_usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBuf0CtrlData1Pid)
+		_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
 
 	}
 }
@@ -219,37 +219,37 @@ func ReceiveUSBControlPacket() ([cdcLineInfoSize]byte, error) {
 	var b [cdcLineInfoSize]byte
 	ep := 0
 
-	for !usbDPSRAM.EPxBufferControl[ep].Out.HasBits(usbBuf0CtrlFull) {
+	for !_usbDPSRAM.EPxBufferControl[ep].Out.HasBits(usbBuf0CtrlFull) {
 		// TODO: timeout
 	}
 
-	ctrl := usbDPSRAM.EPxBufferControl[ep].Out.Get()
-	usbDPSRAM.EPxBufferControl[ep].Out.Set(USBBufferLen & usbBuf0CtrlLenMask)
+	ctrl := _usbDPSRAM.EPxBufferControl[ep].Out.Get()
+	_usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBufferLen & usbBuf0CtrlLenMask)
 	sz := ctrl & usbBuf0CtrlLenMask
 
-	copy(b[:], usbDPSRAM.EPxBuffer[ep].Buffer0[:sz])
+	copy(b[:], _usbDPSRAM.EPxBuffer[ep].Buffer0[:sz])
 
-	usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlData1Pid)
-	usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
+	_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlData1Pid)
+	_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
 
 	return b, nil
 }
 
 func handleEndpointRx(ep uint32) []byte {
-	ctrl := usbDPSRAM.EPxBufferControl[ep].Out.Get()
-	usbDPSRAM.EPxBufferControl[ep].Out.Set(USBBufferLen & usbBuf0CtrlLenMask)
+	ctrl := _usbDPSRAM.EPxBufferControl[ep].Out.Get()
+	_usbDPSRAM.EPxBufferControl[ep].Out.Set(usbBufferLen & usbBuf0CtrlLenMask)
 	sz := ctrl & usbBuf0CtrlLenMask
 
-	return usbDPSRAM.EPxBuffer[ep].Buffer0[:sz]
+	return _usbDPSRAM.EPxBuffer[ep].Buffer0[:sz]
 }
 
 func handleEndpointRxComplete(ep uint32) {
 	epXdata0[ep] = !epXdata0[ep]
 	if epXdata0[ep] || ep == 0 {
-		usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlData1Pid)
+		_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlData1Pid)
 	}
 
-	usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
+	_usbDPSRAM.EPxBufferControl[ep].Out.SetBits(usbBuf0CtrlAvail)
 }
 
 func SendZlp() {
@@ -269,8 +269,8 @@ func sendViaEPIn(ep uint32, data []byte, count int) {
 	// Mark as full
 	val |= usbBuf0CtrlFull
 
-	copy(usbDPSRAM.EPxBuffer[ep&0x7F].Buffer0[:], data[:count])
-	usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
+	copy(_usbDPSRAM.EPxBuffer[ep&0x7F].Buffer0[:], data[:count])
+	_usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
 }
 
 func sendStallViaEPIn(ep uint32) {
@@ -279,41 +279,41 @@ func sendStallViaEPIn(ep uint32) {
 		rp.USBCTRL_REGS.EP_STALL_ARM.Set(rp.USBCTRL_REGS_EP_STALL_ARM_EP0_IN)
 	}
 	val := uint32(usbBuf0CtrlFull)
-	usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
+	_usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
 	val |= uint32(usbBuf0CtrlStall)
-	usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
+	_usbDPSRAM.EPxBufferControl[ep&0x7F].In.Set(val)
 }
 
-type USBDPSRAM struct {
+type usbDPSRAM struct {
 	// Note that EPxControl[0] is not EP0Control but 8-byte setup data.
-	EPxControl [16]USBEndpointControlRegister
+	EPxControl [16]usbEndpointControlRegister
 
-	EPxBufferControl [16]USBBufferControlRegister
+	EPxBufferControl [16]usbBufferControlRegister
 
-	EPxBuffer [16]USBBuffer
+	EPxBuffer [16]usbBuffer
 }
 
-type USBEndpointControlRegister struct {
+type usbEndpointControlRegister struct {
 	In  volatile.Register32
 	Out volatile.Register32
 }
-type USBBufferControlRegister struct {
+type usbBufferControlRegister struct {
 	In  volatile.Register32
 	Out volatile.Register32
 }
 
-type USBBuffer struct {
-	Buffer0 [USBBufferLen]byte
-	Buffer1 [USBBufferLen]byte
+type usbBuffer struct {
+	Buffer0 [usbBufferLen]byte
+	Buffer1 [usbBufferLen]byte
 }
 
 var (
-	usbDPSRAM  = (*USBDPSRAM)(unsafe.Pointer(uintptr(0x50100000)))
+	_usbDPSRAM = (*usbDPSRAM)(unsafe.Pointer(uintptr(0x50100000)))
 	epXdata0   [16]bool
 	setupBytes [8]byte
 )
 
-func (d *USBDPSRAM) setupBytes() []byte {
+func (d *usbDPSRAM) setupBytes() []byte {
 
 	data := d.EPxControl[usb.CONTROL_ENDPOINT].In.Get()
 	setupBytes[0] = byte(data)
@@ -330,7 +330,7 @@ func (d *USBDPSRAM) setupBytes() []byte {
 	return setupBytes[:]
 }
 
-func (d *USBDPSRAM) clear() {
+func (d *usbDPSRAM) clear() {
 	for i := 0; i < len(d.EPxControl); i++ {
 		d.EPxControl[i].In.Set(0)
 		d.EPxControl[i].Out.Set(0)
@@ -373,5 +373,5 @@ const (
 	usbBuf0CtrlAvail    = 0x00000400
 	usbBuf0CtrlLenMask  = 0x000003FF
 
-	USBBufferLen = 64
+	usbBufferLen = 64
 )

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -46,26 +46,26 @@ const (
 )
 
 const (
-	ClkGPOUT0 clockIndex = iota // GPIO Muxing 0
-	ClkGPOUT1                   // GPIO Muxing 1
-	ClkGPOUT2                   // GPIO Muxing 2
-	ClkGPOUT3                   // GPIO Muxing 3
-	ClkRef                      // Watchdog and timers reference clock
-	ClkSys                      // Processors, bus fabric, memory, memory mapped registers
-	ClkPeri                     // Peripheral clock for UART and SPI
-	ClkUSB                      // USB clock
-	ClkADC                      // ADC clock
-	ClkRTC                      // Real time clock
-	NumClocks
+	clkGPOUT0 clockIndex = iota // GPIO Muxing 0
+	clkGPOUT1                   // GPIO Muxing 1
+	clkGPOUT2                   // GPIO Muxing 2
+	clkGPOUT3                   // GPIO Muxing 3
+	clkRef                      // Watchdog and timers reference clock
+	clkSys                      // Processors, bus fabric, memory, memory mapped registers
+	clkPeri                     // Peripheral clock for UART and SPI
+	clkUSB                      // USB clock
+	clkADC                      // ADC clock
+	clkRTC                      // Real time clock
+	numClocks
 )
 
-func CalcClockDiv(srcFreq, freq uint32) uint32 {
+func calcClockDiv(srcFreq, freq uint32) uint32 {
 	// Div register is 24.8 int.frac divider so multiply by 2^8 (left shift by 8)
 	return uint32((uint64(srcFreq) << 8) / uint64(freq))
 }
 
 type clocksType struct {
-	clk   [NumClocks]clockType
+	clk   [numClocks]clockType
 	resus struct {
 		ctrl   volatile.Register32
 		status volatile.Register32
@@ -180,9 +180,9 @@ func irqSetMask(mask uint32, enabled bool) {
 }
 
 func (clks *clocksType) initRTC() {
-	// ClkRTC = pllUSB (48MHz) / 1024 = 46875Hz
-	clkrtc := clks.clock(ClkRTC)
-	clkrtc.configure(0, // No GLMUX
+	// clkRTC = pllUSB (48MHz) / 1024 = 46875Hz
+	crtc := clks.clock(clkRTC)
+	crtc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_RTC_CTRL_AUXSRC_CLKSRC_PLL_USB,
 		48*MHz,
 		46875)

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -49,26 +49,26 @@ const (
 )
 
 const (
-	ClkGPOUT0 clockIndex = iota // GPIO Muxing 0
-	ClkGPOUT1                   // GPIO Muxing 1
-	ClkGPOUT2                   // GPIO Muxing 2
-	ClkGPOUT3                   // GPIO Muxing 3
-	ClkRef                      // Watchdog and timers reference clock
-	ClkSys                      // Processors, bus fabric, memory, memory mapped registers
-	ClkPeri                     // Peripheral clock for UART and SPI
+	clkGPOUT0 clockIndex = iota // GPIO Muxing 0
+	clkGPOUT1                   // GPIO Muxing 1
+	clkGPOUT2                   // GPIO Muxing 2
+	clkGPOUT3                   // GPIO Muxing 3
+	clkRef                      // Watchdog and timers reference clock
+	clkSys                      // Processors, bus fabric, memory, memory mapped registers
+	clkPeri                     // Peripheral clock for UART and SPI
 	ClkHSTX                     // High speed interface
-	ClkUSB                      // USB clock
-	ClkADC                      // ADC clock
-	NumClocks
+	clkUSB                      // USB clock
+	clkADC                      // ADC clock
+	numClocks
 )
 
-func CalcClockDiv(srcFreq, freq uint32) uint32 {
+func calcClockDiv(srcFreq, freq uint32) uint32 {
 	// Div register is 4.16 int.frac divider so multiply by 2^16 (left shift by 16)
 	return uint32((uint64(srcFreq) << 16) / uint64(freq))
 }
 
 type clocksType struct {
-	clk               [NumClocks]clockType
+	clk               [numClocks]clockType
 	dftclk_xosc_ctrl  volatile.Register32
 	dftclk_rosc_ctrl  volatile.Register32
 	dftclk_lposc_ctrl volatile.Register32

--- a/src/machine/machine_rp2_clocks.go
+++ b/src/machine/machine_rp2_clocks.go
@@ -41,7 +41,7 @@ type fc struct {
 
 var clocks = (*clocksType)(unsafe.Pointer(rp.CLOCKS))
 
-var configuredFreq [NumClocks]uint32
+var configuredFreq [numClocks]uint32
 
 type clock struct {
 	*clockType
@@ -68,7 +68,7 @@ func (clks *clocksType) clock(cix clockIndex) clock {
 //
 // Not all clocks have both types of mux.
 func (clk *clock) hasGlitchlessMux() bool {
-	return clk.cix == ClkSys || clk.cix == ClkRef
+	return clk.cix == clkSys || clk.cix == clkRef
 }
 
 // configure configures the clock by selecting the main clock source src
@@ -80,7 +80,7 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 		panic("clock frequency cannot be greater than source frequency")
 	}
 
-	div := CalcClockDiv(srcFreq, freq)
+	div := calcClockDiv(srcFreq, freq)
 
 	// If increasing divisor, set divisor before source. Otherwise set source
 	// before divisor. This avoids a momentary overspeed when e.g. switching
@@ -99,16 +99,16 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 	} else
 	// If no glitchless mux, cleanly stop the clock to avoid glitches
 	// propagating when changing aux mux. Note it would be a really bad idea
-	// to do this on one of the glitchless clocks (ClkSys, ClkRef).
+	// to do this on one of the glitchless clocks (clkSys, clkRef).
 	{
-		// Disable clock. On ClkRef and ClkSys this does nothing,
+		// Disable clock. On clkRef and ClkSys this does nothing,
 		// all other clocks have the ENABLE bit in the same position.
 		clk.ctrl.ClearBits(rp.CLOCKS_CLK_GPOUT0_CTRL_ENABLE_Msk)
 		if configuredFreq[clk.cix] > 0 {
 			// Delay for 3 cycles of the target clock, for ENABLE propagation.
 			// Note XOSC_COUNT is not helpful here because XOSC is not
 			// necessarily running, nor is timer... so, 3 cycles per loop:
-			delayCyc := configuredFreq[ClkSys]/configuredFreq[clk.cix] + 1
+			delayCyc := configuredFreq[clkSys]/configuredFreq[clk.cix] + 1
 			for delayCyc != 0 {
 				// This could be done more efficiently but TinyGo inline
 				// assembly is not yet capable enough to express that. In the
@@ -130,7 +130,7 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 		}
 	}
 
-	// Enable clock. On ClkRef and ClkSys this does nothing,
+	// Enable clock. On clkRef and clkSys this does nothing,
 	// all other clocks have the ENABLE bit in the same position.
 	clk.ctrl.SetBits(rp.CLOCKS_CLK_GPOUT0_CTRL_ENABLE)
 
@@ -157,12 +157,12 @@ func (clks *clocksType) init() {
 	xosc.init()
 
 	// Before we touch PLLs, switch sys and ref cleanly away from their aux sources.
-	clks.clk[ClkSys].ctrl.ClearBits(rp.CLOCKS_CLK_SYS_CTRL_SRC_Msk)
-	for !clks.clk[ClkSys].selected.HasBits(0x1) {
+	clks.clk[clkSys].ctrl.ClearBits(rp.CLOCKS_CLK_SYS_CTRL_SRC_Msk)
+	for !clks.clk[clkSys].selected.HasBits(0x1) {
 	}
 
-	clks.clk[ClkRef].ctrl.ClearBits(rp.CLOCKS_CLK_REF_CTRL_SRC_Msk)
-	for !clks.clk[ClkRef].selected.HasBits(0x1) {
+	clks.clk[clkRef].ctrl.ClearBits(rp.CLOCKS_CLK_REF_CTRL_SRC_Msk)
+	for !clks.clk[clkRef].selected.HasBits(0x1) {
 	}
 
 	// Configure PLLs
@@ -173,41 +173,41 @@ func (clks *clocksType) init() {
 	pllUSB.init(1, 480*MHz, 5, 2)
 
 	// Configure clocks
-	// ClkRef = xosc (12MHz) / 1 = 12MHz
-	clkref := clks.clock(ClkRef)
-	clkref.configure(rp.CLOCKS_CLK_REF_CTRL_SRC_XOSC_CLKSRC,
+	// clkRef = xosc (12MHz) / 1 = 12MHz
+	cref := clks.clock(clkRef)
+	cref.configure(rp.CLOCKS_CLK_REF_CTRL_SRC_XOSC_CLKSRC,
 		0, // No aux mux
 		12*MHz,
 		12*MHz)
 
-	// ClkSys = pllSys (125MHz) / 1 = 125MHz
-	clksys := clks.clock(ClkSys)
-	clksys.configure(rp.CLOCKS_CLK_SYS_CTRL_SRC_CLKSRC_CLK_SYS_AUX,
+	// clkSys = pllSys (125MHz) / 1 = 125MHz
+	csys := clks.clock(clkSys)
+	csys.configure(rp.CLOCKS_CLK_SYS_CTRL_SRC_CLKSRC_CLK_SYS_AUX,
 		rp.CLOCKS_CLK_SYS_CTRL_AUXSRC_CLKSRC_PLL_SYS,
 		125*MHz,
 		125*MHz)
 
-	// ClkUSB = pllUSB (48MHz) / 1 = 48MHz
-	clkusb := clks.clock(ClkUSB)
-	clkusb.configure(0, // No GLMUX
+	// clkUSB = pllUSB (48MHz) / 1 = 48MHz
+	cusb := clks.clock(clkUSB)
+	cusb.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_USB_CTRL_AUXSRC_CLKSRC_PLL_USB,
 		48*MHz,
 		48*MHz)
 
-	// ClkADC = pllUSB (48MHZ) / 1 = 48MHz
-	clkadc := clks.clock(ClkADC)
-	clkadc.configure(0, // No GLMUX
+	// clkADC = pllUSB (48MHZ) / 1 = 48MHz
+	cadc := clks.clock(clkADC)
+	cadc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_ADC_CTRL_AUXSRC_CLKSRC_PLL_USB,
 		48*MHz,
 		48*MHz)
 
 	clks.initRTC()
 
-	// ClkPeri = ClkSys. Used as reference clock for Peripherals.
+	// clkPeri = clkSys. Used as reference clock for Peripherals.
 	// No dividers so just select and enable.
-	// Normally choose ClkSys or ClkUSB.
-	clkperi := clks.clock(ClkPeri)
-	clkperi.configure(0,
+	// Normally choose clkSys or clkUSB.
+	cperi := clks.clock(clkPeri)
+	cperi.configure(0,
 		rp.CLOCKS_CLK_PERI_CTRL_AUXSRC_CLK_SYS,
 		125*MHz,
 		125*MHz)


### PR DESCRIPTION
Unexported USB and Clock constants, variables and types that are not part of the TinyGo machine HAL.

Tagging @cibomahto as a heads-up, thank you for your contribution! awesome stuff c: