### PR TITLE
arm64: remove unnecessary .section directive

### DIFF
--- a/src/internal/task/task_stack_arm64.S
+++ b/src/internal/task/task_stack_arm64.S
@@ -2,7 +2,6 @@
 .global  _tinygo_startTask
 _tinygo_startTask:
 #else
-.section .text.tinygo_startTask
 .global  tinygo_startTask
 tinygo_startTask:
 #endif

--- a/src/runtime/asm_arm64.S
+++ b/src/runtime/asm_arm64.S
@@ -2,7 +2,6 @@
 .global _tinygo_scanCurrentStack
 _tinygo_scanCurrentStack:
 #else
-.section .text.tinygo_scanCurrentStack
 .global tinygo_scanCurrentStack
 tinygo_scanCurrentStack:
 #endif
@@ -39,7 +38,6 @@ tinygo_scanCurrentStack:
 .global _tinygo_longjmp
 _tinygo_longjmp:
 #else
-.section .text.tinygo_longjmp
 .global tinygo_longjmp
 tinygo_longjmp:
 #endif


### PR DESCRIPTION
This directive caused the code to be put in a non-executable area on Windows which caused a segmentation fault. This patch fixes the issue by removing `.section` directives, fixing windows/arm64 support.