### PR TITLE
fix(rp2350): add software spinlocks

### DIFF
--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -13,7 +13,6 @@ import (
 )
 
 const numCPU = 2
-const numSpinlocks = 32
 
 // machineTicks is provided by package machine.
 func machineTicks() uint64
@@ -273,44 +272,6 @@ func coreStackTop(core uint32) uintptr {
 		runtimePanic("unexpected core")
 		return 0
 	}
-}
-
-// These spinlocks are needed by the runtime.
-var (
-	printLock     = spinLock{id: 20}
-	schedulerLock = spinLock{id: 21}
-	atomicsLock   = spinLock{id: 22}
-	futexLock     = spinLock{id: 23}
-)
-
-func resetSpinLocks() {
-	for i := uint8(0); i < numSpinlocks; i++ {
-		l := &spinLock{id: i}
-		l.spinlock().Set(0)
-	}
-}
-
-// A hardware spinlock, one of the 32 spinlocks defined in the SIO peripheral.
-type spinLock struct {
-	id uint8
-}
-
-// Return the spinlock register: rp.SIO.SPINLOCKx
-func (l *spinLock) spinlock() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&rp.SIO.SPINLOCK0), l.id*4))
-}
-
-func (l *spinLock) Lock() {
-	// Wait for the lock to be available.
-	spinlock := l.spinlock()
-	for spinlock.Get() == 0 {
-		arm.Asm("wfe")
-	}
-}
-
-func (l *spinLock) Unlock() {
-	l.spinlock().Set(0)
-	arm.Asm("sev")
 }
 
 // Wait until a signal is received, indicating that it can resume from the

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -3,14 +3,57 @@
 package runtime
 
 import (
+	"device/arm"
 	"device/rp"
 	"runtime/interrupt"
+	"runtime/volatile"
+	"unsafe"
 )
 
 const (
 	sioIrqFifoProc0 = rp.IRQ_SIO_IRQ_PROC0
 	sioIrqFifoProc1 = rp.IRQ_SIO_IRQ_PROC1
 )
+
+const numSpinlocks = 32
+
+// These spinlocks are needed by the runtime.
+var (
+	printLock     = spinLock{id: 20}
+	schedulerLock = spinLock{id: 21}
+	atomicsLock   = spinLock{id: 22}
+	futexLock     = spinLock{id: 23}
+)
+
+func resetSpinLocks() {
+	for i := uint8(0); i < numSpinlocks; i++ {
+		l := &spinLock{id: i}
+		l.spinlock().Set(0)
+	}
+}
+
+// A hardware spinlock, one of the 32 spinlocks defined in the SIO peripheral.
+type spinLock struct {
+	id uint8
+}
+
+// Return the spinlock register: rp.SIO.SPINLOCKx
+func (l *spinLock) spinlock() *volatile.Register32 {
+	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&rp.SIO.SPINLOCK0), l.id*4))
+}
+
+func (l *spinLock) Lock() {
+	// Wait for the lock to be available.
+	spinlock := l.spinlock()
+	for spinlock.Get() == 0 {
+		arm.Asm("wfe")
+	}
+}
+
+func (l *spinLock) Unlock() {
+	l.spinlock().Set(0)
+	arm.Asm("sev")
+}
 
 // On RP2040, each core has its own SIO FIFO IRQ. Core0 enables
 // IRQ_SIO_IRQ_PROC0 and Core1 enables IRQ_SIO_IRQ_PROC1, so each handler can

--- a/src/runtime/runtime_rp2350.go
+++ b/src/runtime/runtime_rp2350.go
@@ -3,8 +3,10 @@
 package runtime
 
 import (
+	"device/arm"
 	"device/rp"
 	"runtime/interrupt"
+	"sync/atomic"
 )
 
 const (
@@ -36,4 +38,51 @@ func handleSIOFifoInterrupt(intr interrupt.Interrupt) {
 	case 1:
 		gcInterruptHandler(currentCPU())
 	}
+}
+
+// These spinlocks are needed by the runtime.
+//
+// Unlike on the RP2040, these are software spinlocks: erratum RP2350-E2 makes
+// the hardware SIO spinlocks unreliable (a core can observe a spinlock as
+// acquired when it isn't). The pico-sdk likewise replaced them with LL/SC
+// based software spinlocks on this chip. The Cortex-M33 supports ldrex/strex,
+// so 32-bit atomics compile to native instructions and are multicore-safe.
+var (
+	printLock     spinLock
+	schedulerLock spinLock
+	atomicsLock   spinLock
+	futexLock     spinLock
+)
+
+// Software spinlocks don't survive in locked state across a soft reset: they
+// live in .bss, which preinit() has already cleared before this is called.
+func resetSpinLocks() {
+}
+
+// A software spinlock, implemented using atomic operations.
+type spinLock struct {
+	atomic.Uint32
+}
+
+func (l *spinLock) Lock() {
+	// Try to replace 0 with 1. Once we succeed, the lock has been acquired.
+	for !l.Uint32.CompareAndSwap(0, 1) {
+		// Wait until the current holder calls Unlock, which executes a "sev".
+		arm.Asm("wfe")
+	}
+}
+
+func (l *spinLock) Unlock() {
+	// Safety check: the spinlock should have been locked.
+	if schedulerAsserts && l.Uint32.Load() != 1 {
+		runtimePanic("unlock of unlocked spinlock")
+	}
+
+	// Unlock the lock. Simply write 0, because we already know it is locked.
+	l.Uint32.Store(0)
+
+	// Wake up cores that are waiting for this lock in Lock() or for some other
+	// event (like a runnable task) in schedulerUnlockAndWait. The hardware
+	// spinlock version on the RP2040 has the same behavior.
+	arm.Asm("sev")
 }


### PR DESCRIPTION
As it turns out, the RP2350 has hardware spinlocks that can be unlocked by writes to nearby addresses, the lower spinlocks currently in use in TinyGo happen to be unlocked by writes to the doorbell interrupt registers used to signal between cores, very possibly leading to some unexpected unlocks. This was not corrected in the A3 or A4 steppings and instead software spinlocks are used by default on RP2350 in pico-sdk: 
> RP2350 Warning. Due to erratum RP2350-E2, writes to new SIO registers above an offset of +0x180 alias the spinlocks, causing spurious lock releases. This SDK by default use atomic memory accesses to implement the hardware_sync_spin_lock API, as a workaround on RP2350 A2.

https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_sync

Another thing I noticed in that section, they also always disable interrupts when the spinlocks are being held, we may want to do the same:
> [...] the default spinlock related methods here (e.g. [spin_lock_blocking](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_sync_1ga091e88a7608ed8dbf3e1e984bae54602)) always disable interrupts while the lock is held as use by IRQ handlers and user code is common/desirable, and spin locks are only expected to be held for brief periods.

These are the software spinlock macros ported over:
https://github.com/raspberrypi/pico-sdk/blob/2.2.0/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h#L112
https://github.com/raspberrypi/pico-sdk/blob/2.2.0/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h#L197