### PR TITLE
build: use the task scheduler on macOS builds to avoid test race failures

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build TinyGo release tarball
         run: make release -j3
       - name: Test stdlib packages
-        run: make tinygo-test
+        run: make tinygo-test TEST_ADDITIONAL_FLAGS="-scheduler=tasks"
       - name: Make release artifact
         run: cp -p build/release.tar.gz build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -481,6 +481,7 @@ TEST_IOFS := false
 endif
 
 TEST_SKIP_FLAG := -skip='TestExtraMethods|TestParseAndBytesRoundTrip/P256/Generic'
+TEST_ADDITIONAL_FLAGS ?=
 
 # Test known-working standard library packages.
 # TODO: parallelize, and only show failing tests (no implied -v flag).
@@ -488,7 +489,7 @@ TEST_SKIP_FLAG := -skip='TestExtraMethods|TestParseAndBytesRoundTrip/P256/Generi
 tinygo-test:
 	@# TestExtraMethods: used by many crypto packages and uses reflect.Type.Method which is not implemented.
 	@# TestParseAndBytesRoundTrip/P256/Generic: relies on t.Skip() which is not implemented
-	$(TINYGO) test $(TEST_SKIP_FLAG) $(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW)
 	@# io/fs requires os.ReadDir, not yet supported on windows or wasi. It also
 	@# requires a large stack-size. Hence, io/fs is only run conditionally.
 	@# For more details, see the comments on issue #3143.


### PR DESCRIPTION
This PR modifies the build to use the task scheduler on macOS builds to avoid the test race condition lockup from #4995 