### PR TITLE
Use diskutil on macOS to extract volume name and path for FAT mounts

### DIFF
--- a/main.go
+++ b/main.go
@@ -1043,7 +1043,7 @@ func findFATMounts(options *compileopts.Options) ([]mountPoint, error) {
 
 			volName, okv := diskInfo["Volume Name"]
 			fsType, okf := diskInfo["File System Personality"]
-			if !(okv && okf) {
+			if !okv || !okf {
 				continue
 			}
 


### PR DESCRIPTION
### Summary

On macOS, this change improves the detection of FAT volumes by parsing `diskutil info` output to extract the volume name and path. This ensures accurate identification of mounted FAT-based filesystems under `/Volumes`.

Fixes https://github.com/tinygo-org/tinygo/issues/4519


### Details

- Replaces hardcoded assumptions about the filesystem layout with dynamic parsing of `diskutil info`
- Extracts `VolumeName` and `FileSystemPersonality` for each mount point
- Adds a check for `scanner.Err()` to handle unexpected parsing issues gracefully
- Sorts results by volume path for consistent ordering

### Platform

- This change only affects the `darwin` (macOS) platform
- No impact on other platforms or existing logic for `linux`/`windows`