### PR TITLE
[WIP] Separate system clock config for rp2xxx devices

### DIFF
--- a/src/machine/board_ae_rp2040.go
+++ b/src/machine/board_ae_rp2040.go
@@ -31,10 +31,10 @@ const (
 	GP27 Pin = GPIO27
 	GP28 Pin = GPIO28
 	GP29 Pin = GPIO29
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // I2C Default pins on Raspberry Pico.
 const (

--- a/src/machine/board_ae_rp2040.go
+++ b/src/machine/board_ae_rp2040.go
@@ -33,9 +33,6 @@ const (
 	GP29 Pin = GPIO29
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // I2C Default pins on Raspberry Pico.
 const (
 	I2C0_SDA_PIN = GP4

--- a/src/machine/board_badger2040-w.go
+++ b/src/machine/board_badger2040-w.go
@@ -68,10 +68,8 @@ SPI0_CS_PIN  Pin = QSPI_CS
 */
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_badger2040-w.go
+++ b/src/machine/board_badger2040-w.go
@@ -68,9 +68,6 @@ SPI0_CS_PIN  Pin = QSPI_CS
 */
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Badger 2040 W"

--- a/src/machine/board_badger2040.go
+++ b/src/machine/board_badger2040.go
@@ -67,10 +67,8 @@ SPI0_CS_PIN  Pin = QSPI_CS
 */
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_badger2040.go
+++ b/src/machine/board_badger2040.go
@@ -67,9 +67,6 @@ SPI0_CS_PIN  Pin = QSPI_CS
 */
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Badger 2040"

--- a/src/machine/board_challenger_rp2040.go
+++ b/src/machine/board_challenger_rp2040.go
@@ -4,10 +4,10 @@ package machine
 
 const (
 	LED = GPIO24
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // GPIO Pins
 const (

--- a/src/machine/board_challenger_rp2040.go
+++ b/src/machine/board_challenger_rp2040.go
@@ -6,9 +6,6 @@ const (
 	LED = GPIO24
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // GPIO Pins
 const (
 	D5  = GPIO2

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -2,8 +2,8 @@
 
 package machine
 
-// Onboard crystal oscillator frequency, in MHz.
-const xoscFreq = 12 // MHz
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // GPIO Pins
 const (

--- a/src/machine/board_feather_rp2040.go
+++ b/src/machine/board_feather_rp2040.go
@@ -2,9 +2,6 @@
 
 package machine
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // GPIO Pins
 const (
 	D4  = GPIO6

--- a/src/machine/board_gopher-badge.go
+++ b/src/machine/board_gopher-badge.go
@@ -61,10 +61,8 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_gopher-badge.go
+++ b/src/machine/board_gopher-badge.go
@@ -61,9 +61,6 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Gopher Badge"

--- a/src/machine/board_kb2040.go
+++ b/src/machine/board_kb2040.go
@@ -2,8 +2,8 @@
 
 package machine
 
-// Onboard crystal oscillator frequency, in MHz.
-const xoscFreq = 12 // MHz
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // GPIO Pins
 const (

--- a/src/machine/board_kb2040.go
+++ b/src/machine/board_kb2040.go
@@ -2,9 +2,6 @@
 
 package machine
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // GPIO Pins
 const (
 	D0  = GPIO0

--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -4,10 +4,10 @@ package machine
 
 const (
 	NeopixelCount = 12
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 const (
 	SWITCH = GPIO0

--- a/src/machine/board_macropad-rp2040.go
+++ b/src/machine/board_macropad-rp2040.go
@@ -6,9 +6,6 @@ const (
 	NeopixelCount = 12
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 const (
 	SWITCH = GPIO0
 	BUTTON = GPIO0

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -95,10 +95,8 @@ const (
 	NINA_SOFT_FLOWCONTROL = false
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 // https://github.com/arduino/ArduinoCore-mbed/blob/master/variants/NANO_RP2040_CONNECT/pins_arduino.h

--- a/src/machine/board_nano-rp2040.go
+++ b/src/machine/board_nano-rp2040.go
@@ -95,9 +95,6 @@ const (
 	NINA_SOFT_FLOWCONTROL = false
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 // https://github.com/arduino/ArduinoCore-mbed/blob/master/variants/NANO_RP2040_CONNECT/pins_arduino.h
 const (

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -33,10 +33,10 @@ const (
 
 	// Onboard LED
 	LED Pin = GPIO25
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // I2C Default pins on Raspberry Pico.
 const (

--- a/src/machine/board_pico.go
+++ b/src/machine/board_pico.go
@@ -35,9 +35,6 @@ const (
 	LED Pin = GPIO25
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // I2C Default pins on Raspberry Pico.
 const (
 	I2C0_SDA_PIN = GP4

--- a/src/machine/board_pico2.go
+++ b/src/machine/board_pico2.go
@@ -33,10 +33,10 @@ const (
 
 	// Onboard LED
 	LED Pin = GPIO25
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // I2C Default pins on Raspberry Pico.
 const (

--- a/src/machine/board_pico2.go
+++ b/src/machine/board_pico2.go
@@ -35,9 +35,6 @@ const (
 	LED Pin = GPIO25
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // I2C Default pins on Raspberry Pico.
 const (
 	I2C0_SDA_PIN = GP4

--- a/src/machine/board_qtpy_rp2040.go
+++ b/src/machine/board_qtpy_rp2040.go
@@ -2,8 +2,8 @@
 
 package machine
 
-// Onboard crystal oscillator frequency, in MHz.
-const xoscFreq = 12 // MHz
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // GPIO Pins
 const (

--- a/src/machine/board_qtpy_rp2040.go
+++ b/src/machine/board_qtpy_rp2040.go
@@ -2,9 +2,6 @@
 
 package machine
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // GPIO Pins
 const (
 	SDA  = GPIO24

--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -2,8 +2,8 @@
 
 package machine
 
-// Onboard crystal oscillator frequency, in MHz.
-const xoscFreq = 12 // MHz
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // GPIO Pins
 const (

--- a/src/machine/board_thingplus_rp2040.go
+++ b/src/machine/board_thingplus_rp2040.go
@@ -2,9 +2,6 @@
 
 package machine
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // GPIO Pins
 const (
 	GP0 Pin = GPIO0 // TX

--- a/src/machine/board_thumby.go
+++ b/src/machine/board_thumby.go
@@ -49,10 +49,8 @@ const (
 	SPI1_SDI_PIN = NoPin
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_thumby.go
+++ b/src/machine/board_thumby.go
@@ -49,9 +49,6 @@ const (
 	SPI1_SDI_PIN = NoPin
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Thumby"

--- a/src/machine/board_tiny2350.go
+++ b/src/machine/board_tiny2350.go
@@ -27,10 +27,10 @@ const (
 	LED_GREEN Pin = GPIO19
 	LED_BLUE  Pin = GPIO20
 	LED           = LED_RED
-
-	// Onboard crystal oscillator frequency, in MHz.
-	xoscFreq = 12 // MHz
 )
+
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // I2C Default pins on Tiny2350.
 const (

--- a/src/machine/board_tiny2350.go
+++ b/src/machine/board_tiny2350.go
@@ -29,9 +29,6 @@ const (
 	LED           = LED_RED
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // I2C Default pins on Tiny2350.
 const (
 	I2C0_SDA_PIN = GP12

--- a/src/machine/board_trinkey_qt2040.go
+++ b/src/machine/board_trinkey_qt2040.go
@@ -13,8 +13,8 @@
 
 package machine
 
-// Onboard crystal oscillator frequency, in MHz
-const xoscFreq = 12 // MHz
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // Onboard LEDs
 const (

--- a/src/machine/board_trinkey_qt2040.go
+++ b/src/machine/board_trinkey_qt2040.go
@@ -13,9 +13,6 @@
 
 package machine
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // Onboard LEDs
 const (
 	NEOPIXEL = GPIO27

--- a/src/machine/board_tufty2040.go
+++ b/src/machine/board_tufty2040.go
@@ -58,10 +58,8 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // USB CDC identifiers
 const (

--- a/src/machine/board_tufty2040.go
+++ b/src/machine/board_tufty2040.go
@@ -58,9 +58,6 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // USB CDC identifiers
 const (
 	usb_STRING_PRODUCT      = "Tufty 2040"

--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -75,10 +75,8 @@ const (
 	SPI1_SDI_PIN Pin = D12
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // UART pins
 const (

--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -75,9 +75,6 @@ const (
 	SPI1_SDI_PIN Pin = D12
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // UART pins
 const (
 	UART0_TX_PIN = GPIO0

--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -63,10 +63,8 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// Onboard crystal oscillator frequency, in MHz.
-const (
-	xoscFreq = 12 // MHz
-)
+// System clock configuration
+var clockCfg = defaultSystemClockCfg
 
 // UART pins
 const (

--- a/src/machine/board_xiao-rp2040.go
+++ b/src/machine/board_xiao-rp2040.go
@@ -63,9 +63,6 @@ const (
 	SPI1_SDI_PIN Pin = NoPin
 )
 
-// System clock configuration
-var clockCfg = defaultSystemClockCfg
-
 // UART pins
 const (
 	UART0_TX_PIN = GPIO0

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -113,6 +113,19 @@ const (
 	fnXIP pinFunc = 0
 )
 
+// System clock configuration
+const (
+	pllSysFreq uint32 = 125*MHz
+	pllSysVcoFreq = 1500*MHz
+	pllSysPostDiv1 = 6
+	pllSysPostDiv2 = 2
+
+	pllUSBFreq uint32 = 48*MHz
+	pllUSBVcoFreq = 480*MHz
+	pllUSBPostDiv1 = 5
+	pllUSBPostDiv2 = 2
+)
+
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {
 	if p == NoPin {
@@ -184,7 +197,7 @@ func (clks *clocksType) initRTC() {
 	crtc := clks.clock(clkRTC)
 	crtc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_RTC_CTRL_AUXSRC_CLKSRC_PLL_USB,
-		48*MHz,
+		pllUSBFreq,
 		46875)
 }
 

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -113,18 +113,20 @@ const (
 	fnXIP pinFunc = 0
 )
 
-// System clock configuration
-const (
-	pllSysFreq     uint32 = 125 * MHz
-	pllSysVcoFreq         = 1500 * MHz
-	pllSysPostDiv1        = 6
-	pllSysPostDiv2        = 2
+// Clock frequency and PLL configuration
+var defaultSystemClockCfg = systemClockCfg{
+	xoscFreq: 12,
 
-	pllUSBFreq     uint32 = 48 * MHz
-	pllUSBVcoFreq         = 480 * MHz
-	pllUSBPostDiv1        = 5
-	pllUSBPostDiv2        = 2
-)
+	pllSysFreq:     125 * MHz,
+	pllSysVcoFreq:  1500 * MHz,
+	pllSysPostDiv1: 6,
+	pllSysPostDiv2: 2,
+
+	pllUSBFreq:     48 * MHz,
+	pllUSBVcoFreq:  480 * MHz,
+	pllUSBPostDiv1: 5,
+	pllUSBPostDiv2: 2,
+}
 
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {
@@ -197,7 +199,7 @@ func (clks *clocksType) initRTC() {
 	crtc := clks.clock(clkRTC)
 	crtc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_RTC_CTRL_AUXSRC_CLKSRC_PLL_USB,
-		pllUSBFreq,
+		clockCfg.pllUSBFreq,
 		46875)
 }
 

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -201,8 +201,6 @@ func (clks *clocksType) initRTC() {
 		46875)
 }
 
-func (clks *clocksType) initTicks() {} // No ticks on RP2040
-
 // startTick starts the watchdog tick.
 // cycles needs to be a divider that when applied to the xosc input,
 // produces a 1MHz clock. So if the xosc frequency is 12MHz,

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -115,15 +115,15 @@ const (
 
 // System clock configuration
 const (
-	pllSysFreq uint32 = 125*MHz
-	pllSysVcoFreq = 1500*MHz
-	pllSysPostDiv1 = 6
-	pllSysPostDiv2 = 2
+	pllSysFreq     uint32 = 125 * MHz
+	pllSysVcoFreq         = 1500 * MHz
+	pllSysPostDiv1        = 6
+	pllSysPostDiv2        = 2
 
-	pllUSBFreq uint32 = 48*MHz
-	pllUSBVcoFreq = 480*MHz
-	pllUSBPostDiv1 = 5
-	pllUSBPostDiv2 = 2
+	pllUSBFreq     uint32 = 48 * MHz
+	pllUSBVcoFreq         = 480 * MHz
+	pllUSBPostDiv1        = 5
+	pllUSBPostDiv2        = 2
 )
 
 // Configure configures the gpio pin as per mode.

--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -114,19 +114,20 @@ const (
 )
 
 // Clock frequency and PLL configuration
-var defaultSystemClockCfg = systemClockCfg{
-	xoscFreq: 12,
+// Note that the system frequency is configured for 125 MHz to allow clk_peri to run at full speed
+const (
+	xoscFreq uint32 = 12
 
-	pllSysFreq:     125 * MHz,
-	pllSysVcoFreq:  1500 * MHz,
-	pllSysPostDiv1: 6,
-	pllSysPostDiv2: 2,
+	pllSysFreq     uint32 = 125 * MHz
+	pllSysVcoFreq  uint32 = 1500 * MHz
+	pllSysPostDiv1 uint32 = 5
+	pllSysPostDiv2 uint32 = 2
 
-	pllUSBFreq:     48 * MHz,
-	pllUSBVcoFreq:  480 * MHz,
-	pllUSBPostDiv1: 5,
-	pllUSBPostDiv2: 2,
-}
+	pllUSBFreq     uint32 = 48 * MHz
+	pllUSBVcoFreq  uint32 = 480 * MHz
+	pllUSBPostDiv1 uint32 = 5
+	pllUSBPostDiv2 uint32 = 2
+)
 
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {
@@ -199,7 +200,7 @@ func (clks *clocksType) initRTC() {
 	crtc := clks.clock(clkRTC)
 	crtc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_RTC_CTRL_AUXSRC_CLKSRC_PLL_USB,
-		clockCfg.pllUSBFreq,
+		pllUSBFreq,
 		46875)
 }
 

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -120,19 +120,20 @@ const (
 	fnNULL    pinFunc = 0x1f
 )
 
-// System clock configuration
-// Note that VcoFreq, PostDiv1, and PostDiv2 must be manually calculated to achive desired output frequency.
-const (
-	pllSysFreq     uint32 = 150 * MHz
-	pllSysVcoFreq         = 1500 * MHz
-	pllSysPostDiv1        = 5
-	pllSysPostDiv2        = 2
+// Clock frequency and PLL configuration
+var defaultSystemClockCfg = systemClockCfg{
+	xoscFreq: 12,
 
-	pllUSBFreq     uint32 = 48 * MHz
-	pllUSBVcoFreq         = 480 * MHz
-	pllUSBPostDiv1        = 5
-	pllUSBPostDiv2        = 2
-)
+	pllSysFreq:     150 * MHz,
+	pllSysVcoFreq:  1500 * MHz,
+	pllSysPostDiv1: 5,
+	pllSysPostDiv2: 2,
+
+	pllUSBFreq:     48 * MHz,
+	pllUSBVcoFreq:  480 * MHz,
+	pllUSBPostDiv1: 5,
+	pllUSBPostDiv2: 2,
+}
 
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -213,12 +213,6 @@ func irqSet(num uint32, enabled bool) {
 
 func (clks *clocksType) initRTC() {} // No RTC on RP2350.
 
-func (clks *clocksType) initTicks() {
-	rp.TICKS.SetTIMER0_CTRL_ENABLE(0)
-	rp.TICKS.SetTIMER0_CYCLES(12)
-	rp.TICKS.SetTIMER0_CTRL_ENABLE(1)
-}
-
 func EnterBootloader() {
 	enterBootloader()
 }
@@ -227,5 +221,9 @@ func EnterBootloader() {
 // On RP2040, the watchdog contained a tick generator used to generate a 1μs tick for the watchdog. This was also
 // distributed to the system timer. On RP2350, the watchdog instead takes a tick input from the system-level ticks block. See Section 8.5.
 func (wd *watchdogImpl) startTick(cycles uint32) {
+	rp.TICKS.SetTIMER0_CTRL_ENABLE(0)
+	rp.TICKS.SetTIMER0_CYCLES(cycles)
+	rp.TICKS.SetTIMER0_CTRL_ENABLE(1)
+
 	rp.TICKS.WATCHDOG_CTRL.SetBits(1)
 }

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -120,6 +120,20 @@ const (
 	fnNULL    pinFunc = 0x1f
 )
 
+// System clock configuration
+// Note that VcoFreq, PostDiv1, and PostDiv2 must be manually calculated to achive desired output frequency.
+const (
+	pllSysFreq uint32 = 150*MHz
+	pllSysVcoFreq = 1500*MHz
+	pllSysPostDiv1 = 5
+	pllSysPostDiv2 = 2
+
+	pllUSBFreq uint32 = 48*MHz
+	pllUSBVcoFreq = 480*MHz
+	pllUSBPostDiv1 = 5
+	pllUSBPostDiv2 = 2
+)
+
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {
 	if p == NoPin {

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -123,15 +123,15 @@ const (
 // System clock configuration
 // Note that VcoFreq, PostDiv1, and PostDiv2 must be manually calculated to achive desired output frequency.
 const (
-	pllSysFreq uint32 = 150*MHz
-	pllSysVcoFreq = 1500*MHz
-	pllSysPostDiv1 = 5
-	pllSysPostDiv2 = 2
+	pllSysFreq     uint32 = 150 * MHz
+	pllSysVcoFreq         = 1500 * MHz
+	pllSysPostDiv1        = 5
+	pllSysPostDiv2        = 2
 
-	pllUSBFreq uint32 = 48*MHz
-	pllUSBVcoFreq = 480*MHz
-	pllUSBPostDiv1 = 5
-	pllUSBPostDiv2 = 2
+	pllUSBFreq     uint32 = 48 * MHz
+	pllUSBVcoFreq         = 480 * MHz
+	pllUSBPostDiv1        = 5
+	pllUSBPostDiv2        = 2
 )
 
 // Configure configures the gpio pin as per mode.

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -121,19 +121,19 @@ const (
 )
 
 // Clock frequency and PLL configuration
-var defaultSystemClockCfg = systemClockCfg{
-	xoscFreq: 12,
+const (
+	xoscFreq uint32 = 12
 
-	pllSysFreq:     150 * MHz,
-	pllSysVcoFreq:  1500 * MHz,
-	pllSysPostDiv1: 5,
-	pllSysPostDiv2: 2,
+	pllSysFreq     uint32 = 150 * MHz
+	pllSysVcoFreq  uint32 = 1500 * MHz
+	pllSysPostDiv1 uint32 = 5
+	pllSysPostDiv2 uint32 = 2
 
-	pllUSBFreq:     48 * MHz,
-	pllUSBVcoFreq:  480 * MHz,
-	pllUSBPostDiv1: 5,
-	pllUSBPostDiv2: 2,
-}
+	pllUSBFreq     uint32 = 48 * MHz
+	pllUSBVcoFreq  uint32 = 480 * MHz
+	pllUSBPostDiv1 uint32 = 5
+	pllUSBPostDiv2 uint32 = 2
+)
 
 // Configure configures the gpio pin as per mode.
 func (p Pin) Configure(config PinConfig) {

--- a/src/machine/machine_rp2_clocks.go
+++ b/src/machine/machine_rp2_clocks.go
@@ -211,6 +211,4 @@ func (clks *clocksType) init() {
 		rp.CLOCKS_CLK_PERI_CTRL_AUXSRC_CLK_SYS,
 		pllSysFreq,
 		pllSysFreq)
-
-	clks.initTicks()
 }

--- a/src/machine/machine_rp2_clocks.go
+++ b/src/machine/machine_rp2_clocks.go
@@ -10,13 +10,13 @@ import (
 )
 
 func CPUFrequency() uint32 {
-	return clockCfg.pllSysFreq
+	return pllSysFreq
 }
 
 // Returns the period of a clock cycle for the raspberry pi pico in nanoseconds.
 // Used in PWM API.
 func cpuPeriod() uint32 {
-	return uint32(1e9) / clockCfg.pllSysFreq // TODO: Discards remainder
+	return uint32(1e9) / pllSysFreq // TODO: Discards remainder
 }
 
 // clockIndex identifies a hardware clock
@@ -143,26 +143,12 @@ func (clk *clock) configure(src, auxsrc, srcFreq, freq uint32) {
 
 }
 
-type systemClockCfg struct {
-	xoscFreq uint32
-
-	pllSysFreq     uint32
-	pllSysVcoFreq  uint32
-	pllSysPostDiv1 uint32
-	pllSysPostDiv2 uint32
-
-	pllUSBFreq     uint32
-	pllUSBVcoFreq  uint32
-	pllUSBPostDiv1 uint32
-	pllUSBPostDiv2 uint32
-}
-
 // init initializes the clock hardware.
 //
 // Must be called before any other clock function.
 func (clks *clocksType) init() {
 	// Start the watchdog tick
-	Watchdog.startTick(clockCfg.xoscFreq)
+	Watchdog.startTick(xoscFreq)
 
 	// Disable resus that may be enabled from previous software
 	rp.CLOCKS.SetCLK_SYS_RESUS_CTRL_CLEAR(0)
@@ -182,38 +168,38 @@ func (clks *clocksType) init() {
 	// Configure PLLs
 	//                   REF     FBDIV VCO            POSTDIV
 	// pllSys: 12 / 1 = 12MHz * 125 = 1500MHZ / 6 / 2 = 125MHz
-	pllSys.init(1, clockCfg.pllSysVcoFreq, clockCfg.pllSysPostDiv1, clockCfg.pllSysPostDiv2)
+	pllSys.init(1, pllSysVcoFreq, pllSysPostDiv1, pllSysPostDiv2)
 	// pllUSB: 12 / 1 = 12MHz * 40  = 480 MHz / 5 / 2 =  48MHz
-	pllUSB.init(1, clockCfg.pllUSBVcoFreq, clockCfg.pllUSBPostDiv1, clockCfg.pllUSBPostDiv2)
+	pllUSB.init(1, pllUSBVcoFreq, pllUSBPostDiv1, pllUSBPostDiv2)
 
 	// Configure clocks
 	// clkRef = xosc (xoscFreq) / 1 = xoscFreq
 	cref := clks.clock(clkRef)
 	cref.configure(rp.CLOCKS_CLK_REF_CTRL_SRC_XOSC_CLKSRC,
 		0, // No aux mux
-		clockCfg.xoscFreq,
-		clockCfg.xoscFreq)
+		xoscFreq,
+		xoscFreq)
 
 	// clkSys = pllSys (pllSysFreq) / 1 = pllSysFreq
 	csys := clks.clock(clkSys)
 	csys.configure(rp.CLOCKS_CLK_SYS_CTRL_SRC_CLKSRC_CLK_SYS_AUX,
 		rp.CLOCKS_CLK_SYS_CTRL_AUXSRC_CLKSRC_PLL_SYS,
-		clockCfg.pllSysFreq,
-		clockCfg.pllSysFreq)
+		pllSysFreq,
+		pllSysFreq)
 
 	// clkUSB = pllUSB (pllUSBFreq) / 1 = 48MHz
 	cusb := clks.clock(clkUSB)
 	cusb.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_USB_CTRL_AUXSRC_CLKSRC_PLL_USB,
-		clockCfg.pllUSBFreq,
-		clockCfg.pllUSBFreq)
+		pllUSBFreq,
+		pllUSBFreq)
 
 	// clkADC = pllUSB (pllUSBFreq) / 1 = 48MHz
 	cadc := clks.clock(clkADC)
 	cadc.configure(0, // No GLMUX
 		rp.CLOCKS_CLK_ADC_CTRL_AUXSRC_CLKSRC_PLL_USB,
-		clockCfg.pllUSBFreq,
-		clockCfg.pllUSBFreq)
+		pllUSBFreq,
+		pllUSBFreq)
 
 	clks.initRTC()
 
@@ -223,6 +209,6 @@ func (clks *clocksType) init() {
 	cperi := clks.clock(clkPeri)
 	cperi.configure(0,
 		rp.CLOCKS_CLK_PERI_CTRL_AUXSRC_CLK_SYS,
-		clockCfg.pllSysFreq,
-		clockCfg.pllSysFreq)
+		pllSysFreq,
+		pllSysFreq)
 }

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -162,7 +162,7 @@ func (i2c *I2C) SetBaudRate(br uint32) error {
 	}
 
 	// I2C is synchronous design that runs from clk_sys
-	freqin := CPUFrequency()
+	freqin := pllSysFreq
 
 	// TODO there are some subtleties to I2C timing which we are completely ignoring here
 	period := (freqin + br/2) / br

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -162,7 +162,7 @@ func (i2c *I2C) SetBaudRate(br uint32) error {
 	}
 
 	// I2C is synchronous design that runs from clk_sys
-	freqin := pllSysFreq
+	freqin := clockCfg.pllSysFreq
 
 	// TODO there are some subtleties to I2C timing which we are completely ignoring here
 	period := (freqin + br/2) / br

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -162,7 +162,7 @@ func (i2c *I2C) SetBaudRate(br uint32) error {
 	}
 
 	// I2C is synchronous design that runs from clk_sys
-	freqin := clockCfg.pllSysFreq
+	freqin := pllSysFreq
 
 	// TODO there are some subtleties to I2C timing which we are completely ignoring here
 	period := (freqin + br/2) / br

--- a/src/machine/machine_rp2_pll.go
+++ b/src/machine/machine_rp2_pll.go
@@ -30,7 +30,7 @@ var (
 //
 // Post Divider 2, postDiv2 with range 1-7.
 func (pll *pll) init(refdiv, vcoFreq, postDiv1, postDiv2 uint32) {
-	refFreq := xoscFreq / refdiv
+	refFreq := clockCfg.xoscFreq / refdiv
 
 	// What are we multiplying the reference clock by to get the vco freq
 	// (The regs are called div, because you divide the vco output and compare it to the refclk)

--- a/src/machine/machine_rp2_pll.go
+++ b/src/machine/machine_rp2_pll.go
@@ -30,7 +30,7 @@ var (
 //
 // Post Divider 2, postDiv2 with range 1-7.
 func (pll *pll) init(refdiv, vcoFreq, postDiv1, postDiv2 uint32) {
-	refFreq := clockCfg.xoscFreq / refdiv
+	refFreq := xoscFreq / refdiv
 
 	// What are we multiplying the reference clock by to get the vco freq
 	// (The regs are called div, because you divide the vco output and compare it to the refclk)

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -104,7 +104,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 }
 
 func (spi SPI) SetBaudRate(br uint32) error {
-	const freqin uint32 = 125 * MHz
+	const freqin uint32 = pllSysFreq
 	const maxBaud uint32 = 66.5 * MHz // max output frequency is 66.5MHz on rp2040. see Note page 527.
 	// Find smallest prescale value which puts output frequency in range of
 	// post-divide. Prescale is an even number from 2 to 254 inclusive.
@@ -130,7 +130,7 @@ func (spi SPI) SetBaudRate(br uint32) error {
 }
 
 func (spi SPI) GetBaudRate() uint32 {
-	const freqin uint32 = 125 * MHz
+	const freqin uint32 = pllSysFreq
 	prescale := spi.Bus.SSPCPSR.Get()
 	postdiv := ((spi.Bus.SSPCR0.Get() & rp.SPI0_SSPCR0_SCR_Msk) >> rp.SPI0_SSPCR0_SCR_Pos) + 1
 	return freqin / (prescale * postdiv)

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -104,7 +104,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 }
 
 func (spi SPI) SetBaudRate(br uint32) error {
-	const freqin uint32 = pllSysFreq
+	var freqin uint32 = clockCfg.pllSysFreq
 	const maxBaud uint32 = 66.5 * MHz // max output frequency is 66.5MHz on rp2040. see Note page 527.
 	// Find smallest prescale value which puts output frequency in range of
 	// post-divide. Prescale is an even number from 2 to 254 inclusive.
@@ -130,7 +130,7 @@ func (spi SPI) SetBaudRate(br uint32) error {
 }
 
 func (spi SPI) GetBaudRate() uint32 {
-	const freqin uint32 = pllSysFreq
+	var freqin uint32 = clockCfg.pllSysFreq
 	prescale := spi.Bus.SSPCPSR.Get()
 	postdiv := ((spi.Bus.SSPCR0.Get() & rp.SPI0_SSPCR0_SCR_Msk) >> rp.SPI0_SSPCR0_SCR_Pos) + 1
 	return freqin / (prescale * postdiv)

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -104,7 +104,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 }
 
 func (spi SPI) SetBaudRate(br uint32) error {
-	var freqin uint32 = clockCfg.pllSysFreq
+	var freqin uint32 = pllSysFreq
 	const maxBaud uint32 = 66.5 * MHz // max output frequency is 66.5MHz on rp2040. see Note page 527.
 	// Find smallest prescale value which puts output frequency in range of
 	// post-divide. Prescale is an even number from 2 to 254 inclusive.
@@ -130,7 +130,7 @@ func (spi SPI) SetBaudRate(br uint32) error {
 }
 
 func (spi SPI) GetBaudRate() uint32 {
-	var freqin uint32 = clockCfg.pllSysFreq
+	var freqin uint32 = pllSysFreq
 	prescale := spi.Bus.SSPCPSR.Get()
 	postdiv := ((spi.Bus.SSPCR0.Get() & rp.SPI0_SSPCR0_SCR_Msk) >> rp.SPI0_SSPCR0_SCR_Pos) + 1
 	return freqin / (prescale * postdiv)

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -75,7 +75,7 @@ func (uart *UART) Configure(config UARTConfig) error {
 
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
-	div := 8 * 125 * MHz / br
+	div := 8 * pllSysFreq / br
 
 	ibrd := div >> 7
 	var fbrd uint32

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -75,7 +75,7 @@ func (uart *UART) Configure(config UARTConfig) error {
 
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
-	div := 8 * pllSysFreq / br
+	div := 8 * clockCfg.pllSysFreq / br
 
 	ibrd := div >> 7
 	var fbrd uint32

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -75,7 +75,7 @@ func (uart *UART) Configure(config UARTConfig) error {
 
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
-	div := 8 * clockCfg.pllSysFreq / br
+	div := 8 * pllSysFreq / br
 
 	ibrd := div >> 7
 	var fbrd uint32

--- a/src/machine/machine_rp2_xosc.go
+++ b/src/machine/machine_rp2_xosc.go
@@ -29,13 +29,13 @@ var xosc = (*xoscType)(unsafe.Pointer(rp.XOSC))
 // This function will block until the crystal oscillator has stabilised.
 func (osc *xoscType) init() {
 	// Assumes 1-15 MHz input
-	if xoscFreq > 15 {
+	if clockCfg.xoscFreq > 15 {
 		panic("xosc frequency cannot be greater than 15MHz")
 	}
 	osc.ctrl.Set(rp.XOSC_CTRL_FREQ_RANGE_1_15MHZ)
 
 	// Set xosc startup delay
-	delay := (((xoscFreq * MHz) / 1000) + 128) / 256 * XOSC_STARTUP_DELAY_MULTIPLIER
+	delay := (((clockCfg.xoscFreq * MHz) / 1000) + 128) / 256 * XOSC_STARTUP_DELAY_MULTIPLIER
 	osc.startup.Set(uint32(delay))
 
 	// Set the enable bit now that we have set freq range and startup delay

--- a/src/machine/machine_rp2_xosc.go
+++ b/src/machine/machine_rp2_xosc.go
@@ -29,13 +29,13 @@ var xosc = (*xoscType)(unsafe.Pointer(rp.XOSC))
 // This function will block until the crystal oscillator has stabilised.
 func (osc *xoscType) init() {
 	// Assumes 1-15 MHz input
-	if clockCfg.xoscFreq > 15 {
+	if xoscFreq > 15 {
 		panic("xosc frequency cannot be greater than 15MHz")
 	}
 	osc.ctrl.Set(rp.XOSC_CTRL_FREQ_RANGE_1_15MHZ)
 
 	// Set xosc startup delay
-	delay := (((clockCfg.xoscFreq * MHz) / 1000) + 128) / 256 * XOSC_STARTUP_DELAY_MULTIPLIER
+	delay := (((xoscFreq * MHz) / 1000) + 128) / 256 * XOSC_STARTUP_DELAY_MULTIPLIER
 	osc.startup.Set(uint32(delay))
 
 	// Set the enable bit now that we have set freq range and startup delay


### PR DESCRIPTION
Here is a first pass at separating the PLL configuration options for the rp2xxx devices, to allow the rp2350 to be configured for 150MHz. I tested (using a logic analyzer) that the UART, USB, I2C, and SPI generate roughly correct speeds.

I moved the configuration into the machine files, but it could be nice to allow a board to override them. If you have a suggestion for how to do that, please let me know.

I know of three issues that should be fixed before submitting the pull request:
* I2C is slow (90khz instead of 100khz), but this appears to be an existing issue and is similar on both parts.
* The 150MHz clock creates a non-integer 6.66ns period, which makes the PWM output inaccurate on the rp2350 
* Currently, the board files have a separate, nonfuctional configuration for the on-board crystal. I created a separate issue for this: https://github.com/tinygo-org/tinygo/issues/4673 , but this touches on the same code.

cc @soypat @deadprogram 