### PR TITLE
ci: add more tests for wasm and baremetal

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -278,7 +278,7 @@ jobs:
         run: make tinygo-test
       - run: make smoketest
       - run: make wasmtest
-      - run: make tinygo-baremetal
+      - run: make tinygo-test-baremetal
   build-linux-cross:
     # Build ARM Linux binaries, ready for release.
     # This intentionally uses an older Linux image, so that we compile against

--- a/targets/riscv-qemu.ld
+++ b/targets/riscv-qemu.ld
@@ -1,15 +1,15 @@
 
 /* Memory map:
  * https://github.com/qemu/qemu/blob/master/hw/riscv/virt.c
- * RAM and flash are set to 1MB each. That should be enough for the foreseeable
- * future. QEMU does not seem to limit the flash/RAM size and in fact doesn't
- * seem to differentiate between it.
+ * Looks like we can use any address starting from 0x80000000 (so 2GB of space).
+ * However, using a large space slows down tests.
  */
 MEMORY
 {
-    FLASH_TEXT (rw) : ORIGIN = 0x80000000, LENGTH = 0x100000
-    RAM (xrw)       : ORIGIN = 0x80100000, LENGTH = 0x100000
+    RAM (rwx) : ORIGIN = 0x80000000, LENGTH = 100M
 }
+
+REGION_ALIAS("FLASH_TEXT", RAM)
 
 _stack_size = 2K;
 


### PR DESCRIPTION
Run a range of tests in CI, to make sure browser wasm and baremetal don't regress too badly.

I have intentionally filtered out tests (instead of making a list of working tests), so that newly added tests to TEST_PACKAGES_FAST will be added here as well (and can be excluded if needed).

Depends on #4784, must be rebased after that PR is merged.