### PR TITLE
build: go back to using MinoruSekine/setup-scoop for Windows CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
           minimum-size: 8GB
           maximum-size: 24GB
           disk-root: "C:"
-      - uses: brechtm/setup-scoop@v2
+      - uses: MinoruSekine/setup-scoop@v4
         with:
           scoop_update: 'false'
       - name: Install Dependencies
@@ -135,7 +135,7 @@ jobs:
           minimum-size: 8GB
           maximum-size: 24GB
           disk-root: "C:"
-      - uses: brechtm/setup-scoop@v2
+      - uses: MinoruSekine/setup-scoop@v4
         with:
           scoop_update: 'false'
       - name: Install Dependencies
@@ -201,7 +201,7 @@ jobs:
           minimum-size: 8GB
           maximum-size: 24GB
           disk-root: "C:"
-      - uses: brechtm/setup-scoop@v2
+      - uses: MinoruSekine/setup-scoop@v4
         with:
           scoop_update: 'false'
       - name: Install Dependencies


### PR DESCRIPTION
This PR goes back to using the `MinoruSekine/setup-scoop` Github Action for Windows CI builds. We were using a very old fork due to reasons which I think no longer apply.