### PR TITLE
machine: don't inline RTT WriteByte everywhere

### DIFF
--- a/src/machine/serial-rtt.go
+++ b/src/machine/serial-rtt.go
@@ -123,6 +123,12 @@ func (b *rttBuffer) buffered() int {
 	return int((writeOffset - readOffset) % rttBufferSizeDown)
 }
 
+// Write a single byte to the RTT output buffer.
+//
+// This method is set to not be inlined, to avoid blowing up binary size as a
+// result of inlining writeByte everywhere a println exists.
+//
+//go:noinline
 func (s *rttSerial) WriteByte(b byte) error {
 	s.buffersUp[0].writeByte(b)
 	return nil


### PR DESCRIPTION
With `-opt=2`, WriteByte gets inlined everywhere a println statement exists. This blows up binary size for very little gain. In my case, the binary size roughly doubled. Instead, don't inline it so that the binary size remains somewhat reasonable. This might slow down WriteByte a tiny bit, but likely not by any significant amount.