### PR TITLE
Ensure build output directory is created

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -604,6 +604,11 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		},
 	}
 
+	// Create the output directory, if needed
+	if err := os.MkdirAll(filepath.Dir(outpath), 0777); err != nil {
+		return result, err
+	}
+
 	// Check whether we only need to create an object file.
 	// If so, we don't need to link anything and will be finished quickly.
 	outext := filepath.Ext(outpath)


### PR DESCRIPTION
`tinygo build -o /path/to/out .` expected `/path/to` to already exist, which is different behaviour to `go build`. This change ensures tinygo creates any directories needed to be able to build to the specified output dir.

I wasn't certain how to effectively test this change within this repo (this is my first TinyGo contribution), any advice would be welcome!

fixes #4687