### PR TITLE
riscv-qemu: actually sleep in time.Sleep()

### DIFF
--- a/src/device/riscv/csr.go
+++ b/src/device/riscv/csr.go
@@ -275,3 +275,61 @@ const (
 	DPC      CSR = 0x7B1 // Debug PC.
 	DSCRATCH CSR = 0x7B2 // Debug scratch register.
 )
+
+// Bitfields for the CSR registers above.
+const (
+	// MSTATUS (common bits between RV32 and RV64)
+	MSTATUS_SIE  = 1 << 1
+	MSTATUS_MIE  = 1 << 3
+	MSTATUS_SPIE = 1 << 5
+	MSTATUS_UBE  = 1 << 6
+	MSTATUS_MPIE = 1 << 7
+	MSTATUS_SPP  = 1 << 8
+	MSTATUS_MPRV = 1 << 17
+	MSTATUS_SUM  = 1 << 18
+	MSTATUS_MXR  = 1 << 19
+	MSTATUS_TVM  = 1 << 20
+	MSTATUS_TW   = 1 << 21
+	MSTATUS_TSR  = 1 << 22
+
+	MIE_SSIE = 1 << 1
+	MIE_MSIE = 1 << 3
+	MIE_STIE = 1 << 5
+	MIE_MTIE = 1 << 7
+	MIE_SEIE = 1 << 9
+	MIE_MEIE = 1 << 11
+
+	MIP_SSIP = 1 << 1
+	MIP_MSIP = 1 << 3
+	MIP_STIP = 1 << 5
+	MIP_MTIP = 1 << 7
+	MIP_SEIP = 1 << 9
+	MIP_MEIP = 1 << 11
+)
+
+// Interrupt constants
+const (
+	// MCAUSE values with the topmost bit (interrupt bit) set.
+	SupervisorSoftwareInterrupt = 1
+	MachineSoftwareInterrupt    = 3
+	SupervisorTimerInterrupt    = 5
+	MachineTimerInterrupt       = 7
+	SupervisorExternalInterrupt = 9
+	MachineExternalInterrupt    = 11
+
+	// MCAUSE values with the topmost bit (interrupt bit) clear.
+	InstructionAddressMisaligned = 0
+	InstructionAccessFault       = 1
+	IllegalInstruction           = 2
+	Breakpoint                   = 3
+	LoadAddressMisaligned        = 4
+	LoadAccessFault              = 5
+	StoreOrAMOAddressMisaligned  = 6
+	StoreOrAMOAccessFault        = 7
+	EnvironmentCallFromUMode     = 8
+	EnvironmentCallFromSMode     = 9
+	EnvironmentCallFromMMode     = 11
+	InstructionPageFault         = 12
+	LoadPageFault                = 13
+	StoreOrAMOPageFault          = 15
+)

--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -189,13 +189,13 @@ func handleInterrupt() {
 		}
 
 		// enable CPU interrupts
-		riscv.MSTATUS.SetBits(1 << 3)
+		riscv.MSTATUS.SetBits(riscv.MSTATUS_MIE)
 
 		// Call registered interrupt handler(s)
 		callHandler(int(interruptNumber))
 
 		// disable CPU interrupts
-		riscv.MSTATUS.ClearBits(1 << 3)
+		riscv.MSTATUS.ClearBits(riscv.MSTATUS_MIE)
 
 		// restore interrupt threshold to enable interrupt again
 		reg.Set(thresholdSave)
@@ -207,7 +207,7 @@ func handleInterrupt() {
 
 		// do not enable CPU interrupts now
 		// the 'MRET' in src/device/riscv/handleinterrupt.S will copies the state of MPIE back into MIE, and subsequently clears MPIE.
-		// riscv.MSTATUS.SetBits(0x8)
+		// riscv.MSTATUS.SetBits(riscv.MSTATUS_MIE)
 	} else {
 		// Topmost bit is clear, so it is an exception of some sort.
 		// We could implement support for unsupported instructions here (such as
@@ -221,13 +221,13 @@ func handleException(mcause uintptr) {
 	println("*** Exception:   code:", uint32(mcause&0x1f))
 	println("*** Exception: mcause:", mcause)
 	switch uint32(mcause & 0x1f) {
-	case 1:
+	case riscv.InstructionAccessFault:
 		println("***    virtual address:", riscv.MTVAL.Get())
-	case 2:
+	case riscv.IllegalInstruction:
 		println("***            opcode:", riscv.MTVAL.Get())
-	case 5:
+	case riscv.LoadAccessFault:
 		println("***      read address:", riscv.MTVAL.Get())
-	case 7:
+	case riscv.StoreOrAMOAccessFault:
 		println("***     write address:", riscv.MTVAL.Get())
 	}
 	for {

--- a/targets/riscv-qemu.json
+++ b/targets/riscv-qemu.json
@@ -4,5 +4,5 @@
 	"build-tags": ["virt", "qemu"],
 	"default-stack-size": 8192,
 	"linkerscript": "targets/riscv-qemu.ld",
-	"emulator": "qemu-system-riscv32 -machine virt -nographic -bios none -device virtio-rng-device -kernel {}"
+	"emulator": "qemu-system-riscv32 -machine virt,aclint=on -nographic -bios none -device virtio-rng-device -kernel {}"
 }


### PR DESCRIPTION
Instead of just incrementing the timestamp, this causes the system to actually sleep when calling time.Sleep. The direct effect is that this works as expected:

    $ tinygo run -target=riscv-qemu examples/serial
    hello world!
    hello world!
    hello world!
    [..etc]

This commit also adds a bare bones handler for exceptions (such as invalid memory writes), since we're adding an interrupt handler anyway.

While this patch doesn't add that much functionality, having interrupt support is going to be needed for multicore support on riscv-qemu. My plan is to first add this support to riscv-qemu (based on the earlier work I did for the RP2040 and demoed at FOSDEM 2025) and once the basics are in place and fully tested we can extend this support to the RP2040. Writing for QEMU first makes it much easier to debug any issues that will come up.