### PR TITLE
runtime: fix sleep duration for long sleeps

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -43,8 +43,8 @@ func TestBinarySize(t *testing.T) {
 	tests := []sizeTest{
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3884, 280, 0, 2268},
-		{"microbit", "examples/serial", 2852, 360, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7337, 1491, 116, 6912},
+		{"microbit", "examples/serial", 2844, 360, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7349, 1491, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/runtime/runtime_atsamd21.go
+++ b/src/runtime/runtime_atsamd21.go
@@ -273,6 +273,9 @@ func nanosecondsToTicks(ns int64) timeUnit {
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks := uint32(d)
+		if d > 0xffff_ffff {
+			ticks = 0xffff_ffff
+		}
 		if !timerSleep(ticks) {
 			// Bail out early to handle a non-time interrupt.
 			return

--- a/src/runtime/runtime_atsamd51.go
+++ b/src/runtime/runtime_atsamd51.go
@@ -266,6 +266,9 @@ func nanosecondsToTicks(ns int64) timeUnit {
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks := uint32(d)
+		if d > 0xffff_ffff {
+			ticks = 0xffff_ffff
+		}
 		if !timerSleep(ticks) {
 			return
 		}

--- a/src/runtime/runtime_nrf.go
+++ b/src/runtime/runtime_nrf.go
@@ -78,6 +78,9 @@ func buffered() int {
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks := uint32(d) & 0x7fffff // 23 bits (to be on the safe side)
+		if d > 0x7fffff {
+			ticks = 0x7fffff
+		}
 		rtc_sleep(ticks)
 		d -= timeUnit(ticks)
 	}

--- a/src/runtime/runtime_nrf52840.go
+++ b/src/runtime/runtime_nrf52840.go
@@ -81,6 +81,9 @@ func buffered() int {
 func sleepTicks(d timeUnit) {
 	for d != 0 {
 		ticks := uint32(d) & 0x7fffff // 23 bits (to be on the safe side)
+		if d > 0x7fffff {
+			ticks = 0x7fffff
+		}
 		rtc_sleep(ticks)
 		d -= timeUnit(ticks)
 	}


### PR DESCRIPTION
Long sleep durations weren't implemented correctly, by simply casting to a smaller number of bits. What we want is a saturating downcast, which is what I've used here instead.

This should fix https://github.com/tinygo-org/tinygo/issues/3356.

---

Tested blinky on nrf52840 and samd21, didn't test any other board/chip.