### PR TITLE
Revert "fix: implement testing {Skip,Fail}Now"

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -17,7 +17,6 @@ import (
 	"io/fs"
 	"math/rand"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -208,8 +207,9 @@ func (c *common) Failed() bool {
 // current goroutine).
 func (c *common) FailNow() {
 	c.Fail()
+
 	c.finished = true
-	runtime.Goexit()
+	c.Error("FailNow is incomplete, requires runtime.Goexit()")
 }
 
 // log generates the output.
@@ -281,7 +281,7 @@ func (c *common) Skipf(format string, args ...interface{}) {
 func (c *common) SkipNow() {
 	c.skip()
 	c.finished = true
-	runtime.Goexit()
+	c.Error("SkipNow is incomplete, requires runtime.Goexit()")
 }
 
 func (c *common) skip() {


### PR DESCRIPTION
This reverts commit c5879c682c834e242aa86f86df2ba4984dfd9ba9.

It doesn't look like this is working (see https://github.com/tinygo-org/tinygo/pull/4736#issuecomment-2679670226), and it doesn't have any tests anyway to prove that it does work. So I think it's best to revert it for now and add a working implementation with tests in the future.