### PR TITLE
ci: upgrade to Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -297,7 +297,7 @@ jobs:
           - goarch: arm
             toolchain: arm-linux-gnueabihf
             libc: armhf
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-linux
     steps:
       - name: Checkout


### PR DESCRIPTION
Ubuntu 20.04 got deprecated, but we want to keep using an older version for the widest compatibility. So we'll switch to Ubuntu 22.04 instead.