### PR TITLE
build: update Linux builds to run on ubuntu-latest since 20.04 is being retired

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,7 +169,7 @@ jobs:
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch
     # potential bugs.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -297,7 +297,7 @@ jobs:
           - goarch: arm
             toolchain: arm-linux-gnueabihf
             libc: armhf
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build-linux
     steps:
       - name: Checkout

--- a/tests/wasm/setup_test.go
+++ b/tests/wasm/setup_test.go
@@ -33,8 +33,16 @@ func runargs(t *testing.T, args ...string) error {
 }
 
 func chromectx(t *testing.T) context.Context {
+	// see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.NoSandbox,
+	)
+
+	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	t.Cleanup(cancel)
+
 	// looks for locally installed Chrome
-	ctx, ccancel := chromedp.NewContext(context.Background(), chromedp.WithErrorf(t.Errorf), chromedp.WithDebugf(t.Logf), chromedp.WithLogf(t.Logf))
+	ctx, ccancel := chromedp.NewContext(allocCtx, chromedp.WithErrorf(t.Errorf), chromedp.WithDebugf(t.Logf), chromedp.WithLogf(t.Logf))
 	t.Cleanup(ccancel)
 
 	// Wait for browser to be ready.


### PR DESCRIPTION
This PR updates Linux CI builds to run on `ubuntu-latest` since "The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025"