### PR TITLE
build: update wasmtime used for CI to 29.0.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "19.0.1"
+          version: "29.0.1"
       - name: Install wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
       - name: Download release artifact
@@ -198,7 +198,7 @@ jobs:
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "19.0.1"
+          version: "29.0.1"
       - name: Setup `wasm-tools`
         uses: bytecodealliance/actions/wasm-tools/setup@v1
       - name: Restore LLVM source cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,7 +109,7 @@ jobs:
             C:/Users/runneradmin/go/pkg/mod
       - name: Install wasmtime
         run: |
-          scoop install wasmtime@14.0.4
+          scoop install wasmtime@29.0.1
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo
@@ -216,7 +216,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          scoop install binaryen && scoop install wasmtime@14.0.4
+          scoop install binaryen && scoop install wasmtime@29.0.1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go


### PR DESCRIPTION
This PR updates the version of wasmtime used for CI to `29.0.1` to fix issue with install during CI tests,

Similar to https://github.com/bytecodealliance/actions/issues/14