### PR TITLE
runtime: use int64 for `timeUnit` everywhere

### DIFF
--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -8,6 +8,17 @@ import (
 
 const Compiler = "tinygo"
 
+// Unit for the 'ticks' and 'sleepTicks' functions.
+//
+// This is the native time unit for the given system. One timeUnit tick might be
+// 1ns or 100ns on a desktop system, or 1/32768s on baremetal systems with a
+// low-power RTC. Many other tick durations are possible.
+//
+// Conversion from time units to nanoseconds and back is done using
+// ticksToNanoseconds and nanosecondsToTicks, which need to be implemented for
+// each system as needed.
+type timeUnit int64
+
 // The compiler will fill this with calls to the initialization function of each
 // package.
 func initAll()

--- a/src/runtime/runtime_arm7tdmi.go
+++ b/src/runtime/runtime_arm7tdmi.go
@@ -7,8 +7,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 func putchar(c byte) {
 	// dummy, TODO
 }

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -12,8 +12,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -11,8 +11,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //export Reset_Handler
 func main() {
 	arm.SCB.CPACR.Set(0) // disable FPU if it is enabled

--- a/src/runtime/runtime_avr.go
+++ b/src/runtime/runtime_avr.go
@@ -12,9 +12,6 @@ import (
 
 const BOARD = "arduino"
 
-// timeUnit in nanoseconds
-type timeUnit int64
-
 // Watchdog timer periods. These can be off by a large margin (hence the jump
 // between 64ms and 125ms which is not an exact double), so don't rely on this
 // for accurate time keeping.

--- a/src/runtime/runtime_avrtiny.go
+++ b/src/runtime/runtime_avrtiny.go
@@ -22,8 +22,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //export main
 func main() {
 	// Initialize RTC.

--- a/src/runtime/runtime_cortexm_qemu.go
+++ b/src/runtime/runtime_cortexm_qemu.go
@@ -11,8 +11,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 var timestamp timeUnit
 
 //export Reset_Handler

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -8,8 +8,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 // Initialize .bss: zero-initialized global variables.
 // The .data section has already been loaded by the ROM bootloader.
 func clearbss() {

--- a/src/runtime/runtime_esp8266.go
+++ b/src/runtime/runtime_esp8266.go
@@ -9,8 +9,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 var currentTime timeUnit = 0
 
 func putchar(c byte) {

--- a/src/runtime/runtime_fe310.go
+++ b/src/runtime/runtime_fe310.go
@@ -14,8 +14,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //export main
 func main() {
 	// Zero the PLIC enable bits on startup: they are not zeroed at reset.

--- a/src/runtime/runtime_k210.go
+++ b/src/runtime/runtime_k210.go
@@ -13,8 +13,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 //export main
 func main() {
 

--- a/src/runtime/runtime_mimxrt1062_time.go
+++ b/src/runtime/runtime_mimxrt1062_time.go
@@ -10,8 +10,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 const (
 	lastCycle      = SYSTICK_FREQ/1000 - 1
 	cyclesPerMicro = CORE_FREQ / 1000000

--- a/src/runtime/runtime_nintendoswitch.go
+++ b/src/runtime/runtime_nintendoswitch.go
@@ -4,8 +4,6 @@ package runtime
 
 import "unsafe"
 
-type timeUnit int64
-
 const (
 	// Handles
 	infoTypeTotalMemorySize = 6          // Total amount of memory available for process.

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -10,8 +10,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //go:linkname systemInit SystemInit
 func systemInit()
 

--- a/src/runtime/runtime_nrf52840.go
+++ b/src/runtime/runtime_nrf52840.go
@@ -11,8 +11,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //go:linkname systemInit SystemInit
 func systemInit()
 

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -14,8 +14,6 @@ func machineTicks() uint64
 // machineLightSleep is provided by package machine.
 func machineLightSleep(uint64)
 
-type timeUnit int64
-
 // ticks returns the number of ticks (microseconds) elapsed since power up.
 func ticks() timeUnit {
 	t := machineTicks()

--- a/src/runtime/runtime_rp2350.go
+++ b/src/runtime/runtime_rp2350.go
@@ -14,8 +14,6 @@ func machineTicks() uint64
 // machineLightSleep is provided by package machine.
 func machineLightSleep(uint64)
 
-type timeUnit int64
-
 // ticks returns the number of ticks (microseconds) elapsed since power up.
 func ticks() timeUnit {
 	t := machineTicks()

--- a/src/runtime/runtime_stm32.go
+++ b/src/runtime/runtime_stm32.go
@@ -4,8 +4,6 @@ package runtime
 
 import "device/arm"
 
-type timeUnit int64
-
 //export Reset_Handler
 func main() {
 	preinit()

--- a/src/runtime/runtime_tinygoriscv_qemu.go
+++ b/src/runtime/runtime_tinygoriscv_qemu.go
@@ -11,10 +11,6 @@ import (
 // This file implements the VirtIO RISC-V interface implemented in QEMU, which
 // is an interface designed for emulation.
 
-// One tick is 100ns by default in QEMU.
-// (This is not a standard, just the default used by QEMU).
-type timeUnit int64
-
 //export main
 func main() {
 	preinit()
@@ -61,6 +57,8 @@ func handleInterrupt() {
 	riscv.MCAUSE.Set(0)
 }
 
+// One tick is 100ns by default in QEMU.
+// (This is not a standard, just the default used by QEMU).
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks) * 100 // one tick is 100ns
 }

--- a/src/runtime/runtime_tkey.go
+++ b/src/runtime/runtime_tkey.go
@@ -10,8 +10,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 //export main
 func main() {
 	preinit()

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -61,8 +61,6 @@ func clock_gettime(clk_id int32, ts *timespec) {
 	}
 }
 
-type timeUnit int64
-
 // Note: tv_sec and tv_nsec normally vary in size by platform. However, we're
 // using the time64 variant (see clock_gettime above), so the formats are the
 // same between 32-bit and 64-bit architectures.

--- a/src/runtime/runtime_wasip1.go
+++ b/src/runtime/runtime_wasip1.go
@@ -6,8 +6,6 @@ import (
 	"unsafe"
 )
 
-type timeUnit int64
-
 // libc constructors
 //
 //export __wasm_call_ctors

--- a/src/runtime/runtime_wasip2.go
+++ b/src/runtime/runtime_wasip2.go
@@ -12,8 +12,6 @@ import (
 	"internal/cm"
 )
 
-type timeUnit int64
-
 func init() {
 	wasiclirun.Exports.Run = func() cm.BoolResult {
 		callMain()

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -2,7 +2,7 @@
 
 package runtime
 
-type timeUnit float64 // time in milliseconds, just like Date.now() in JavaScript
+type timeUnit int64
 
 var handleEvent func()
 
@@ -11,17 +11,16 @@ func setEventHandler(fn func()) {
 	handleEvent = fn
 }
 
+// We use 1ns per tick, to simplify things.
+// It would probably be fine to use 1µs per tick, since performance.now only
+// promises a resolution of 5µs, but 1ns makes the conversions here a bit more
+// straightforward (since nothing needs to be converted).
 func ticksToNanoseconds(ticks timeUnit) int64 {
-	// The JavaScript API works in float64 milliseconds, so convert to
-	// nanoseconds first before converting to a timeUnit (which is a float64),
-	// to avoid precision loss.
-	return int64(ticks * 1e6)
+	return int64(ticks)
 }
 
 func nanosecondsToTicks(ns int64) timeUnit {
-	// The JavaScript API works in float64 milliseconds, so convert to timeUnit
-	// (which is a float64) first before dividing, to avoid precision loss.
-	return timeUnit(ns) / 1e6
+	return timeUnit(ns)
 }
 
 // This function is called by the scheduler.

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -2,8 +2,6 @@
 
 package runtime
 
-type timeUnit int64
-
 var handleEvent func()
 
 //go:linkname setEventHandler syscall/js.setEventHandler

--- a/src/runtime/runtime_wasm_unknown.go
+++ b/src/runtime/runtime_wasm_unknown.go
@@ -5,8 +5,6 @@ package runtime
 // TODO: this is essentially reactor mode wasm. So we might want to support
 // -buildmode=c-shared (and default to it).
 
-type timeUnit int64
-
 // libc constructors
 //
 //export __wasm_call_ctors
@@ -23,9 +21,6 @@ func ticksToNanoseconds(ticks timeUnit) int64 {
 func nanosecondsToTicks(ns int64) timeUnit {
 	return timeUnit(ns)
 }
-
-// with the wasm32-unknown-unknown target there is no way to determine any `precision`
-const timePrecisionNanoseconds = 1000
 
 func sleepTicks(d timeUnit) {
 }

--- a/src/runtime/runtime_windows.go
+++ b/src/runtime/runtime_windows.go
@@ -123,8 +123,6 @@ func preinit() {
 	heapEnd = heapStart + heapSize
 }
 
-type timeUnit int64
-
 var stackTop uintptr
 
 func ticksToNanoseconds(ticks timeUnit) int64 {

--- a/src/runtime/time_nxpmk66f18.go
+++ b/src/runtime/time_nxpmk66f18.go
@@ -39,8 +39,6 @@ import (
 	"runtime/volatile"
 )
 
-type timeUnit int64
-
 func ticksToNanoseconds(ticks timeUnit) int64 {
 	return int64(ticks) * 1000
 }

--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -283,12 +283,12 @@
 					},
 				},
 				gojs: {
-					// func ticks() float64
+					// func ticks() int64
 					"runtime.ticks": () => {
-						return timeOrigin + performance.now();
+						return BigInt((timeOrigin + performance.now()) * 1e6);
 					},
 
-					// func sleepTicks(timeout float64)
+					// func sleepTicks(timeout int64)
 					"runtime.sleepTicks": (timeout) => {
 						// Do not sleep, only reactivate scheduler after the given timeout.
 						setTimeout(() => {
@@ -298,7 +298,7 @@
 							} catch (e) {
 								if (e !== wasmExit) throw e;
 							}
-						}, timeout);
+						}, Number(timeout)/1e6);
 					},
 
 					// func finalizeRef(v ref)


### PR DESCRIPTION
This changes `timeUnit` to be int64 everywhere. This required a small change to the wasm (browser) target, and allowed to move the type to a central location to reduce duplication.