### PR TITLE
fix: additional params to create chromium browser for testing

### DIFF
--- a/tests/wasm/setup_test.go
+++ b/tests/wasm/setup_test.go
@@ -36,6 +36,13 @@ func chromectx(t *testing.T) context.Context {
 	// see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
 		chromedp.NoSandbox,
+		chromedp.Flag("disable-web-security", true),
+		chromedp.Flag("safebrowsing-disable-auto-update", true),
+		chromedp.IgnoreCertErrors,
+		chromedp.Flag("disable-sync", true),
+		chromedp.Flag("disable-default-apps", true),
+		chromedp.NoFirstRun,
+		chromedp.Headless,
 	)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)


### PR DESCRIPTION
This PR attempts to fix CI errors by adding some additional params to create the chromium browser for wasm testing.