### PR TITLE
machine: use larger SPI MAXCNT on nrf52833 and nrf52840

### DIFF
--- a/src/machine/machine_nrf52.go
+++ b/src/machine/machine_nrf52.go
@@ -69,3 +69,5 @@ const eraseBlockSizeValue = 4096
 func eraseBlockSize() int64 {
 	return eraseBlockSizeValue
 }
+
+const spiMaxBufferSize = 255 // from the datasheet: TXD.MAXCNT and RXD.MAXCNT

--- a/src/machine/machine_nrf52833.go
+++ b/src/machine/machine_nrf52833.go
@@ -90,3 +90,5 @@ const eraseBlockSizeValue = 4096
 func eraseBlockSize() int64 {
 	return eraseBlockSizeValue
 }
+
+const spiMaxBufferSize = 0xffff // from the datasheet: TXD.MAXCNT and RXD.MAXCNT

--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -108,3 +108,5 @@ const eraseBlockSizeValue = 4096
 func eraseBlockSize() int64 {
 	return eraseBlockSizeValue
 }
+
+const spiMaxBufferSize = 0xffff // from the datasheet: TXD.MAXCNT and RXD.MAXCNT


### PR DESCRIPTION
These chips have a larger upper limit for the DMA transfer than the nrf52832. For best performance, we should be splitting the transfer in as large blocks as possible on the given hardware.