### PR TITLE
main: change -json flag to match upstream Go

### DIFF
--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -53,7 +53,6 @@ type Options struct {
 	Programmer      string
 	OpenOCDCommands []string
 	LLVMFeatures    string
-	PrintJSON       bool
 	Monitor         bool
 	BaudRate        int
 	Timeout         time.Duration

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tinygo-org/tinygo/builder"
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/diagnostics"
 )
@@ -64,7 +65,11 @@ func testErrorMessages(t *testing.T, filename string, options *compileopts.Optio
 
 	// Try to build a binary (this should fail with an error).
 	tmpdir := t.TempDir()
-	err := Build(filename, tmpdir+"/out", options)
+	config, err := builder.NewConfig(options)
+	if err != nil {
+		t.Fatal("expected to get a compiler error")
+	}
+	err = Build(filename, tmpdir+"/out", config)
 	if err == nil {
 		t.Fatal("expected to get a compiler error")
 	}


### PR DESCRIPTION
This changes the -json flag for build/run/flash/gdb etc commands to not print `compileopts.Config` but instead match upstream Go and print build errors in a structured way.

For more details, see the proposal: https://github.com/golang/go/issues/62067

---

I plan to build upon this proposal to emit slightly more verbose output that also shows start and end positions in the output. This will be useful for better diagnostics in the TinyGo Playground. See: https://github.com/tinygo-org/playground/pull/26