### PR TITLE
fix(rp2): misc spinlock-related fixes

### DIFF
--- a/src/machine/machine_rp2.go
+++ b/src/machine/machine_rp2.go
@@ -58,6 +58,10 @@ func machineInit() {
 
 	// Peripheral clocks should now all be running
 	unresetBlockWait(RESETS_RESET_Msk)
+
+	// DBGPAUSE pauses the timer when a debugger is connected. This prevents
+	// sleep functions from ever returning, so disable it.
+	timer.setDbgPause(false)
 }
 
 //go:linkname ticks runtime.machineTicks

--- a/src/machine/machine_rp2_timer.go
+++ b/src/machine/machine_rp2_timer.go
@@ -101,3 +101,15 @@ func (tmr *timerType) lightSleep(us uint64) {
 	// Disable interrupt
 	intr.Disable()
 }
+
+// setDbgPause sets whether this timer is paused when a debugger is connected.
+func (tmr *timerType) setDbgPause(enable bool) {
+	const bitPos = 1
+	const bitMask = 0b11
+	val := uint32(0b00)
+	if enable {
+		// Disable timer when debugger is connected to either core.
+		val = 0b11
+	}
+	tmr.dbgPause.ReplaceBits(val, bitMask, bitPos)
+}

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -311,15 +311,13 @@ func (l *spinLock) Lock() {
 	// Wait for the lock to be available.
 	spinlock := l.spinlock()
 	for spinlock.Get() == 0 {
-		// TODO: use wfe and send an event when unlocking so the CPU can go to
-		// sleep while waiting for the lock.
-		// Unfortunately when doing that, time.Sleep() seems to hang somewhere.
-		// This needs some debugging to figure out.
+		arm.Asm("wfe")
 	}
 }
 
 func (l *spinLock) Unlock() {
 	l.spinlock().Set(0)
+	arm.Asm("sev")
 }
 
 // Wait until a signal is received, indicating that it can resume from the

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -291,10 +291,10 @@ func coreStackTop(core uint32) uintptr {
 
 // These spinlocks are needed by the runtime.
 var (
-	printLock     = spinLock{id: 0}
-	schedulerLock = spinLock{id: 1}
-	atomicsLock   = spinLock{id: 2}
-	futexLock     = spinLock{id: 3}
+	printLock     = spinLock{id: 20}
+	schedulerLock = spinLock{id: 21}
+	atomicsLock   = spinLock{id: 22}
+	futexLock     = spinLock{id: 23}
 )
 
 // A hardware spinlock, one of the 32 spinlocks defined in the SIO peripheral.


### PR DESCRIPTION
DBGPAUSE pauses the timer used for sleep pauses when a debugger is attached, which gets annoying to debug. Might be related to https://github.com/tinygo-org/tinygo/blob/v0.39.0/src/runtime/runtime_rp2.go#L314