### PR TITLE
GNUmakefile: shrink TinyGo binaries on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
         # tar: needed for actions/cache@v4
         # git+openssh: needed for checkout (I think?)
         # ruby: needed to install fpm
-        run: apk add tar git openssh make g++ ruby-dev
+        run: apk add tar git openssh make g++ ruby-dev mold
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-19-linux-alpine-v1
+          key: llvm-build-19-linux-alpine-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -222,7 +222,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-19-linux-asserts-v1
+          key: llvm-build-19-linux-asserts-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -329,7 +329,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-19-linux-${{ matrix.goarch }}-v3
+          key: llvm-build-19-linux-${{ matrix.goarch }}-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
With these flags, the TinyGo binary gets 17MB (10.6%) smaller. That seems like a quite useful win for such a small change!

This is only for Linux for now. MacOS and Windows can be tested later, the flags for those probably need to be modified.

Originally inspired by:
https://discourse.llvm.org/t/state-of-the-art-for-reducing-executable-size-with-heavily-optimized-program/87952/18 There are some other flags like -Wl,--pack-dyn-relocs=relr that did not shrink binary size in my testing, so I've left them out.

---

Of course the size of the compiler is not nearly as important as the size of the binaries it produces, but I still think this is a small win.