### PR TITLE
Optimize flash writes on SAMD21

### DIFF
--- a/src/machine/machine_atsamd21.go
+++ b/src/machine/machine_atsamd21.go
@@ -1904,7 +1904,7 @@ func (f flashBlockDevice) ReadAt(p []byte, off int64) (n int, err error) {
 }
 
 // WriteAt writes the given number of bytes to the block device.
-// Only word (32 bits) length data can be programmed.
+// Data is written to the page buffer in 4-byte chunks, then saved to flash memory.
 // See Atmel-42181G–SAM-D21_Datasheet–09/2015 page 359.
 // If the length of p is not long enough it will be padded with 0xFF bytes.
 // This method assumes that the destination is already erased.
@@ -1921,8 +1921,10 @@ func (f flashBlockDevice) WriteAt(p []byte, off int64) (n int, err error) {
 	waitWhileFlashBusy()
 
 	for j := 0; j < len(padded); j += int(f.WriteBlockSize()) {
-		// write word
-		*(*uint32)(unsafe.Pointer(address)) = binary.LittleEndian.Uint32(padded[j : j+int(f.WriteBlockSize())])
+		// page buffer is 64 bytes long, but only 4 bytes can be written at once
+		for k := 0; k < int(f.WriteBlockSize()); k += 4 {
+			*(*uint32)(unsafe.Pointer(address + uintptr(k))) = binary.LittleEndian.Uint32(padded[j+k : j+k+4])
+		}
 
 		sam.NVMCTRL.SetADDR(uint32(address >> 1))
 		sam.NVMCTRL.CTRLA.Set(sam.NVMCTRL_CTRLA_CMD_WP | (sam.NVMCTRL_CTRLA_CMDEX_KEY << sam.NVMCTRL_CTRLA_CMDEX_Pos))
@@ -1944,7 +1946,7 @@ func (f flashBlockDevice) Size() int64 {
 	return int64(FlashDataEnd() - FlashDataStart())
 }
 
-const writeBlockSize = 4
+const writeBlockSize = 64
 
 // WriteBlockSize returns the block size in which data can be written to
 // memory. It can be used by a client to optimize writes, non-aligned writes


### PR DESCRIPTION
In its current implementation, the `machine.Flash.WriteAt()` function on SAMD21 will copy data to the internal flash memory in 4-byte chunks -- even if the page buffer is actually 64 bytes long for all chip variants.

The existing code can be improved to get ~12x faster write speeds, which will be useful when #4844 (USB mass storage) is merged and SAMD21 support is added.

I get these results when writing 4kB of data:

|        | at 48MHz | at 8MHz |
|--------|----------|---------|
| before | 229ms    | 261ms   |
| after  | 17ms     | 23ms    |

This will also make sure that no more than 4 writes are performed to the same flash _row_ (256 bytes long). The datasheet says:

> on this flash technology, a max number of 8 consecutive write is allowed per row. Once this number is reached, a row erase is mandatory.

Based on my long-term testing (working on a device that reads and writes a lot), it seems to work as expected. Data is saved to the expected memory location and can be read after the reset. It would be nice if someone else could take a look.

Of course, this is a breaking change. If some application assumes the block size of 4, it will not work properly.

There's also SAMD51 that could benefit from similar change, but I don't have any device to test with.

References:

- Datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_DataSheet_DS40001882F.pdf
  - "Table 10-3. SAM D21 Flash Memory Parameters"
  - "Table 37-42. Maximum Operating Frequency" and the notice below the table
  - "22.6.4.3 NVM Write"
