### PR TITLE
machine: fix RP2040 Pico board on the playground

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -585,6 +585,8 @@ ifneq ($(WASM), 0)
 	@$(MD5SUM) test.wasm
 	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=gopher_badge         examples/blinky1
 	@$(MD5SUM) test.wasm
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=pico                 examples/blinky1
+	@$(MD5SUM) test.wasm
 endif
 	# test all targets/boards
 	$(TINYGO) build -size short -o test.hex -target=pca10040-s132v6     examples/blinky1

--- a/src/machine/machine_rp2_pins.go
+++ b/src/machine/machine_rp2_pins.go
@@ -1,4 +1,4 @@
-//go:build rp2040 || rp2350 || gopher_badge
+//go:build rp2040 || rp2350 || gopher_badge || pico
 
 package machine
 


### PR DESCRIPTION
Right now it doesn't compile, with errors like the following:

    # machine
    /app/tinygo/src/machine/board_pico.go:7:13: undefined: GPIO0
    /app/tinygo/src/machine/board_pico.go:8:13: undefined: GPIO1
    /app/tinygo/src/machine/board_pico.go:9:13: undefined: GPIO2
    /app/tinygo/src/machine/board_pico.go:10:13: undefined: GPIO3
    [...etc...]

This patch should fix that.

Also added a smoke test, since somehow this wasn't being tested (hence why it broke, probably).