### PR TITLE
crypto/tls: add Dialer.DialContext() to fix websocket client

### DIFF
--- a/src/crypto/tls/tls.go
+++ b/src/crypto/tls/tls.go
@@ -101,7 +101,13 @@ type Dialer struct {
 //
 // The returned Conn, if any, will always be of type *Conn.
 func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	return nil, errors.New("tls:DialContext not implemented")
+	switch network {
+	case "tcp", "tcp4":
+	default:
+		return nil, fmt.Errorf("Network %s not supported", network)
+	}
+
+	return net.DialTLS(addr)
 }
 
 // LoadX509KeyPair reads and parses a public/private key pair from a pair


### PR DESCRIPTION
The latest golang.org/x/net websocket package v0.33.0 needs Dialer.DailContext in crypto/tls.  This PR adds it.

Apps using golang.org/x/net are encouraged to use v0.33.0 to address:

CVE-2024-45338: Non-linear parsing of case-insensitive content in golang.org/x/net/html
CVE-2023-45288: net/http, x/net/http2: close connections when receiving too many headers

Tested with examples/net/websocket/dial.