### PR TITLE
refactor: use *SPI everywhere to make consistent for implementations.

### DIFF
--- a/src/machine/board_feather-stm32f405.go
+++ b/src/machine/board_feather-stm32f405.go
@@ -186,15 +186,15 @@ const (
 )
 
 var (
-	SPI1 = SPI{
+	SPI1 = &SPI{
 		Bus:             stm32.SPI2,
 		AltFuncSelector: AF5_SPI1_SPI2,
 	}
-	SPI2 = SPI{
+	SPI2 = &SPI{
 		Bus:             stm32.SPI3,
 		AltFuncSelector: AF6_SPI3,
 	}
-	SPI3 = SPI{
+	SPI3 = &SPI{
 		Bus:             stm32.SPI1,
 		AltFuncSelector: AF5_SPI1_SPI2,
 	}

--- a/src/machine/board_lgt92.go
+++ b/src/machine/board_lgt92.go
@@ -84,10 +84,10 @@ var (
 	I2C0 = I2C1
 
 	// SPI
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus: stm32.SPI1,
 	}
-	SPI1 = &SPI0
+	SPI1 = SPI0
 )
 
 func init() {

--- a/src/machine/board_maixbit_baremetal.go
+++ b/src/machine/board_maixbit_baremetal.go
@@ -6,10 +6,10 @@ import "device/kendryte"
 
 // SPI on the MAix Bit.
 var (
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus: kendryte.SPI0,
 	}
-	SPI1 = SPI{
+	SPI1 = &SPI{
 		Bus: kendryte.SPI1,
 	}
 )

--- a/src/machine/board_mksnanov3.go
+++ b/src/machine/board_mksnanov3.go
@@ -89,11 +89,11 @@ const (
 
 // Since the first interface is named SPI1, both SPI0 and SPI1 refer to SPI1.
 var (
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus:             stm32.SPI1,
 		AltFuncSelector: AF5_SPI1_SPI2,
 	}
-	SPI1 = &SPI0
+	SPI1 = SPI0
 )
 
 const (

--- a/src/machine/board_nucleol031k6.go
+++ b/src/machine/board_nucleol031k6.go
@@ -86,11 +86,11 @@ var (
 	I2C0 = I2C1
 
 	// SPI
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus:             stm32.SPI1,
 		AltFuncSelector: 0,
 	}
-	SPI1 = &SPI0
+	SPI1 = SPI0
 )
 
 func init() {

--- a/src/machine/board_stm32f469disco.go
+++ b/src/machine/board_stm32f469disco.go
@@ -59,11 +59,11 @@ const (
 // Since the first interface is named SPI1, both SPI0 and SPI1 refer to SPI1.
 // TODO: implement SPI2 and SPI3.
 var (
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus:             stm32.SPI1,
 		AltFuncSelector: AF5_SPI1_SPI2,
 	}
-	SPI1 = &SPI0
+	SPI1 = SPI0
 )
 
 const (

--- a/src/machine/board_stm32f4disco.go
+++ b/src/machine/board_stm32f4disco.go
@@ -86,11 +86,11 @@ const (
 // Since the first interface is named SPI1, both SPI0 and SPI1 refer to SPI1.
 // TODO: implement SPI2 and SPI3.
 var (
-	SPI0 = SPI{
+	SPI0 = &SPI{
 		Bus:             stm32.SPI1,
 		AltFuncSelector: AF5_SPI1_SPI2,
 	}
-	SPI1 = &SPI0
+	SPI1 = SPI0
 )
 
 const (

--- a/src/machine/machine_atmega.go
+++ b/src/machine/machine_atmega.go
@@ -257,7 +257,7 @@ type SPI struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (s SPI) Configure(config SPIConfig) error {
+func (s *SPI) Configure(config SPIConfig) error {
 
 	// This is only here to help catch a bug with the configuration
 	// where a machine missed a value.
@@ -330,7 +330,7 @@ func (s SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes the byte into the register and returns the read content
-func (s SPI) Transfer(b byte) (byte, error) {
+func (s *SPI) Transfer(b byte) (byte, error) {
 	s.spdr.Set(uint8(b))
 
 	for !s.spsr.HasBits(s.spsrSPIF) {

--- a/src/machine/machine_atmega1280.go
+++ b/src/machine/machine_atmega1280.go
@@ -927,7 +927,7 @@ func (pwm PWM) Set(channel uint8, value uint32) {
 }
 
 // SPI configuration
-var SPI0 = SPI{
+var SPI0 = &SPI{
 	spcr: avr.SPCR,
 	spdr: avr.SPDR,
 	spsr: avr.SPSR,

--- a/src/machine/machine_atmega1284p.go
+++ b/src/machine/machine_atmega1284p.go
@@ -71,7 +71,7 @@ func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 }
 
 // SPI configuration
-var SPI0 = SPI{
+var SPI0 = &SPI{
 	spcr: avr.SPCR,
 	spsr: avr.SPSR,
 	spdr: avr.SPDR,

--- a/src/machine/machine_atmega2560.go
+++ b/src/machine/machine_atmega2560.go
@@ -131,7 +131,7 @@ func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 }
 
 // SPI configuration
-var SPI0 = SPI{
+var SPI0 = &SPI{
 	spcr: avr.SPCR,
 	spdr: avr.SPDR,
 	spsr: avr.SPSR,

--- a/src/machine/machine_atmega328p.go
+++ b/src/machine/machine_atmega328p.go
@@ -25,7 +25,7 @@ var I2C0 = &I2C{
 }
 
 // SPI configuration
-var SPI0 = SPI{
+var SPI0 = &SPI{
 	spcr: avr.SPCR,
 	spdr: avr.SPDR,
 	spsr: avr.SPSR,

--- a/src/machine/machine_atmega328pb.go
+++ b/src/machine/machine_atmega328pb.go
@@ -60,7 +60,7 @@ var I2C1 = &I2C{
 }
 
 // SPI configuration
-var SPI0 = SPI{
+var SPI0 = &SPI{
 	spcr: avr.SPCR0,
 	spdr: avr.SPDR0,
 	spsr: avr.SPSR0,
@@ -82,7 +82,7 @@ var SPI0 = SPI{
 	cs:  PB2,
 }
 
-var SPI1 = SPI{
+var SPI1 = &SPI{
 	spcr: avr.SPCR1,
 	spdr: avr.SPDR1,
 	spsr: avr.SPSR1,

--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1224,7 +1224,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Use default pins if not set.
 	if config.SCK == 0 && config.SDO == 0 && config.SDI == 0 {
 		config.SCK = SPI0_SCK_PIN
@@ -1346,7 +1346,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	// write data
 	spi.Bus.DATA.Set(uint32(w))
 
@@ -1375,7 +1375,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
 //
 //	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	switch {
 	case w == nil:
 		// read only, so write zero and read a result.
@@ -1396,7 +1396,7 @@ func (spi SPI) Tx(w, r []byte) error {
 	return nil
 }
 
-func (spi SPI) tx(tx []byte) {
+func (spi *SPI) tx(tx []byte) {
 	for i := 0; i < len(tx); i++ {
 		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPI_INTFLAG_DRE) {
 		}
@@ -1411,7 +1411,7 @@ func (spi SPI) tx(tx []byte) {
 	}
 }
 
-func (spi SPI) rx(rx []byte) {
+func (spi *SPI) rx(rx []byte) {
 	spi.Bus.DATA.Set(0)
 	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPI_INTFLAG_DRE) {
 	}
@@ -1427,7 +1427,7 @@ func (spi SPI) rx(rx []byte) {
 	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
 }
 
-func (spi SPI) txrx(tx, rx []byte) {
+func (spi *SPI) txrx(tx, rx []byte) {
 	spi.Bus.DATA.Set(uint32(tx[0]))
 	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPI_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_atsamd51.go
+++ b/src/machine/machine_atsamd51.go
@@ -1431,7 +1431,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Use default pins if not set.
 	if config.SCK == 0 && config.SDO == 0 && config.SDI == 0 {
 		config.SCK = SPI0_SCK_PIN
@@ -1574,7 +1574,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	// write data
 	spi.Bus.DATA.Set(uint32(w))
 
@@ -1603,7 +1603,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
 //
 //	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	switch {
 	case w == nil:
 		// read only, so write zero and read a result.
@@ -1624,7 +1624,7 @@ func (spi SPI) Tx(w, r []byte) error {
 	return nil
 }
 
-func (spi SPI) tx(tx []byte) {
+func (spi *SPI) tx(tx []byte) {
 	for i := 0; i < len(tx); i++ {
 		for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
 		}
@@ -1639,7 +1639,7 @@ func (spi SPI) tx(tx []byte) {
 	}
 }
 
-func (spi SPI) rx(rx []byte) {
+func (spi *SPI) rx(rx []byte) {
 	spi.Bus.DATA.Set(0)
 	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
 	}
@@ -1655,7 +1655,7 @@ func (spi SPI) rx(rx []byte) {
 	rx[len(rx)-1] = byte(spi.Bus.DATA.Get())
 }
 
-func (spi SPI) txrx(tx, rx []byte) {
+func (spi *SPI) txrx(tx, rx []byte) {
 	spi.Bus.DATA.Set(uint32(tx[0]))
 	for !spi.Bus.INTFLAG.HasBits(sam.SERCOM_SPIM_INTFLAG_DRE) {
 	}

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -354,7 +354,7 @@ type SPIConfig struct {
 }
 
 // Configure and make the SPI peripheral ready to use.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	if config.Frequency == 0 {
 		config.Frequency = 4e6 // default to 4MHz
 	}
@@ -445,7 +445,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 
 // Transfer writes/reads a single byte using the SPI interface. If you need to
 // transfer larger amounts of data, Tx will be faster.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.MISO_DLEN.Set(7 << esp.SPI_MISO_DLEN_USR_MISO_DBITLEN_Pos)
 	spi.Bus.MOSI_DLEN.Set(7 << esp.SPI_MOSI_DLEN_USR_MOSI_DBITLEN_Pos)
 
@@ -464,7 +464,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // interface, there must always be the same number of bytes written as bytes read.
 // This is accomplished by sending zero bits if r is bigger than w or discarding
 // the incoming data if w is bigger than r.
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	toTransfer := len(w)
 	if len(r) > toTransfer {
 		toTransfer = len(r)

--- a/src/machine/machine_esp32c3_spi.go
+++ b/src/machine/machine_esp32c3_spi.go
@@ -114,7 +114,7 @@ func freqToClockDiv(hz uint32) uint32 {
 }
 
 // Configure and make the SPI peripheral ready to use.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// right now this is only setup to work for the esp32c3 spi2 bus
 	if spi.Bus != esp.SPI2 {
 		return ErrInvalidSPIBus
@@ -216,7 +216,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 
 // Transfer writes/reads a single byte using the SPI interface. If you need to
 // transfer larger amounts of data, Tx will be faster.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.SetMS_DLEN_MS_DATA_BITLEN(7)
 
 	spi.Bus.SetW0(uint32(w))
@@ -238,7 +238,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // interface, there must always be the same number of bytes written as bytes read.
 // This is accomplished by sending zero bits if r is bigger than w or discarding
 // the incoming data if w is bigger than r.
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	toTransfer := len(w)
 	if len(r) > toTransfer {
 		toTransfer = len(r)

--- a/src/machine/machine_fe310.go
+++ b/src/machine/machine_fe310.go
@@ -140,7 +140,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Use default pins if not set.
 	if config.SCK == 0 && config.SDO == 0 && config.SDI == 0 {
 		config.SCK = SPI0_SCK_PIN
@@ -197,7 +197,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	// wait for tx ready
 	for spi.Bus.TXDATA.HasBits(sifive.QSPI_TXDATA_FULL) {
 	}

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -60,13 +60,13 @@ type SPIConfig struct {
 	Mode      uint8
 }
 
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	spiConfigure(spi.Bus, config.SCK, config.SDO, config.SDI)
 	return nil
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	return spiTransfer(spi.Bus, w), nil
 }
 
@@ -87,7 +87,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
 //
 //	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	var wptr, rptr *byte
 	var wlen, rlen int
 	if len(w) != 0 {

--- a/src/machine/machine_generic_peripherals.go
+++ b/src/machine/machine_generic_peripherals.go
@@ -8,7 +8,7 @@ package machine
 var (
 	UART0 = hardwareUART0
 	UART1 = hardwareUART1
-	SPI0  = SPI{0}
-	SPI1  = SPI{1}
+	SPI0  = &SPI{0}
+	SPI1  = &SPI{1}
 	I2C0  = &I2C{0}
 )

--- a/src/machine/machine_k210.go
+++ b/src/machine/machine_k210.go
@@ -419,7 +419,7 @@ type SPIConfig struct {
 // Configure is intended to setup the SPI interface.
 // Only SPI controller 0 and 1 can be used because SPI2 is a special
 // peripheral-mode controller and SPI3 is used for flashing.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Use default pins if not set.
 	if config.SCK == 0 && config.SDO == 0 && config.SDI == 0 {
 		config.SCK = SPI0_SCK_PIN
@@ -476,7 +476,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.SSIENR.Set(0)
 
 	// Set transfer-receive mode.

--- a/src/machine/machine_nrf51.go
+++ b/src/machine/machine_nrf51.go
@@ -34,8 +34,8 @@ type SPI struct {
 
 // There are 2 SPI interfaces on the NRF51.
 var (
-	SPI0 = SPI{Bus: nrf.SPI0}
-	SPI1 = SPI{Bus: nrf.SPI1}
+	SPI0 = &SPI{Bus: nrf.SPI0}
+	SPI1 = &SPI{Bus: nrf.SPI1}
 )
 
 // SPIConfig is used to store config info for SPI.
@@ -49,7 +49,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the SPI interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Disable bus to configure it
 	spi.Bus.ENABLE.Set(nrf.SPI_ENABLE_ENABLE_Disabled)
 
@@ -122,7 +122,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	spi.Bus.TXD.Set(uint32(w))
 	for spi.Bus.EVENTS_READY.Get() == 0 {
 	}
@@ -150,7 +150,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
 //
 //	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	var err error
 
 	switch {

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -199,9 +199,9 @@ type SPI struct {
 
 // There are 3 SPI interfaces on the NRF528xx.
 var (
-	SPI0 = SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
-	SPI1 = SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
-	SPI2 = SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
+	SPI0 = &SPI{Bus: nrf.SPIM0, buf: new([1]byte)}
+	SPI1 = &SPI{Bus: nrf.SPIM1, buf: new([1]byte)}
+	SPI2 = &SPI{Bus: nrf.SPIM2, buf: new([1]byte)}
 )
 
 // SPIConfig is used to store config info for SPI.
@@ -215,7 +215,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to set up the SPI interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 	// Disable bus to configure it
 	spi.Bus.ENABLE.Set(nrf.SPIM_ENABLE_ENABLE_Disabled)
 
@@ -288,7 +288,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 	buf := spi.buf[:]
 	buf[0] = w
 	err := spi.Tx(buf[:], buf[:])
@@ -300,7 +300,7 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 // as bytes read. Therefore, if the number of bytes don't match it will be
 // padded until they fit: if len(w) > len(r) the extra bytes received will be
 // dropped and if len(w) < len(r) extra 0 bytes will be sent.
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	// Unfortunately the hardware (on the nrf52832) only supports up to 255
 	// bytes in the buffers, so if either w or r is longer than that the
 	// transfer needs to be broken up in pieces.

--- a/src/machine/machine_stm32_spi.go
+++ b/src/machine/machine_stm32_spi.go
@@ -21,7 +21,7 @@ type SPIConfig struct {
 }
 
 // Configure is intended to setup the STM32 SPI1 interface.
-func (spi SPI) Configure(config SPIConfig) error {
+func (spi *SPI) Configure(config SPIConfig) error {
 
 	// -- CONFIGURING THE SPI IN MASTER MODE --
 	//
@@ -98,7 +98,7 @@ func (spi SPI) Configure(config SPIConfig) error {
 }
 
 // Transfer writes/reads a single byte using the SPI interface.
-func (spi SPI) Transfer(w byte) (byte, error) {
+func (spi *SPI) Transfer(w byte) (byte, error) {
 
 	// 1. Enable the SPI by setting the SPE bit to 1.
 	// 2. Write the first data item to be transmitted into the SPI_DR register

--- a/src/machine/machine_stm32f103.go
+++ b/src/machine/machine_stm32f103.go
@@ -333,16 +333,16 @@ type SPI struct {
 // Since the first interface is named SPI1, both SPI0 and SPI1 refer to SPI1.
 // TODO: implement SPI2 and SPI3.
 var (
-	SPI1 = SPI{Bus: stm32.SPI1}
+	SPI1 = &SPI{Bus: stm32.SPI1}
 	SPI0 = SPI1
 )
 
-func (spi SPI) config8Bits() {
+func (spi *SPI) config8Bits() {
 	// no-op on this series
 }
 
 // Set baud rate for SPI
-func (spi SPI) getBaudRate(config SPIConfig) uint32 {
+func (spi *SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32
 
 	// set frequency dependent on PCLK2 prescaler (div 1)
@@ -368,7 +368,7 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 }
 
 // Configure SPI pins for input output and clock
-func (spi SPI) configurePins(config SPIConfig) {
+func (spi *SPI) configurePins(config SPIConfig) {
 	config.SCK.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
 	config.SDO.Configure(PinConfig{Mode: PinOutput50MHz + PinOutputModeAltPushPull})
 	config.SDI.Configure(PinConfig{Mode: PinInputModeFloating})

--- a/src/machine/machine_stm32f4.go
+++ b/src/machine/machine_stm32f4.go
@@ -672,17 +672,17 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
-func (spi SPI) config8Bits() {
+func (spi *SPI) config8Bits() {
 	// no-op on this series
 }
 
-func (spi SPI) configurePins(config SPIConfig) {
+func (spi *SPI) configurePins(config SPIConfig) {
 	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
 	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
 }
 
-func (spi SPI) getBaudRate(config SPIConfig) uint32 {
+func (spi *SPI) getBaudRate(config SPIConfig) uint32 {
 	var clock uint32
 	switch spi.Bus {
 	case stm32.SPI1:

--- a/src/machine/machine_stm32l0.go
+++ b/src/machine/machine_stm32l0.go
@@ -234,12 +234,12 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
-func (spi SPI) config8Bits() {
+func (spi *SPI) config8Bits() {
 	// no-op on this series
 }
 
 // Set baud rate for SPI
-func (spi SPI) getBaudRate(config SPIConfig) uint32 {
+func (spi *SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32
 
 	localFrequency := config.Frequency
@@ -289,7 +289,7 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 }
 
 // Configure SPI pins for input output and clock
-func (spi SPI) configurePins(config SPIConfig) {
+func (spi *SPI) configurePins(config SPIConfig) {
 	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
 	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)

--- a/src/machine/machine_stm32l4.go
+++ b/src/machine/machine_stm32l4.go
@@ -309,14 +309,14 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
-func (spi SPI) config8Bits() {
+func (spi *SPI) config8Bits() {
 	// Set rx threshold to 8-bits, so RXNE flag is set for 1 byte
 	// (common STM32 SPI implementation does 8-bit transfers only)
 	spi.Bus.CR2.SetBits(stm32.SPI_CR2_FRXTH)
 }
 
 // Set baud rate for SPI
-func (spi SPI) getBaudRate(config SPIConfig) uint32 {
+func (spi *SPI) getBaudRate(config SPIConfig) uint32 {
 	var conf uint32
 
 	// Default
@@ -359,7 +359,7 @@ func (spi SPI) getBaudRate(config SPIConfig) uint32 {
 }
 
 // Configure SPI pins for input output and clock
-func (spi SPI) configurePins(config SPIConfig) {
+func (spi *SPI) configurePins(config SPIConfig) {
 	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
 	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)

--- a/src/machine/machine_stm32wlx.go
+++ b/src/machine/machine_stm32wlx.go
@@ -235,19 +235,19 @@ type SPI struct {
 	AltFuncSelector uint8
 }
 
-func (spi SPI) config8Bits() {
+func (spi *SPI) config8Bits() {
 	// Set rx threshold to 8-bits, so RXNE flag is set for 1 byte
 	// (common STM32 SPI implementation does 8-bit transfers only)
 	spi.Bus.CR2.SetBits(stm32.SPI_CR2_FRXTH)
 }
 
-func (spi SPI) configurePins(config SPIConfig) {
+func (spi *SPI) configurePins(config SPIConfig) {
 	config.SCK.ConfigureAltFunc(PinConfig{Mode: PinModeSPICLK}, spi.AltFuncSelector)
 	config.SDO.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDO}, spi.AltFuncSelector)
 	config.SDI.ConfigureAltFunc(PinConfig{Mode: PinModeSPISDI}, spi.AltFuncSelector)
 }
 
-func (spi SPI) getBaudRate(config SPIConfig) uint32 {
+func (spi *SPI) getBaudRate(config SPIConfig) uint32 {
 	var clock uint32
 
 	// We keep this switch and separate management of SPI Clocks

--- a/src/machine/spi_tx.go
+++ b/src/machine/spi_tx.go
@@ -22,7 +22,7 @@ package machine
 // This form sends zeros, putting the result into the rx buffer. Good for reading a "result packet":
 //
 //	spi.Tx(nil, rx)
-func (spi SPI) Tx(w, r []byte) error {
+func (spi *SPI) Tx(w, r []byte) error {
 	var err error
 
 	switch {


### PR DESCRIPTION
This PR is to fix #4663 "in reverse" by making SPI a pointer everywhere, as discussed in the comments.

See https://github.com/tinygo-org/tinygo/issues/4663#issuecomment-2553136448