### PR TITLE
Add version to cached C libraries

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -15,6 +15,9 @@ import (
 
 // Library is a container for information about a single C library, such as a
 // compiler runtime or libc.
+//
+// Note: whenever a library gets changed, the version in compileopts/config.go
+// probably also needs to be incremented.
 type Library struct {
 	// The library name, such as compiler-rt or picolibc.
 	name string
@@ -50,7 +53,7 @@ type Library struct {
 // As a side effect, this call creates the library header files if they didn't
 // exist yet.
 func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJob, abortLock func(), err error) {
-	outdir := config.LibcPath(l.name)
+	outdir := config.LibraryPath(l.name)
 	archiveFilePath := filepath.Join(outdir, "lib.a")
 
 	// Create a lock on the output (if supported).


### PR DESCRIPTION
This may be a bit of a weird place to put the library path, but otherwise it's difficult to get the pathname for the `Config.CFlags` function. So I've put it here.

This should help to avoid stale library caches. The idea is to increment it every time something changes to a library that means it needs to be recompiled. It's a manual process.

See for example: https://github.com/tinygo-org/tinygo/issues/4828