### PR TITLE
fix(rp2040): use int64 in ReadTemperature to avoid int32 overflow

### DIFF
--- a/src/machine/machine_rp2_adc.go
+++ b/src/machine/machine_rp2_adc.go
@@ -100,7 +100,8 @@ func ReadTemperature() (millicelsius int32) {
 	rp.ADC.CS.SetBits(rp.ADC_CS_TS_EN)
 
 	// T = 27 - (ADC_voltage - 0.706)/0.001721
-	return (27000<<16 - (int32(thermChan.getVoltage())-706<<16)*581) >> 16
+	// 1/0.001721 ≈ 581
+	return int32(((int64(27000) << 16) - ((int64(thermChan.getVoltage()) - (int64(706) << 16)) * 581)) >> 16)
 }
 
 // waitForReady spins waiting for the ADC peripheral to become ready.


### PR DESCRIPTION
### Summary
This PR fixes the implementation of `ReadTemperature` for the RP2040 target.  
The previous code used `int32` intermediates, which caused arithmetic overflow when the ADC voltage deviated more than ±56 mV from 706 mV.  
Since the internal temperature sensor of the RP2040 typically operates between 537 mV and 821 mV (-40°C to 125°C), overflow occurred in normal conditions.  
As a result, the function sometimes returned corrupted values such as `-31.8°C`.

### Changes
- Promote intermediate calculations in `ReadTemperature` (RP2040) to `int64`.
- Keep the return type `int32` (milli-°C) for API compatibility.

### Before (buggy)

temperature: 32.8℃
temperature: 32.8℃
temperature: -31.8℃
temperature: -31.8℃
...

### After (fixed)
temperature: 31.8℃
temperature: 32.8℃
temperature: 32.8℃
temperature: 32.8℃
temperature: 33.7℃
...

### Impact
- Prevents overflow in the normal RP2040 sensor range (-40°C to 125°C).
- Produces stable, monotonic readings without spurious negative jumps.
- No breaking API change.


