### PR TITLE
ci: make the goroutines test less racy

### DIFF
--- a/testdata/goroutines.go
+++ b/testdata/goroutines.go
@@ -14,9 +14,9 @@ func init() {
 func main() {
 	println("main 1")
 	go sub()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	println("main 2")
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	println("main 3")
 
 	// Await a blocking call.
@@ -103,7 +103,7 @@ func acquire(m *sync.Mutex, wg *sync.WaitGroup) {
 
 func sub() {
 	println("sub 1")
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	println("sub 2")
 }
 


### PR DESCRIPTION
Since we switched to OS threads for goroutines, the testdata/goroutines.go test has been flaky. Not surprising, if threads need to be scheduled within 1ms on a busy CI system. This PR makes the test a bit less flaky (hopefully) by increasing the time to 100ms.