### PR TITLE
fix: update version of clang to 17 to accommodate latest Go 1.25 Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.25 AS tinygo-llvm
 
 RUN apt-get update && \
-    apt-get install -y apt-utils make cmake clang-15 ninja-build && \
+    apt-get install -y apt-utils make cmake clang-17 ninja-build && \
     rm -rf \
         /var/lib/apt/lists/* \
         /var/log/* \


### PR DESCRIPTION
This PR is to fix the Docker build by updating the version of clang to `clang-17` to accommodate the latest Go 1.25 Docker base image.