### PR TITLE
targets: match Pico2 stack size to Pico

### DIFF
--- a/targets/pico2.json
+++ b/targets/pico2.json
@@ -3,5 +3,6 @@
         "rp2350"
     ],
     "build-tags": ["pico2"],
-    "serial-port": ["2e8a:000A"]
+    "serial-port": ["2e8a:000A"],
+    "default-stack-size": 8192
 }


### PR DESCRIPTION
Took me a while to debug weird crashes after switching from Pico to Pico2.