### PR TITLE
ci: update GH actions builds to use Go 1.25.4

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -134,7 +134,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.3'
+          go-version: '1.25.4'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This PR updates all GH actions builds to use the new Go 1.25.4 release.