### PR TITLE
Wasilibc builtin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,6 @@ commands:
             - go-cache-v4-{{ checksum "go.mod" }}
       - llvm-source-linux
       - run: go install -tags=llvm<<parameters.llvm>> .
-      - restore_cache:
-          keys:
-            - wasi-libc-sysroot-systemclang-v7
-      - run: make wasi-libc
-      - save_cache:
-          key: wasi-libc-sysroot-systemclang-v7
-          paths:
-            - lib/wasi-libc/sysroot
       - when:
           condition: <<parameters.fmt-check>>
           steps:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -89,15 +89,6 @@ jobs:
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
-      - name: Cache wasi-libc sysroot
-        uses: actions/cache@v4
-        id: cache-wasi-libc
-        with:
-          key: wasi-libc-sysroot-${{ matrix.os }}-v1
-          path: lib/wasi-libc/sysroot
-      - name: Build wasi-libc
-        if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
-        run: make wasi-libc
       - name: make gen-device
         run: make -j3 gen-device
       - name: Test TinyGo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,15 +104,6 @@ jobs:
         run: |
           apk add cmake samurai python3
           make binaryen STATIC=1
-      - name: Cache wasi-libc
-        uses: actions/cache@v4
-        id: cache-wasi-libc
-        with:
-          key: wasi-libc-sysroot-linux-alpine-v2
-          path: lib/wasi-libc/sysroot
-      - name: Build wasi-libc
-        if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
-        run: make wasi-libc
       - name: Install fpm
         run: |
           gem install --version 4.0.7 public_suffix
@@ -258,15 +249,6 @@ jobs:
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: make binaryen
-      - name: Cache wasi-libc
-        uses: actions/cache@v4
-        id: cache-wasi-libc
-        with:
-          key: wasi-libc-sysroot-linux-asserts-v6
-          path: lib/wasi-libc/sysroot
-      - name: Build wasi-libc
-        if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
-        run: make wasi-libc
       - run: make gen-device -j4
       - name: Test TinyGo
         run: make ASSERT=1 test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,15 +91,6 @@ jobs:
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
-      - name: Cache wasi-libc sysroot
-        uses: actions/cache@v4
-        id: cache-wasi-libc
-        with:
-          key: wasi-libc-sysroot-v5
-          path: lib/wasi-libc/sysroot
-      - name: Build wasi-libc
-        if: steps.cache-wasi-libc.outputs.cache-hit != 'true'
-        run: make wasi-libc
       - name: Cache Go cache
         uses: actions/cache@v4
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -259,13 +259,6 @@ build/wasm-opt$(EXE):
 	cp lib/binaryen/bin/wasm-opt$(EXE) build/wasm-opt$(EXE)
 endif
 
-# Build wasi-libc sysroot
-.PHONY: wasi-libc
-wasi-libc: lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a
-lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a:
-	@if [ ! -e lib/wasi-libc/Makefile ]; then echo "Submodules have not been downloaded. Please download them using:\n  git submodule update --init"; exit 1; fi
-	cd lib/wasi-libc && $(MAKE) -j4 EXTRA_CFLAGS="-O2 -g -DNDEBUG -mnontrapping-fptoint -msign-ext" MALLOC_IMPL=none CC="$(CLANG)" AR=$(LLVM_AR) NM=$(LLVM_NM)
-
 # Generate WASI syscall bindings
 WASM_TOOLS_MODULE=go.bytecodealliance.org
 .PHONY: wasi-syscall
@@ -293,7 +286,7 @@ endif
 tinygo: ## Build the TinyGo compiler
 	@if [ ! -f "$(LLVM_BUILDDIR)/bin/llvm-config" ]; then echo "Fetch and build LLVM first by running:"; echo "  $(MAKE) llvm-source"; echo "  $(MAKE) $(LLVM_BUILDDIR)"; exit 1; fi
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GOENVFLAGS) $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags "byollvm osusergo" .
-test: wasi-libc check-nodejs-version
+test: check-nodejs-version
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags "byollvm osusergo" $(GOTESTPKGS)
 
 # Standard library packages that pass tests on darwin, linux, wasi, and windows, but take over a minute in wasi
