### PR TITLE
os: remove VFS layer

### DIFF
--- a/src/os/file.go
+++ b/src/os/file.go
@@ -41,11 +41,7 @@ var lstat = Lstat
 // Mkdir creates a directory. If the operation fails, it will return an error of
 // type *PathError.
 func Mkdir(path string, perm FileMode) error {
-	fs, suffix := findMount(path)
-	if fs == nil {
-		return &PathError{Op: "mkdir", Path: path, Err: ErrNotExist}
-	}
-	err := fs.Mkdir(suffix, perm)
+	err := currentFS().Mkdir(path, perm)
 	if err != nil {
 		return &PathError{Op: "mkdir", Path: path, Err: err}
 	}
@@ -64,11 +60,7 @@ func fixCount(n int, err error) (int, error) {
 // Remove removes a file or (empty) directory. If the operation fails, it will
 // return an error of type *PathError.
 func Remove(path string) error {
-	fs, suffix := findMount(path)
-	if fs == nil {
-		return &PathError{Op: "remove", Path: path, Err: ErrNotExist}
-	}
-	err := fs.Remove(suffix)
+	err := currentFS().Remove(path)
 	if err != nil {
 		return err
 	}
@@ -83,11 +75,7 @@ func (f *File) Name() string {
 // OpenFile opens the named file. If the operation fails, the returned error
 // will be of type *PathError.
 func OpenFile(name string, flag int, perm FileMode) (*File, error) {
-	fs, suffix := findMount(name)
-	if fs == nil {
-		return nil, &PathError{Op: "open", Path: name, Err: ErrNotExist}
-	}
-	handle, err := fs.OpenFile(suffix, flag, perm)
+	handle, err := currentFS().OpenFile(name, flag, perm)
 	if err != nil {
 		return nil, &PathError{Op: "open", Path: name, Err: err}
 	}

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -11,12 +11,6 @@ import (
 	"syscall"
 )
 
-func init() {
-	// Mount the host filesystem at the root directory. This is what most
-	// programs will be expecting.
-	Mount("/", unixFilesystem{})
-}
-
 // Stdin, Stdout, and Stderr are open Files pointing to the standard input,
 // standard output, and standard error file descriptors.
 var (
@@ -44,6 +38,11 @@ func Chdir(dir string) error {
 // If there is an error, it will be of type *LinkError.
 func Rename(oldpath, newpath string) error {
 	return rename(oldpath, newpath)
+}
+
+// Always directly access the filesystem.
+func currentFS() Filesystem {
+	return unixFilesystem{}
 }
 
 // unixFilesystem is an empty handle for a Unix/Linux filesystem. All operations

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -24,6 +24,11 @@ const isOS = false
 // number. It implements the FileHandle interface.
 type stdioFileHandle uint8
 
+// At the moment, no filesystems are supported on non-OS systems.
+func currentFS() Filesystem {
+	return dummyFilesystem{}
+}
+
 // file is the real representation of *File.
 // The extra level of indirection ensures that no clients of os
 // can overwrite this data, which could cause the finalizer


### PR DESCRIPTION
This was largely non-working and I don't think anybody actually used it. So let's remove it.

I hope to implement some sort of virtual filesystem support later that actually works, which is simpler with the non-working abstraction removed.