### PR TITLE
fix: infer target for wasm when GOOS and GOARCH are set

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -569,21 +569,21 @@ smoketest: testchdir
 	@$(MD5SUM) test.hex
 	# test simulated boards on play.tinygo.org
 ifneq ($(WASM), 0)
-	$(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=hifive1b             examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=hifive1b             examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=reelboard            examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=reelboard            examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=microbit             examples/microbit-blink
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=microbit             examples/microbit-blink
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=circuitplay_express  examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=circuitplay_express  examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=circuitplay_bluefruit examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=circuitplay_bluefruit examples/blinky1
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=mch2022              examples/machinetest
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=mch2022              examples/machinetest
 	@$(MD5SUM) test.wasm
-	$(TINYGO) build -size short -o test.wasm -tags=gopher_badge         examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=gopher_badge         examples/blinky1
 	@$(MD5SUM) test.wasm
 endif
 	# test all targets/boards

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -69,7 +69,6 @@ func TestClangAttributes(t *testing.T) {
 		{GOOS: "darwin", GOARCH: "arm64"},
 		{GOOS: "windows", GOARCH: "amd64"},
 		{GOOS: "windows", GOARCH: "arm64"},
-		{GOOS: "wasip1", GOARCH: "wasm"},
 	} {
 		name := "GOOS=" + options.GOOS + ",GOARCH=" + options.GOARCH
 		if options.GOARCH == "arm" {

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -356,17 +356,7 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			return nil, fmt.Errorf("invalid GOMIPS=%s: must be hardfloat or softfloat", options.GOMIPS)
 		}
 	case "wasm":
-		llvmarch = "wasm32"
-		spec.CPU = "generic"
-		spec.Features = "+bulk-memory,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types"
-		spec.BuildTags = append(spec.BuildTags, "tinygo.wasm")
-		spec.CFlags = append(spec.CFlags,
-			"-mbulk-memory",
-			"-mnontrapping-fptoint",
-			"-mno-multivalue",
-			"-mno-reference-types",
-			"-msign-ext",
-		)
+		return nil, fmt.Errorf("GOARCH=wasm but GOOS is unset. Please set GOOS to wasm, wasip1, or wasip2.")
 	default:
 		return nil, fmt.Errorf("unknown GOARCH=%s", options.GOARCH)
 	}
@@ -446,23 +436,8 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			"--no-insert-timestamp",
 			"--no-dynamicbase",
 		)
-	case "wasip1":
-		spec.GC = "" // use default GC
-		spec.Scheduler = "asyncify"
-		spec.Linker = "wasm-ld"
-		spec.RTLib = "compiler-rt"
-		spec.Libc = "wasi-libc"
-		spec.DefaultStackSize = 1024 * 64 // 64kB
-		spec.LDFlags = append(spec.LDFlags,
-			"--stack-first",
-			"--no-demangle",
-		)
-		spec.Emulator = "wasmtime run --dir={tmpDir}::/tmp {}"
-		spec.ExtraFiles = append(spec.ExtraFiles,
-			"src/runtime/asm_tinygowasm.S",
-			"src/internal/task/task_asyncify_wasm.S",
-		)
-		llvmos = "wasi"
+	case "wasm", "wasip1", "wasip2":
+		return nil, fmt.Errorf("GOOS=%s but GOARCH is unset. Please set GOARCH to wasm", options.GOOS)
 	default:
 		return nil, fmt.Errorf("unknown GOOS=%s", options.GOOS)
 	}

--- a/main.go
+++ b/main.go
@@ -1684,8 +1684,24 @@ func main() {
 			usage(command)
 			os.Exit(1)
 		}
-		if options.Target == "" && filepath.Ext(outpath) == ".wasm" {
-			options.Target = "wasm"
+		if options.Target == "" {
+			switch {
+			case options.GOARCH == "wasm":
+				switch options.GOOS {
+				case "js":
+					options.Target = "wasm"
+				case "wasip1":
+					options.Target = "wasip1"
+				case "wasip2":
+					options.Target = "wasip2"
+				default:
+					fmt.Fprintln(os.Stderr, "GOARCH=wasm but GOOS is not set correctly. Please set GOOS to wasm, wasip1, or wasip2.")
+					os.Exit(1)
+				}
+			case filepath.Ext(outpath) == ".wasm":
+				fmt.Fprintln(os.Stderr, "you appear to want to build a wasm file, but have not specified either a target flag, or the GOARCH/GOOS to use.")
+				os.Exit(1)
+			}
 		}
 
 		err := Build(pkgName, outpath, options)


### PR DESCRIPTION
This PR fixes the `tinygo build` command to only infer `target` for wasm targets when `GOOS` and `GOARCH` are set correctly, not just based on file extension.

This is intended to be a better version of #4447 by handling all of the current wasm ENV var variations for highest compatibility with big Go.