### PR TITLE
internal/task: add SA_RESTART flag to GC interrupts

### DIFF
--- a/src/internal/task/task_threads.c
+++ b/src/internal/task/task_threads.c
@@ -58,6 +58,7 @@ void tinygo_task_init(void *mainTask, pthread_t *thread, int *numCPU, void *cont
     // Using pthread_kill, we can still send the signal to a specific thread.
     struct sigaction act = { 0 };
     act.sa_handler = tinygo_task_gc_pause;
+    act.sa_flags = SA_RESTART;
     sigaction(taskPauseSignal, &act, NULL);
 
     // Obtain the number of CPUs available on program start (for NumCPU).


### PR DESCRIPTION
This makes sure system calls like read don't return EINTR but instead restart the call on an interrupt. This is by far the more sensible option, the default POSIX behavior of returning EINTR is extremely error-prone.

Found this bug while trying to use the upstream testing package instead of our own.