### PR TITLE
machine: compute rp2 clock dividers from crystal and target frequency

### DIFF
--- a/src/machine/machine_rp2_pll.go
+++ b/src/machine/machine_rp2_pll.go
@@ -111,7 +111,7 @@ var errVCOOverflow = errors.New("VCO calculation overflow; use lower MHz")
 //
 // Example for 12MHz crystal and RP2350:
 //
-//	fbdiv, refdiv, pd1, pd2, _ := pllSearch{LockRefDiv:1}.CalcDivs(12*MHz, 133*MHz, MHz)
+//	fbdiv, refdiv, pd1, pd2, _ := pllSearch{LockRefDiv:1}.CalcDivs(12*MHz, 150*MHz, MHz)
 type pllSearch struct {
 	LowerVCO   bool
 	LockRefDiv uint8


### PR DESCRIPTION
Follow-up to #4728 which implemented the algorithm for finding the dividers.

The calculation is computed at compile time by interp, as verified by the unchanging size for example/blinky1 for -target pico.

@soypat you [mentioned](https://github.com/tinygo-org/tinygo/pull/4728#discussion_r1955270154) that you couldn't get TinyGo to compute the dividers at compile time. However, this PR doesn't change the size of the blinky1 example for `-target pico`. What did I miss?