### PR TITLE
Fix for #4678: top-level 'make lint' wasn't working

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1000,7 +1000,7 @@ endif
 tools:
 	cd internal/tools && go generate -tags tools ./
 
-LINTFILESCMD=find src/os/ src/reflect/ -type f -name '*.go'
+LINTDIRS=src/os/ src/reflect/
 .PHONY: lint
 lint: tools ## Lint source tree
 	revive -version
@@ -1008,7 +1008,7 @@ lint: tools ## Lint source tree
 	# revive.toml isn't flexible enough to filter out just one kind of error from a checker, so do it with grep here.
 	# Can't use grep with friendly formatter.  Plain output isn't too bad, though.
 	# Use 'grep .' to get rid of stray blank line
-	revive -config revive.toml compiler/... $$( $(LINTFILESCMD) ) \
+	revive -config revive.toml compiler/... $$( find $(LINTDIRS) -type f -name '*.go' ) \
 		| grep -v "should have comment or be unexported" \
 		| grep '.' \
 		| awk '{print}; END {exit NR>0}'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1000,6 +1000,7 @@ endif
 tools:
 	cd internal/tools && go generate -tags tools ./
 
+LINTFILESCMD=find src/os/ src/reflect/ -type f -name '*.go'
 .PHONY: lint
 lint: tools ## Lint source tree
 	revive -version
@@ -1007,7 +1008,10 @@ lint: tools ## Lint source tree
 	# revive.toml isn't flexible enough to filter out just one kind of error from a checker, so do it with grep here.
 	# Can't use grep with friendly formatter.  Plain output isn't too bad, though.
 	# Use 'grep .' to get rid of stray blank line
-	revive -config revive.toml compiler/... src/{os,reflect}/*.go | grep -v "should have comment or be unexported" | grep '.' | awk '{print}; END {exit NR>0}'
+	revive -config revive.toml compiler/... $$( $(LINTFILESCMD) ) \
+		| grep -v "should have comment or be unexported" \
+		| grep '.' \
+		| awk '{print}; END {exit NR>0}'
 
 SPELLDIRSCMD=find . -depth 1 -type d  | egrep -wv '.git|lib|llvm|src'; find src -depth 1 | egrep -wv 'device|internal|net|vendor'; find src/internal -depth 1 -type d | egrep -wv src/internal/wasi
 .PHONY: spell


### PR DESCRIPTION
As noted in #4678, the revive command seems to have had a syntax error in the file input glob. It appears to have been broken in a way that did not result in a return code being set. This change uses 'find' to build the input to the linter.

Note that it is expected to fail the CI script, because it is uncovering some existing lint issues that were not being caught.