### PR TITLE
ci:uninstall cmake before install

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -79,6 +79,7 @@ jobs:
           rm -rf llvm-project
           make llvm-source
           # install dependencies
+          brew uninstall cmake || true
           HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
           # build!
           make llvm-build


### PR DESCRIPTION
fixed  https://github.com/tinygo-org/tinygo/actions/runs/17543650117/job/49860578495?pr=5028

```bash
Updating files: 100% (146556/146556), done.
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.

To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake

Error: Process completed with exit code 1.
```