### PR TITLE
fix(rp2): possible integer overflow while computing factors for SPI  baudrate

### DIFF
--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -108,7 +108,7 @@ func (spi *SPI) SetBaudRate(br uint32) error {
 	var prescale, postdiv uint32
 	freq := CPUFrequency()
 	for prescale = 2; prescale < 255; prescale += 2 {
-		if freq < (prescale+2)*256*br {
+		if uint64(freq) < uint64((prescale+2)*256)*uint64(br) {
 			break
 		}
 	}


### PR DESCRIPTION
Because of integer overflows incorrect factors are calculated for baudrates which are a bit larger than integer multiples of 4194304.
For example for baudrates of 8_400_000 or 58_800_000. Fixed the same way in newer versions of the pico SDK.