### PR TITLE
test: update the test corpus to comment out hanging tests

### DIFF
--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -157,7 +157,7 @@
   - pkg: encoding/ianaindex
   - pkg: encoding/japanese
   - pkg: encoding/korean
-  - pkg: encoding/simplifiedchinese
+  # - pkg: encoding/simplifiedchinese -- causes Linux to hang
   - pkg: encoding/traditionalchinese
   - pkg: encoding/unicode
   - pkg: encoding/unicode/utf32
@@ -234,7 +234,7 @@
     slow: true
   - pkg: mathext
   - pkg: mathext/prng
-  - pkg: optimize/convex/lp
+  # - pkg: optimize/convex/lp --  causes Linux to hang.
     skipwasi: true # takes too long
   - pkg: optimize/functions
   - pkg: spatial/r2


### PR DESCRIPTION
This PR updates the test corpus to comment out 2 tests that currently cause Linux to hang. Thanks to @niaow for pointing this out.