### PR TITLE
fix: expand RTT debugger compatibility

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -35,8 +35,8 @@ func Monitor(executable, port string, config *compileopts.Config) error {
 		// Use the RTT interface, which is documented (in part) here:
 		// https://wiki.segger.com/RTT
 
-		// Try to find the "machine.rttSerialInstance" symbol, which is the RTT
-		// control block.
+		// Try to find the "_SEGGER_RTT" symbol (machine.rttSerialInstance)
+		// symbol, which is the RTT control block.
 		file, err := elf.Open(executable)
 		if err != nil {
 			return fmt.Errorf("could not open ELF file to determine RTT control block: %w", err)
@@ -48,7 +48,7 @@ func Monitor(executable, port string, config *compileopts.Config) error {
 		}
 		var address uint64
 		for _, symbol := range symbols {
-			if symbol.Name == "machine.rttSerialInstance" {
+			if symbol.Name == "_SEGGER_RTT" {
 				address = symbol.Value
 				break
 			}

--- a/src/machine/serial-rtt.go
+++ b/src/machine/serial-rtt.go
@@ -16,6 +16,8 @@ import (
 )
 
 // This symbol name is known by the compiler, see monitor.go.
+//
+//go:linkname rttSerialInstance _SEGGER_RTT
 var rttSerialInstance rttSerial
 
 var Serial = &rttSerialInstance


### PR DESCRIPTION
I recently saw/fell in love with the idea of the https://github.com/piersfinlayson/airfrog debugger tool (wireless SWD+RTT) and got a bit jealous of the [probe-rs debugger](https://probe.rs/docs/tools/debugger/#a-visual-guide-of-implemented-features) features/tight integration with VSCode. Turns out it is largely powered by the https://github.com/Marus/cortex-debug extension, which was not originally written with rust in mind so I've been working on some things to make it easier to use (like an example launch.json for VSCode, etc.).

This PR in particular expands RTT debugger compatibility by adding a `_SEGGER_RTT` symbol alias to `machine.rttSerialInstance` for RTT debuggers (such as Marus/cortex-debug) that are hard-coded to look for the `_SEGGER_RTT` symbol specifically and struggle with memory scanning. probe-rs does [something similar-ish](https://github.com/probe-rs/rtt-target/blob/117d9519a5d3b1f4bc024bc05f9e3c5dec0a57f5/rtt-target/src/lib.rs#L262), but since [monitor.go](https://github.com/tinygo-org/tinygo/blob/3869f76887feef6c444308e7e1531b7cac1bbd10/monitor.go#L38) specifically looks for `machine.rttSerialInstance` we need both to exist to avoid breaking compatibility.

Example output from an nm dump:
```
$ arm-none-eabi-nm -S -l -p my-program.elf |egrep 'rttSerialInst|SEGGER'
20001068 00000048 b machine.rttSerialInstance   /Users/michaelsmith/git/tinygo/src/machine/serial-rtt.go:19
20001068 00000048 b _SEGGER_RTT
```