### PR TITLE
interp: correctly mark functions as modifying memory

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,8 +43,8 @@ func TestBinarySize(t *testing.T) {
 	tests := []sizeTest{
 		// microcontrollers
 		{"hifive1b", "examples/echo", 4560, 280, 0, 2268},
-		{"microbit", "examples/serial", 2908, 388, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7293, 1487, 116, 6912},
+		{"microbit", "examples/serial", 2916, 388, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7315, 1489, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -970,9 +970,9 @@ func (r *runner) runAtRuntime(fn *function, inst instruction, locals []value, me
 	case llvm.Call:
 		llvmFn := operands[len(operands)-1]
 		args := operands[:len(operands)-1]
-		for _, arg := range args {
-			if arg.Type().TypeKind() == llvm.PointerTypeKind {
-				err := mem.markExternalStore(arg)
+		for _, op := range operands {
+			if op.Type().TypeKind() == llvm.PointerTypeKind {
+				err := mem.markExternalStore(op)
 				if err != nil {
 					return r.errorAt(inst, err)
 				}

--- a/src/runtime/algorithm.go
+++ b/src/runtime/algorithm.go
@@ -23,13 +23,13 @@ func fastrand() uint32 {
 	return xorshift32State
 }
 
-func init() {
+func initRand() {
 	r, _ := hardwareRand()
 	xorshift64State = uint64(r | 1) // protect against 0
 	xorshift32State = uint32(xorshift64State)
 }
 
-var xorshift32State uint32
+var xorshift32State uint32 = 1
 
 func xorshift32(x uint32) uint32 {
 	// Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs".
@@ -49,7 +49,7 @@ func fastrand64() uint64 {
 	return xorshift64State
 }
 
-var xorshift64State uint64
+var xorshift64State uint64 = 1
 
 // 64-bit xorshift multiply rng from http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
 func xorshiftMult64(x uint64) uint64 {

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -35,6 +35,7 @@ func wasmEntryReactor() {
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
 	initHeap()
+	initRand()
 
 	if hasScheduler {
 		// A package initializer might do funky stuff like start a goroutine and

--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -247,6 +247,7 @@ func sleep(duration int64) {
 // With a scheduler, init and the main function are invoked in a goroutine before starting the scheduler.
 func run() {
 	initHeap()
+	initRand()
 	go func() {
 		initAll()
 		callMain()

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -13,6 +13,7 @@ const hasParallelism = false
 // With the "none" scheduler, init and the main function are invoked directly.
 func run() {
 	initHeap()
+	initRand()
 	initAll()
 	callMain()
 	mainExited = true


### PR DESCRIPTION
This is a fix for an interp bug I found in #4732.
Making a draft PR since I want to see the impact of this, it could be big. I might need to modify the PR.