### PR TITLE
windows: add support for the Boehm GC

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1007,6 +1007,7 @@ endif
 	@cp -rp lib/mingw-w64/mingw-w64-crt/stdio/ucrt_*                build/release/tinygo/lib/mingw-w64/mingw-w64-crt/stdio
 	@cp -rp lib/mingw-w64/mingw-w64-headers/crt/                    build/release/tinygo/lib/mingw-w64/mingw-w64-headers
 	@cp -rp lib/mingw-w64/mingw-w64-headers/defaults/include        build/release/tinygo/lib/mingw-w64/mingw-w64-headers/defaults
+	@cp -rp lib/mingw-w64/mingw-w64-headers/include                 build/release/tinygo/lib/mingw-w64/mingw-w64-headers
 	@cp -rp lib/nrfx/*                   build/release/tinygo/lib/nrfx
 	@cp -rp lib/picolibc/newlib/libc/ctype       build/release/tinygo/lib/picolibc/newlib/libc
 	@cp -rp lib/picolibc/newlib/libc/include     build/release/tinygo/lib/picolibc/newlib/libc

--- a/builder/build.go
+++ b/builder/build.go
@@ -182,12 +182,13 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 		defer unlock()
 		libcDependencies = append(libcDependencies, libcJob)
 	case "mingw-w64":
-		job, unlock, err := libMinGW.load(config, tmpdir, nil)
+		var unlock func()
+		libcJob, unlock, err = libMinGW.load(config, tmpdir, nil)
 		if err != nil {
 			return BuildResult{}, err
 		}
 		defer unlock()
-		libcDependencies = append(libcDependencies, job)
+		libcDependencies = append(libcDependencies, libcJob)
 		libcDependencies = append(libcDependencies, makeMinGWExtraLibs(tmpdir, config.GOARCH())...)
 	case "":
 		// no library specified, so nothing to do

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -395,8 +395,10 @@ func (c *Config) LibcCFlags() []string {
 			"-nostdlibinc",
 			"-isystem", filepath.Join(path, "include"),
 			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "crt"),
+			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "include"),
 			"-isystem", filepath.Join(root, "lib", "mingw-w64", "mingw-w64-headers", "defaults", "include"),
 			"-D_UCRT",
+			"-D_WIN32_WINNT=0x0a00", // target Windows 10
 		}
 	case "":
 		// No libc specified, nothing to add.

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -427,7 +427,7 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 			"src/runtime/runtime_unix.c",
 			"src/runtime/signal.c")
 	case "windows":
-		spec.GC = "precise"
+		spec.GC = "boehm"
 		spec.Linker = "ld.lld"
 		spec.Libc = "mingw-w64"
 		// Note: using a medium code model, low image base and no ASLR

--- a/src/runtime/asm_amd64_windows.S
+++ b/src/runtime/asm_amd64_windows.S
@@ -12,8 +12,8 @@ tinygo_scanCurrentStack:
     pushq %r15
 
     // Scan the stack.
-    subq $8, %rsp // adjust the stack before the call to maintain 16-byte alignment
-    movq %rsp, %rdi
+    subq $8, %rsp   // adjust the stack before the call to maintain 16-byte alignment
+    movq %rsp, %rcx // pass the stack pointer as the first parameter
     callq tinygo_scanstack
 
     // Restore the stack pointer. Registers do not need to be restored as they


### PR DESCRIPTION
This adds support for the Boehm GC on Windows, and sets it as the default. It also fixes a rather important bug for the GC on Windows, that I'm surprised we haven't found earlier.