### PR TITLE
machine/rp2: expose usb endpoint stall handling

### DIFF
--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -67,7 +67,7 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 
 		if !ok {
 			// Stall endpoint?
-			sendStallViaEPIn(0)
+			USBDev.SetStallEPIn(0)
 		}
 
 	}

--- a/src/machine/machine_rp2350_usb.go
+++ b/src/machine/machine_rp2350_usb.go
@@ -70,7 +70,7 @@ func handleUSBIRQ(intr interrupt.Interrupt) {
 
 		if !ok {
 			// Stall endpoint?
-			sendStallViaEPIn(0)
+			USBDev.SetStallEPIn(0)
 		}
 
 	}

--- a/src/machine/usb/config.go
+++ b/src/machine/usb/config.go
@@ -1,11 +1,12 @@
 package usb
 
 type EndpointConfig struct {
-	Index     uint8
-	IsIn      bool
-	TxHandler func()
-	RxHandler func([]byte)
-	Type      uint8
+	Index        uint8
+	IsIn         bool
+	TxHandler    func()
+	RxHandler    func([]byte)
+	StallHandler func(Setup) bool
+	Type         uint8
 }
 
 type SetupConfig struct {


### PR DESCRIPTION
Since the USB mass storage PR (#4844) is getting a bit monolithic I figured I'd break out smaller parts of it as I can. I figure I'll work my way through the MCUs that support USB natively, but here's the RP2 changes to start. If there's any suggestions on which MCUs would make the most sense to add support next I'm happy to hear it