### PR TITLE
rp2: disable digital input for analog inputs

### DIFF
--- a/src/machine/machine_rp2_2350.go
+++ b/src/machine/machine_rp2_2350.go
@@ -150,6 +150,8 @@ func (p Pin) Configure(config PinConfig) {
 	case PinAnalog:
 		p.setFunc(fnNULL)
 		p.pulloff()
+		// Disable digital input.
+		p.padCtrl().ClearBits(rp.PADS_BANK0_GPIO0_IE)
 	case PinUART:
 		p.setFunc(fnUART)
 	case PinPWM:


### PR DESCRIPTION
This is what the Pico SDK does[0] and may fix #4936.

Untested.

[0] https://github.com/raspberrypi/pico-sdk/blob/ee68c78d0afae2b69c03ae1a72bf5cc267a2d94c/src/rp2_common/hardware_adc/include/hardware/adc.h#L101