### PR TITLE
cgo: *actually* fix build warnings on Windows ARM

### DIFF
--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -71,7 +71,7 @@ unsigned tinygo_clang_Cursor_isMacroFunctionLike(GoCXCursor c);
 //     libclang.go:68:5: note: previous declaration is here
 // See: https://github.com/golang/go/issues/49721
 #if defined(_WIN32)
-#define CGO_DECL // __declspec(dllexport)
+#define CGO_DECL __declspec(dllexport)
 #else
 #define CGO_DECL
 #endif


### PR DESCRIPTION
See: https://github.com/tinygo-org/tinygo/pull/4628

This removes the comment, which actually fixes the issue. #4628 was incorrect.