### PR TITLE
fix: use OpenOCD flash method on microbit v2 when using Nordic Semi SoftDevice

### DIFF
--- a/targets/microbit-v2-s113v7.json
+++ b/targets/microbit-v2-s113v7.json
@@ -1,3 +1,4 @@
 {
-	"inherits": ["microbit-v2", "nrf52833-s113v7"]
+	"inherits": ["microbit-v2", "nrf52833-s113v7"],
+	"flash-method": "openocd"
 }


### PR DESCRIPTION
This PR fixes the Microbit v2 flash method when using Nordic Semi SoftDevice to use OpenOCD. Otherwise, the device actually just locks up and does not run until a hard reset.