### PR TITLE
fix: add SPI and I2C to teensy 4.1

### DIFF
--- a/src/machine/board_teensy41.go
+++ b/src/machine/board_teensy41.go
@@ -299,45 +299,45 @@ const (
 )
 
 var (
-        SPI0 = SPI1 // SPI0 is an alias of SPI1 (LPSPI4)
-        SPI1 = &SPI{
-                Bus: nxp.LPSPI4,
-                muxSDI: muxSelect{ // D12 (PB1 [B0_01])
-                        mux: nxp.IOMUXC_LPSPI4_SDI_SELECT_INPUT_DAISY_GPIO_B0_01_ALT3,
-                        sel: &nxp.IOMUXC.LPSPI4_SDI_SELECT_INPUT,
-                },
-                muxSDO: muxSelect{ // D11 (PB2 [B0_02])
-                        mux: nxp.IOMUXC_LPSPI4_SDO_SELECT_INPUT_DAISY_GPIO_B0_02_ALT3,
-                        sel: &nxp.IOMUXC.LPSPI4_SDO_SELECT_INPUT,
-                },
-                muxSCK: muxSelect{ // D13 (PB3 [B0_03])
-                        mux: nxp.IOMUXC_LPSPI4_SCK_SELECT_INPUT_DAISY_GPIO_B0_03_ALT3,
-                        sel: &nxp.IOMUXC.LPSPI4_SCK_SELECT_INPUT,
-                },
-                muxCS: muxSelect{ // D10 (PB0 [B0_00])
-                        mux: nxp.IOMUXC_LPSPI4_PCS0_SELECT_INPUT_DAISY_GPIO_B0_00_ALT3,
-                        sel: &nxp.IOMUXC.LPSPI4_PCS0_SELECT_INPUT,
-                },
-        }
-        SPI2 = &SPI{
-                Bus: nxp.LPSPI3,
-                muxSDI: muxSelect{ // D1 (PA2 [AD_B0_02])
-                        mux: nxp.IOMUXC_LPSPI3_SDI_SELECT_INPUT_DAISY_GPIO_AD_B0_02_ALT7,
-                        sel: &nxp.IOMUXC.LPSPI3_SDI_SELECT_INPUT,
-                },
-                muxSDO: muxSelect{ // D26 (PA30 [AD_B1_14])
-                        mux: nxp.IOMUXC_LPSPI3_SDO_SELECT_INPUT_DAISY_GPIO_AD_B1_14_ALT2,
-                        sel: &nxp.IOMUXC.LPSPI3_SDO_SELECT_INPUT,
-                },
-                muxSCK: muxSelect{ // D27 (PA31 [AD_B1_15])
-                        mux: nxp.IOMUXC_LPSPI3_SCK_SELECT_INPUT_DAISY_GPIO_AD_B1_15,
-                        sel: &nxp.IOMUXC.LPSPI3_SCK_SELECT_INPUT,
-                },
-                muxCS: muxSelect{ // D0 (PA3 [AD_B0_03])
-                        mux: nxp.IOMUXC_LPSPI3_PCS0_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT7,
-                        sel: &nxp.IOMUXC.LPSPI3_PCS0_SELECT_INPUT,
-                },
-        }
+	SPI0 = SPI1 // SPI0 is an alias of SPI1 (LPSPI4)
+	SPI1 = &SPI{
+		Bus: nxp.LPSPI4,
+		muxSDI: muxSelect{ // D12 (PB1 [B0_01])
+			mux: nxp.IOMUXC_LPSPI4_SDI_SELECT_INPUT_DAISY_GPIO_B0_01_ALT3,
+			sel: &nxp.IOMUXC.LPSPI4_SDI_SELECT_INPUT,
+		},
+		muxSDO: muxSelect{ // D11 (PB2 [B0_02])
+			mux: nxp.IOMUXC_LPSPI4_SDO_SELECT_INPUT_DAISY_GPIO_B0_02_ALT3,
+			sel: &nxp.IOMUXC.LPSPI4_SDO_SELECT_INPUT,
+		},
+		muxSCK: muxSelect{ // D13 (PB3 [B0_03])
+			mux: nxp.IOMUXC_LPSPI4_SCK_SELECT_INPUT_DAISY_GPIO_B0_03_ALT3,
+			sel: &nxp.IOMUXC.LPSPI4_SCK_SELECT_INPUT,
+		},
+		muxCS: muxSelect{ // D10 (PB0 [B0_00])
+			mux: nxp.IOMUXC_LPSPI4_PCS0_SELECT_INPUT_DAISY_GPIO_B0_00_ALT3,
+			sel: &nxp.IOMUXC.LPSPI4_PCS0_SELECT_INPUT,
+		},
+	}
+	SPI2 = &SPI{
+		Bus: nxp.LPSPI3,
+		muxSDI: muxSelect{ // D1 (PA2 [AD_B0_02])
+			mux: nxp.IOMUXC_LPSPI3_SDI_SELECT_INPUT_DAISY_GPIO_AD_B0_02_ALT7,
+			sel: &nxp.IOMUXC.LPSPI3_SDI_SELECT_INPUT,
+		},
+		muxSDO: muxSelect{ // D26 (PA30 [AD_B1_14])
+			mux: nxp.IOMUXC_LPSPI3_SDO_SELECT_INPUT_DAISY_GPIO_AD_B1_14_ALT2,
+			sel: &nxp.IOMUXC.LPSPI3_SDO_SELECT_INPUT,
+		},
+		muxSCK: muxSelect{ // D27 (PA31 [AD_B1_15])
+			mux: nxp.IOMUXC_LPSPI3_SCK_SELECT_INPUT_DAISY_GPIO_AD_B1_15,
+			sel: &nxp.IOMUXC.LPSPI3_SCK_SELECT_INPUT,
+		},
+		muxCS: muxSelect{ // D0 (PA3 [AD_B0_03])
+			mux: nxp.IOMUXC_LPSPI3_PCS0_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT7,
+			sel: &nxp.IOMUXC.LPSPI3_PCS0_SELECT_INPUT,
+		},
+	}
 )
 
 // #====================================================#
