### PR TITLE
fix ticker stop race condition by clearing period before removing timer

### DIFF
--- a/src/runtime/time_go122.go
+++ b/src/runtime/time_go122.go
@@ -53,6 +53,11 @@ func startTimer(tim *timer) {
 
 //go:linkname stopTimer time.stopTimer
 func stopTimer(tim *timer) bool {
+	// Set period to 0 to prevent the timer from being re-added to the queue
+	// if the callback is currently running. This must be done before removing
+	// the timer to avoid a race condition where the callback re-adds the timer
+	// after it's been removed.
+	tim.period = 0
 	return removeTimer(tim) != nil
 }
 

--- a/src/runtime/time_go123.go
+++ b/src/runtime/time_go123.go
@@ -52,6 +52,11 @@ func newTimer(when, period int64, f func(arg any, seq uintptr, delta int64), arg
 
 //go:linkname stopTimer time.stopTimer
 func stopTimer(tim *timeTimer) bool {
+	// Set period to 0 to prevent the timer from being re-added to the queue
+	// if the callback is currently running. This must be done before removing
+	// the timer to avoid a race condition where the callback re-adds the timer
+	// after it's been removed.
+	tim.timer.period = 0
 	return removeTimer(&tim.timer) != nil
 }
 


### PR DESCRIPTION
The job failed during the TestBuild/ARM64Linux/timers.go test. The log says: "fail: ticker should have stopped!" and "ticker was stopped (didn't send anything after 750ms)", indicating that the test expected the ticker to stop, but it did not behave as intended.

I was hitting this error in CI, so I [asked ](https://github.com/cataggar/tinygo/issues/4)Copilot to fix it and the fix looks good to me. At least the tests now pass.