### PR TITLE
fix: point the submodule for musl-libc to TinyGo org mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/tinygo-org/stm32-svd
 [submodule "lib/musl"]
 	path = lib/musl
-	url = git://git.musl-libc.org/musl
+	url = https://github.com/tinygo-org/musl-libc.git
 [submodule "lib/binaryen"]
 	path = lib/binaryen
 	url = https://github.com/WebAssembly/binaryen.git


### PR DESCRIPTION
This PR fixes the intermittent CI errors by pointing the submodule for musl-libc to a mirror in the TinyGo GitHub org. The git server for git.musl-libc.org is having troubles, and it also seems like a safer bet to have our own mirror just in case.