### PR TITLE
compileopts: lower "large stack" limit to 16kb

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -226,7 +226,7 @@ func (c *Config) StackSize() uint64 {
 
 // MaxStackAlloc returns the size of the maximum allocation to put on the stack vs heap.
 func (c *Config) MaxStackAlloc() uint64 {
-	if c.StackSize() > 32*1024 {
+	if c.StackSize() >= 16*1024 {
 		return 1024
 	}
 


### PR DESCRIPTION
I'm running with `-stack-size 16kb` and running into excessive allocations because the otherwise non-escaping buffer in

https://github.com/golang/go/blob/c53cb642deea152e28281133bc0053f5ec0ce358/src/crypto/internal/fips140/sha512/sha512block.go#L97

is moved to the heap.