@@ -361,47 +361,47 @@ const (
 )
 
 var (
-        I2C0  = I2C1 // I2C0 is an alias for I2C1 (LPI2C1)
-        I2C1  = &_I2C1
-        _I2C1 = I2C{
-                Bus: nxp.LPI2C1,
-                sda: I2C1_SDA_PIN, // D18 (PA17 [AD_B1_01])
-                scl: I2C1_SCL_PIN, // D19 (PA16 [AD_B1_00])
-                muxSDA: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C1_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_01_ALT3,
-                        sel: &nxp.IOMUXC.LPI2C1_SDA_SELECT_INPUT,
-                },
-                muxSCL: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C1_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_00_ALT3,
-                        sel: &nxp.IOMUXC.LPI2C1_SCL_SELECT_INPUT,
-                },
-        }
-        I2C2  = &_I2C2
-        _I2C2 = I2C{
-                Bus: nxp.LPI2C3,
-                sda: I2C2_SDA_PIN, // D17 (PA22 [AD_B1_06])
-                scl: I2C2_SCL_PIN, // D16 (PA23 [AD_B1_07])
-                muxSDA: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C3_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_06_ALT1,
-                        sel: &nxp.IOMUXC.LPI2C3_SDA_SELECT_INPUT,
-                },
-                muxSCL: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C3_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT1,
-                        sel: &nxp.IOMUXC.LPI2C3_SCL_SELECT_INPUT,
-                },
-        }
-        I2C3  = &_I2C3
-        _I2C3 = I2C{
-                Bus: nxp.LPI2C4,
-                sda: I2C3_SDA_PIN, // D25 (PA13 [AD_B0_13])
-                scl: I2C3_SCL_PIN, // D24 (PA12 [AD_B0_12])
-                muxSDA: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C4_SDA_SELECT_INPUT_DAISY_GPIO_AD_B0_13_ALT0,
-                        sel: &nxp.IOMUXC.LPI2C4_SDA_SELECT_INPUT,
-                },
-                muxSCL: muxSelect{
-                        mux: nxp.IOMUXC_LPI2C4_SCL_SELECT_INPUT_DAISY_GPIO_AD_B0_12_ALT0,
-                        sel: &nxp.IOMUXC.LPI2C4_SCL_SELECT_INPUT,
-                },
-        }
+	I2C0  = I2C1 // I2C0 is an alias for I2C1 (LPI2C1)
+	I2C1  = &_I2C1
+	_I2C1 = I2C{
+		Bus: nxp.LPI2C1,
+		sda: I2C1_SDA_PIN, // D18 (PA17 [AD_B1_01])
+		scl: I2C1_SCL_PIN, // D19 (PA16 [AD_B1_00])
+		muxSDA: muxSelect{
+			mux: nxp.IOMUXC_LPI2C1_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_01_ALT3,
+			sel: &nxp.IOMUXC.LPI2C1_SDA_SELECT_INPUT,
+		},
+		muxSCL: muxSelect{
+			mux: nxp.IOMUXC_LPI2C1_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_00_ALT3,
+			sel: &nxp.IOMUXC.LPI2C1_SCL_SELECT_INPUT,
+		},
+	}
+	I2C2  = &_I2C2
+	_I2C2 = I2C{
+		Bus: nxp.LPI2C3,
+		sda: I2C2_SDA_PIN, // D17 (PA22 [AD_B1_06])
+		scl: I2C2_SCL_PIN, // D16 (PA23 [AD_B1_07])
+		muxSDA: muxSelect{
+			mux: nxp.IOMUXC_LPI2C3_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_06_ALT1,
+			sel: &nxp.IOMUXC.LPI2C3_SDA_SELECT_INPUT,
+		},
+		muxSCL: muxSelect{
+			mux: nxp.IOMUXC_LPI2C3_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT1,
+			sel: &nxp.IOMUXC.LPI2C3_SCL_SELECT_INPUT,
+		},
+	}
+	I2C3  = &_I2C3
+	_I2C3 = I2C{
+		Bus: nxp.LPI2C4,
+		sda: I2C3_SDA_PIN, // D25 (PA13 [AD_B0_13])
+		scl: I2C3_SCL_PIN, // D24 (PA12 [AD_B0_12])
+		muxSDA: muxSelect{
+			mux: nxp.IOMUXC_LPI2C4_SDA_SELECT_INPUT_DAISY_GPIO_AD_B0_13_ALT0,
+			sel: &nxp.IOMUXC.LPI2C4_SDA_SELECT_INPUT,
+		},
+		muxSCL: muxSelect{
+			mux: nxp.IOMUXC_LPI2C4_SCL_SELECT_INPUT_DAISY_GPIO_AD_B0_12_ALT0,
+			sel: &nxp.IOMUXC.LPI2C4_SCL_SELECT_INPUT,
+		},
+	}
 )

