### PR TITLE
targets: set default stack size to 8k for rp2040/rp2350 based boards

### DIFF
--- a/targets/badger2040-w.json
+++ b/targets/badger2040-w.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["badger2040_w", "cyw43439"],
     "ldflags": [
         "--defsym=__flash_size=1020K"

--- a/targets/badger2040.json
+++ b/targets/badger2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["badger2040"],
     "ldflags": [
         "--defsym=__flash_size=1020K"

--- a/targets/challenger-rp2040.json
+++ b/targets/challenger-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:1023"],
+    "default-stack-size": 8192,
     "build-tags": ["challenger_rp2040"],
     "ldflags": [
         "--defsym=__flash_size=8M"

--- a/targets/feather-rp2040.json
+++ b/targets/feather-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["239a:80f1"],
+    "default-stack-size": 8192,
     "build-tags": ["feather_rp2040"],
     "ldflags": [
         "--defsym=__flash_size=8192K"

--- a/targets/gopher-badge.json
+++ b/targets/gopher-badge.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["gopher_badge"],
     "ldflags": [
         "--defsym=__flash_size=8M"

--- a/targets/macropad-rp2040.json
+++ b/targets/macropad-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "build-tags": ["macropad_rp2040"],
+    "default-stack-size": 8192,
     "serial-port": ["239a:8107"],
     "ldflags": [
         "--defsym=__flash_size=8M"

--- a/targets/nano-rp2040.json
+++ b/targets/nano-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2341:005e"],
+    "default-stack-size": 8192,
     "build-tags": ["nano_rp2040", "ninafw", "ninafw_machine_init"],
     "ldflags": [
         "--defsym=__flash_size=16M"

--- a/targets/qtpy-rp2040.json
+++ b/targets/qtpy-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["239a:80f7"],
+    "default-stack-size": 8192,
     "build-tags": ["qtpy_rp2040"],
     "ldflags": [
         "--defsym=__flash_size=8192K"

--- a/targets/tiny2350.json
+++ b/targets/tiny2350.json
@@ -6,5 +6,6 @@
     "ldflags": [
         "--defsym=__flash_size=4M"
     ],
-    "serial-port": ["2e8a:000f"]
+    "serial-port": ["2e8a:000f"],
+    "default-stack-size": 8192
 }

--- a/targets/trinkey-qt2040.json
+++ b/targets/trinkey-qt2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["239a:8109"],
+    "default-stack-size": 8192,
     "build-tags": ["trinkey_qt2040"],
     "ldflags": [
         "--defsym=__flash_size=8192K"

--- a/targets/tufty2040.json
+++ b/targets/tufty2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["tufty2040"],
     "ldflags": [
         "--defsym=__flash_size=1020K"

--- a/targets/waveshare-rp2040-tiny.json
+++ b/targets/waveshare-rp2040-tiny.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["waveshare_rp2040_tiny"],
     "ldflags": [
         "--defsym=__flash_size=1020K"

--- a/targets/waveshare-rp2040-zero.json
+++ b/targets/waveshare-rp2040-zero.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
     "build-tags": ["waveshare_rp2040_zero"],
     "ldflags": [
         "--defsym=__flash_size=1020K"

--- a/targets/xiao-rp2040.json
+++ b/targets/xiao-rp2040.json
@@ -3,6 +3,7 @@
         "rp2040"
     ],
     "serial-port": ["2e8a:000a"],
+    "default-stack-size": 8192,
     "build-tags": ["xiao_rp2040"],
     "ldflags": [
         "--defsym=__flash_size=1020K"


### PR DESCRIPTION
This PR sets the default stack size to 8k for rp2040/rp2350 based boards where this was not already the case.

Should avoid a lot of errors from just forgetting to add that flag, since either everyone practically just sets it, or in a number of cases is already the default.