### PR TITLE
wasm: refactor/modify stub signal handling

### DIFF
--- a/src/runtime/runtime_wasip1.go
+++ b/src/runtime/runtime_wasip1.go
@@ -149,20 +149,3 @@ type (
 		}
 	}
 )
-
-// Need to stub these for `os/signal`, but wasi doesn't support signals.
-
-//go:linkname signal_disable os/signal.signal_disable
-func signal_disable(uint32) {}
-
-//go:linkname signal_enable os/signal.signal_enable
-func signal_enable(uint32) {}
-
-//go:linkname signal_ignore os/signal.signal_ignore
-func signal_ignore(uint32) {}
-
-//go:linkname signal_ignored os/signal.signal_ignored
-func signal_ignored(uint32) bool { return false }
-
-//go:linkname signal_recv os/signal.signal_recv
-func signal_recv() uint32 { return ^uint32(0) }

--- a/src/runtime/runtime_wasip2.go
+++ b/src/runtime/runtime_wasip2.go
@@ -50,20 +50,3 @@ func sleepTicks(d timeUnit) {
 func ticks() timeUnit {
 	return timeUnit(monotonicclock.Now())
 }
-
-// Need to stub these for `os/signal`, but wasi doesn't support signals.
-
-//go:linkname signal_disable os/signal.signal_disable
-func signal_disable(uint32) {}
-
-//go:linkname signal_enable os/signal.signal_enable
-func signal_enable(uint32) {}
-
-//go:linkname signal_ignore os/signal.signal_ignore
-func signal_ignore(uint32) {}
-
-//go:linkname signal_ignored os/signal.signal_ignored
-func signal_ignored(uint32) bool { return false }
-
-//go:linkname signal_recv os/signal.signal_recv
-func signal_recv() uint32 { return ^uint32(0) }

--- a/src/runtime/signalstub.go
+++ b/src/runtime/signalstub.go
@@ -1,0 +1,21 @@
+//go:build tinygo.wasm || baremetal
+
+package runtime
+
+// Some platforms don't support Unix signals (and never will), so we need to
+// stub the signal functions.
+
+//go:linkname signal_disable os/signal.signal_disable
+func signal_disable(uint32) {}
+
+//go:linkname signal_enable os/signal.signal_enable
+func signal_enable(uint32) {}
+
+//go:linkname signal_ignore os/signal.signal_ignore
+func signal_ignore(uint32) {}
+
+//go:linkname signal_waitUntilIdle os/signal.signalWaitUntilIdle
+func signal_waitUntilIdle() {}
+
+//go:linkname signal_recv os/signal.signal_recv
+func signal_recv() uint32 { return ^uint32(0) }


### PR DESCRIPTION
This commit changes signal handling in a few ways:

  * It stubs signals for all wasm targets (not just wasi) and baremetal, since none of those have traditional POSIX signals. And moves the code for that into a single file, instead of duplicating it.
  * It removes the stub for signal_ignored since the value `false` might be wrong in some cases and it doesn't usually seem to be called (it is not called in tsgo). Should be trivial to re-add if it is shown to be needed.
  * It adds a stub for `os/signal.signalWaitUntilIdle` which _is_ called by tsgo.