### PR TITLE
Boehm GC for WebAssembly

### DIFF
--- a/builder/bdwgc.go
+++ b/builder/bdwgc.go
@@ -14,7 +14,7 @@ var BoehmGC = Library{
 	name: "bdwgc",
 	cflags: func(target, headerPath string) []string {
 		libdir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/bdwgc")
-		return []string{
+		flags := []string{
 			// use a modern environment
 			"-DUSE_MMAP",              // mmap is available
 			"-DUSE_MUNMAP",            // return memory to the OS using munmap
@@ -30,6 +30,7 @@ var BoehmGC = Library{
 			// Use a minimal environment.
 			"-DNO_MSGBOX_ON_ERROR", // don't call MessageBoxA on Windows
 			"-DDONT_USE_ATEXIT",
+			"-DNO_GETENV",
 
 			// Special flag to work around the lack of __data_start in ld.lld.
 			// TODO: try to fix this in LLVM/lld directly so we don't have to
@@ -49,12 +50,13 @@ var BoehmGC = Library{
 
 			"-I" + libdir + "/include",
 		}
+		return flags
 	},
 	needsLibc: true,
 	sourceDir: func() string {
 		return filepath.Join(goenv.Get("TINYGOROOT"), "lib/bdwgc")
 	},
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		sources := []string{
 			"allchblk.c",
 			"alloc.c",

--- a/builder/builtins.go
+++ b/builder/builtins.go
@@ -226,7 +226,7 @@ var libCompilerRT = Library{
 		// Development build.
 		return filepath.Join(goenv.Get("TINYGOROOT"), "lib/compiler-rt-builtins")
 	},
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		builtins := append([]string{}, genericBuiltins...) // copy genericBuiltins
 		switch compileopts.CanonicalArchName(target) {
 		case "arm":

--- a/builder/library.go
+++ b/builder/library.go
@@ -38,7 +38,7 @@ type Library struct {
 	sourceDir func() string
 
 	// The source files, relative to sourceDir.
-	librarySources func(target string) ([]string, error)
+	librarySources func(target string, libcNeedsMalloc bool) ([]string, error)
 
 	// The source code for the crt1.o file, relative to sourceDir.
 	crt1Source string
@@ -226,7 +226,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 
 	// Create jobs to compile all sources. These jobs are depended upon by the
 	// archive job above, so must be run first.
-	paths, err := l.librarySources(target)
+	paths, err := l.librarySources(target, config.LibcNeedsMalloc())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builder/mingw-w64.go
+++ b/builder/mingw-w64.go
@@ -48,7 +48,7 @@ var libMinGW = Library{
 		}
 		return flags
 	},
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		// These files are needed so that printf and the like are supported.
 		var sources []string
 		if strings.Split(target, "-")[0] == "i386" {

--- a/builder/musl.go
+++ b/builder/musl.go
@@ -121,7 +121,7 @@ var libMusl = Library{
 		return cflags
 	},
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/musl/src") },
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		arch := compileopts.MuslArchitecture(target)
 		globs := []string{
 			"conf/*.c",

--- a/builder/picolibc.go
+++ b/builder/picolibc.go
@@ -43,7 +43,7 @@ var libPicolibc = Library{
 		}
 	},
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/picolibc/newlib") },
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		sources := append([]string(nil), picolibcSources...)
 		if !strings.HasPrefix(target, "avr") {
 			// Small chips without long jumps can't compile many files (printf,

--- a/builder/wasilibc.go
+++ b/builder/wasilibc.go
@@ -120,7 +120,7 @@ var libWasiLibc = Library{
 		return nil
 	},
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc") },
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, libcNeedsMalloc bool) ([]string, error) {
 		type filePattern struct {
 			glob    string
 			exclude []string
@@ -167,6 +167,11 @@ var libWasiLibc = Library{
 			{glob: "libc-bottom-half/cloudlibc/src/libc/*/*.c"},
 			{glob: "libc-bottom-half/cloudlibc/src/libc/sys/*/*.c"},
 			{glob: "libc-bottom-half/sources/*.c"},
+		}
+
+		// We're using the Boehm GC, so we need a heap implementation in the libc.
+		if libcNeedsMalloc {
+			globs = append(globs, filePattern{glob: "dlmalloc/src/dlmalloc.c"})
 		}
 
 		// See: LIBC_TOP_HALF_MUSL_SOURCES in the Makefile

--- a/builder/wasmbuiltins.go
+++ b/builder/wasmbuiltins.go
@@ -41,7 +41,7 @@ var libWasmBuiltins = Library{
 		}
 	},
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc") },
-	librarySources: func(target string) ([]string, error) {
+	librarySources: func(target string, _ bool) ([]string, error) {
 		return []string{
 			// memory builtins needed for llvm.memcpy.*, llvm.memmove.*, and
 			// llvm.memset.* LLVM intrinsics.

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -22,7 +22,8 @@ import (
 // builder.Library struct but that's hard to do since we want to know the
 // library path in advance in several places).
 var libVersions = map[string]int{
-	"musl": 3,
+	"musl":  3,
+	"bdwgc": 2,
 }
 
 // Config keeps all configuration affecting the build in a single struct.
@@ -133,7 +134,7 @@ func (c *Config) GC() string {
 // that can be traced by the garbage collector.
 func (c *Config) NeedsStackObjects() bool {
 	switch c.GC() {
-	case "conservative", "custom", "precise":
+	case "conservative", "custom", "precise", "boehm":
 		for _, tag := range c.BuildTags() {
 			if tag == "tinygo.wasm" {
 				return true
@@ -258,6 +259,15 @@ func MuslArchitecture(triple string) string {
 	return CanonicalArchName(triple)
 }
 
+// Returns true if the libc needs to include malloc, for the libcs where this
+// matters.
+func (c *Config) LibcNeedsMalloc() bool {
+	if c.GC() == "boehm" && c.Target.Libc == "wasi-libc" {
+		return true
+	}
+	return false
+}
+
 // LibraryPath returns the path to the library build directory. The path will be
 // a library path in the cache directory (which might not yet be built).
 func (c *Config) LibraryPath(name string) string {
@@ -281,9 +291,14 @@ func (c *Config) LibraryPath(name string) string {
 		archname += "-v" + strconv.Itoa(v)
 	}
 
+	options := ""
+	if c.LibcNeedsMalloc() {
+		options += "+malloc"
+	}
+
 	// No precompiled library found. Determine the path name that will be used
 	// in the build cache.
-	return filepath.Join(goenv.Get("GOCACHE"), name+"-"+archname)
+	return filepath.Join(goenv.Get("GOCACHE"), name+options+"-"+archname)
 }
 
 // DefaultBinaryExtension returns the default extension for binaries, such as

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -470,6 +470,12 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 		return nil, fmt.Errorf("unknown GOOS=%s", options.GOOS)
 	}
 
+	if spec.GC == "boehm" {
+		// Add this file only when needed. This fixes a build failure on
+		// Windows.
+		spec.ExtraFiles = append(spec.ExtraFiles, "src/runtime/gc_boehm.c")
+	}
+
 	// Target triples (which actually have four components, but are called
 	// triples for historical reasons) have the form:
 	//   arch-vendor-os-environment

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tinygo-org/tinygo
 go 1.22.0
 
 require (
-	github.com/aykevl/go-wasm v0.0.2-0.20240825160117-b76c3f9f0982
+	github.com/aykevl/go-wasm v0.0.2-0.20250317121156-42b86c494139
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/chromedp/cdproto v0.0.0-20220113222801-0725d94bb6ee
 	github.com/chromedp/chromedp v0.7.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aykevl/go-wasm v0.0.2-0.20240825160117-b76c3f9f0982 h1:cD7QfvrJdYmBw2tFP/VyKPT8ZESlcrwSwo7SvH9Y4dc=
-github.com/aykevl/go-wasm v0.0.2-0.20240825160117-b76c3f9f0982/go.mod h1:7sXyiaA0WtSogCu67R2252fQpVmJMh9JWJ9ddtGkpWw=
+github.com/aykevl/go-wasm v0.0.2-0.20250317121156-42b86c494139 h1:2O/WuAt8J5id3khcAtVB90czG80m+v0sfkLE07GrCVg=
+github.com/aykevl/go-wasm v0.0.2-0.20250317121156-42b86c494139/go.mod h1:7sXyiaA0WtSogCu67R2252fQpVmJMh9JWJ9ddtGkpWw=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=

--- a/main_test.go
+++ b/main_test.go
@@ -178,11 +178,27 @@ func TestBuild(t *testing.T) {
 
 		t.Run("WebAssembly", func(t *testing.T) {
 			t.Parallel()
+
 			runPlatTests(optionsFromTarget("wasm", sema), tests, t)
+			// Test with -gc=boehm.
+			t.Run("gc.go-boehm", func(t *testing.T) {
+				t.Parallel()
+				optionsBoehm := optionsFromTarget("wasm", sema)
+				optionsBoehm.GC = "boehm"
+				runTest("gc.go", optionsBoehm, t, nil, nil)
+			})
 		})
-		t.Run("WASI", func(t *testing.T) {
+		t.Run("WASIp1", func(t *testing.T) {
 			t.Parallel()
 			runPlatTests(optionsFromTarget("wasip1", sema), tests, t)
+
+			// Test with -gc=boehm.
+			t.Run("gc.go-boehm", func(t *testing.T) {
+				t.Parallel()
+				optionsBoehm := optionsFromTarget("wasip1", sema)
+				optionsBoehm.GC = "boehm"
+				runTest("gc.go", optionsBoehm, t, nil, nil)
+			})
 		})
 		t.Run("WASIp2", func(t *testing.T) {
 			t.Parallel()

--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !(custommalloc || wasm_unknown)
+//go:build tinygo.wasm && !(custommalloc || wasm_unknown || gc.boehm)
 
 package runtime
 

--- a/src/runtime/gc_boehm.c
+++ b/src/runtime/gc_boehm.c
@@ -1,0 +1,37 @@
+//go:build none
+
+// This file is included in the build on systems that support the Boehm GC,
+// despite the //go:build line above.
+
+#include <stdint.h>
+
+typedef void (* GC_push_other_roots_proc)(void);
+void GC_set_push_other_roots(GC_push_other_roots_proc);
+
+typedef void(* GC_warn_proc)(const char *msg, uintptr_t arg);
+void GC_set_warn_proc(GC_warn_proc p);
+
+void tinygo_runtime_bdwgc_callback(void);
+
+static void callback(void) {
+    tinygo_runtime_bdwgc_callback();
+}
+
+static void warn_proc(const char *msg, uintptr_t arg) {
+}
+
+void tinygo_runtime_bdwgc_init(void) {
+    GC_set_push_other_roots(callback);
+#if defined(__wasm__)
+    // There are a lot of warnings on WebAssembly in the form:
+    //
+    //     GC Warning: Repeated allocation of very large block (appr. size 68 KiB):
+    //         May lead to memory leak and poor performance
+    //
+    // The usual advice is to use something like GC_malloc_ignore_off_page but
+    // unfortunately for most allocations that's not allowed: Go allocations can
+    // legitimately hold pointers further than one page in the allocation. So
+    // instead we just disable the warning.
+    GC_set_warn_proc(warn_proc);
+#endif
+}

--- a/src/runtime/gc_stack_portable.go
+++ b/src/runtime/gc_stack_portable.go
@@ -1,4 +1,4 @@
-//go:build (gc.conservative || gc.custom || gc.precise) && tinygo.wasm
+//go:build (gc.conservative || gc.custom || gc.precise || gc.boehm) && tinygo.wasm
 
 package runtime
 

--- a/targets/wasip1.json
+++ b/targets/wasip1.json
@@ -23,7 +23,8 @@
 		"--no-demangle"
 	],
 	"extra-files": [
-		"src/runtime/asm_tinygowasm.S"
+		"src/runtime/asm_tinygowasm.S",
+		"src/runtime/gc_boehm.c"
 	],
 	"emulator":      "wasmtime run --dir={tmpDir}::/tmp {}"
 }

--- a/targets/wasm.json
+++ b/targets/wasm.json
@@ -24,7 +24,8 @@
 		"--no-demangle"
 	],
 	"extra-files": [
-		"src/runtime/asm_tinygowasm.S"
+		"src/runtime/asm_tinygowasm.S",
+		"src/runtime/gc_boehm.c"
 	],
 	"emulator":      "node {root}/targets/wasm_exec.js {}"
 }

--- a/tests/runtime_wasi/malloc_test.go
+++ b/tests/runtime_wasi/malloc_test.go
@@ -124,32 +124,3 @@ func TestMallocFree(t *testing.T) {
 		})
 	}
 }
-
-func TestMallocEmpty(t *testing.T) {
-	ptr := libc_malloc(0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
-	}
-}
-
-func TestCallocEmpty(t *testing.T) {
-	ptr := libc_calloc(0, 1)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
-	}
-	ptr = libc_calloc(1, 0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
-	}
-}
-
-func TestReallocEmpty(t *testing.T) {
-	ptr := libc_malloc(1)
-	if ptr == nil {
-		t.Error("expected pointer but was nil")
-	}
-	ptr = libc_realloc(ptr, 0)
-	if ptr != nil {
-		t.Errorf("expected nil pointer, got %p", ptr)
-	}
-}


### PR DESCRIPTION
See: https://github.com/tinygo-org/tinygo/pull/4385

This is an incomplete port. Things that need to be resolved are:

 - [x] #4385 needs to be merged first, and this PR needs to be rebased.
 - [x] We need to have two separate builds of wasi-libc since the `MALLOC_IMPL` macro is going to be different. I think it's easiest to start doing this build not when creating a TinyGo tarball but when running TinyGo itself (similar to picolibc, musl, etc). This makes it easier to build different variants easily and when needed.

The performance improvements can be large. For example, for the html package some benchmarks are more than 50% faster:

```
$ benchstat html-precise.txt html-boehm.txt
               │ html-precise.txt │           html-boehm.txt           │
               │      sec/op      │   sec/op     vs base               │
Escape               110.29µ ± 0%   73.62µ ± 3%  -33.25% (p=0.002 n=6)
EscapeNone            48.37µ ± 0%   49.15µ ± 1%   +1.62% (p=0.002 n=6)
Unescape             192.31µ ± 5%   84.53µ ± 3%  -56.04% (p=0.002 n=6)
UnescapeNone          2.638µ ± 1%   2.559µ ± 4%        ~ (p=0.132 n=6)
UnescapeSparse        45.44µ ± 2%   18.55µ ± 1%  -59.17% (p=0.002 n=6)
UnescapeDense        182.55µ ± 1%   79.63µ ± 1%  -56.38% (p=0.002 n=6)
geomean               53.11µ        32.40µ       -39.00%
```

Pause times should also be reduced quite a bit, likely much more than the performance improvements. I did not test those, though.

If you want to try this PR, you will have to rebuild wasi-libc:

```
$ rm -rf lib/wasi-libc/sysroot/ lib/wasi-libc/build
$ make wasi-libc
```

(Also note that only wasip1 is supported right now, other wasm variants should be easy to add in the future).