### PR TITLE
machine: add international and language keyboard keys

### DIFF
--- a/src/machine/usb/hid/keyboard/keycode.go
+++ b/src/machine/usb/hid/keyboard/keycode.go
@@ -209,6 +209,21 @@ const (
 	KeyF23         Keycode = 114 | 0xF000
 	KeyF24         Keycode = 115 | 0xF000
 
+	// International keys for Japanese and other language keyboards
+	KeyInternational1 Keycode = 0x87 | 0xF000 // JIS "\" and "_"
+	KeyInternational2 Keycode = 0x88 | 0xF000 // JIS Katakana/Hiragana
+	KeyInternational3 Keycode = 0x89 | 0xF000 // JIS "¥" and "|"
+	KeyInternational4 Keycode = 0x8A | 0xF000 // JIS Henkan
+	KeyInternational5 Keycode = 0x8B | 0xF000 // JIS Muhenkan
+	KeyInternational6 Keycode = 0x8C | 0xF000 // JIS Numpad ","
+
+	// Language keys for input method switching
+	KeyLanguage1 Keycode = 0x90 | 0xF000 // Hangul/English
+	KeyLanguage2 Keycode = 0x91 | 0xF000 // Hanja
+	KeyLanguage3 Keycode = 0x92 | 0xF000 // JIS Katakana
+	KeyLanguage4 Keycode = 0x93 | 0xF000 // JIS Hiragana
+	KeyLanguage5 Keycode = 0x94 | 0xF000 // JIS Zenkaku/Hankaku
+
 	KeyUpArrow    Keycode = KeyUp
 	KeyDownArrow  Keycode = KeyDown
 	KeyLeftArrow  Keycode = KeyLeft
@@ -222,6 +237,34 @@ const (
 	KeyRightShift Keycode = KeyModifierRightShift
 	KeyRightAlt   Keycode = KeyModifierRightAlt
 	KeyRightGUI   Keycode = KeyModifierRightGUI
+
+	// QMK compatibility aliases for international keys
+	KeyInt1 Keycode = KeyInternational1
+	KeyInt2 Keycode = KeyInternational2
+	KeyInt3 Keycode = KeyInternational3
+	KeyInt4 Keycode = KeyInternational4
+	KeyInt5 Keycode = KeyInternational5
+	KeyInt6 Keycode = KeyInternational6
+
+	// QMK compatibility aliases for language keys
+	KeyLng1 Keycode = KeyLanguage1
+	KeyLng2 Keycode = KeyLanguage2
+	KeyLng3 Keycode = KeyLanguage3
+	KeyLng4 Keycode = KeyLanguage4
+	KeyLng5 Keycode = KeyLanguage5
+
+	// Common keyboard layout aliases
+	KeyRo               Keycode = KeyInternational1 // Japanese "ろ"
+	KeyKatakanaHiragana Keycode = KeyInternational2 // Japanese Katakana/Hiragana
+	KeyYen              Keycode = KeyInternational3 // Japanese "¥"
+	KeyHenkan           Keycode = KeyInternational4 // Japanese Henkan
+	KeyMuhenkan         Keycode = KeyInternational5 // Japanese Muhenkan
+	KeyKpJpComma        Keycode = KeyInternational6 // Japanese Numpad ","
+	KeyHangeul          Keycode = KeyLanguage1      // Korean Hangul/English
+	KeyHanja            Keycode = KeyLanguage2      // Korean Hanja
+	KeyKatakana         Keycode = KeyLanguage3      // Japanese Katakana
+	KeyHiragana         Keycode = KeyLanguage4      // Japanese Hiragana
+	KeyZenkakuHankaku   Keycode = KeyLanguage5      // Japanese Zenkaku/Hankaku
 )
 
 // Keycodes for layout US English (0x0904)


### PR DESCRIPTION
 ## Summary

  Adds support for international and language keyboard keys (0x87-0x94) to the USB HID keyboard implementation. These keys are essential for non-US keyboard layouts, particularly
  Japanese and Korean keyboards.

  ## Changes

  - **International Keys (0x87-0x8C)**: Added `KeyInternational1` through `KeyInternational6` for Japanese keyboard support
    - `KeyInternational1` (0x87): JIS "\" and "_" key
    - `KeyInternational2` (0x88): JIS Katakana/Hiragana toggle
    - `KeyInternational3` (0x89): JIS "¥" and "|" key  
    - `KeyInternational4` (0x8A): JIS Henkan (conversion)
    - `KeyInternational5` (0x8B): JIS Muhenkan (non-conversion)
    - `KeyInternational6` (0x8C): JIS Numpad comma

  - **Language Keys (0x90-0x94)**: Added `KeyLanguage1` through `KeyLanguage5` for input method switching
    - `KeyLanguage1` (0x90): Hangul/English toggle (Korean)
    - `KeyLanguage2` (0x91): Hanja conversion (Korean)
    - `KeyLanguage3` (0x92): JIS Katakana mode
    - `KeyLanguage4` (0x93): JIS Hiragana mode  
    - `KeyLanguage5` (0x94): JIS Zenkaku/Hankaku toggle

  - **Compatibility Aliases**: Added QMK-compatible aliases (`KeyInt1`-`KeyInt6`, `KeyLng1`-`KeyLng5`) and descriptive aliases (`KeyYen`, `KeyHenkan`, etc.)

  ## Rationale

  These keys are defined in the USB HID specification and are commonly used in:
  - Japanese keyboards (JIS layout)
  - Korean keyboards
  - Other international layouts

  The existing HID descriptor already supports the full 0x00-0xFF key range, so no descriptor changes were required.

  ## Testing

  - Keys are properly defined with correct HID usage codes
  - Maintains backward compatibility with existing code
  - No changes to HID descriptor needed (already supports full range)

  ## References

  - USB HID Usage Tables v1.22, Section 10 (Keyboard/Keypad Page)
  - Based on QMK firmware's key definitions for compatibility