### PR TITLE
flash: add -o flag support to save built binary (Fixes #4937)

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,10 +341,6 @@ func dirsToModuleRootAbs(maindir, modroot string) []string {
 
 // validateOutputFormat checks if the output file extension matches the expected format
 func validateOutputFormat(outpath, expectedExt string) error {
-	if outpath == "" {
-		return nil // no output file specified
-	}
-
 	actualExt := filepath.Ext(outpath)
 	if actualExt != expectedExt {
 		return fmt.Errorf("output format %s does not match target format %s", actualExt, expectedExt)

--- a/main.go
+++ b/main.go
@@ -339,8 +339,21 @@ func dirsToModuleRootAbs(maindir, modroot string) []string {
 	return dirs
 }
 
+// validateOutputFormat checks if the output file extension matches the expected format
+func validateOutputFormat(outpath, expectedExt string) error {
+	if outpath == "" {
+		return nil // no output file specified
+	}
+
+	actualExt := filepath.Ext(outpath)
+	if actualExt != expectedExt {
+		return fmt.Errorf("output format %s does not match target format %s", actualExt, expectedExt)
+	}
+	return nil
+}
+
 // Flash builds and flashes the built binary to the given serial port.
-func Flash(pkgName, port string, options *compileopts.Options) error {
+func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 	config, err := builder.NewConfig(options)
 	if err != nil {
 		return err
@@ -389,13 +402,24 @@ func Flash(pkgName, port string, options *compileopts.Options) error {
 	if !options.Work {
 		defer os.RemoveAll(tmpdir)
 	}
-
+	// Validate output format before building
+	if outpath != "" {
+		if err := validateOutputFormat(outpath, fileExt); err != nil {
+			return err
+		}
+	}
 	// Build the binary.
 	result, err := builder.Build(pkgName, fileExt, tmpdir, config)
 	if err != nil {
 		return err
 	}
 
+	// Save output file if specified (after build, before flashing)
+	if outpath != "" {
+		if err := copyFile(result.Binary, outpath); err != nil {
+			return fmt.Errorf("failed to save output file: %v", err)
+		}
+	}
 	// do we need port reset to put MCU into bootloader mode?
 	if config.Target.PortReset == "true" && flashMethod != "openocd" {
 		port, err := getDefaultPort(port, config.Target.SerialPort)
@@ -1297,6 +1321,11 @@ extension at all.`
 			(https://tinygo.org/docs/reference/microcontrollers/).
 			Examples: "arduino-nano", "d1mini", "xiao".
 
+	-o={filename}:
+			Save the built binary to the specified output file. The file
+			format must match the target's expected format (e.g., .hex,
+			.uf2). Both flashing and saving will be performed.
+
 	-monitor: 
 			Start the serial monitor (see below) immediately after
 			flashing. However, some microcontrollers need a split second
@@ -1627,7 +1656,7 @@ func main() {
 		flag.BoolVar(&flagTest, "test", false, "supply -test flag to go list")
 	}
 	var outpath string
-	if command == "help" || command == "build" || command == "test" {
+	if command == "help" || command == "build" || command == "test" || command == "flash" {
 		flag.StringVar(&outpath, "o", "", "output filename")
 	}
 
@@ -1778,7 +1807,7 @@ func main() {
 	case "flash", "gdb", "lldb":
 		pkgName := filepath.ToSlash(flag.Arg(0))
 		if command == "flash" {
-			err := Flash(pkgName, *port, options)
+			err := Flash(pkgName, *port, outpath, options)
 			printBuildOutput(err, *flagJSON)
 		} else {
 			if !options.Debug {


### PR DESCRIPTION
This PR adds `-o` flag support to the `tinygo flash` command, allowing users to save the built binary to a specified output file. This brings `flash` in line with the behavior of `tinygo build`, promoting consistency and improving usability.

Fixes #4937

## Changes
- **Added `-o` flag support** to the `flash` command
- **Introduced `validateOutputFormat` function** to check compatibility with the target format
- **Saved output file after build and before flashing**
- **Updated help text** for the `flash` command with usage examples

## Behavior
- When `-o` is specified, the binary is both **saved** and **flashed**
- Output file format must match the target's expected format (e.g., `.uf2`, `.hex`)
- If the format is invalid, the command fails **before building**
- The saved file is identical to what is flashed

## Testing Results
```bash
# Build works as usual
$ tinygo build -o build.uf2 --target waveshare-rp2040-zero .
   code    data     bss |   flash     ram
 258388    1664    5352 |  260052    7016

# Flash with -o saves file and flashes the device
$ tinygo flash -o flash.uf2 --target waveshare-rp2040-zero .
   code    data     bss |   flash     ram
 258388    1664    5352 |  260052    7016

# Format validation works
$ tinygo flash -o flash.hex --target waveshare-rp2040-zero .
output format .hex does not match target format .uf2

# File content is identical between build and flash
$ sha256sum flash.uf2 build.uf2
95cc493412d9937433cd0ba9e8d667be92de19bab18eaba6cc49ada4b8d3a8c5 *flash.uf2
95cc493412d9937433cd0ba9e8d667be92de19bab18eaba6cc49ada4b8d3a8c5 *build.uf2

# Updated Help Output
$ tinygo help flash
Flash the program to a microcontroller. Some common flags are described below.

        -target={name}:
                        Specifies the type of microcontroller that is used. The name of the
                        microcontroller is given on the individual pages for each board type
                        listed under Microcontrollers
                        (https://tinygo.org/docs/reference/microcontrollers/).
                        Examples: "arduino-nano", "d1mini", "xiao".

        -o={filename}:
                        Save the built binary to the specified output file. The file
                        format must match the target's expected format (e.g., .hex,
                        .uf2). Both flashing and saving will be performed.

        -monitor:
                        Start the serial monitor (see below) immediately after
                        flashing. However, some microcontrollers need a split second
                        or two to configure the serial port after flashing, and
                        using the "-monitor" flag can fail because the serial
                        monitor starts too quickly. In that case, use the "tinygo
                        monitor" command explicitly.
```

