### PR TITLE
rp2: use the correct channel mask for rp2350 ADC; hold lock during read

### DIFF
--- a/src/machine/machine_rp2_adc.go
+++ b/src/machine/machine_rp2_adc.go
@@ -73,14 +73,15 @@ func (c ADCChannel) Configure(config ADCConfig) error {
 func (c ADCChannel) getOnce() uint16 {
 	// Make it safe to sample multiple ADC channels in separate go routines.
 	adcLock.Lock()
-	rp.ADC.CS.ReplaceBits(uint32(c), 0b111, rp.ADC_CS_AINSEL_Pos)
+	rp.ADC.CS.ReplaceBits(uint32(c)<<rp.ADC_CS_AINSEL_Pos, rp.ADC_CS_AINSEL_Msk, 0)
 	rp.ADC.CS.SetBits(rp.ADC_CS_START_ONCE)
 
 	waitForReady()
+	v := rp.ADC.RESULT.Get()
 	adcLock.Unlock()
 
 	// rp2040 is a 12-bit ADC, scale raw reading to 16-bits.
-	return uint16(rp.ADC.RESULT.Get()) << 4
+	return uint16(v) << 4
 }
 
 // getVoltage does a one-shot sample and returns a millivolts reading.


### PR DESCRIPTION
Found while investigating https://github.com/orgs/tinygo-org/discussions/4936.

Untested.