### PR TITLE
machine,nrf528,i2c: fix multiple resume-stop on bus error

### DIFF
--- a/src/machine/machine_nrf528xx.go
+++ b/src/machine/machine_nrf528xx.go
@@ -78,14 +78,14 @@ func (i2c *I2C) Tx(addr uint16, w, r []byte) (err error) {
 		// Allow scheduler to run
 		gosched()
 
-		// Handle errors by ensuring STOP sent on bus
-		if i2c.Bus.EVENTS_ERROR.Get() != 0 {
+		// Handle first occurrence of error by ensuring STOP sent on bus
+		if err == nil && i2c.Bus.EVENTS_ERROR.Get() != 0 {
+			err = twiCError(i2c.Bus.ERRORSRC.Get())
 			if i2c.Bus.EVENTS_STOPPED.Get() == 0 {
 				// STOP cannot be sent during SUSPEND
 				i2c.Bus.TASKS_RESUME.Set(1)
 				i2c.Bus.TASKS_STOP.Set(1)
 			}
-			err = twiCError(i2c.Bus.ERRORSRC.Get())
 		}
 	}
 


### PR DESCRIPTION
As already shown in #4998,  in case of an error the i2c TX method in nrf528xx loops until a stop condition is fulfilled. In case of an error, a resume-stop command on bus will be called, so the bus can finish its work and exit the loop afterwards - no "hard" return in case of error is done and needed.

With the current code, after the first error occurs, each loop checks again for an error and practically (assuming the error is not gone) sends the resume-stop sequence again and again until the stop state is reached (triggered by the first resume-stop-sequence) and the loop is finished. On long run with existing errors, e.g the device is not connected on the bus, and cyclic calls (e.g. each 10 seconds) this leads reproducible to hang of the loop with the [bme280](https://github.com/tinygo-org/drivers/tree/release/bme280) driver.

The provided code change improves the code for this topics:
* checks for the error code before the resume-stop is called, so the real error is finally contained in err variable
* skips the complete error check if the first error was detected - this fixes the originated problem