### PR TITLE
Add Arduino M0 Pro support

### DIFF
--- a/src/machine/board_arduino_m0_pro.go
+++ b/src/machine/board_arduino_m0_pro.go
@@ -1,0 +1,95 @@
+//go:build sam && atsamd21 && arduino_m0_pro
+
+package machine
+
+// used to reset into bootloader
+const resetMagicValue = 0x07738135
+
+// GPIO Pins - Digital Low
+const (
+	D0 = PA11 // RX
+	D1 = PA10 // TX
+	D2 = PA08
+	D3 = PA09 // PWM available
+	D4 = PA14 // PWM available
+	D5 = PA15 // PWM available
+	D6 = PA20 // PWM available
+	D7 = PA21
+)
+
+// GPIO Pins - Digital High
+const (
+	D8  = PA06 // PWM available
+	D9  = PA07 // PWM available
+	D10 = PA18 // PWM available
+	D11 = PA16 // PWM available
+	D12 = PA19 // PWM available
+	D13 = PA17 // PWM available
+)
+
+// ADC pins
+const (
+	AREF Pin = PA03
+	ADC0 Pin = PA02
+	ADC1 Pin = PB08
+	ADC2 Pin = PB09
+	ADC3 Pin = PA04
+	ADC4 Pin = PA05
+	ADC5 Pin = PB02
+)
+
+// LEDs on the Arduino M0 Pro
+const (
+	LED      = LED1
+	LED1 Pin = D13
+	LED2 Pin = PA27 // TX LED
+	LED3 Pin = PB03 // RX LED
+)
+
+// SPI pins
+const (
+	SPI0_SDO_PIN Pin = PB10 // MOSI
+	SPI0_SDI_PIN Pin = PB12 // MISO
+	SPI0_SCK_PIN Pin = PB11 // SCK
+)
+
+// I2C pins
+const (
+	SDA_PIN Pin = PA22 // SDA: Pin 20
+	SCL_PIN Pin = PA23 // SCL: Pin 21
+)
+
+// I2S pins - might not be exposed
+const (
+	I2S_SCK_PIN Pin = PA10
+	I2S_SDO_PIN Pin = PA07
+	I2S_SDI_PIN     = NoPin
+	I2S_WS_PIN  Pin = PA11
+)
+
+// UART pins
+const (
+	UART_RX_PIN Pin = D0
+	UART_TX_PIN Pin = D1
+)
+
+// 'native' USB port pins
+const (
+	USBCDC_DM_PIN Pin = PA24
+	USBCDC_DP_PIN Pin = PA25
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Arduino M0 Pro"
+	usb_STRING_MANUFACTURER = "Arduino LLC"
+
+	usb_VID uint16 = 0x2A03
+	usb_PID uint16 = 0x804F
+)
+
+// 32.768 KHz Crystal
+const (
+	XIN32  Pin = PA00
+	XOUT32 Pin = PA01
+)

--- a/src/machine/machine_generic_peripherals.go
+++ b/src/machine/machine_generic_peripherals.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !arduino_mkr1000 && !arduino_mkrwifi1010 && !arduino_nano33 && !arduino_zero && !circuitplay_express && !feather_m0 && !feather_m4 && !grandcentral_m4 && !itsybitsy_m0 && !itsybitsy_m4 && !matrixportal_m4 && !metro_m4_airlift && !p1am_100 && !pybadge && !pygamer && !pyportal && !qtpy && !trinket_m0 && !wioterminal && !xiao
+//go:build !baremetal && !arduino_mkr1000 && !arduino_mkrwifi1010 && !arduino_nano33 && !arduino_zero && !arduino_m0_pro && !circuitplay_express && !feather_m0 && !feather_m4 && !grandcentral_m4 && !itsybitsy_m0 && !itsybitsy_m4 && !matrixportal_m4 && !metro_m4_airlift && !p1am_100 && !pybadge && !pygamer && !pyportal && !qtpy && !trinket_m0 && !wioterminal && !xiao
 
 package machine
 

--- a/targets/arduino-m0-pro.json
+++ b/targets/arduino-m0-pro.json
@@ -1,0 +1,7 @@
+{
+    "inherits": ["atsamd21g18au"],
+    "build-tags": ["arduino_m0_pro"],
+    "serial-port": ["2A03:004D","2A03:804D","2A03:004F","2A03:804F"],
+    "flash-command": "avrdude -c stk500v2 -b 57600 -p atmega2560 -P {port} -U flash:w:{hex}:i -v",
+    "flash-1200-bps-reset": "true"
+}

--- a/targets/atsamd21g18au.json
+++ b/targets/atsamd21g18au.json
@@ -1,0 +1,11 @@
+{
+	"inherits": ["cortex-m0plus"],
+	"build-tags": ["atsamd21g18au", "atsamd21g18", "atsamd21", "sam"],
+	"serial": "usb",
+	"linkerscript": "targets/atsamd21.ld",
+	"extra-files": [
+		"src/device/sam/atsamd21g18au.s"
+	],
+	"openocd-transport": "swd",
+	"openocd-target": "at91samdXX"
+}


### PR DESCRIPTION
This is an ongoing PR.

It was heavily based on [boards.txt](https://github.com/arduino/ArduinoCore-samd/blob/master/boards.txt#L563-L611) from Arduino repo.

It fails to build with:
```
tinygo flash -target arduino-m0-pro ./main.go

Avrdude version 8.0
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /opt/homebrew/etc/avrdude.conf
User configuration file <User>/.avrduderc does not exist
Warning: system wide configuration file version (7.3)
does not match Avrdude build version (8.0)

Using port            : /dev/cu.usbmodem004F1
Using programmer      : stk500v2
Setting baud rate     : 57600
AVR part              : ATmega2560
Programming modes     : SPM, ISP, HVPP, JTAG
Programmer type       : STK500V2
Description           : Atmel STK500 version 2.x firmware
Programmer model      : AVRISP
HW version            : 3
FW Version Controller : 4.05
Vtarget               : 0.0 V
SCK period            : 0.1 us

AVR device initialized and ready to accept instructions
Device signature = 1E 98 01 (ATmega2560)
Auto-erasing chip as flash memory needs programming (-U flash:w:...)
specify the -D option to disable this feature
Erased chip
Reading 6184 bytes for flash from input file main.hex
in 1 section [0x2000, 0x3827]: 25 pages and 216 pad bytes
Writing 6184 bytes to flash
Writing | ################################################## | 100% 0.21 s 
Reading | ################################################## | 100% 0.18 s 
Warning: flash verification mismatch
  device 0xff != input 0x00 at addr 0x2000 (error)
  device 0xff != input 0x08 at addr 0x2001 (error)
  device 0xff != input 0x00 at addr 0x2002 (error)
  device 0xff != input 0x20 at addr 0x2003 (error)
  device 0xff != input 0x19 at addr 0x2004 (error)
  device 0xff != input 0x32 at addr 0x2005 (error)
  device 0xff != input 0x00 at addr 0x2006 (error)
  device 0xff != input 0x00 at addr 0x2007 (error)
  device 0xff != input 0x37 at addr 0x2008 (error)
  device 0xff != input 0x21 at addr 0x2009 (error)
  suppressing further verification errors
Error: flash verification mismatch

Avrdude done.  Thank you.
failed to flash /var/folders/m4/q3fvlgld52d2m3k1wmmvb1pm0000gn/T/tinygo2035335312/main.hex: exit status 1
```