### PR TITLE
docs: README wasm updates and LICENSE year update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-Copyright (c) 2018-2023 The TinyGo Authors. All rights reserved.
+Copyright (c) 2018-2025 The TinyGo Authors. All rights reserved.
 
 TinyGo includes portions of the Go standard library.
-Copyright (c) 2009-2023 The Go Authors. All rights reserved.
+Copyright (c) 2009-2024 The Go Authors. All rights reserved.
 
 TinyGo includes portions of LLVM, which is under the Apache License v2.0 with
 LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.

--- a/README.md
+++ b/README.md
@@ -48,20 +48,22 @@ Here is a small TinyGo program for use by a WASI host application:
 ```go
 package main
 
-//go:wasm-module yourmodulename
-//export add
+//go:wasmexport add
 func add(x, y uint32) uint32 {
 	return x + y
 }
-
-// main is required for the `wasip1` target, even if it isn't used.
-func main() {}
 ```
 
-This compiles the above TinyGo program for use on any WASI runtime:
+This compiles the above TinyGo program for use on any WASI Preview 1 runtime:
 
 ```shell
-tinygo build -o main.wasm -target=wasip1 main.go
+tinygo build -buildmode=c-shared -o add.wasm -target=wasip1 add.go
+```
+
+You can also use the same syntax as Go 1.24+:
+
+```shell
+GOARCH=wasip1 GOOS=wasm tinygo build -buildmode=c-shared -o add.wasm add.go
 ```
 
 ## Installation


### PR DESCRIPTION
This PR updates the README with the latest info on how to compile for WASM targets.

It also adds a second commit to update the license year to 2025.