### PR TITLE
feature: ability to generate nrf firmware manifest for Open DFU format

### DIFF
--- a/builder/nrfutil.go
+++ b/builder/nrfutil.go
@@ -19,7 +19,7 @@ type jsonManifest struct {
 			DataFile       string        `json:"dat_file"`
 			InitPacketData nrfInitPacket `json:"init_packet_data"`
 		} `json:"application"`
-		DFUVersion float64 `json:"dfu_version"` // yes, this is a JSON number, not a string
+		DFUVersion float64 `json:"dfu_version,omitempty"` // yes, this is a JSON number, not a string
 	} `json:"manifest"`
 }
 
@@ -93,7 +93,19 @@ func makeDFUFirmwareImage(options *compileopts.Options, infile, outfile string) 
 	manifest.Manifest.Application.BinaryFile = "application.bin"
 	manifest.Manifest.Application.DataFile = "application.dat"
 	manifest.Manifest.Application.InitPacketData = initPacket
-	manifest.Manifest.DFUVersion = 0.5
+
+	// use build tag "nrf_open_dfu" to indicate open DFU format, otherwise defaults to secure DFU
+	openDFU := false
+	for _, tag := range options.Tags {
+		if tag == "nrf_open_dfu" {
+			openDFU = true
+			break
+		}
+	}
+
+	if !openDFU {
+		manifest.Manifest.DFUVersion = 0.5
+	}
 
 	// Write the JSON manifest to the file.
 	jsonw, err := w.Create("manifest.json")


### PR DESCRIPTION
This PR is to add the ability to generate a nrf firmware manifest for "Open DFU" format using the `nrf_open_dfu` build tag. 

Intended to fix #4089 & #4748

How to test:

```shell
tinygo flash -target=pca10059 -tags=nrf_open_dfu examples/blinky1
```

If this works as expected, then it should flash the board correctly.

I wonder if this should be the new default value for newer nrf boards?