### PR TITLE
machine: replace hard-coded cpu frequencies on rp2xxx

### DIFF
--- a/src/machine/machine_rp2_clocks.go
+++ b/src/machine/machine_rp2_clocks.go
@@ -144,7 +144,7 @@ var pllsysFB, pllsysPD1, pllsysPD2 uint32
 // Note that the entire init function is computed at compile time
 // by interp.
 func init() {
-	fb, _, pd1, pd2, err := pllSearch{LockRefDiv: 1}.CalcDivs(xoscFreq*MHz, uint64(CPUFrequency()), MHz)
+	fb, _, pd1, pd2, err := pllSearch{LockRefDiv: 1}.CalcDivs(xoscFreq*MHz, cpuFreq, MHz)
 	if err != nil {
 		panic(err)
 	}
@@ -185,15 +185,15 @@ func (clks *clocksType) init() {
 	cref := clks.clock(clkRef)
 	cref.configure(rp.CLOCKS_CLK_REF_CTRL_SRC_XOSC_CLKSRC,
 		0, // No aux mux
-		12*MHz,
-		12*MHz)
+		xoscFreq,
+		xoscFreq)
 
 	// clkSys = pllSys (125MHz) / 1 = 125MHz
 	csys := clks.clock(clkSys)
 	csys.configure(rp.CLOCKS_CLK_SYS_CTRL_SRC_CLKSRC_CLK_SYS_AUX,
 		rp.CLOCKS_CLK_SYS_CTRL_AUXSRC_CLKSRC_PLL_SYS,
-		125*MHz,
-		125*MHz)
+		cpuFreq,
+		cpuFreq)
 
 	// clkUSB = pllUSB (48MHz) / 1 = 48MHz
 	cusb := clks.clock(clkUSB)
@@ -217,8 +217,8 @@ func (clks *clocksType) init() {
 	cperi := clks.clock(clkPeri)
 	cperi.configure(0,
 		rp.CLOCKS_CLK_PERI_CTRL_AUXSRC_CLK_SYS,
-		125*MHz,
-		125*MHz)
+		cpuFreq,
+		cpuFreq)
 
 	clks.initTicks()
 }

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -104,13 +104,13 @@ func (spi SPI) Transfer(w byte) (byte, error) {
 }
 
 func (spi SPI) SetBaudRate(br uint32) error {
-	const freqin uint32 = 125 * MHz
 	const maxBaud uint32 = 66.5 * MHz // max output frequency is 66.5MHz on rp2040. see Note page 527.
 	// Find smallest prescale value which puts output frequency in range of
 	// post-divide. Prescale is an even number from 2 to 254 inclusive.
 	var prescale, postdiv uint32
+	freq := CPUFrequency()
 	for prescale = 2; prescale < 255; prescale += 2 {
-		if freqin < (prescale+2)*256*br {
+		if freq < (prescale+2)*256*br {
 			break
 		}
 	}
@@ -120,7 +120,7 @@ func (spi SPI) SetBaudRate(br uint32) error {
 	// Find largest post-divide which makes output <= baudrate. Post-divide is
 	// an integer in the range 1 to 256 inclusive.
 	for postdiv = 256; postdiv > 1; postdiv-- {
-		if freqin/(prescale*(postdiv-1)) > br {
+		if freq/(prescale*(postdiv-1)) > br {
 			break
 		}
 	}

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -75,7 +75,7 @@ func (uart *UART) Configure(config UARTConfig) error {
 
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
-	div := 8 * 125 * MHz / br
+	div := 8 * CPUFrequency() / br
 
 	ibrd := div >> 7
 	var fbrd uint32


### PR DESCRIPTION
Missed from the earlier change that bumped the rp2350 frequency.

@soypat sorry for missing this.