### PR TITLE
targets: add target for pico2-w board

### DIFF
--- a/targets/pico2-w.json
+++ b/targets/pico2-w.json
@@ -1,0 +1,4 @@
+{
+    "inherits": ["pico2"],
+    "build-tags": ["pico2-w", "cyw43439"]
+}


### PR DESCRIPTION
This PR adds the `pico2-w` board target.

Taken from @amken3d previous PR