### PR TITLE
machine: use pointer receiver in simulated PWM peripherals

### DIFF
--- a/src/machine/machine_atsamd21_simulator.go
+++ b/src/machine/machine_atsamd21_simulator.go
@@ -7,7 +7,7 @@ package machine
 // The timer channels/pins match the hardware, and encode the same information
 // as pinTimerMapping but in a more generic (less efficient) way.
 
-var TCC0 = timerType{
+var TCC0 = &timerType{
 	instance:   0,
 	frequency:  48e6,
 	bits:       24,
@@ -20,7 +20,7 @@ var TCC0 = timerType{
 	},
 }
 
-var TCC1 = timerType{
+var TCC1 = &timerType{
 	instance:   1,
 	frequency:  48e6,
 	bits:       24,
@@ -33,7 +33,7 @@ var TCC1 = timerType{
 	},
 }
 
-var TCC2 = timerType{
+var TCC2 = &timerType{
 	instance:   2,
 	frequency:  48e6,
 	bits:       16,

--- a/src/machine/machine_nrf52840_simulator.go
+++ b/src/machine/machine_nrf52840_simulator.go
@@ -7,7 +7,7 @@ package machine
 // Channel values below are nil, so that they get filled in on the first use.
 // This is the same as what happens on baremetal.
 
-var PWM0 = timerType{
+var PWM0 = &timerType{
 	instance:   0,
 	frequency:  16e6,
 	bits:       15,
@@ -20,7 +20,7 @@ var PWM0 = timerType{
 	},
 }
 
-var PWM1 = timerType{
+var PWM1 = &timerType{
 	instance:   1,
 	frequency:  16e6,
 	bits:       15,
@@ -33,7 +33,7 @@ var PWM1 = timerType{
 	},
 }
 
-var PWM2 = timerType{
+var PWM2 = &timerType{
 	instance:   2,
 	frequency:  16e6,
 	bits:       15,
@@ -46,7 +46,7 @@ var PWM2 = timerType{
 	},
 }
 
-var PWM3 = timerType{
+var PWM3 = &timerType{
 	instance:   3,
 	frequency:  16e6,
 	bits:       15,

--- a/src/machine/machine_rp2040_simulator.go
+++ b/src/machine/machine_rp2040_simulator.go
@@ -7,7 +7,7 @@
 
 package machine
 
-var PWM0 = timerType{
+var PWM0 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -18,7 +18,7 @@ var PWM0 = timerType{
 	},
 }
 
-var PWM1 = timerType{
+var PWM1 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -29,7 +29,7 @@ var PWM1 = timerType{
 	},
 }
 
-var PWM2 = timerType{
+var PWM2 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -40,7 +40,7 @@ var PWM2 = timerType{
 	},
 }
 
-var PWM3 = timerType{
+var PWM3 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -51,7 +51,7 @@ var PWM3 = timerType{
 	},
 }
 
-var PWM4 = timerType{
+var PWM4 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -62,7 +62,7 @@ var PWM4 = timerType{
 	},
 }
 
-var PWM5 = timerType{
+var PWM5 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -73,7 +73,7 @@ var PWM5 = timerType{
 	},
 }
 
-var PWM6 = timerType{
+var PWM6 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,
@@ -84,7 +84,7 @@ var PWM6 = timerType{
 	},
 }
 
-var PWM7 = timerType{
+var PWM7 = &timerType{
 	instance:   0,
 	frequency:  200e6,
 	bits:       16,


### PR DESCRIPTION
I only discovered this issue after a while. All the baremetal PWM implementations use pointers to a PWM instance, instead of the PWM instance itself. For consistency (and because it's a better idea in general), the simulated PWMs need to work the same.