### PR TITLE
darwin: support Boehm GC (and use by default)

### DIFF
--- a/builder/bdwgc.go
+++ b/builder/bdwgc.go
@@ -25,6 +25,7 @@ var BoehmGC = Library{
 			"-DALL_INTERIOR_POINTERS",  // scan interior pointers (needed for Go)
 			"-DIGNORE_DYNAMIC_LOADING", // we don't support dynamic loading at the moment
 			"-DNO_GETCONTEXT",          // musl doesn't support getcontext()
+			"-DGC_DISABLE_INCREMENTAL", // don't mess with SIGSEGV and such
 
 			// Use a minimal environment.
 			"-DNO_MSGBOX_ON_ERROR", // don't call MessageBoxA on Windows
@@ -68,8 +69,6 @@ var BoehmGC = Library{
 			"new_hblk.c",
 			"obj_map.c",
 			"os_dep.c",
-			"pthread_stop_world.c",
-			"pthread_support.c",
 			"reclaim.c",
 		}
 		if strings.Split(target, "-")[2] == "windows" {

--- a/builder/build.go
+++ b/builder/build.go
@@ -150,8 +150,8 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 	var libcJob *compileJob
 	switch config.Target.Libc {
 	case "darwin-libSystem":
-		job := makeDarwinLibSystemJob(config, tmpdir)
-		libcDependencies = append(libcDependencies, job)
+		libcJob = makeDarwinLibSystemJob(config, tmpdir)
+		libcDependencies = append(libcDependencies, libcJob)
 	case "musl":
 		var unlock func()
 		libcJob, unlock, err = libMusl.load(config, tmpdir, nil)

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -380,7 +380,7 @@ func defaultTarget(options *Options) (*TargetSpec, error) {
 	llvmvendor := "unknown"
 	switch options.GOOS {
 	case "darwin":
-		spec.GC = "precise"
+		spec.GC = "boehm"
 		platformVersion := "10.12.0"
 		if options.GOARCH == "arm64" {
 			platformVersion = "11.0.0" // first macosx platform with arm64 support


### PR DESCRIPTION
This mostly required some updates to macos-minimal-sdk to add the needed header files and symbols.