### PR TITLE
rp2040: allow writing to the UART inside interrupts

### DIFF
--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -104,7 +104,9 @@ func (uart *UART) SetBaudRate(br uint32) {
 func (uart *UART) writeByte(c byte) error {
 	// wait until buffer is not full
 	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_TXFF) {
-		gosched()
+		if !interrupt.In() {
+			gosched()
+		}
 	}
 
 	// write data
@@ -114,7 +116,9 @@ func (uart *UART) writeByte(c byte) error {
 
 func (uart *UART) flush() {
 	for uart.Bus.UARTFR.HasBits(rp.UART0_UARTFR_BUSY) {
-		gosched()
+		if !interrupt.In() {
+			gosched()
+		}
 	}
 }
 


### PR DESCRIPTION
Writing to the UART takes time and that may not be a good idea inside an interrupt, but it is essential for debugging sometimes (especially since USB-CDC typically doesn't work inside an interrupt). However, `runtime.Gosched()` tries to switch to a different goroutine and will panic when it is called inside an interrupt.

This fixes UART support in interrupts for the RP2040 at least. You can test it with `-serial=uart` and connecting a USB-UART adapter to the right pins.