### PR TITLE
nrf: fix adc read near zero

### DIFF
--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -183,7 +183,12 @@ func (a *ADC) Get() uint16 {
 		resolutionAdjustment = 4 // 12bit
 	}
 
-	return rawValue.Get() << resolutionAdjustment
+	value := int16(rawValue.Get())
+	if value < 0 {
+		value = 0
+	}
+
+	return uint16(value << resolutionAdjustment)
 }
 
 // SPI on the NRF.


### PR DESCRIPTION
Hopefully fixes bug introduced in #4701

I still don't understand:
1) how tests passed on PR but failed on dev after merge
2) why would `rawValue.Get()` return negative value