### PR TITLE
compiler: add support for GODEBUG=gotypesalias=1

### DIFF
--- a/compiler/map.go
+++ b/compiler/map.go
@@ -248,7 +248,7 @@ func (b *builder) createMapIteratorNext(rangeVal ssa.Value, llvmRangeVal, it llv
 // can be compared with runtime.memequal.  Note that padding bytes are undef
 // and can alter two "equal" structs being equal when compared with memequal.
 func hashmapIsBinaryKey(keyType types.Type) bool {
-	switch keyType := keyType.(type) {
+	switch keyType := keyType.Underlying().(type) {
 	case *types.Basic:
 		return keyType.Info()&(types.IsBoolean|types.IsInteger) != 0
 	case *types.Pointer:
@@ -263,8 +263,6 @@ func hashmapIsBinaryKey(keyType types.Type) bool {
 		return true
 	case *types.Array:
 		return hashmapIsBinaryKey(keyType.Elem())
-	case *types.Named:
-		return hashmapIsBinaryKey(keyType.Underlying())
 	default:
 		return false
 	}

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,6 @@
             # has `md5sum`).
             export MD5SUM=md5sum
 
-            # Work around #4819, missing support for generic type aliases.
-            export GODEBUG=gotypesalias=0
-
             # Ugly hack to make the Clang resources directory available.
             export GOFLAGS="\"-ldflags=-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${llvmPackages_20.clang.cc.lib}/lib/clang/20\" -tags=llvm20"
           '';


### PR DESCRIPTION
Since we now require Go 1.22, this became a lot simpler (since we can now refer to `types.Alias` and `types.Unalias`).