### PR TITLE
fix: remove macOS 15 from CI build matrix. It was already being teste…

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -18,13 +18,11 @@ jobs:
       matrix:
         # macos-13: amd64 (oldest supported version as of 18-10-2024)
         # macos-14: arm64 (oldest arm64 version)
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-13, macos-14]
         include:
           - os: macos-13
             goarch: amd64
           - os: macos-14
-            goarch: arm64
-          - os: macos-15
             goarch: arm64
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/tinygo-org/stm32-svd
 [submodule "lib/musl"]
 	path = lib/musl
-	url = git://git.musl-libc.org/musl
+	url = https://github.com/tinygo-org/musl-libc.git
 [submodule "lib/binaryen"]
 	path = lib/binaryen
 	url = https://github.com/WebAssembly/binaryen.git


### PR DESCRIPTION
This PR fixes a build failure remove macOS 15 from CI build matrix. It is already being tested by the `test-macos-homebrew` job, and the build artifact conflicts with the actual build artifact that we want, which is built on macOS 14 for backwards-compatibility.

