### PR TITLE
compiler: crypto/internal/sysrand is allowed to use unsafe signatures

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -165,6 +165,7 @@ jobs:
           ln -s ~/lib/tinygo/bin/tinygo ~/go/bin/tinygo
       - run: make tinygo-test-wasip1-fast
       - run: make tinygo-test-wasip2-fast
+      - run: make tinygo-test-wasm
       - run: make smoketest
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -407,6 +407,9 @@ TEST_PACKAGES_WINDOWS := \
 	text/template/parse \
 	$(nil)
 
+TEST_PACKAGES_WASM := \
+	crypto/sha256
+
 # Report platforms on which each standard library package is known to pass tests
 jointmp := $(shell echo /tmp/join.$$$$)
 report-stdlib-tests-pass:
@@ -450,6 +453,8 @@ tinygo-bench-fast:
 	$(TINYGO) test -bench . $(TEST_PACKAGES_HOST)
 
 # Same thing, except for wasi rather than the current platform.
+tinygo-test-wasm:
+	$(TINYGO) test -target wasm $(TEST_PACKAGES_WASM)
 tinygo-test-wasi:
 	$(TINYGO) test -target wasip1 $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW) ./tests/runtime_wasi
 tinygo-test-wasip1:

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -446,7 +446,7 @@ func (c *compilerContext) parsePragmas(info *functionInfo, f *ssa.Function) {
 // The list of allowed types is based on this proposal:
 // https://github.com/golang/go/issues/59149
 func (c *compilerContext) checkWasmImportExport(f *ssa.Function, pragma string) {
-	if c.pkg.Path() == "runtime" || c.pkg.Path() == "syscall/js" || c.pkg.Path() == "syscall" {
+	if c.pkg.Path() == "runtime" || c.pkg.Path() == "syscall/js" || c.pkg.Path() == "syscall" || c.pkg.Path() == "crypto/internal/sysrand" {
 		// The runtime is a special case. Allow all kinds of parameters
 		// (importantly, including pointers).
 		return

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -134,6 +134,10 @@ func Pipe() (r *File, w *File, err error) {
 	return nil, nil, ErrNotImplemented
 }
 
+func Symlink(oldname, newname string) error {
+	return ErrNotImplemented
+}
+
 func Readlink(name string) (string, error) {
 	return "", ErrNotImplemented
 }


### PR DESCRIPTION
Apparently this package imports `runtime.getRandomData` from the gojs module. This is not yet implemented, but simply allowing this package to do such imports gets crypto/sha256 to compile.