### PR TITLE
main: update to use `Get-CimInstance` as `wmic` is being deprecated

### DIFF
--- a/main.go
+++ b/main.go
@@ -1062,9 +1062,8 @@ func findFATMounts(options *compileopts.Options) ([]mountPoint, error) {
 		return points, nil
 	case "windows":
 		// Obtain a list of all currently mounted volumes.
-		cmd := executeCommand(options, "wmic",
-			"PATH", "Win32_LogicalDisk",
-			"get", "DeviceID,VolumeName,FileSystem,DriveType")
+		cmd := executeCommand(options, "powershell", "-c",
+			"Get-CimInstance -ClassName Win32_LogicalDisk | Select-Object DeviceID, DriveType, FileSystem, VolumeName")
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		err := cmd.Run()


### PR DESCRIPTION
When performing a clean installation of Windows 11 24H2, `WMIC` is disabled by default.
In this state, `tinygo flash` fails.
Moving forward, I believe we should adopt a method that does not depend on `WMIC`.

Since `wmic` is becoming obsolete, it has been updated to use `Get-CimInstance`.
`Get-CimInstance` has been available since the initial version of Windows 10.

WMI command line (WMIC) utility deprecation: Next steps
https://techcommunity.microsoft.com/blog/windows-itpro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/4039242


The outputs of each command are as follows. Both can be processed without issues using the current code.

new:

```
$ powershell -c "Get-CimInstance -ClassName Win32_LogicalDisk | Select-Object DeviceID, DriveType, FileSystem, VolumeName"

DeviceID DriveType FileSystem VolumeName
-------- --------- ---------- ----------
C:               3 NTFS
D:               3 NTFS       Volume
I:               4 NTFS       i4tb
P:               4 NTFS       Public
Z:               4 NTFS       j8tb
```

old:

```
$ wmic PATH Win32_LogicalDisk get DeviceID,VolumeName,FileSystem,DriveType
DeviceID  DriveType  FileSystem  VolumeName
C:        3          NTFS
D:        3          NTFS        Volume
I:        4          NTFS        i4tb
P:        4          NTFS        Public
Z:        4          NTFS        j8tb
```