--- a/src/machine/board_teensy41.go
+++ b/src/machine/board_teensy41.go
@@ -279,7 +279,6 @@ var (
 // #===========#==========#===============#=================-=========#
 // |   SPI1    |  LPSPI4  | PLL2(132 MHz) | D12/D11/D13/D10 : 3/3/3/3 |
 // |   SPI2    |  LPSPI3  | PLL2(132 MHz) |  D1/D26/D27/D0  : 7/2/2/7 |
-// |   SPI3    |  LPSPI1  | PLL2(132 MHz) | D34/D35/D37/D36 : 4/4/4/4 |
 // #===========#==========#===============#=================-=========#
 const (
 	SPI1_SDI_PIN = D12
@@ -291,11 +290,48 @@ const (
 	SPI2_SDO_PIN = D26
 	SPI2_SCK_PIN = D27
 	SPI2_CS_PIN  = D0
+)
 
-	SPI3_SDI_PIN = D34
-	SPI3_SDO_PIN = D35
-	SPI3_SCK_PIN = D37
-	SPI3_CS_PIN  = D36
+var (
+        SPI0 = SPI1 // SPI0 is an alias of SPI1 (LPSPI4)
+        SPI1 = &SPI{
+                Bus: nxp.LPSPI4,
+                muxSDI: muxSelect{ // D12 (PB1 [B0_01])
+                        mux: nxp.IOMUXC_LPSPI4_SDI_SELECT_INPUT_DAISY_GPIO_B0_01_ALT3,
+                        sel: &nxp.IOMUXC.LPSPI4_SDI_SELECT_INPUT,
+                },
+                muxSDO: muxSelect{ // D11 (PB2 [B0_02])
+                        mux: nxp.IOMUXC_LPSPI4_SDO_SELECT_INPUT_DAISY_GPIO_B0_02_ALT3,
+                        sel: &nxp.IOMUXC.LPSPI4_SDO_SELECT_INPUT,
+                },
+                muxSCK: muxSelect{ // D13 (PB3 [B0_03])
+                        mux: nxp.IOMUXC_LPSPI4_SCK_SELECT_INPUT_DAISY_GPIO_B0_03_ALT3,
+                        sel: &nxp.IOMUXC.LPSPI4_SCK_SELECT_INPUT,
+                },
+                muxCS: muxSelect{ // D10 (PB0 [B0_00])
+                        mux: nxp.IOMUXC_LPSPI4_PCS0_SELECT_INPUT_DAISY_GPIO_B0_00_ALT3,
+                        sel: &nxp.IOMUXC.LPSPI4_PCS0_SELECT_INPUT,
+                },
+        }
+        SPI2 = &SPI{
+                Bus: nxp.LPSPI3,
+                muxSDI: muxSelect{ // D1 (PA2 [AD_B0_02])
+                        mux: nxp.IOMUXC_LPSPI3_SDI_SELECT_INPUT_DAISY_GPIO_AD_B0_02_ALT7,
+                        sel: &nxp.IOMUXC.LPSPI3_SDI_SELECT_INPUT,
+                },
+                muxSDO: muxSelect{ // D26 (PA30 [AD_B1_14])
+                        mux: nxp.IOMUXC_LPSPI3_SDO_SELECT_INPUT_DAISY_GPIO_AD_B1_14_ALT2,
+                        sel: &nxp.IOMUXC.LPSPI3_SDO_SELECT_INPUT,
+                },
+                muxSCK: muxSelect{ // D27 (PA31 [AD_B1_15])
+                        mux: nxp.IOMUXC_LPSPI3_SCK_SELECT_INPUT_DAISY_GPIO_AD_B1_15,
+                        sel: &nxp.IOMUXC.LPSPI3_SCK_SELECT_INPUT,
+                },
+                muxCS: muxSelect{ // D0 (PA3 [AD_B0_03])
+                        mux: nxp.IOMUXC_LPSPI3_PCS0_SELECT_INPUT_DAISY_GPIO_AD_B0_03_ALT7,
+                        sel: &nxp.IOMUXC.LPSPI3_PCS0_SELECT_INPUT,
+                },
+        }
 )
 
 // #====================================================#
@@ -316,4 +352,50 @@ const (
 
 	I2C3_SDA_PIN = D25
 	I2C3_SCL_PIN = D24
+)
+
+var (
+        I2C0  = I2C1 // I2C0 is an alias for I2C1 (LPI2C1)
+        I2C1  = &_I2C1
+        _I2C1 = I2C{
+                Bus: nxp.LPI2C1,
+                sda: I2C1_SDA_PIN, // D18 (PA17 [AD_B1_01])
+                scl: I2C1_SCL_PIN, // D19 (PA16 [AD_B1_00])
+                muxSDA: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C1_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_01_ALT3,
+                        sel: &nxp.IOMUXC.LPI2C1_SDA_SELECT_INPUT,
+                },
+                muxSCL: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C1_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_00_ALT3,
+                        sel: &nxp.IOMUXC.LPI2C1_SCL_SELECT_INPUT,
+                },
+        }
+        I2C2  = &_I2C2
+        _I2C2 = I2C{
+                Bus: nxp.LPI2C3,
+                sda: I2C2_SDA_PIN, // D17 (PA22 [AD_B1_06])
+                scl: I2C2_SCL_PIN, // D16 (PA23 [AD_B1_07])
+                muxSDA: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C3_SDA_SELECT_INPUT_DAISY_GPIO_AD_B1_06_ALT1,
+                        sel: &nxp.IOMUXC.LPI2C3_SDA_SELECT_INPUT,
+                },
+                muxSCL: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C3_SCL_SELECT_INPUT_DAISY_GPIO_AD_B1_07_ALT1,
+                        sel: &nxp.IOMUXC.LPI2C3_SCL_SELECT_INPUT,
+                },
+        }
+        I2C3  = &_I2C3
+        _I2C3 = I2C{
+                Bus: nxp.LPI2C4,
+                sda: I2C3_SDA_PIN, // D25 (PA13 [AD_B0_13])
+                scl: I2C3_SCL_PIN, // D24 (PA12 [AD_B0_12])
+                muxSDA: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C4_SDA_SELECT_INPUT_DAISY_GPIO_AD_B0_13_ALT0,
+                        sel: &nxp.IOMUXC.LPI2C4_SDA_SELECT_INPUT,
+                },
+                muxSCL: muxSelect{
+                        mux: nxp.IOMUXC_LPI2C4_SCL_SELECT_INPUT_DAISY_GPIO_AD_B0_12_ALT0,
+                        sel: &nxp.IOMUXC.LPI2C4_SCL_SELECT_INPUT,
+                },
+        }
 )

