### PR TITLE
machine: Add board support for BigTreeTech SKR Pico

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -630,6 +630,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=btt-skr-pico        examples/blinky1
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10031            examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=reelboard           examples/blinky1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -630,7 +630,7 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=btt-skr-pico        examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=btt-skr-pico        examples/uart
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10031            examples/blinky1
 	@$(MD5SUM) test.hex

--- a/src/machine/board_btt_skr_pico.go
+++ b/src/machine/board_btt_skr_pico.go
@@ -35,8 +35,8 @@ const (
 
 // TMC stepper driver UART
 const (
-	TMC_UART_TX = GPIO8
-	TMC_UART_RX = GPIO9
+	TMC_UART_TX = UART1_TX_PIN
+	TMC_UART_RX = UART1_RX_PIN
 )
 
 // Endstops
@@ -78,23 +78,23 @@ const (
 	xoscFreq = 12 // MHz
 )
 
-// I2C. We don't have this available, so map it to defaults
+// I2C. We don't have this available
 const (
-	I2C0_SDA_PIN = GPIO4
-	I2C0_SCL_PIN = GPIO5
+	I2C0_SDA_PIN = NoPin
+	I2C0_SCL_PIN = NoPin
 
-	I2C1_SDA_PIN = GPIO2
-	I2C1_SCL_PIN = GPIO3
+	I2C1_SDA_PIN = NoPin
+	I2C1_SCL_PIN = NoPin
 )
 
-// SPI default pins
+// SPI. We don't have this available
 const (
-	SPI0_SCK_PIN = GPIO18
-	SPI0_SDO_PIN = GPIO19 // Tx
-	SPI0_SDI_PIN = GPIO16 // Rx
-	SPI1_SCK_PIN = GPIO10
-	SPI1_SDO_PIN = GPIO11 // Tx
-	SPI1_SDI_PIN = GPIO12 // Rx
+	SPI0_SCK_PIN = NoPin
+	SPI0_SDO_PIN = NoPin // Tx
+	SPI0_SDI_PIN = NoPin // Rx
+	SPI1_SCK_PIN = NoPin
+	SPI1_SDO_PIN = NoPin // Tx
+	SPI1_SDI_PIN = NoPin // Rx
 )
 
 // USB CDC identifiers
@@ -112,8 +112,8 @@ var (
 const (
 	UART0_TX_PIN = GPIO0
 	UART0_RX_PIN = GPIO1
-	UART1_TX_PIN = TMC_UART_TX
-	UART1_RX_PIN = TMC_UART_RX
+	UART1_TX_PIN = GPIO8
+	UART1_RX_PIN = GPIO9
 	UART_TX_PIN  = UART0_TX_PIN
 	UART_RX_PIN  = UART0_RX_PIN
 )

--- a/src/machine/board_btt_skr_pico.go
+++ b/src/machine/board_btt_skr_pico.go
@@ -90,11 +90,11 @@ const (
 // SPI. We don't have this available
 const (
 	SPI0_SCK_PIN = NoPin
-	SPI0_SDO_PIN = NoPin // Tx
-	SPI0_SDI_PIN = NoPin // Rx
+	SPI0_SDO_PIN = NoPin
+	SPI0_SDI_PIN = NoPin
 	SPI1_SCK_PIN = NoPin
-	SPI1_SDO_PIN = NoPin // Tx
-	SPI1_SDI_PIN = NoPin // Rx
+	SPI1_SDO_PIN = NoPin
+	SPI1_SDI_PIN = NoPin
 )
 
 // USB CDC identifiers

--- a/src/machine/board_btt_skr_pico.go
+++ b/src/machine/board_btt_skr_pico.go
@@ -11,71 +11,90 @@ package machine
 // TMC stepper driver motor direction.
 // X/Y/Z/E refers to motors for X/Y/Z and the extruder.
 const (
-	X_DIR Pin = GPIO10
-	Y_DIR Pin = GPIO5
-	Z_DIR Pin = ADC2
-	E_DIR Pin = GPIO13
+	X_DIR = GPIO10
+	Y_DIR = GPIO5
+	Z_DIR = ADC2
+	E_DIR = GPIO13
 )
 
 // TMC stepper driver motor step
 const (
-	X_STEP Pin = GPIO11
-	Y_STEP Pin = GPIO6
-	Z_STEP Pin = GPIO19
-	E_STEP Pin = GPIO14
+	X_STEP = GPIO11
+	Y_STEP = GPIO6
+	Z_STEP = GPIO19
+	E_STEP = GPIO14
 )
 
 // TMC stepper driver enable
 const (
-	X_ENABLE Pin = GPIO12
-	Y_ENABLE Pin = GPIO7
-	Z_ENABLE Pin = GPIO2
-	E_ENABLE Pin = GPIO15
+	X_ENABLE = GPIO12
+	Y_ENABLE = GPIO7
+	Z_ENABLE = GPIO2
+	E_ENABLE = GPIO15
 )
 
 // TMC stepper driver UART
 const (
-	TMC_UART_TX Pin = GPIO8
-	TMC_UART_RX Pin = GPIO9
+	TMC_UART_TX = GPIO8
+	TMC_UART_RX = GPIO9
 )
 
 // Endstops
 const (
-	X_ENDSTOP Pin = GPIO4
-	Y_ENDSTOP Pin = GPIO3
-	Z_ENDSTOP Pin = GPIO25
-	E_ENDSTOP Pin = GPIO16
+	X_ENDSTOP = GPIO4
+	Y_ENDSTOP = GPIO3
+	Z_ENDSTOP = GPIO25
+	E_ENDSTOP = GPIO16
 )
 
 // Fan PWM
 const (
-	FAN1_PWM Pin = GPIO17
-	FAN2_PWM Pin = GPIO18
-	FAN3_PWM Pin = GPIO20
+	FAN1_PWM = GPIO17
+	FAN2_PWM = GPIO18
+	FAN3_PWM = GPIO20
 )
 
 // Heater PWM
 const (
-	HEATER_BED_PWM      Pin = GPIO21
-	HEATER_EXTRUDER_PWM Pin = GPIO23
+	HEATER_BED_PWM      = GPIO21
+	HEATER_EXTRUDER_PWM = GPIO23
 )
 
 // Thermistors
 const (
-	THERM_BED          = ADC0 // Bed heater
-	THERM_EXTRUDER Pin = ADC1 // Toolhead heater
+	THERM_BED      = ADC0 // Bed heater
+	THERM_EXTRUDER = ADC1 // Toolhead heater
 )
 
 // Misc
 const (
-	RGB        Pin = GPIO24 // Neopixel
-	SERVO_ADC3 Pin = ADC3   // Servo
-	PROBE      Pin = GPIO22 // Probe
+	RGB        = GPIO24 // Neopixel
+	SERVO_ADC3 = ADC3   // Servo
+	PROBE      = GPIO22 // Probe
 )
 
 // Onboard crystal oscillator frequency, in MHz.
 const (
 	xoscFreq = 12 // MHz
+)
+
+// I2C. We don't have this available, so map it to defaults
+const (
+	I2C0_SDA_PIN = GPIO4
+	I2C0_SCL_PIN = GPIO5
+
+	I2C1_SDA_PIN = GPIO2
+	I2C1_SCL_PIN = GPIO3
+)
+
+// SPI default pins
+const (
+	SPI0_SCK_PIN = GPIO18
+	SPI0_SDO_PIN = GPIO19 // Tx
+	SPI0_SDI_PIN = GPIO16 // Rx
+	SPI1_SCK_PIN = GPIO10
+	SPI1_SDO_PIN = GPIO11 // Tx
+	SPI1_SDI_PIN = GPIO12 // Rx
 )
 
 // USB CDC identifiers
@@ -93,6 +112,8 @@ var (
 const (
 	UART0_TX_PIN = GPIO0
 	UART0_RX_PIN = GPIO1
+	UART1_TX_PIN = TMC_UART_TX
+	UART1_RX_PIN = TMC_UART_RX
 	UART_TX_PIN  = UART0_TX_PIN
 	UART_RX_PIN  = UART0_RX_PIN
 )

--- a/src/machine/board_btt_skr_pico.go
+++ b/src/machine/board_btt_skr_pico.go
@@ -13,7 +13,7 @@ package machine
 const (
 	X_DIR = GPIO10
 	Y_DIR = GPIO5
-	Z_DIR = ADC2
+	Z_DIR = GPIO28
 	E_DIR = GPIO13
 )
 
@@ -62,15 +62,15 @@ const (
 
 // Thermistors
 const (
-	THERM_BED      = ADC0 // Bed heater
-	THERM_EXTRUDER = ADC1 // Toolhead heater
+	THERM_BED      = GPIO26 // Bed heater
+	THERM_EXTRUDER = GPIO27 // Toolhead heater
 )
 
 // Misc
 const (
-	RGB        = GPIO24 // Neopixel
-	SERVO_ADC3 = ADC3   // Servo
-	PROBE      = GPIO22 // Probe
+	RGB   = GPIO24 // Neopixel
+	SERVO = GPIO29 // Servo
+	PROBE = GPIO22 // Probe
 )
 
 // Onboard crystal oscillator frequency, in MHz.

--- a/src/machine/board_btt_skr_pico.go
+++ b/src/machine/board_btt_skr_pico.go
@@ -1,0 +1,100 @@
+//go:build btt_skr_pico
+
+// This contains the pin mappings for the BigTreeTech SKR Pico.
+//
+// Purchase link: https://biqu.equipment/products/btt-skr-pico-v1-0
+// Board schematic: https://github.com/bigtreetech/SKR-Pico/blob/master/Hardware/BTT%20SKR%20Pico%20V1.0-SCH.pdf
+// Pin diagram: https://github.com/bigtreetech/SKR-Pico/blob/master/Hardware/BTT%20SKR%20Pico%20V1.0-PIN.pdf
+
+package machine
+
+// TMC stepper driver motor direction.
+// X/Y/Z/E refers to motors for X/Y/Z and the extruder.
+const (
+	X_DIR Pin = GPIO10
+	Y_DIR Pin = GPIO5
+	Z_DIR Pin = ADC2
+	E_DIR Pin = GPIO13
+)
+
+// TMC stepper driver motor step
+const (
+	X_STEP Pin = GPIO11
+	Y_STEP Pin = GPIO6
+	Z_STEP Pin = GPIO19
+	E_STEP Pin = GPIO14
+)
+
+// TMC stepper driver enable
+const (
+	X_ENABLE Pin = GPIO12
+	Y_ENABLE Pin = GPIO7
+	Z_ENABLE Pin = GPIO2
+	E_ENABLE Pin = GPIO15
+)
+
+// TMC stepper driver UART
+const (
+	TMC_UART_TX Pin = GPIO8
+	TMC_UART_RX Pin = GPIO9
+)
+
+// Endstops
+const (
+	X_ENDSTOP Pin = GPIO4
+	Y_ENDSTOP Pin = GPIO3
+	Z_ENDSTOP Pin = GPIO25
+	E_ENDSTOP Pin = GPIO16
+)
+
+// Fan PWM
+const (
+	FAN1_PWM Pin = GPIO17
+	FAN2_PWM Pin = GPIO18
+	FAN3_PWM Pin = GPIO20
+)
+
+// Heater PWM
+const (
+	HEATER_BED_PWM      Pin = GPIO21
+	HEATER_EXTRUDER_PWM Pin = GPIO23
+)
+
+// Thermistors
+const (
+	THERM_BED          = ADC0 // Bed heater
+	THERM_EXTRUDER Pin = ADC1 // Toolhead heater
+)
+
+// Misc
+const (
+	RGB        Pin = GPIO24 // Neopixel
+	SERVO_ADC3 Pin = ADC3   // Servo
+	PROBE      Pin = GPIO22 // Probe
+)
+
+// Onboard crystal oscillator frequency, in MHz.
+const (
+	xoscFreq = 12 // MHz
+)
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "SKR Pico"
+	usb_STRING_MANUFACTURER = "BigTreeTech"
+)
+
+var (
+	usb_VID uint16 = 0x2e8a
+	usb_PID uint16 = 0x0003
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+)
+
+var DefaultUART = UART0

--- a/targets/btt-skr-pico.json
+++ b/targets/btt-skr-pico.json
@@ -1,0 +1,13 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "build-tags": ["btt_rp2040"],
+    "serial-port": ["2e8a:000A"],
+    "ldflags": [
+        "--defsym=__flash_size=16M"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}

--- a/targets/btt-skr-pico.json
+++ b/targets/btt-skr-pico.json
@@ -2,7 +2,7 @@
     "inherits": [
         "rp2040"
     ],
-    "build-tags": ["btt_rp2040"],
+    "build-tags": ["btt_skr_pico"],
     "serial-port": ["2e8a:000A"],
     "ldflags": [
         "--defsym=__flash_size=16M"


### PR DESCRIPTION
First PR, so I hope I'm doing this right 😄 

This adds support for the [SKR Pico](https://github.com/bigtreetech/SKR-Pico/tree/master) 3D printer mainboard. I have yet to get this over to real hardware yet, so consider it draft until I've properly tested it.