### PR TITLE
machine: bump rp2350 CPUFrequency to 150 MHz

### DIFF
--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	cpuFreq          = 125 * MHz
 	_NUMBANK0_GPIOS  = 30
 	_NUMBANK0_IRQS   = 4
 	_NUMIRQ          = 32

--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	cpuFreq          = 150 * MHz
 	_NUMBANK0_GPIOS  = 48
 	_NUMBANK0_IRQS   = 6
 	rp2350ExtraReg   = 1

--- a/src/machine/machine_rp2_clocks.go
+++ b/src/machine/machine_rp2_clocks.go
@@ -10,7 +10,7 @@ import (
 )
 
 func CPUFrequency() uint32 {
-	return 125 * MHz
+	return cpuFreq
 }
 
 // clockIndex identifies a hardware clock


### PR DESCRIPTION
Leave rp2040 speed bump to 200 MHz for a future change, because it requires bumping the core voltage as well[0].

[0] https://github.com/raspberrypi/pico-sdk/releases/tag/2.1.1