### PR TITLE
fe310: add I2C pins for the HiFive1b

### DIFF
--- a/src/machine/board_fe310.go
+++ b/src/machine/board_fe310.go
@@ -15,8 +15,8 @@ const (
 	P09 Pin = 9
 	P10 Pin = 10
 	P11 Pin = 11
-	P12 Pin = 12
-	P13 Pin = 13
+	P12 Pin = 12 // peripherals: I2C0 SDA
+	P13 Pin = 13 // peripherals: I2C0 SCL
 	P14 Pin = 14
 	P15 Pin = 15
 	P16 Pin = 16


### PR DESCRIPTION
This extends https://github.com/tinygo-org/tinygo/pull/4952 with some missing pins.