### PR TITLE
fix: do not install cmake on macOS CI build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf llvm-project
           make llvm-source
           # install dependencies
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake ninja
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
           # build!
           make llvm-build
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;


### PR DESCRIPTION
This PR  fixes the macOS CI by not installing cmake on macOS CI. It appears to be installed by default and since Homebrew has recently been updated, there is now a version mismatch.