### PR TITLE
Add goroutine benchmark to examples

### DIFF
--- a/src/examples/bench-goro/bench.go
+++ b/src/examples/bench-goro/bench.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"machine"
+	"runtime"
+	"sync"
+	"time"
+)
+
+const N = 500000
+const Ngoro = 4
+
+func main() {
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(Ngoro)
+	for i := 0; i < Ngoro; i++ {
+		go adder(&wg, N)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	goroutineCtxSwitchOverhead := (elapsed / (Ngoro * N)).String()
+
+	elapsedstr := elapsed.String()
+	machine.LED.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	for {
+		println("bench:", elapsedstr, "goroutine ctx switch:", goroutineCtxSwitchOverhead)
+		machine.LED.High()
+		time.Sleep(elapsed)
+		machine.LED.Low()
+		time.Sleep(elapsed)
+	}
+}
+
+func adder(wg *sync.WaitGroup, num int) {
+	for i := 0; i < num; i++ {
+		runtime.Gosched()
+	}
+	wg.Done()
+}


### PR DESCRIPTION
Added `src/examples/bench-goro` example.

Output on Raspberry Pi Pico (2040)

```
bench: 3.730954s goroutine ctx switch: 1.865µs
```

And now with new changes to the CPU frequency (125->200MHz:

```
bench: 2.372861s goroutine ctx switch: 1.186µs
```
