### PR TITLE
chore: update all CI builds to test Go 1.25-rc3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
     # This tests the latest supported LLVM version when linking against system
     # libraries.
     docker:
-      - image: golang:1.25rc2-bullseye
+      - image: golang:1.25rc3-bullseye
     steps:
       - test-linux:
           llvm: "20"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -134,7 +134,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25rc2-alpine
+      image: golang:1.25rc3-alpine
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.0-rc.2'
+          go-version: '1.25.0-rc.3'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.25rc2 AS tinygo-llvm
+FROM golang:1.25rc3 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-15 ninja-build && \
@@ -33,7 +33,7 @@ RUN cd /tinygo/ && \
 
 # tinygo-compiler copies the compiler build over to a base Go container (without
 # all the build tools etc).
-FROM golang:1.25rc2 AS tinygo-compiler
+FROM golang:1.25rc3 AS tinygo-compiler
 
 # Copy tinygo build.
 COPY --from=tinygo-compiler-build /tinygo/build/release/tinygo /tinygo


### PR DESCRIPTION
This PR updates all CI builds to test Go 1.25-rc3