### PR TITLE
compiler, runtime: implement recoverable divide-by-zero panic

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -383,6 +383,7 @@ TEST_PACKAGES_LINUX := \
 	crypto/hmac \
 	debug/dwarf \
 	debug/plan9obj \
+	encoding/binary \
 	go/constant \
 	image \
 	io/ioutil \
@@ -406,6 +407,7 @@ TEST_PACKAGES_WINDOWS := \
 	compress/flate \
 	crypto/des \
 	crypto/hmac \
+	encoding/binary \
 	go/constant \
 	math/bits \
 	strconv \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -362,6 +362,7 @@ TEST_PACKAGES_FAST = \
 # debug/plan9obj requires os.ReadAt, which is not yet supported on windows
 # image requires recover(), which is not yet supported on wasi
 # io/ioutil requires os.ReadDir, which is not yet supported on windows or wasi
+# math/bits: needs panic()/recover()
 # mime: fail on wasi; neds panic()/recover()
 # mime/multipart: needs wasip1 syscall.FDFLAG_NONBLOCK
 # mime/quotedprintable requires syscall.Faccessat
@@ -382,8 +383,10 @@ TEST_PACKAGES_LINUX := \
 	crypto/hmac \
 	debug/dwarf \
 	debug/plan9obj \
+	go/constant \
 	image \
 	io/ioutil \
+	math/bits \
 	mime \
 	mime/multipart \
 	mime/quotedprintable \
@@ -403,6 +406,8 @@ TEST_PACKAGES_WINDOWS := \
 	compress/flate \
 	crypto/des \
 	crypto/hmac \
+	go/constant \
+	math/bits \
 	strconv \
 	text/template/parse \
 	$(nil)

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -688,20 +688,25 @@ func (c *compilerContext) getGlobalInfo(g *ssa.Global) globalInfo {
 	// Check for //go: pragmas, which may change the link name (among others).
 	doc := c.astComments[info.linkName]
 	if doc != nil {
-		info.parsePragmas(doc)
+		info.parsePragmas(doc, g)
 	}
 	return info
 }
 
 // Parse //go: pragma comments from the source. In particular, it parses the
 // //go:extern pragma on globals.
-func (info *globalInfo) parsePragmas(doc *ast.CommentGroup) {
+func (info *globalInfo) parsePragmas(doc *ast.CommentGroup, g *ssa.Global) {
 	for _, comment := range doc.List {
 		if !strings.HasPrefix(comment.Text, "//go:") {
 			continue
 		}
 		parts := strings.Fields(comment.Text)
 		switch parts[0] {
+		case "//go:linkname":
+			if len(parts) == 3 && g.Name() == parts[1] {
+				info.linkName = parts[2]
+				info.extern = true
+			}
 		case "//go:extern":
 			info.extern = true
 			if len(parts) == 2 {

--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -2,6 +2,12 @@ package main
 
 import _ "unsafe"
 
+// Use the go:linkname mechanism to link this global to a different package.
+// This is used in math/bits.
+//
+//go:linkname linknamedGlobal runtime.testLinknamedGlobal
+var linknamedGlobal int
+
 // Creates an external global with name extern_global.
 //
 //go:extern extern_global

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -3,6 +3,7 @@ source_filename = "pragma.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+@runtime.testLinknamedGlobal = external global i32, align 4
 @extern_global = external global [0 x i8], align 1
 @main.alignedGlobal = hidden global [4 x i32] zeroinitializer, align 32
 @main.alignedGlobal16 = hidden global [4 x i32] zeroinitializer, align 16

--- a/src/runtime/error.go
+++ b/src/runtime/error.go
@@ -4,5 +4,22 @@ package runtime
 type Error interface {
 	error
 
+	// Method to indicate this is indeed a runtime error.
 	RuntimeError()
 }
+
+type runtimeError struct {
+	msg string
+}
+
+func (r runtimeError) Error() string {
+	return r.msg
+}
+
+// Purely here to satisfy the Error interface.
+func (r runtimeError) RuntimeError() {}
+
+var (
+	divideError   error = runtimeError{"runtime error: integer divide by zero"}
+	overflowError error = runtimeError{"runtime error: integer overflow"}
+)

--- a/src/runtime/error.go
+++ b/src/runtime/error.go
@@ -21,5 +21,6 @@ func (r runtimeError) RuntimeError() {}
 
 var (
 	divideError   error = runtimeError{"runtime error: integer divide by zero"}
+	lookupError   error = runtimeError{"runtime error: index out of range"}
 	overflowError error = runtimeError{"runtime error: integer overflow"}
 )

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -187,7 +187,7 @@ func nilMapPanic() {
 
 // Panic when trying to access an array or slice out of bounds.
 func lookupPanic() {
-	runtimePanicAt(returnAddress(0), "index out of range")
+	_panic(lookupError)
 }
 
 // Panic when trying to slice a slice out of bounds.

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -220,7 +220,7 @@ func negativeShiftPanic() {
 
 // Panic when there is a divide by zero.
 func divideByZeroPanic() {
-	runtimePanicAt(returnAddress(0), "divide by zero")
+	_panic(divideError)
 }
 
 func blockingPanic() {

--- a/testdata/recover.go
+++ b/testdata/recover.go
@@ -32,6 +32,7 @@ func main() {
 
 	println("\n# runtime panics")
 	runtimePanicDivByZero(1, 0)
+	runtimePanicLookup([]int{1, 2, 3}, 10)
 
 	println("\n# runtime.Goexit")
 	runtimeGoexit()
@@ -125,6 +126,16 @@ func runtimePanicDivByZero(a, b int) int {
 	}()
 
 	return a / b
+}
+
+func runtimePanicLookup(slice []int, index int) int {
+	defer func() {
+		if err := recover(); err != nil {
+			println("recovered:", err)
+		}
+	}()
+
+	return slice[index]
 }
 
 func runtimeGoexit() {

--- a/testdata/recover.go
+++ b/testdata/recover.go
@@ -30,6 +30,9 @@ func main() {
 	println("\n# defer panic")
 	deferPanic()
 
+	println("\n# runtime panics")
+	runtimePanicDivByZero(1, 0)
+
 	println("\n# runtime.Goexit")
 	runtimeGoexit()
 }
@@ -112,6 +115,16 @@ func deferPanic() {
 
 	defer panic("deferred panic")
 	println("defer panic")
+}
+
+func runtimePanicDivByZero(a, b int) int {
+	defer func() {
+		if err := recover(); err != nil {
+			println("recovered:", err)
+		}
+	}()
+
+	return a / b
 }
 
 func runtimeGoexit() {


### PR DESCRIPTION
This gets the math/bits package tests to pass.

Unfortunately, this also has a binary size impact of around 150-200 bytes in many cases. I'm a bit on the edge on whether this is worth it, since it's mostly used for getting package tests to work. But at the same time, having working package tests is very valuable.