### PR TITLE
feature: Add flag to ignore go compatibility matrix

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -33,10 +33,13 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if gorootMajor != 1 || gorootMinor < minorMin || gorootMinor > minorMax {
-		// Note: when this gets updated, also update the Go compatibility matrix:
-		// https://github.com/tinygo-org/tinygo-site/blob/dev/content/docs/reference/go-compat-matrix.md
-		return nil, fmt.Errorf("requires go version 1.%d through 1.%d, got go%d.%d", minorMin, minorMax, gorootMajor, gorootMinor)
+
+	if options.GoCompatibility {
+		if gorootMajor != 1 || gorootMinor < minorMin || gorootMinor > minorMax {
+			// Note: when this gets updated, also update the Go compatibility matrix:
+			// https://github.com/tinygo-org/tinygo-site/blob/dev/content/docs/reference/go-compat-matrix.md
+			return nil, fmt.Errorf("requires go version 1.%d through 1.%d, got go%d.%d", minorMin, minorMax, gorootMajor, gorootMinor)
+		}
 	}
 
 	// Check that the Go toolchain version isn't too new, if we haven't been

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	WITPackage      string // pass through to wasm-tools component embed invocation
 	WITWorld        string // pass through to wasm-tools component embed -w option
 	ExtLDFlags      []string
+	GoCompatibility bool // enable to check for Go version compatibility
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/main.go
+++ b/main.go
@@ -1635,6 +1635,7 @@ func main() {
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
 	baudrate := flag.Int("baudrate", 115200, "baudrate of serial monitor")
+	gocompatibility := flag.Bool("go-compatibility", true, "enable to check for Go versions compatibility, you can also configure this by setting the TINYGOGOCOMPATIBILITY environment variable")
 
 	// Internal flags, that are only intended for TinyGo development.
 	printIR := flag.Bool("internal-printir", false, "print LLVM IR")
@@ -1712,6 +1713,16 @@ func main() {
 		ocdCommands = strings.Split(*ocdCommandsString, ",")
 	}
 
+	val, ok := os.LookupEnv("TINYGOGOCOMPATIBILITY")
+	if ok {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not parse TINYGOGOCOMPATIBILITY value %q: %v\n", val, err)
+			os.Exit(1)
+		}
+		*gocompatibility = b
+	}
+
 	options := &compileopts.Options{
 		GOOS:            goenv.Get("GOOS"),
 		GOARCH:          goenv.Get("GOARCH"),
@@ -1748,6 +1759,7 @@ func main() {
 		Timeout:         *timeout,
 		WITPackage:      witPackage,
 		WITWorld:        witWorld,
+		GoCompatibility: *gocompatibility,
 	}
 	if *printCommands {
 		options.PrintCommands = printCommand

--- a/main.go
+++ b/main.go
@@ -1713,11 +1713,11 @@ func main() {
 		ocdCommands = strings.Split(*ocdCommandsString, ",")
 	}
 
-	val, ok := os.LookupEnv("TINYGOGOCOMPATIBILITY")
+	val, ok := os.LookupEnv("TINYGO_GOCOMPATIBILITY")
 	if ok {
 		b, err := strconv.ParseBool(val)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not parse TINYGOGOCOMPATIBILITY value %q: %v\n", val, err)
+			fmt.Fprintf(os.Stderr, "could not parse TINYGO_GOCOMPATIBILITY value %q: %v\n", val, err)
 			os.Exit(1)
 		}
 		*gocompatibility = b

--- a/main.go
+++ b/main.go
@@ -1635,7 +1635,7 @@ func main() {
 	cpuprofile := flag.String("cpuprofile", "", "cpuprofile output")
 	monitor := flag.Bool("monitor", false, "enable serial monitor")
 	baudrate := flag.Int("baudrate", 115200, "baudrate of serial monitor")
-	gocompatibility := flag.Bool("go-compatibility", true, "enable to check for Go versions compatibility, you can also configure this by setting the TINYGOGOCOMPATIBILITY environment variable")
+	gocompatibility := flag.Bool("go-compatibility", true, "enable to check for Go versions compatibility, you can also configure this by setting the TINYGO_GOCOMPATIBILITY environment variable")
 
 	// Internal flags, that are only intended for TinyGo development.
 	printIR := flag.Bool("internal-printir", false, "print LLVM IR")


### PR DESCRIPTION
close #5075 

I define no-compatibility option to skip checking whether the version is within the supported Go version. By this, though this option enables us to do TinyGo with unsupported version, it's not what we recommend. It's just the way to avoid stable support.