### PR TITLE
machine: add simulated PWM/timer peripherals

### DIFF
--- a/src/machine/machine_atsamd21_simulator.go
+++ b/src/machine/machine_atsamd21_simulator.go
@@ -1,0 +1,45 @@
+//go:build !baremetal && (gemma_m0 || qtpy || trinket_m0 || arduino_mkr1000 || arduino_mkrwifi1010 || arduino_nano33 || arduino_zero || circuitplay_express || feather_m0_express || feather_m0 || itsybitsy_m0 || p1am_100 || xiao)
+
+// Simulated atsamd21 chips.
+
+package machine
+
+// The timer channels/pins match the hardware, and encode the same information
+// as pinTimerMapping but in a more generic (less efficient) way.
+
+var TCC0 = timerType{
+	instance:   0,
+	frequency:  48e6,
+	bits:       24,
+	prescalers: []int{1, 2, 4, 8, 16, 64, 256, 1024},
+	channelPins: [][]Pin{
+		{PA04, PA08, PB10, PA14, PB16, PA22, PB30}, // channel 0
+		{PA05, PA09, PB11, PA15, PB17, PA23, PB31}, // channel 1
+		{PA10, PB12, PA12, PA16, PA18, PA20},       // channel 2
+		{PA11, PB13, PA13, PA17, PA19, PA21},       // channel 3
+	},
+}
+
+var TCC1 = timerType{
+	instance:   1,
+	frequency:  48e6,
+	bits:       24,
+	prescalers: []int{1, 2, 4, 8, 16, 64, 256, 1024},
+	channelPins: [][]Pin{
+		{PA06, PA10, PA30}, // channel 0
+		{PA07, PA11, PA31}, // channel 1
+		{PA08, PA24, PB30}, // channel 2
+		{PA09, PA25, PB31}, // channel 3
+	},
+}
+
+var TCC2 = timerType{
+	instance:   2,
+	frequency:  48e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 64, 256, 1024},
+	channelPins: [][]Pin{
+		{PA00, PA12, PA16}, // channel 0
+		{PA01, PA13, PA17}, // channel 1
+	},
+}

--- a/src/machine/machine_nrf52840_simulator.go
+++ b/src/machine/machine_nrf52840_simulator.go
@@ -1,0 +1,60 @@
+//go:build !baremetal && (bluemicro840 || circuitplay_bluefruit || clue_alpha || feather_nrf52840_sense || feather_nrf52840 || itsybitsy_nrf52840 || mdbt50qrx || nano_33_ble || nicenano || nrf52840_mdk || particle_3rd_gen || pca10056 || pca10059 || rak4631 || reelboard || xiao_ble)
+
+// Simulator support for nrf52840 based boards.
+
+package machine
+
+// Channel values below are nil, so that they get filled in on the first use.
+// This is the same as what happens on baremetal.
+
+var PWM0 = timerType{
+	instance:   0,
+	frequency:  16e6,
+	bits:       15,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128},
+	channelPins: [][]Pin{
+		nil, // channel 0
+		nil, // channel 1
+		nil, // channel 2
+		nil, // channel 3
+	},
+}
+
+var PWM1 = timerType{
+	instance:   1,
+	frequency:  16e6,
+	bits:       15,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128},
+	channelPins: [][]Pin{
+		nil, // channel 0
+		nil, // channel 1
+		nil, // channel 2
+		nil, // channel 3
+	},
+}
+
+var PWM2 = timerType{
+	instance:   2,
+	frequency:  16e6,
+	bits:       15,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128},
+	channelPins: [][]Pin{
+		nil, // channel 0
+		nil, // channel 1
+		nil, // channel 2
+		nil, // channel 3
+	},
+}
+
+var PWM3 = timerType{
+	instance:   3,
+	frequency:  16e6,
+	bits:       15,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128},
+	channelPins: [][]Pin{
+		nil, // channel 0
+		nil, // channel 1
+		nil, // channel 2
+		nil, // channel 3
+	},
+}

--- a/src/machine/machine_rp2040_simulator.go
+++ b/src/machine/machine_rp2040_simulator.go
@@ -1,0 +1,96 @@
+//go:build !baremetal && (ae_rp2040 || badger2040_w || badger2040 || challenger_rp2040 || elecrow_rp2040 || feather_rp2040 || gopher_badge || kb2040 || macropad_rp2040 || nano_rp2040 || pico || qtpy_rp2040 || thingplus_rp2040 || thumby || trinkey_qt2040 || tufty2040 || waveshare_rp2040_tiny || waveshare_rp2040_zero || xiao_rp2040)
+
+// Simulator support for the RP2040.
+//
+// This is *only* for the RP2040. RP2350 is a different chip with slightly
+// different characteristics.
+
+package machine
+
+var PWM0 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256}, // actually a continuing range, TODO
+	channelPins: [][]Pin{
+		{GPIO0, GPIO16}, // channel A (0)
+		{GPIO1, GPIO17}, // channel B (1)
+	},
+}
+
+var PWM1 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO2, GPIO18}, // channel A (0)
+		{GPIO3, GPIO19}, // channel B (1)
+	},
+}
+
+var PWM2 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO4, GPIO20}, // channel A (0)
+		{GPIO5, GPIO21}, // channel B (1)
+	},
+}
+
+var PWM3 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO6, GPIO22}, // channel A (0)
+		{GPIO7, GPIO23}, // channel B (1)
+	},
+}
+
+var PWM4 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO8, GPIO24}, // channel A (0)
+		{GPIO9, GPIO25}, // channel B (1)
+	},
+}
+
+var PWM5 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO10, GPIO26}, // channel A (0)
+		{GPIO11, GPIO27}, // channel B (1)
+	},
+}
+
+var PWM6 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO12, GPIO28}, // channel A (0)
+		{GPIO13, GPIO29}, // channel B (1)
+	},
+}
+
+var PWM7 = timerType{
+	instance:   0,
+	frequency:  200e6,
+	bits:       16,
+	prescalers: []int{1, 2, 4, 8, 16, 32, 64, 128, 256},
+	channelPins: [][]Pin{
+		{GPIO14}, // channel A (0)
+		{GPIO15}, // channel B (1)
+	},
+}


### PR DESCRIPTION
I will soon use these as part of the TinyGo tour, to explain the PWM peripherals on common chips.