### PR TITLE
compileopts: re-enable support for GOARCH=wasm

### DIFF
--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -178,6 +178,21 @@ func (spec *TargetSpec) resolveInherits() error {
 
 // Load a target specification.
 func LoadTarget(options *Options) (*TargetSpec, error) {
+	if options.Target == "" && options.GOARCH == "wasm" {
+		// Set a specific target if we're building from a known GOOS/GOARCH
+		// combination that is defined in a target JSON file.
+		switch options.GOOS {
+		case "js":
+			options.Target = "wasm"
+		case "wasip1":
+			options.Target = "wasip1"
+		case "wasip2":
+			options.Target = "wasip2"
+		default:
+			return nil, errors.New("GOARCH=wasm but GOOS is not set correctly. Please set GOOS to wasm, wasip1, or wasip2.")
+		}
+	}
+
 	if options.Target == "" {
 		return defaultTarget(options)
 	}

--- a/main.go
+++ b/main.go
@@ -1684,24 +1684,9 @@ func main() {
 			usage(command)
 			os.Exit(1)
 		}
-		if options.Target == "" {
-			switch {
-			case options.GOARCH == "wasm":
-				switch options.GOOS {
-				case "js":
-					options.Target = "wasm"
-				case "wasip1":
-					options.Target = "wasip1"
-				case "wasip2":
-					options.Target = "wasip2"
-				default:
-					fmt.Fprintln(os.Stderr, "GOARCH=wasm but GOOS is not set correctly. Please set GOOS to wasm, wasip1, or wasip2.")
-					os.Exit(1)
-				}
-			case filepath.Ext(outpath) == ".wasm":
-				fmt.Fprintln(os.Stderr, "you appear to want to build a wasm file, but have not specified either a target flag, or the GOARCH/GOOS to use.")
-				os.Exit(1)
-			}
+		if filepath.Ext(outpath) == ".wasm" && options.GOARCH != "wasm" && options.Target == "" {
+			fmt.Fprintln(os.Stderr, "you appear to want to build a wasm file, but have not specified either a target flag, or the GOARCH/GOOS to use.")
+			os.Exit(1)
 		}
 
 		err := Build(pkgName, outpath, options)


### PR DESCRIPTION
Support for GOARCH=wasm was broken entirely. With this PR, it should work again for supported values of GOOS.

This fixes the following error for example:

    $ make tinygo-test-wasip1
    GOOS=wasip1 GOARCH=wasm /home/ayke/bin/tinygo test cmp compress/lzw compress/zlib [...etc]
    cannot resolve packages: GOARCH=wasm but GOOS is unset. Please set GOOS to wasm, wasip1, or wasip2.
    make: *** [GNUmakefile:489: tinygo-test-wasip1] Error 1