### PR TITLE
machine: make sure DMA buffers do not escape unnecessarily

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -159,6 +159,8 @@ func (c *compilerContext) getFunction(fn *ssa.Function) (llvm.Type, llvm.Value) 
 		llvmFn.AddFunctionAttr(c.ctx.CreateEnumAttribute(llvm.AttributeKindID("noreturn"), 0))
 	case "internal/abi.NoEscape":
 		llvmFn.AddAttributeAtIndex(1, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("nocapture"), 0))
+	case "machine.keepAliveNoEscape", "machine.unsafeNoEscape":
+		llvmFn.AddAttributeAtIndex(1, c.ctx.CreateEnumAttribute(llvm.AttributeKindID("nocapture"), 0))
 	case "runtime.alloc":
 		// Tell the optimizer that runtime.alloc is an allocator, meaning that it
 		// returns values that are never null and never alias to an existing value.

--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -49,7 +49,7 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error) {
 
 	// Configure for a single shot to perform both write and read (as applicable)
 	if len(w) != 0 {
-		i2c.Bus.TXD.PTR.Set(uint32(uintptr(unsafe.Pointer(&w[0]))))
+		i2c.Bus.TXD.PTR.Set(uint32(unsafeNoEscape(unsafe.Pointer(unsafe.SliceData(w)))))
 		i2c.Bus.TXD.MAXCNT.Set(uint32(len(w)))
 
 		// If no read, immediately signal stop after TX
@@ -58,7 +58,7 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error) {
 		}
 	}
 	if len(r) != 0 {
-		i2c.Bus.RXD.PTR.Set(uint32(uintptr(unsafe.Pointer(&r[0]))))
+		i2c.Bus.RXD.PTR.Set(uint32(unsafeNoEscape(unsafe.Pointer(unsafe.SliceData(r)))))
 		i2c.Bus.RXD.MAXCNT.Set(uint32(len(r)))
 
 		// Auto-start Rx after Tx and Stop after Rx
@@ -89,6 +89,11 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error) {
 		}
 	}
 
+	// Make sure the w and r buffers stay alive until this point, so they won't
+	// be garbage collected while the buffers are used by the hardware.
+	keepAliveNoEscape(unsafe.Pointer(unsafe.SliceData(w)))
+	keepAliveNoEscape(unsafe.Pointer(unsafe.SliceData(r)))
+
 	return
 }
 
