### PR TITLE
fix: Convert syscall/js.stringVal's arg as signed int to unsigned 

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -321,6 +321,7 @@
 
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (value_ptr, value_len) => {
+						value_ptr >>>= 0;
 						const s = loadString(value_ptr, value_len);
 						return boxValue(s);
 					},


### PR DESCRIPTION
fixed #4763 

`syscall/js.stringVal` 's argument `value_ptr` may become negative (unexpected) value, and cause error which I mentioned the issue above.
Converting it into unsigned int solves the problem. 