### PR TITLE
wasm: fix C realloc and optimize it a bit

### DIFF
--- a/compiler/map.go
+++ b/compiler/map.go
@@ -250,6 +250,9 @@ func (b *builder) createMapIteratorNext(rangeVal ssa.Value, llvmRangeVal, it llv
 func hashmapIsBinaryKey(keyType types.Type) bool {
 	switch keyType := keyType.Underlying().(type) {
 	case *types.Basic:
+		// TODO: unsafe.Pointer is also a binary key, but to support that we
+		// need to fix an issue with interp first (see
+		// https://github.com/tinygo-org/tinygo/pull/4898).
 		return keyType.Info()&(types.IsBoolean|types.IsInteger) != 0
 	case *types.Pointer:
 		return true


### PR DESCRIPTION
  - Do not use make([]byte, ...) to allocate, instead allocate a slice of pointers. This makes sure the precise GC will scan the contents of the allocation, since C could very well put pointers in there.
  - Simplify the map to use the pointer as the key and the size as the value, instead of storing the slices directly in the map.

---

I didn't really test this apart from running ./testdata/cgo. I'm not entirely sure how to properly test this. But if we start using libc_realloc for cabi_realloc I think @ydnar has some test cases on hand?