@@ -117,7 +122,7 @@ func (i2c *I2C) Listen(addr uint8) error {
 //
 // For request events, the caller MUST call `Reply` to avoid hanging the i2c bus indefinitely.
 func (i2c *I2C) WaitForEvent(buf []byte) (evt I2CTargetEvent, count int, err error) {
-	i2c.BusT.RXD.PTR.Set(uint32(uintptr(unsafe.Pointer(&buf[0]))))
+	i2c.BusT.RXD.PTR.Set(uint32(unsafeNoEscape(unsafe.Pointer(unsafe.SliceData(buf)))))
 	i2c.BusT.RXD.MAXCNT.Set(uint32(len(buf)))
 
 	i2c.BusT.TASKS_PREPARERX.Set(nrf.TWIS_TASKS_PREPARERX_TASKS_PREPARERX_Trigger)
@@ -133,6 +138,10 @@ func (i2c *I2C) WaitForEvent(buf []byte) (evt I2CTargetEvent, count int, err err
 			return I2CReceive, 0, twisError(i2c.BusT.ERRORSRC.Get())
 		}
 	}
+
+	// Make sure buf stays alive until this point, so it won't be garbage
+	// collected while it is used by the hardware.
+	keepAliveNoEscape(unsafe.Pointer(unsafe.SliceData(buf)))
 
 	count = 0
 	evt = I2CFinish
@@ -163,7 +172,7 @@ func (i2c *I2C) WaitForEvent(buf []byte) (evt I2CTargetEvent, count int, err err
 
 // Reply supplies the response data the controller.
 func (i2c *I2C) Reply(buf []byte) error {
-	i2c.BusT.TXD.PTR.Set(uint32(uintptr(unsafe.Pointer(&buf[0]))))
+	i2c.BusT.TXD.PTR.Set(uint32(unsafeNoEscape(unsafe.Pointer(unsafe.SliceData(buf)))))
 	i2c.BusT.TXD.MAXCNT.Set(uint32(len(buf)))
 
 	i2c.BusT.EVENTS_STOPPED.Set(0)
@@ -179,6 +188,10 @@ func (i2c *I2C) Reply(buf []byte) error {
 			return twisError(i2c.BusT.ERRORSRC.Get())
 		}
 	}
+
+	// Make sure the buffer stays alive until this point, so it won't be garbage
+	// collected while it is used by the hardware.
+	keepAliveNoEscape(unsafe.Pointer(unsafe.SliceData(buf)))
 
 	i2c.BusT.EVENTS_STOPPED.Set(0)
 

--- a/transform/testdata/allocs2.go
+++ b/transform/testdata/allocs2.go
@@ -1,11 +1,16 @@
 package main
 
+import (
+	"runtime/volatile"
+	"unsafe"
+)
+
 func main() {
 	n1 := 5
 	derefInt(&n1)
 
 	// This should eventually be modified to not escape.
-	n2 := 6 // OUT: object allocated on the heap: escapes at line 9
+	n2 := 6 // OUT: object allocated on the heap: escapes at line 14
 	returnIntPtr(&n2)
 
 	s1 := make([]int, 3)
@@ -15,7 +20,7 @@ func main() {
 	readIntSlice(s2[:])
 
 	// This should also be modified to not escape.
-	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 19
+	s3 := make([]int, 3) // OUT: object allocated on the heap: escapes at line 24
 	returnIntSlice(s3)
 
 	useSlice(make([]int, getUnknownNumber())) // OUT: object allocated on the heap: size is not constant
@@ -23,14 +28,14 @@ func main() {
 	s4 := make([]byte, 300) // OUT: object allocated on the heap: object size 300 exceeds maximum stack allocation size 256
 	readByteSlice(s4)
 
-	s5 := make([]int, 4) // OUT: object allocated on the heap: escapes at line 27
+	s5 := make([]int, 4) // OUT: object allocated on the heap: escapes at line 32
 	_ = append(s5, 5)
 
 	s6 := make([]int, 3)
 	s7 := []int{1, 2, 3}
 	copySlice(s6, s7)
 
-	c1 := getComplex128() // OUT: object allocated on the heap: escapes at line 34
+	c1 := getComplex128() // OUT: object allocated on the heap: escapes at line 39
 	useInterface(c1)
 
 	n3 := 5
@@ -38,13 +43,13 @@ func main() {
 		return n3
 	}()
 
-	callVariadic(3, 5, 8) // OUT: object allocated on the heap: escapes at line 41
+	callVariadic(3, 5, 8) // OUT: object allocated on the heap: escapes at line 46
 
-	s8 := []int{3, 5, 8} // OUT: object allocated on the heap: escapes at line 44
+	s8 := []int{3, 5, 8} // OUT: object allocated on the heap: escapes at line 49
 	callVariadic(s8...)
 
-	n4 := 3 // OUT: object allocated on the heap: escapes at line 48
-	n5 := 7 // OUT: object allocated on the heap: escapes at line 48
+	n4 := 3 // OUT: object allocated on the heap: escapes at line 53
+	n5 := 7 // OUT: object allocated on the heap: escapes at line 53
 	func() {
 		n4 = n5
 	}()
@@ -58,6 +63,19 @@ func main() {
 	var rbuf [5]rune
 	s = string(rbuf[:])
 	println(s)
+
+	// Unsafe usage of DMA buffers: the compiler thinks this buffer won't be
+	// used anymore after the volatile store.
+	var dmaBuf1 [4]byte
+	pseudoVolatile.Set(uint32(unsafeNoEscape(unsafe.Pointer(&dmaBuf1[0]))))
+
+	// Safe usage of DMA buffers: keep the buffer alive until it is no longer
+	// needed, but don't mark it as needing to be heap allocated. The compiler
+	// will keep the buffer stack allocated if possible.
+	var dmaBuf2 [4]byte
+	pseudoVolatile.Set(uint32(unsafeNoEscape(unsafe.Pointer(&dmaBuf2[0]))))
+	// ...use the buffer in the DMA peripheral
+	keepAliveNoEscape(unsafe.Pointer(&dmaBuf2[0]))
 }
 
 func derefInt(x *int) int {
@@ -93,3 +111,13 @@ func useInterface(interface{})
 func callVariadic(...int)
 
 func useSlice([]int)
+
+// See the function with the same name in the machine package.
+//
+//go:linkname unsafeNoEscape machine.unsafeNoEscape
+func unsafeNoEscape(ptr unsafe.Pointer) uintptr
+
+//go:linkname keepAliveNoEscape machine.keepAliveNoEscape
+func keepAliveNoEscape(ptr unsafe.Pointer)
+
+var pseudoVolatile volatile.Register32


### PR DESCRIPTION
Writing the pointer of a buffer to memory-mapped I/O will normally cause it to escape, which forces the compiler to heap-allocate the buffer. But we do know how long the value stays alive, so we can tell the compiler to keep it alive exactly until it is not needed anymore - and tell it to not treat the pointer-to-uintptr cast as escaping.

This PR tries to solve the same problem as https://github.com/tinygo-org/tinygo/pull/4889 but in a different way. In fact, see https://github.com/tinygo-org/tinygo/pull/4889#issuecomment-2904700154 where I first came up with this idea. Basically, with this PR, the allocation inside `legacy.ReadRegister` (but probably not `legacy.WriteRegister`!) should be fixed. See: https://github.com/tinygo-org/drivers/pull/766.

It's perhaps not the cleanest solution, but it seems to work in my tests.

@ysoldak can you take a look?

@dgryski @eliasnaur you may also be interested in this PR.