### PR TITLE
testing: implement {Skip,Fail}Now 

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -17,6 +17,7 @@ import (
 	"io/fs"
 	"math/rand"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -207,9 +208,8 @@ func (c *common) Failed() bool {
 // current goroutine).
 func (c *common) FailNow() {
 	c.Fail()
-
 	c.finished = true
-	c.Error("FailNow is incomplete, requires runtime.Goexit()")
+	runtime.Goexit()
 }
 
 // log generates the output.
@@ -281,7 +281,7 @@ func (c *common) Skipf(format string, args ...interface{}) {
 func (c *common) SkipNow() {
 	c.skip()
 	c.finished = true
-	c.Error("SkipNow is incomplete, requires runtime.Goexit()")
+	runtime.Goexit()
 }
 
 func (c *common) skip() {


### PR DESCRIPTION
PR https://github.com/tinygo-org/tinygo/pull/4623 implements runtime.GoExit() with which we can improve the testing package and align it more to upstream testing behavior https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/testing/testing.go;l=1150