@@ -526,9 +519,9 @@ test-corpus:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags byollvm -run TestCorpus . -corpus=testdata/corpus.yaml
 test-corpus-fast:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags byollvm -run TestCorpus -short . -corpus=testdata/corpus.yaml
-test-corpus-wasi: wasi-libc
+test-corpus-wasi:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags byollvm -run TestCorpus . -corpus=testdata/corpus.yaml -target=wasip1
-test-corpus-wasip2: wasi-libc
+test-corpus-wasip2:
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags byollvm -run TestCorpus . -corpus=testdata/corpus.yaml -target=wasip2
 
 .PHONY: testchdir
@@ -939,7 +932,7 @@ endif
 wasmtest:
 	$(GO) test ./tests/wasm
 
-build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
+build/release: tinygo gen-device $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
 	@mkdir -p build/release/tinygo/bin
 	@mkdir -p build/release/tinygo/lib/bdwgc
 	@mkdir -p build/release/tinygo/lib/clang/include
@@ -954,7 +947,7 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
 	@mkdir -p build/release/tinygo/lib/nrfx
 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libc
 	@mkdir -p build/release/tinygo/lib/picolibc/newlib/libm
-	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-bottom-half/headers
+	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-bottom-half
 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/arch
 	@mkdir -p build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@mkdir -p build/release/tinygo/lib/wasi-cli/
@@ -1017,15 +1010,36 @@ endif
 	@cp -rp lib/picolibc/newlib/libm/common      build/release/tinygo/lib/picolibc/newlib/libm
 	@cp -rp lib/picolibc/newlib/libm/math        build/release/tinygo/lib/picolibc/newlib/libm
 	@cp -rp lib/picolibc-stdio.c         build/release/tinygo/lib
-	@cp -rp lib/wasi-libc/libc-bottom-half/headers/public           build/release/tinygo/lib/wasi-libc/libc-bottom-half/headers
+	@cp -rp lib/wasi-libc/libc-bottom-half/cloudlibc                build/release/tinygo/lib/wasi-libc/libc-bottom-half
+	@cp -rp lib/wasi-libc/libc-bottom-half/headers                  build/release/tinygo/lib/wasi-libc/libc-bottom-half
+	@cp -rp lib/wasi-libc/libc-bottom-half/sources                  build/release/tinygo/lib/wasi-libc/libc-bottom-half
+	@cp -rp lib/wasi-libc/libc-top-half/headers                     build/release/tinygo/lib/wasi-libc/libc-top-half
 	@cp -rp lib/wasi-libc/libc-top-half/musl/arch/generic           build/release/tinygo/lib/wasi-libc/libc-top-half/musl/arch
 	@cp -rp lib/wasi-libc/libc-top-half/musl/arch/wasm32            build/release/tinygo/lib/wasi-libc/libc-top-half/musl/arch
+	@cp -rp lib/wasi-libc/libc-top-half/musl/include                build/release/tinygo/lib/wasi-libc/libc-top-half/musl
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/conf               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/dirent             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/env                build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/errno              build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/exit               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/fcntl              build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/fenv               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/include            build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/internal           build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/legacy             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/locale             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/math               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/misc               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/multibyte          build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/network            build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/stat               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/stdio              build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/stdlib             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/string             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
-	@cp -rp lib/wasi-libc/libc-top-half/musl/include                build/release/tinygo/lib/wasi-libc/libc-top-half/musl
-	@cp -rp lib/wasi-libc/sysroot                                   build/release/tinygo/lib/wasi-libc/sysroot
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/thread             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/time               build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/musl/src/unistd             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+	@cp -rp lib/wasi-libc/libc-top-half/sources                     build/release/tinygo/lib/wasi-libc/libc-top-half
 	@cp -rp lib/wasi-cli/wit                                        build/release/tinygo/lib/wasi-cli/wit
 	@cp -rp llvm-project/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
 	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins

