### PR TITLE
Normalize expected path for chdir tests

### DIFF
--- a/tests/testing/chdir/chdir.go
+++ b/tests/testing/chdir/chdir.go
@@ -20,6 +20,11 @@ func main() {
 	}
 	if runtime.GOOS == "windows" {
 		cwd = filepath.ToSlash(cwd)
+	} else {
+		expectDir, err = filepath.EvalSymlinks(expectDir)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	if cwd != expectDir {
 		log.Fatalf("expected:\"%v\" != os.Getwd():\"%v\"", expectDir, cwd)


### PR DESCRIPTION
The expected path comes from a simple string concatenation in shell, but `os.Getwd` appears to have the normalized working directory, so this can fail if any parent directory is a symlink.