### PR TITLE
feature: add buildmode=wasi-legacy for wasi modules

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -667,6 +667,16 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		ldflags = append(ldflags, "--no-entry")
 	}
 
+	if config.Options.BuildMode == "wasi-legacy" {
+		if !strings.HasPrefix(config.Triple(), "wasm32-") {
+			return result, fmt.Errorf("buildmode wasi-legacy is only supported on wasm")
+		}
+
+		if config.Options.Scheduler != "none" {
+			return result, fmt.Errorf("buildmode wasi-legacy only supports scheduler=none")
+		}
+	}
+
 	// Add compiler-rt dependency if needed. Usually this is a simple load from
 	// a cache.
 	if config.Target.RTLib == "compiler-rt" {

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	validBuildModeOptions     = []string{"default", "c-shared"}
+	validBuildModeOptions     = []string{"default", "c-shared", "wasi-legacy"}
 	validGCOptions            = []string{"none", "leaking", "conservative", "custom", "precise"}
 	validSchedulerOptions     = []string{"none", "tasks", "asyncify"}
 	validSerialOptions        = []string{"none", "uart", "usb", "rtt"}

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -283,6 +283,11 @@ func (c *compilerContext) getFunctionInfo(f *ssa.Function) functionInfo {
 		info.wasmName = "_start"
 		info.exported = true
 	}
+	if info.linkName == "runtime.wasmEntryLegacy" && c.BuildMode == "wasi-legacy" {
+		info.linkName = "_start"
+		info.wasmName = "_start"
+		info.exported = true
+	}
 
 	// Check for //go: pragmas, which may change the link name (among others).
 	c.parsePragmas(&info, f)

--- a/main.go
+++ b/main.go
@@ -1501,7 +1501,7 @@ func main() {
 	var tags buildutil.TagsFlag
 	flag.Var(&tags, "tags", "a space-separated list of extra build tags")
 	target := flag.String("target", "", "chip/board name or JSON target specification file")
-	buildMode := flag.String("buildmode", "", "build mode to use (default, c-shared)")
+	buildMode := flag.String("buildmode", "", "build mode to use (default, c-shared, wasi-legacy)")
 	var stackSize uint64
 	flag.Func("stack-size", "goroutine stack size (if unknown at compile time)", func(s string) error {
 		size, err := bytesize.Parse(s)

--- a/main_test.go
+++ b/main_test.go
@@ -594,6 +594,15 @@ func TestWasmExport(t *testing.T) {
 			noOutput:  true, // wasm-unknown cannot produce output
 			command:   true,
 		},
+		// Test buildmode=wasi-legacy with WASI.
+		{
+			name:      "WASIp1-legacy",
+			target:    "wasip1",
+			buildMode: "wasi-legacy",
+			scheduler: "none",
+			file:      "wasmexport-noscheduler.go",
+			command:   true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -51,6 +51,15 @@ func wasmEntryReactor() {
 	}
 }
 
+// This is the _start entry point, when using -buildmode=wasi-legacy.
+func wasmEntryLegacy() {
+	// These need to be initialized early so that the heap can be initialized.
+	initializeCalled = true
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	run()
+}
+
 // Whether the runtime was initialized by a call to _initialize or _start.
 var initializeCalled bool
 


### PR DESCRIPTION
This PR adds a `-buildmode=wasi-legacy` flag to support existing base of users who expected the older behavior for wasi modules to not return an exit code as if they were reactors.

See #4726 for some details on what this is intended to address.

To try it out:

```shell
tinygo build -o plugin.wasm -scheduler=none -target=wasi -buildmode=wasi-legacy plugin.go
```
