### PR TITLE
add support for Elecrow Pico rp2040 W5 boards

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -861,7 +861,7 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=tkey                examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=elecrow_rp2040      examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=elecrow-rp2040      examples/blinky1
 	@$(MD5SUM) test.hex
 ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/export

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -861,6 +861,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=tkey                examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=elecrow_rp2040      examples/blinky1
+	@$(MD5SUM) test.hex
 ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/export
 	$(TINYGO) build -size short -o wasm.wasm -target=wasm               examples/wasm/main

--- a/src/machine/board_elecrow-rp2040-w5.go
+++ b/src/machine/board_elecrow-rp2040-w5.go
@@ -1,0 +1,94 @@
+//go:build elecrow_rp2040
+
+// This file contains the pin mappings for the Elecrow Pico rp2040 W5 boards.
+//
+// Elecrow Pico rp2040 W5 is a microcontroller using the Raspberry Pi RP2040
+// chip and rtl8720d Wifi chip.
+//
+// - https://www.elecrow.com/wiki/PICO_W5_RP2040_Dev_Board.html
+package machine
+
+// GPIO pins
+const (
+	GP0  Pin = GPIO0
+	GP1  Pin = GPIO1
+	GP2  Pin = GPIO2
+	GP3  Pin = GPIO3
+	GP4  Pin = GPIO4
+	GP5  Pin = GPIO5
+	GP6  Pin = GPIO6
+	GP7  Pin = GPIO7
+	GP8  Pin = GPIO8
+	GP9  Pin = GPIO9
+	GP10 Pin = GPIO10
+	GP11 Pin = GPIO11
+	GP12 Pin = GPIO12
+	GP13 Pin = GPIO13
+	GP14 Pin = GPIO14
+	GP15 Pin = GPIO15
+	GP16 Pin = GPIO16
+	GP17 Pin = GPIO17
+	GP18 Pin = GPIO18
+	GP19 Pin = GPIO19
+	GP20 Pin = GPIO20
+	GP21 Pin = GPIO21
+	GP22 Pin = GPIO22
+	GP26 Pin = GPIO26
+	GP27 Pin = GPIO27
+	GP28 Pin = GPIO28
+
+	// Onboard LED
+	LED Pin = GPIO25
+
+	// Onboard crystal oscillator frequency, in MHz.
+	xoscFreq = 12 // MHz
+)
+
+// I2C Default pins on Raspberry Pico.
+const (
+	I2C0_SDA_PIN = GP4
+	I2C0_SCL_PIN = GP5
+
+	I2C1_SDA_PIN = GP2
+	I2C1_SCL_PIN = GP3
+)
+
+// SPI default pins
+const (
+	// Default Serial Clock Bus 0 for SPI communications
+	SPI0_SCK_PIN = GPIO18
+	// Default Serial Out Bus 0 for SPI communications
+	SPI0_SDO_PIN = GPIO19 // Tx
+	// Default Serial In Bus 0 for SPI communications
+	SPI0_SDI_PIN = GPIO16 // Rx
+
+	// Default Serial Clock Bus 1 for SPI communications
+	SPI1_SCK_PIN = GPIO10
+	// Default Serial Out Bus 1 for SPI communications
+	SPI1_SDO_PIN = GPIO11 // Tx
+	// Default Serial In Bus 1 for SPI communications
+	SPI1_SDI_PIN = GPIO12 // Rx
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART1_TX_PIN = GPIO4 // Wired to rtl8720d UART1_Tx
+	UART1_RX_PIN = GPIO5 // Wired to rtl8720n UART1_Rx
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+var DefaultUART = UART0
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "Pico"
+	usb_STRING_MANUFACTURER = "Raspberry Pi"
+)
+
+var (
+	usb_VID uint16 = 0x2E8A
+	usb_PID uint16 = 0x000A
+)

--- a/targets/elecrow-rp2040.json
+++ b/targets/elecrow-rp2040.json
@@ -1,0 +1,12 @@
+{
+    "inherits": ["rp2040"],
+    "build-tags": ["elecrow_rp2040"],
+    "serial-port": ["2e8a:000a"],
+    "default-stack-size": 8192,
+    "ldflags": [
+        "--defsym=__flash_size=8M"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}


### PR DESCRIPTION
https://www.elecrow.com/pico-w5-microcontroller-development-boards-rp2040-microcontroller-board-support-wifi-2-4ghz-5ghz-bluetooth5.html

Just the basics to get several test to work (blinky1, flash).

This board has an rtl8720d Wifi/bluetooth chip wired to UART1, but the rtl8720d firmware installed is the AT cmd set, not the RPC interface used by the rtl8720dn driver, so no wifi support at the moment.