### PR TITLE
Makefile: avoid some shell commands

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,14 +44,10 @@ TINYGO ?= $(call detect,tinygo,tinygo $(CURDIR)/build/tinygo)
 
 # Check for ccache if the user hasn't set it to on or off.
 ifeq (, $(CCACHE))
-    # Use CCACHE for LLVM if possible
-    ifneq (, $(shell command -v ccache 2> /dev/null))
-        CCACHE := ON
-    else
-        CCACHE := OFF
-    endif
+    LLVM_OPTION += '-DLLVM_CCACHE_BUILD=$(if $(shell command -v ccache 2> /dev/null),ON,OFF)'
+else
+    LLVM_OPTION += '-DLLVM_CCACHE_BUILD=$(CCACHE)'
 endif
-LLVM_OPTION += '-DLLVM_CCACHE_BUILD=$(CCACHE)'
 
 # Allow enabling LLVM assertions
 ifeq (1, $(ASSERT))

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -445,8 +445,8 @@ TEST_PACKAGES_NONBAREMETAL = \
 	$(nil)
 
 # Report platforms on which each standard library package is known to pass tests
-jointmp := $(shell echo /tmp/join.$$$$)
 report-stdlib-tests-pass:
+	$(eval jointmp := $(shell echo /tmp/join.$$$$))
 	@for t in $(TEST_PACKAGES_DARWIN); do echo "$$t darwin"; done | sort > $(jointmp).darwin
 	@for t in $(TEST_PACKAGES_LINUX); do echo "$$t linux"; done | sort > $(jointmp).linux
 	@for t in $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW); do echo "$$t darwin linux wasi windows"; done | sort > $(jointmp).portable

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,6 @@ LLVM_NM ?= $(call findLLVMTool,llvm-nm)
 
 # Go binary and GOROOT to select
 GO ?= go
-export GOROOT = $(shell $(GO) env GOROOT)
 
 # Flags to pass to go test.
 GOTESTFLAGS ?=

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,13 +8,20 @@ LLVM_PROJECTDIR ?= llvm-project
 CLANG_SRC ?= $(LLVM_PROJECTDIR)/clang
 LLD_SRC ?= $(LLVM_PROJECTDIR)/lld
 
+ifeq ($(OS),Windows_NT)
+    # avoid calling uname on Windows
+    uname := Windows_NT
+else
+    uname := $(shell uname -s)
+endif
+
 # Try to autodetect LLVM build tools.
 # Versions are listed here in descending priority order.
 LLVM_VERSIONS = 19 18 17 16 15
 errifempty = $(if $(1),$(1),$(error $(2)))
 detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
 toolSearchPathsVersion = $(1)-$(2)
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(uname),Darwin)
 	# Also explicitly search Brew's copy, which is not in PATH by default.
 	BREW_PREFIX := $(shell brew --prefix)
 	toolSearchPathsVersion += $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)-$(2) $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)
@@ -127,14 +134,14 @@ ifeq ($(OS),Windows_NT)
 
     USE_SYSTEM_BINARYEN ?= 1
 
-else ifeq ($(shell uname -s),Darwin)
+else ifeq ($(uname),Darwin)
     MD5SUM ?= md5
 
     CGO_LDFLAGS += -lxar
 
     USE_SYSTEM_BINARYEN ?= 1
 
-else ifeq ($(shell uname -s),FreeBSD)
+else ifeq ($(uname),FreeBSD)
     MD5SUM ?= md5
     START_GROUP = -Wl,--start-group
     END_GROUP = -Wl,--end-group
@@ -449,11 +456,11 @@ report-stdlib-tests-pass:
 	@rm $(jointmp).*
 
 # Standard library packages that pass tests quickly on the current platform
-ifeq ($(shell uname),Darwin)
+ifeq ($(uname),Darwin)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_DARWIN)
 TEST_IOFS := true
 endif
-ifeq ($(shell uname),Linux)
+ifeq ($(uname),Linux)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_LINUX)
 TEST_IOFS := true
 endif


### PR DESCRIPTION
This avoids 8 shell commands on Windows that were run at all times (and 7 on other OSes). 5 by using `$(OS)` instead of an uname call, and three other commands that were run unconditionally.

This won't make much of a difference on Unix-like operating systems with fast subprocess calls, but it makes a very noticeable difference on Windows. Timing varies a lot, but before this change `make` would often take over 2 seconds just to evaluate the make file:

```
$ time make foo
make: *** No rule to make target 'foo'.  Stop.

real    0m2.454s
user    0m0.015s
sys     0m0.280s
```

With this change, it's a lot faster:

```
$ time make foo
make: *** No rule to make target 'foo'.  Stop.

real    0m0.427s
user    0m0.015s
sys     0m0.265s
```

I think this avoids all shell commands on Windows when they are not needed.