### PR TITLE
transform: PtrToInt and IntToPtr do not escape

### DIFF
--- a/transform/allocs.go
+++ b/transform/allocs.go
@@ -160,6 +160,10 @@ func valueEscapesAt(value llvm.Value) llvm.Value {
 		case llvm.ICmp:
 			// Comparing pointers don't let the pointer escape.
 			// This is often a compiler-inserted nil check.
+		case llvm.PtrToInt:
+			// Pointer to int conversion doesn't let the pointer escape.
+		case llvm.IntToPtr:
+			// Int to pointer conversion doesn't let the pointer escape.
 		default:
 			// Unknown instruction, might escape.
 			return use

--- a/transform/testdata/allocs2.go
+++ b/transform/testdata/allocs2.go
@@ -1,11 +1,13 @@
 package main
 
+import "unsafe"
+
 func main() {
 	n1 := 5
 	derefInt(&n1)
 
 	// This should eventually be modified to not escape.
-	n2 := 6 // OUT: object allocated on the heap: escapes at line 9
+	n2 := 6 // OUT: object allocated on the heap: escapes at line 11
 	returnIntPtr(&n2)
 
 	s1 := make([]int, 3)
@@ -15,7 +17,7 @@ func main() {
 	readIntSlice(s2[:])
 
 	// This should also be modified to not escape.
-	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 19
+	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 21
 	returnIntSlice(s3)
 
 	useSlice(make([]int, getUnknownNumber())) // OUT: object allocated on the heap: size is not constant
@@ -23,14 +25,14 @@ func main() {
 	s4 := make([]byte, 300) // OUT: object allocated on the heap: object size 300 exceeds maximum stack allocation size 256
 	readByteSlice(s4)
 
-	s5 := make([]int, 4) // OUT: object allocated on the heap: escapes at line 27
+	s5 := make([]int, 4) // OUT: object allocated on the heap: escapes at line 29
 	_ = append(s5, 5)
 
 	s6 := make([]int, 3)
 	s7 := []int{1, 2, 3}
 	copySlice(s6, s7)
 
-	c1 := getComplex128() // OUT: object allocated on the heap: escapes at line 34
+	c1 := getComplex128() // OUT: object allocated on the heap: escapes at line 36
 	useInterface(c1)
 
 	n3 := 5
@@ -38,13 +40,13 @@ func main() {
 		return n3
 	}()
 
-	callVariadic(3, 5, 8) // OUT: object allocated on the heap: escapes at line 41
+	callVariadic(3, 5, 8) // OUT: object allocated on the heap: escapes at line 43
 
-	s8 := []int{3, 5, 8} // OUT: object allocated on the heap: escapes at line 44
+	s8 := []int{3, 5, 8} // OUT: object allocated on the heap: escapes at line 46
 	callVariadic(s8...)
 
-	n4 := 3 // OUT: object allocated on the heap: escapes at line 48
-	n5 := 7 // OUT: object allocated on the heap: escapes at line 48
+	n4 := 3 // OUT: object allocated on the heap: escapes at line 50
+	n5 := 7 // OUT: object allocated on the heap: escapes at line 50
 	func() {
 		n4 = n5
 	}()
@@ -58,6 +60,11 @@ func main() {
 	var rbuf [5]rune
 	s = string(rbuf[:])
 	println(s)
+
+	// This shouldn't escape either.
+	n6 := 3
+	n7 := uintptr(unsafe.Pointer(&n6))
+	println(n7)
 }
 
 func derefInt(x *int) int {


### PR DESCRIPTION
This hints compiler that constructs like `uintptr(unsafe.Pointer(&x))` do not escape. Handled by `llvm.PtrToInt` case.
(I've also added `llvm.IntToPtr`, for completeness, but I'm not sure what code matches it. Feel free to reject.)

### Disclaimer

This change may very well be completely wrong; can such constructs escape?
Hence a draft, merely a conversation starter.

### Context

I2C implementations on RP2040 and NRF52 behave differently regarding allocation behavior.
NRF52 implementation escapes to heap while RP2040 does not.
The issue was tracked down to lines 52 and 61 of this file: https://github.com/tinygo-org/tinygo/blob/release/src/machine/machine_nrf528xx.go

### Reproducer
```
$ tinygo build -target=feather-nrf52840 -print-allocs=main -o test.uf2 ./src/examples/i2c-target
.../tinygo/src/examples/i2c-target/main.go:101:13: object allocated on the heap: escapes at line 105
.../tinygo/src/examples/i2c-target/main.go:77:43: object allocated on the heap: escapes at line 77
.../tinygo/src/examples/i2c-target/main.go:76:12: object allocated on the heap: escapes at line 77
.../tinygo/src/examples/i2c-target/main.go:66:43: object allocated on the heap: escapes at line 66
.../tinygo/src/examples/i2c-target/main.go:57:43: object allocated on the heap: escapes at line 57
.../tinygo/src/examples/i2c-target/main.go:56:13: object allocated on the heap: escapes at line 57
```

And this does not escape at all
```
$ tinygo build -target=nano-rp2040 -print-allocs=main -o test.uf2 ./src/examples/i2c-target
```

~After this change both do not escape anymore.~
I was over-optimistic and probably tired, it still escapes in NRF52 case, but I don't understand why.

Thanks @dgryski for pointing at `allocs.go`