### PR TITLE
targets: add target for Microbit v2 with SoftDevice S140 support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -626,6 +626,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=microbit-v2-s113v7  examples/microbit-blink
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=microbit-v2-s140v7  examples/microbit-blink
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=nrf52840-mdk        examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=pca10031            examples/blinky1

--- a/targets/microbit-v2-s140v7.json
+++ b/targets/microbit-v2-s140v7.json
@@ -1,0 +1,4 @@
+{
+	"inherits": ["microbit-v2", "nrf52833-s140v7"],
+	"flash-method": "openocd"
+}

--- a/targets/nrf52833-s140v7.json
+++ b/targets/nrf52833-s140v7.json
@@ -1,0 +1,7 @@
+{
+	"build-tags": ["softdevice", "s140v7"],
+	"linkerscript": "targets/nrf52833-s140v7.ld",
+	"ldflags": [
+		"--defsym=__softdevice_stack=0x700"
+	]
+}

--- a/targets/nrf52833-s140v7.ld
+++ b/targets/nrf52833-s140v7.ld
@@ -1,0 +1,14 @@
+
+MEMORY
+{
+    FLASH_TEXT (rw) : ORIGIN = 0x00000000 + 0x00027000, LENGTH = 0x80000 - 0x00027000
+    RAM (xrw)       : ORIGIN = 0x20000000 + 0x000039c0,  LENGTH = 0x20000 - 0x000039c0
+}
+
+_stack_size = 4K + __softdevice_stack;
+
+/* These values are needed for the Nordic SoftDevice. */
+__app_ram_base = ORIGIN(RAM);
+__softdevice_stack = DEFINED(__softdevice_stack) ? __softdevice_stack : 0;
+
+INCLUDE "targets/arm.ld"


### PR DESCRIPTION
This PR adds a target for Microbit v2 with SoftDevice S140 support, which includes both peripheral and central, albeit at a higher memory cost, leaving less memory for user programs.