--- a/src/machine/board_teensy41.go
+++ b/src/machine/board_teensy41.go
@@ -279,6 +279,7 @@ var (
 // #===========#==========#===============#=================-=========#
 // |   SPI1    |  LPSPI4  | PLL2(132 MHz) | D12/D11/D13/D10 : 3/3/3/3 |
 // |   SPI2    |  LPSPI3  | PLL2(132 MHz) |  D1/D26/D27/D0  : 7/2/2/7 |
+// |   SPI3    |  LPSPI1  | PLL2(132 MHz) | D42/D43/D45/D44 : 4/4/4/4 |
 // #===========#==========#===============#=================-=========#
 const (
 	SPI1_SDI_PIN = D12
@@ -290,6 +291,11 @@ const (
 	SPI2_SDO_PIN = D26
 	SPI2_SCK_PIN = D27
 	SPI2_CS_PIN  = D0
+
+	SPI3_SDI_PIN = D42
+	SPI3_SDO_PIN = D43
+	SPI3_SCK_PIN = D45
+	SPI3_CS_PIN  = D44
 )
 
 var (


### PR DESCRIPTION
Adds support for SPI and I2C to the teensy41 board.

SPI3 was removed because the pin definitions are incorrect and a part of the SD card.

Tested SPI1 and SPI2 and all three I2C buses with basic examples.