--- a/builder/bdwgc.go
+++ b/builder/bdwgc.go
@@ -49,6 +49,7 @@ var BoehmGC = Library{
 			"-I" + libdir + "/include",
 		}
 	},
+	needsLibc: true,
 	sourceDir: func() string {
 		return filepath.Join(goenv.Get("TINYGOROOT"), "lib/bdwgc")
 	},

--- a/builder/library.go
+++ b/builder/library.go
@@ -48,13 +48,8 @@ type Library struct {
 // target config. In other words, pass this libc if the library needs a libc to
 // compile.
 func (l *Library) load(config *compileopts.Config, tmpdir string, libc *compileJob) (job *compileJob, abortLock func(), err error) {
-	outdir, precompiled := config.LibcPath(l.name)
+	outdir := config.LibcPath(l.name)
 	archiveFilePath := filepath.Join(outdir, "lib.a")
-	if precompiled {
-		// Found a precompiled library for this OS/architecture. Return the path
-		// directly.
-		return dummyCompileJob(archiveFilePath), func() {}, nil
-	}
 
 	// Create a lock on the output (if supported).
 	// This is a bit messy, but avoids a deadlock because it is ordered consistently with other library loads within a build.

--- a/builder/wasilibc.go
+++ b/builder/wasilibc.go
@@ -1,0 +1,278 @@
+package builder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tinygo-org/tinygo/goenv"
+)
+
+var libWasiLibc = Library{
+	name: "wasi-libc",
+	makeHeaders: func(target, includeDir string) error {
+		bits := filepath.Join(includeDir, "bits")
+		err := os.Mkdir(bits, 0777)
+		if err != nil {
+			return err
+		}
+
+		muslDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib", "wasi-libc/libc-top-half/musl")
+		err = buildMuslAllTypes("wasm32", muslDir, bits)
+		if err != nil {
+			return err
+		}
+
+		// See MUSL_OMIT_HEADERS in the Makefile.
+		omitHeaders := map[string]struct{}{
+			"syslog.h":   {},
+			"wait.h":     {},
+			"ucontext.h": {},
+			"paths.h":    {},
+			"utmp.h":     {},
+			"utmpx.h":    {},
+			"lastlog.h":  {},
+			"elf.h":      {},
+			"link.h":     {},
+			"pwd.h":      {},
+			"shadow.h":   {},
+			"grp.h":      {},
+			"mntent.h":   {},
+			"netdb.h":    {},
+			"resolv.h":   {},
+			"pty.h":      {},
+			"dlfcn.h":    {},
+			"setjmp.h":   {},
+			"ulimit.h":   {},
+			"wordexp.h":  {},
+			"spawn.h":    {},
+			"termios.h":  {},
+			"libintl.h":  {},
+			"aio.h":      {},
+
+			"stdarg.h": {},
+			"stddef.h": {},
+
+			"pthread.h": {},
+		}
+
+		for _, glob := range [][2]string{
+			{"libc-bottom-half/headers/public/*.h", ""},
+			{"libc-bottom-half/headers/public/wasi/*.h", "wasi"},
+			{"libc-top-half/musl/arch/wasm32/bits/*.h", "bits"},
+			{"libc-top-half/musl/include/*.h", ""},
+			{"libc-top-half/musl/include/netinet/*.h", "netinet"},
+			{"libc-top-half/musl/include/sys/*.h", "sys"},
+		} {
+			matches, _ := filepath.Glob(filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc", glob[0]))
+			outDir := filepath.Join(includeDir, glob[1])
+			os.MkdirAll(outDir, 0o777)
+			for _, match := range matches {
+				name := filepath.Base(match)
+				if _, ok := omitHeaders[name]; ok {
+					continue
+				}
+				data, err := os.ReadFile(match)
+				if err != nil {
+					return err
+				}
+				err = os.WriteFile(filepath.Join(outDir, name), data, 0o666)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	},
+	cflags: func(target, headerPath string) []string {
+		libcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc")
+		return []string{
+			"-Werror",
+			"-Wall",
+			"-std=gnu11",
+			"-nostdlibinc",
+			"-mnontrapping-fptoint", "-msign-ext",
+			"-Wno-null-pointer-arithmetic", "-Wno-unused-parameter", "-Wno-sign-compare", "-Wno-unused-variable", "-Wno-unused-function", "-Wno-ignored-attributes", "-Wno-missing-braces", "-Wno-ignored-pragmas", "-Wno-unused-but-set-variable", "-Wno-unknown-warning-option",
+			"-Wno-parentheses", "-Wno-shift-op-parentheses", "-Wno-bitwise-op-parentheses", "-Wno-logical-op-parentheses", "-Wno-string-plus-int", "-Wno-dangling-else", "-Wno-unknown-pragmas",
+			"-DNDEBUG",
+			"-D__wasilibc_printscan_no_long_double",
+			"-D__wasilibc_printscan_full_support_option=\"long double support is disabled\"",
+			"-isystem", headerPath,
+			"-I" + libcDir + "/libc-top-half/musl/src/include",
+			"-I" + libcDir + "/libc-top-half/musl/src/internal",
+			"-I" + libcDir + "/libc-top-half/musl/arch/wasm32",
+			"-I" + libcDir + "/libc-top-half/musl/arch/generic",
+			"-I" + libcDir + "/libc-top-half/headers/private",
+		}
+	},
+	cflagsForFile: func(path string) []string {
+		if strings.HasPrefix(path, "libc-bottom-half"+string(os.PathSeparator)) {
+			libcDir := filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc")
+			return []string{
+				"-I" + libcDir + "/libc-bottom-half/headers/private",
+				"-I" + libcDir + "/libc-bottom-half/cloudlibc/src/include",
+				"-I" + libcDir + "/libc-bottom-half/cloudlibc/src",
+			}
+		}
+		return nil
+	},
+	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc") },
+	librarySources: func(target string) ([]string, error) {
+		type filePattern struct {
+			glob    string
+			exclude []string
+		}
+
+		// See: LIBC_TOP_HALF_MUSL_SOURCES in the Makefile
+		globs := []filePattern{
+			// Top half: mostly musl sources.
+			{glob: "libc-top-half/sources/*.c"},
+			{glob: "libc-top-half/musl/src/conf/*.c"},
+			{glob: "libc-top-half/musl/src/internal/*.c", exclude: []string{
+				"procfdname.c", "syscall.c", "syscall_ret.c", "vdso.c", "version.c",
+			}},
+			{glob: "libc-top-half/musl/src/locale/*.c", exclude: []string{
+				"dcngettext.c", "textdomain.c", "bind_textdomain_codeset.c"}},
+			{glob: "libc-top-half/musl/src/math/*.c", exclude: []string{
+				"__signbit.c", "__signbitf.c", "__signbitl.c",
+				"__fpclassify.c", "__fpclassifyf.c", "__fpclassifyl.c",
+				"ceilf.c", "ceil.c",
+				"floorf.c", "floor.c",
+				"truncf.c", "trunc.c",
+				"rintf.c", "rint.c",
+				"nearbyintf.c", "nearbyint.c",
+				"sqrtf.c", "sqrt.c",
+				"fabsf.c", "fabs.c",
+				"copysignf.c", "copysign.c",
+				"fminf.c", "fmaxf.c",
+				"fmin.c", "fmax.c,",
+			}},
+			{glob: "libc-top-half/musl/src/multibyte/*.c"},
+			{glob: "libc-top-half/musl/src/stdio/*.c", exclude: []string{
+				"vfwscanf.c", "vfwprintf.c", // long double is unsupported
+				"__lockfile.c", "flockfile.c", "funlockfile.c", "ftrylockfile.c",
+				"rename.c",
+				"tmpnam.c", "tmpfile.c", "tempnam.c",
+				"popen.c", "pclose.c",
+				"remove.c",
+				"gets.c"}},
+			{glob: "libc-top-half/musl/src/stdlib/*.c"},
+			{glob: "libc-top-half/musl/src/string/*.c", exclude: []string{
+				"strsignal.c"}},
+
+			// Bottom half: connect top half to WASI equivalents.
+			{glob: "libc-bottom-half/cloudlibc/src/libc/*/*.c"},
+			{glob: "libc-bottom-half/cloudlibc/src/libc/sys/*/*.c"},
+			{glob: "libc-bottom-half/sources/*.c"},
+		}
+
+		// See: LIBC_TOP_HALF_MUSL_SOURCES in the Makefile
+		sources := []string{
+			"libc-top-half/musl/src/misc/a64l.c",
+			"libc-top-half/musl/src/misc/basename.c",
+			"libc-top-half/musl/src/misc/dirname.c",
+			"libc-top-half/musl/src/misc/ffs.c",
+			"libc-top-half/musl/src/misc/ffsl.c",
+			"libc-top-half/musl/src/misc/ffsll.c",
+			"libc-top-half/musl/src/misc/fmtmsg.c",
+			"libc-top-half/musl/src/misc/getdomainname.c",
+			"libc-top-half/musl/src/misc/gethostid.c",
+			"libc-top-half/musl/src/misc/getopt.c",
+			"libc-top-half/musl/src/misc/getopt_long.c",
+			"libc-top-half/musl/src/misc/getsubopt.c",
+			"libc-top-half/musl/src/misc/uname.c",
+			"libc-top-half/musl/src/misc/nftw.c",
+			"libc-top-half/musl/src/errno/strerror.c",
+			"libc-top-half/musl/src/network/htonl.c",
+			"libc-top-half/musl/src/network/htons.c",
+			"libc-top-half/musl/src/network/ntohl.c",
+			"libc-top-half/musl/src/network/ntohs.c",
+			"libc-top-half/musl/src/network/inet_ntop.c",
+			"libc-top-half/musl/src/network/inet_pton.c",
+			"libc-top-half/musl/src/network/inet_aton.c",
+			"libc-top-half/musl/src/network/in6addr_any.c",
+			"libc-top-half/musl/src/network/in6addr_loopback.c",
+			"libc-top-half/musl/src/fenv/fenv.c",
+			"libc-top-half/musl/src/fenv/fesetround.c",
+			"libc-top-half/musl/src/fenv/feupdateenv.c",
+			"libc-top-half/musl/src/fenv/fesetexceptflag.c",
+			"libc-top-half/musl/src/fenv/fegetexceptflag.c",
+			"libc-top-half/musl/src/fenv/feholdexcept.c",
+			"libc-top-half/musl/src/exit/exit.c",
+			"libc-top-half/musl/src/exit/atexit.c",
+			"libc-top-half/musl/src/exit/assert.c",
+			"libc-top-half/musl/src/exit/quick_exit.c",
+			"libc-top-half/musl/src/exit/at_quick_exit.c",
+			"libc-top-half/musl/src/time/strftime.c",
+			"libc-top-half/musl/src/time/asctime.c",
+			"libc-top-half/musl/src/time/asctime_r.c",
+			"libc-top-half/musl/src/time/ctime.c",
+			"libc-top-half/musl/src/time/ctime_r.c",
+			"libc-top-half/musl/src/time/wcsftime.c",
+			"libc-top-half/musl/src/time/strptime.c",
+			"libc-top-half/musl/src/time/difftime.c",
+			"libc-top-half/musl/src/time/timegm.c",
+			"libc-top-half/musl/src/time/ftime.c",
+			"libc-top-half/musl/src/time/gmtime.c",
+			"libc-top-half/musl/src/time/gmtime_r.c",
+			"libc-top-half/musl/src/time/timespec_get.c",
+			"libc-top-half/musl/src/time/getdate.c",
+			"libc-top-half/musl/src/time/localtime.c",
+			"libc-top-half/musl/src/time/localtime_r.c",
+			"libc-top-half/musl/src/time/mktime.c",
+			"libc-top-half/musl/src/time/__tm_to_secs.c",
+			"libc-top-half/musl/src/time/__month_to_secs.c",
+			"libc-top-half/musl/src/time/__secs_to_tm.c",
+			"libc-top-half/musl/src/time/__year_to_secs.c",
+			"libc-top-half/musl/src/time/__tz.c",
+			"libc-top-half/musl/src/fcntl/creat.c",
+			"libc-top-half/musl/src/dirent/alphasort.c",
+			"libc-top-half/musl/src/dirent/versionsort.c",
+			"libc-top-half/musl/src/env/__stack_chk_fail.c",
+			"libc-top-half/musl/src/env/clearenv.c",
+			"libc-top-half/musl/src/env/getenv.c",
+			"libc-top-half/musl/src/env/putenv.c",
+			"libc-top-half/musl/src/env/setenv.c",
+			"libc-top-half/musl/src/env/unsetenv.c",
+			"libc-top-half/musl/src/unistd/posix_close.c",
+			"libc-top-half/musl/src/stat/futimesat.c",
+			"libc-top-half/musl/src/legacy/getpagesize.c",
+			"libc-top-half/musl/src/thread/thrd_sleep.c",
+		}
+
+		basepath := goenv.Get("TINYGOROOT") + "/lib/wasi-libc/"
+		for _, pattern := range globs {
+			matches, err := filepath.Glob(basepath + pattern.glob)
+			if err != nil {
+				// From the documentation:
+				// > Glob ignores file system errors such as I/O errors reading
+				// > directories. The only possible returned error is
+				// > ErrBadPattern, when pattern is malformed.
+				// So the only possible error is when the (statically defined)
+				// pattern is wrong. In other words, a programming bug.
+				return nil, fmt.Errorf("wasi-libc: could not glob source dirs: %w", err)
+			}
+			if len(matches) == 0 {
+				return nil, fmt.Errorf("wasi-libc: did not find any files for pattern %#v", pattern)
+			}
+			excludeSet := map[string]struct{}{}
+			for _, exclude := range pattern.exclude {
+				excludeSet[exclude] = struct{}{}
+			}
+			for _, match := range matches {
+				if _, ok := excludeSet[filepath.Base(match)]; ok {
+					continue
+				}
+				relpath, err := filepath.Rel(basepath, match)
+				if err != nil {
+					// Not sure if this is even possible.
+					return nil, err
+				}
+				sources = append(sources, relpath)
+			}
+		}
+		return sources, nil
+	},
+}

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -247,10 +247,9 @@ func MuslArchitecture(triple string) string {
 	return CanonicalArchName(triple)
 }
 
-// LibcPath returns the path to the libc directory. The libc path will be either
-// a precompiled libc shipped with a TinyGo build, or a libc path in the cache
-// directory (which might not yet be built).
-func (c *Config) LibcPath(name string) (path string, precompiled bool) {
+// LibcPath returns the path to the libc directory. The libc path will be a libc
+// path in the cache directory (which might not yet be built).
+func (c *Config) LibcPath(name string) string {
 	archname := c.Triple()
 	if c.CPU() != "" {
 		archname += "-" + c.CPU()
@@ -266,17 +265,9 @@ func (c *Config) LibcPath(name string) (path string, precompiled bool) {
 		archname += "-" + c.Target.Libc
 	}
 
-	// Try to load a precompiled library.
-	precompiledDir := filepath.Join(goenv.Get("TINYGOROOT"), "pkg", archname, name)
-	if _, err := os.Stat(precompiledDir); err == nil {
-		// Found a precompiled library for this OS/architecture. Return the path
-		// directly.
-		return precompiledDir, true
-	}
-
 	// No precompiled library found. Determine the path name that will be used
 	// in the build cache.
-	return filepath.Join(goenv.Get("GOCACHE"), name+"-"+archname), false
+	return filepath.Join(goenv.Get("GOCACHE"), name+"-"+archname)
 }
 
 // DefaultBinaryExtension returns the default extension for binaries, such as
@@ -360,7 +351,7 @@ func (c *Config) LibcCFlags() []string {
 	case "picolibc":
 		root := goenv.Get("TINYGOROOT")
 		picolibcDir := filepath.Join(root, "lib", "picolibc", "newlib", "libc")
-		path, _ := c.LibcPath("picolibc")
+		path := c.LibcPath("picolibc")
 		return []string{
 			"-nostdlibinc",
 			"-isystem", filepath.Join(path, "include"),
@@ -370,7 +361,7 @@ func (c *Config) LibcCFlags() []string {
 		}
 	case "musl":
 		root := goenv.Get("TINYGOROOT")
-		path, _ := c.LibcPath("musl")
+		path := c.LibcPath("musl")
 		arch := MuslArchitecture(c.Triple())
 		return []string{
 			"-nostdlibinc",
@@ -390,7 +381,7 @@ func (c *Config) LibcCFlags() []string {
 		return nil
 	case "mingw-w64":
 		root := goenv.Get("TINYGOROOT")
-		path, _ := c.LibcPath("mingw-w64")
+		path := c.LibcPath("mingw-w64")
 		return []string{
 			"-nostdlibinc",
 			"-isystem", filepath.Join(path, "include"),

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -371,10 +371,10 @@ func (c *Config) LibcCFlags() []string {
 			"-isystem", filepath.Join(root, "lib", "musl", "include"),
 		}
 	case "wasi-libc":
-		root := goenv.Get("TINYGOROOT")
+		path := c.LibcPath("wasi-libc")
 		return []string{
 			"-nostdlibinc",
-			"-isystem", root + "/lib/wasi-libc/sysroot/include",
+			"-isystem", filepath.Join(path, "include"),
 		}
 	case "wasmbuiltins":
 		// nothing to add (library is purely for builtins)

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
 #   make llvm-source            # fetch compiler-rt
 #   git submodule update --init # fetch lots of other libraries and SVD files
 #   make gen-device -j4         # build src/device/*/*.go files
-#   make wasi-libc              # build support for wasi/wasm
 #
 # With this, you should have an environment that can compile anything - except
 # for the Xtensa architecture (ESP8266/ESP32) because support for that lives in
@@ -64,14 +63,6 @@
             #openocd
           ];
           shellHook= ''
-            # Configure CLANG, LLVM_AR, and LLVM_NM for `make wasi-libc`.
-            # Without setting these explicitly, Homebrew versions might be used
-            # or the default `ar` and `nm` tools might be used (which don't
-            # support wasi).
-            export CLANG="clang-18 -resource-dir ${llvmPackages_18.clang.cc.lib}/lib/clang/18"
-            export LLVM_AR=llvm-ar
-            export LLVM_NM=llvm-nm
-
             # Make `make smoketest` work (the default is `md5`, while Nix only
             # has `md5sum`).
             export MD5SUM=md5sum


### PR DESCRIPTION
Instead of relying on a build when TinyGo is being built, do it like all other libraries when it is needed.

This brings a few benefits:

  * No more running `make wasi-libc` on the command line as a special case for WebAssembly. The generic `git submodule update --init` step is now enough for wasi-libc.
  * It becomes much easier to customize the build per system. For example: include/exclude malloc as needed, disable/enable bulk memory operations per target, etc.

---

In particular, this PR makes it easier to build wasi-libc with and without malloc support: #4812 needs malloc but I'd rather not enable it in all cases (wasi-libc malloc would conflict with the `malloc` symbol we provide in the TinyGo runtime using our own GC).

To the WebAssembly people (@dgryski, @ydnar, etc): while I think this is a step forward, it might break things. This PR might need some extra testing (though `make test-corpus-wasi` passes so that's something).