### PR TITLE
internal/syscall/unix: use our own version of this package

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -269,6 +269,8 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 
 	if needsSyscallPackage {
 		paths["syscall/"] = true // include syscall/js
+		paths["internal/syscall/"] = true
+		paths["internal/syscall/unix/"] = false
 	}
 	return paths
 }

--- a/src/internal/syscall/unix/constants.go
+++ b/src/internal/syscall/unix/constants.go
@@ -1,0 +1,7 @@
+package unix
+
+const (
+	R_OK = 0x4
+	W_OK = 0x2
+	X_OK = 0x1
+)

--- a/src/internal/syscall/unix/eaccess.go
+++ b/src/internal/syscall/unix/eaccess.go
@@ -1,0 +1,10 @@
+package unix
+
+import "syscall"
+
+func Eaccess(path string, mode uint32) error {
+	// We don't support this syscall on baremetal or wasm.
+	// Callers are generally able to deal with this since unix.Eaccess also
+	// isn't available on Android.
+	return syscall.ENOSYS
+}

--- a/src/internal/syscall/unix/getrandom.go
+++ b/src/internal/syscall/unix/getrandom.go
@@ -1,0 +1,12 @@
+package unix
+
+type GetRandomFlag uintptr
+
+const (
+	GRND_NONBLOCK GetRandomFlag = 0x0001
+	GRND_RANDOM   GetRandomFlag = 0x0002
+)
+
+func GetRandom(p []byte, flags GetRandomFlag) (n int, err error) {
+	panic("todo: unix.GetRandom")
+}


### PR DESCRIPTION
The upstream one assumes it's running on a Unix system (which makes sense), but this package is also used on baremetal. So replace it on systems that need a replaced syscall package.