### PR TITLE
runtime: temporarily store waspi2 memory allocations from cabi_realloc

### DIFF
--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -8,16 +8,19 @@ import "unsafe"
 // code linked from other languages can allocate memory without colliding with
 // our GC allocations.
 
-var allocs = make(map[uintptr][]byte)
+// Map of allocations, where the key is the allocated pointer and the value is
+// the size of the allocation.
+var allocs = make(map[unsafe.Pointer]uintptr)
 
 //export malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
 	if size == 0 {
 		return nil
 	}
-	buf := make([]byte, size)
+	const wordSize = unsafe.Sizeof(unsafe.Pointer(nil))
+	buf := make([]unsafe.Pointer, (size+wordSize-1)/wordSize)
 	ptr := unsafe.Pointer(&buf[0])
-	allocs[uintptr(ptr)] = buf
+	allocs[ptr] = size
 	return ptr
 }
 
@@ -26,8 +29,8 @@ func libc_free(ptr unsafe.Pointer) {
 	if ptr == nil {
 		return
 	}
-	if _, ok := allocs[uintptr(ptr)]; ok {
-		delete(allocs, uintptr(ptr))
+	if _, ok := allocs[ptr]; ok {
+		delete(allocs, ptr)
 	} else {
 		panic("free: invalid pointer")
 	}
@@ -48,18 +51,22 @@ func libc_realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer {
 
 	// It's hard to optimize this to expand the current buffer with our GC, but
 	// it is theoretically possible. For now, just always allocate fresh.
-	buf := make([]byte, size)
+	// TODO: we could skip this if the new allocation is smaller than the old.
+	const wordSize = unsafe.Sizeof(unsafe.Pointer(nil))
+	buf := make([]unsafe.Pointer, (size+wordSize-1)/wordSize)
+	ptr := unsafe.Pointer(&buf[0])
 
 	if oldPtr != nil {
-		if oldBuf, ok := allocs[uintptr(oldPtr)]; ok {
-			copy(buf, oldBuf)
-			delete(allocs, uintptr(oldPtr))
+		if oldSize, ok := allocs[oldPtr]; ok {
+			oldBuf := unsafe.Slice((*byte)(oldPtr), oldSize)
+			newBuf := unsafe.Slice((*byte)(ptr), size)
+			copy(newBuf, oldBuf)
+			delete(allocs, oldPtr)
 		} else {
 			panic("realloc: invalid pointer")
 		}
 	}
 
-	ptr := unsafe.Pointer(&buf[0])
-	allocs[uintptr(ptr)] = buf
+	allocs[ptr] = size
 	return ptr
 }

--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -96,8 +96,15 @@ func wasmExportExit() {
 	// //go:wasmexport function has exited.
 	schedulerExit = true
 
+	// Clear wasm allocations.
+	wasmAllocs = nil
+
 	task.Pause()
 
 	// TODO: we could cache the allocated stack so we don't have to keep
 	// allocating a new stack on every //go:wasmexport call.
 }
+
+// wasmAllocs holds memory allocated by the host in guest memory.
+// See func cabi_realloc for more information.
+var wasmAllocs []unsafe.Pointer


### PR DESCRIPTION
This is an initial take at solving the interaction between the TinyGo GC and the Component Model allocation scheme (`cabi_realloc`).

Specifically, when the host calls an exported function with argument(s) that require allocations, these are first allocated in the guest via calls to `cabi_realloc`, then these pointer(s) are passed to the function exported with `go:wasmexport`.

Because these allocated pointers are not stored anywhere in the TinyGo stack or heap, they are subject to immediate collection. This can happen if the host wants to copy a large string into the guest memory, and performs a sequence of `cabi_realloc` calls to grow the target memory.

The fix is simple: hold onto the pointers allocated by `cabi_realloc` until the next `wasmexport` function returns.

This logic currently works for reactor modules, where allocations created with `cabi_realloc` are held in memory until a `go:wasmexport` function exits. Caveat: when used with a long-running program like the default `wasi-cli` world, any allocations created via `cabi_realloc` will be held forever until func `main` exits.

This is intended to fix the problem in https://github.com/bytecodealliance/go-modules/issues/348.