### PR TITLE
interp: better errors when debugging interp

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -577,7 +577,7 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 						// runtime instead of at compile time. But we need to
 						// revert any changes made by the call first.
 						if r.debug {
-							fmt.Fprintln(os.Stderr, indent+"!! revert because of error:", callErr.Err)
+							fmt.Fprintln(os.Stderr, indent+"!! revert because of error:", callErr.Error())
 						}
 						callMem.revert()
 						err := r.runAtRuntime(fn, inst, locals, &mem, indent)


### PR DESCRIPTION
When debugging is enabled for interp, print better errors in a specific case.

Before:

    !! revert because of error: interp: unsupported instruction (to be emitted at runtime)

After:

    !! revert because of error: /usr/local/go1.24.0/src/regexp/syntax/parse.go:927:27: interp: unsupported instruction (to be emitted at runtime)

So this adds error location information, which can be quite useful.