### PR TITLE
riscv32: use `gdb` binary as a fallback

### DIFF
--- a/targets/riscv32.json
+++ b/targets/riscv32.json
@@ -12,5 +12,8 @@
 	"ldflags": [
 		"-melf32lriscv"
 	],
-	"gdb": ["gdb-multiarch"]
+	"gdb": [
+		"gdb-multiarch",
+		"gdb"
+	]
 }


### PR DESCRIPTION
At least on my system (Fedora 42) the standard gdb binary is capable of debugging riscv-qemu binaries (running inside qemu-system-riscv32).