### PR TITLE
fix: update macOS CI to build a new v2 cached LLVM to verify cmake install fix

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-19-${{ matrix.os }}-v1
+          key: llvm-source-19-${{ matrix.os }}-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -70,7 +70,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-19-${{ matrix.os }}-v1
+          key: llvm-build-19-${{ matrix.os }}-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR updates the macOS CI to build a new v2 cached LLVM 19 to verify cmake install fix that was part of #5030 