### PR TITLE
machine: don't block the rp2xxx UART interrupt handler

### DIFF
--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -67,7 +67,7 @@ func (uart *UART) Configure(config UARTConfig) error {
 	uart.Interrupt.SetPriority(0x80)
 	uart.Interrupt.Enable()
 
-	// setup interrupt on receive
+	// Setup interrupt on receive.
 	uart.Bus.UARTIMSC.Set(rp.UART0_UARTIMSC_RXIM)
 
 	return nil
@@ -153,7 +153,7 @@ func initUART(uart *UART) {
 // handleInterrupt should be called from the appropriate interrupt handler for
 // this UART instance.
 func (uart *UART) handleInterrupt(interrupt.Interrupt) {
-	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_RXFE) {
+	for !uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_RXFE) {
+		uart.Receive(byte((uart.Bus.UARTDR.Get() & 0xFF)))
 	}
-	uart.Receive(byte((uart.Bus.UARTDR.Get() & 0xFF)))
 }


### PR DESCRIPTION
Don't block forever if there's nothing to receive. On the other hand, process the entire FIFO, not just a single byte.

This fixes an issue where the rp2350 would hang after programming through openocd, because the UART0 interrupt would be spuriously pending.

CC @deadprogram who wrote https://github.com/tinygo-org/tinygo/commit/87e48c105791187ae1bbd096ae55029de2b072a3 and may know if I missed a subtlety here.