### PR TITLE
fix: ensure use of pointers for SPI interface on missing machines

### DIFF
--- a/src/machine/board_gnse.go
+++ b/src/machine/board_gnse.go
@@ -77,7 +77,7 @@ var (
 	I2C0 = I2C1
 
 	// SPI
-	SPI3 = SPI{
+	SPI3 = &SPI{
 		Bus: stm32.SPI3,
 	}
 )

--- a/src/machine/board_hifive1b_baremetal.go
+++ b/src/machine/board_hifive1b_baremetal.go
@@ -6,7 +6,7 @@ import "device/sifive"
 
 // SPI on the HiFive1.
 var (
-	SPI1 = SPI{
+	SPI1 = &SPI{
 		Bus: sifive.QSPI1,
 	}
 )

--- a/src/machine/board_lorae5.go
+++ b/src/machine/board_lorae5.go
@@ -85,7 +85,7 @@ var (
 	I2C0 = I2C2
 
 	// SPI
-	SPI3 = SPI{
+	SPI3 = &SPI{
 		Bus: stm32.SPI3,
 	}
 )

--- a/src/machine/board_nucleowl55jc.go
+++ b/src/machine/board_nucleowl55jc.go
@@ -84,7 +84,7 @@ var (
 	I2C0 = I2C1
 
 	// SPI
-	SPI3 = SPI{
+	SPI3 = &SPI{
 		Bus: stm32.SPI3,
 	}
 )

--- a/src/machine/board_teensy40.go
+++ b/src/machine/board_teensy40.go
@@ -263,9 +263,8 @@ const (
 )
 
 var (
-	SPI0  = SPI1 // SPI0 is an alias of SPI1 (LPSPI4)
-	SPI1  = &_SPI1
-	_SPI1 = SPI{
+	SPI0 = SPI1 // SPI0 is an alias of SPI1 (LPSPI4)
+	SPI1 = &SPI{
 		Bus: nxp.LPSPI4,
 		muxSDI: muxSelect{ // D12 (PB1 [B0_01])
 			mux: nxp.IOMUXC_LPSPI4_SDI_SELECT_INPUT_DAISY_GPIO_B0_01_ALT3,
@@ -284,8 +283,7 @@ var (
 			sel: &nxp.IOMUXC.LPSPI4_PCS0_SELECT_INPUT,
 		},
 	}
-	SPI2  = &_SPI2
-	_SPI2 = SPI{
+	SPI2 = &SPI{
 		Bus: nxp.LPSPI3,
 		muxSDI: muxSelect{ // D1 (PA2 [AD_B0_02])
 			mux: nxp.IOMUXC_LPSPI3_SDI_SELECT_INPUT_DAISY_GPIO_AD_B0_02_ALT7,
@@ -304,8 +302,7 @@ var (
 			sel: &nxp.IOMUXC.LPSPI3_PCS0_SELECT_INPUT,
 		},
 	}
-	SPI3  = &_SPI3
-	_SPI3 = SPI{
+	SPI3 = &SPI{
 		Bus: nxp.LPSPI1,
 		muxSDI: muxSelect{ // D34 (PC15 [SD_B0_03])
 			mux: nxp.IOMUXC_LPSPI1_SDI_SELECT_INPUT_DAISY_GPIO_SD_B0_03_ALT4,

--- a/src/machine/machine_atsamd21e18.go
+++ b/src/machine/machine_atsamd21e18.go
@@ -22,10 +22,10 @@ var (
 	sercomI2CM2 = &I2C{Bus: sam.SERCOM2_I2CM, SERCOM: 2}
 	sercomI2CM3 = &I2C{Bus: sam.SERCOM3_I2CM, SERCOM: 3}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPI, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPI, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPI, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPI, SERCOM: 3}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPI, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPI, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPI, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPI, SERCOM: 3}
 )
 
 func init() {

--- a/src/machine/machine_atsamd21g18.go
+++ b/src/machine/machine_atsamd21g18.go
@@ -26,12 +26,12 @@ var (
 	sercomI2CM4 = &I2C{Bus: sam.SERCOM4_I2CM, SERCOM: 4}
 	sercomI2CM5 = &I2C{Bus: sam.SERCOM5_I2CM, SERCOM: 5}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPI, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPI, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPI, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPI, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPI, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPI, SERCOM: 5}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPI, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPI, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPI, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPI, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPI, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPI, SERCOM: 5}
 )
 
 func init() {

--- a/src/machine/machine_atsamd51g19.go
+++ b/src/machine/machine_atsamd51g19.go
@@ -18,12 +18,12 @@ var (
 	sercomI2CM4 = &I2C{Bus: sam.SERCOM4_I2CM, SERCOM: 4}
 	sercomI2CM5 = &I2C{Bus: sam.SERCOM5_I2CM, SERCOM: 5}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsamd51j19.go
+++ b/src/machine/machine_atsamd51j19.go
@@ -18,12 +18,12 @@ var (
 	sercomI2CM4 = &I2C{Bus: sam.SERCOM4_I2CM, SERCOM: 4}
 	sercomI2CM5 = &I2C{Bus: sam.SERCOM5_I2CM, SERCOM: 5}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsamd51j20.go
+++ b/src/machine/machine_atsamd51j20.go
@@ -18,12 +18,12 @@ var (
 	sercomI2CM4 = &I2C{Bus: sam.SERCOM4_I2CM, SERCOM: 4}
 	sercomI2CM5 = &I2C{Bus: sam.SERCOM5_I2CM, SERCOM: 5}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsamd51p19.go
+++ b/src/machine/machine_atsamd51p19.go
@@ -20,14 +20,14 @@ var (
 	sercomI2CM6 = &I2C{Bus: sam.SERCOM6_I2CM, SERCOM: 6}
 	sercomI2CM7 = &I2C{Bus: sam.SERCOM7_I2CM, SERCOM: 7}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
-	sercomSPIM6 = SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
-	sercomSPIM7 = SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM6 = &SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
+	sercomSPIM7 = &SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsamd51p20.go
+++ b/src/machine/machine_atsamd51p20.go
@@ -20,14 +20,14 @@ var (
 	sercomI2CM6 = &I2C{Bus: sam.SERCOM6_I2CM, SERCOM: 6}
 	sercomI2CM7 = &I2C{Bus: sam.SERCOM7_I2CM, SERCOM: 7}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
-	sercomSPIM6 = SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
-	sercomSPIM7 = SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM6 = &SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
+	sercomSPIM7 = &SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsame51j19.go
+++ b/src/machine/machine_atsame51j19.go
@@ -18,12 +18,12 @@ var (
 	sercomI2CM4 = &I2C{Bus: sam.SERCOM4_I2CM, SERCOM: 4}
 	sercomI2CM5 = &I2C{Bus: sam.SERCOM5_I2CM, SERCOM: 5}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_atsame54p20.go
+++ b/src/machine/machine_atsame54p20.go
@@ -20,14 +20,14 @@ var (
 	sercomI2CM6 = &I2C{Bus: sam.SERCOM6_I2CM, SERCOM: 6}
 	sercomI2CM7 = &I2C{Bus: sam.SERCOM7_I2CM, SERCOM: 7}
 
-	sercomSPIM0 = SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
-	sercomSPIM1 = SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
-	sercomSPIM2 = SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
-	sercomSPIM3 = SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
-	sercomSPIM4 = SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
-	sercomSPIM5 = SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
-	sercomSPIM6 = SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
-	sercomSPIM7 = SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
+	sercomSPIM0 = &SPI{Bus: sam.SERCOM0_SPIM, SERCOM: 0}
+	sercomSPIM1 = &SPI{Bus: sam.SERCOM1_SPIM, SERCOM: 1}
+	sercomSPIM2 = &SPI{Bus: sam.SERCOM2_SPIM, SERCOM: 2}
+	sercomSPIM3 = &SPI{Bus: sam.SERCOM3_SPIM, SERCOM: 3}
+	sercomSPIM4 = &SPI{Bus: sam.SERCOM4_SPIM, SERCOM: 4}
+	sercomSPIM5 = &SPI{Bus: sam.SERCOM5_SPIM, SERCOM: 5}
+	sercomSPIM6 = &SPI{Bus: sam.SERCOM6_SPIM, SERCOM: 6}
+	sercomSPIM7 = &SPI{Bus: sam.SERCOM7_SPIM, SERCOM: 7}
 )
 
 // setSERCOMClockGenerator sets the GCLK for sercom

--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -334,8 +334,8 @@ type SPI struct {
 
 var (
 	// SPI0 and SPI1 are reserved for use by the caching system etc.
-	SPI2 = SPI{esp.SPI2}
-	SPI3 = SPI{esp.SPI3}
+	SPI2 = &SPI{esp.SPI2}
+	SPI3 = &SPI{esp.SPI3}
 )
 
 // SPIConfig configures a SPI peripheral on the ESP32. Make sure to set at least

--- a/src/machine/machine_esp32c3_spi.go
+++ b/src/machine/machine_esp32c3_spi.go
@@ -52,7 +52,7 @@ type SPI struct {
 
 var (
 	// SPI0 and SPI1 are reserved for use by the caching system etc.
-	SPI2 = SPI{esp.SPI2}
+	SPI2 = &SPI{esp.SPI2}
 )
 
 // SPIConfig is used to store config info for SPI.

--- a/src/machine/machine_generic.go
+++ b/src/machine/machine_generic.go
@@ -248,14 +248,14 @@ var (
 	sercomI2CM6 = &I2C{6}
 	sercomI2CM7 = &I2C{7}
 
-	sercomSPIM0 = SPI{0}
-	sercomSPIM1 = SPI{1}
-	sercomSPIM2 = SPI{2}
-	sercomSPIM3 = SPI{3}
-	sercomSPIM4 = SPI{4}
-	sercomSPIM5 = SPI{5}
-	sercomSPIM6 = SPI{6}
-	sercomSPIM7 = SPI{7}
+	sercomSPIM0 = &SPI{0}
+	sercomSPIM1 = &SPI{1}
+	sercomSPIM2 = &SPI{2}
+	sercomSPIM3 = &SPI{3}
+	sercomSPIM4 = &SPI{4}
+	sercomSPIM5 = &SPI{5}
+	sercomSPIM6 = &SPI{6}
+	sercomSPIM7 = &SPI{7}
 )
 
 // GetRNG returns 32 bits of random data from the WASI random source.


### PR DESCRIPTION
This PR is to ensure use of pointers for SPI interface on atsam21/atsam51 and other machines that were missing the correct implementation.

Recent build errors in `drivers` repo and other indicated that PR #4756 was not actually complete. This PR is to address that.