### PR TITLE
Fix linker errors for `runtime.vgetrandom` and `crypto/internal/sysrand.fatal`

### DIFF
--- a/src/runtime/rand.go
+++ b/src/runtime/rand.go
@@ -1,0 +1,11 @@
+package runtime
+
+import _ "unsafe"
+
+// TODO: Use hardware when available
+//
+//go:linkname vgetrandom
+func vgetrandom(p []byte, flags uint32) (ret int, supported bool) { return 0, false }
+
+//go:linkname fatal crypto/internal/sysrand.fatal
+func fatal(msg string) { runtimePanic(msg) }

--- a/tests/os/smoke/smoke_test.go
+++ b/tests/os/smoke/smoke_test.go
@@ -4,6 +4,8 @@ package os_smoke_test
 // Intended to catch build tag mistakes affecting bare metal targets.
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -23,5 +25,12 @@ func TestFmt(t *testing.T) {
 		t.Errorf("printf returned error %s", err)
 	} else if n != 14 {
 		t.Errorf("printf returned %d, expected 14", n)
+	}
+}
+
+// Regression test for https://github.com/tinygo-org/tinygo/issues/4921
+func TestRand(t *testing.T) {
+	if _, err := rsa.GenerateKey(rand.Reader, 2048); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
Fixes #4921

This bug has been present since 0.36 or 0.37, as it's related to Go 1.24 changes to randomness. 

This PR includes a regression test. The easiest way I've found to exercise these private functions is to generate an RSA key.