### PR TITLE
docs: Add build verification command for macOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -85,10 +85,16 @@ Try running TinyGo:
 
     ./build/tinygo help
 
-Also, make sure the `tinygo` binary really is statically linked. Check this
-using `ldd` (not to be confused with `lld`):
+Also, make sure the `tinygo` binary really is statically linked. The command to check for 
+dynamic dependencies differs depending on your operating system.
+
+On Linux, use `ldd` (not to be confused with `lld`):
 
     ldd ./build/tinygo
+
+On macOS, use otool -L:
+
+    otool -L ./build/tinygo
 
 The result should not contain libclang or libLLVM.
 


### PR DESCRIPTION
The build verification guide only provided instructions using the 'ldd' command, which is specific to Linux and not available on macOS.

```
tinygo
❯ otool -L ./build/tinygo
./build/tinygo:
        /usr/lib/libxar.1.dylib (compatibility version 1.0.0, current version 1.3.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.180.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3502.1.255)
        /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
```