### PR TITLE
targets: turn on GC for TKey1 device

### DIFF
--- a/targets/tkey.json
+++ b/targets/tkey.json
@@ -7,7 +7,7 @@
     ],
     "linkerscript": "targets/tkey.ld",
     "scheduler": "none",
-    "gc": "leaking",
+    "gc": "conservative",
     "flash-command": "tkey-runapp {bin}",
     "serial": "uart"
 }


### PR DESCRIPTION
This PR turns on GC for the TKey1 device target, since it does in fact work.

Also very much needed, since many crypto packages require heap allocations.