### PR TITLE
compiler: use Tarjan's SCC algorithm to detect loops for defer

### DIFF
--- a/compiler/asserts.go
+++ b/compiler/asserts.go
@@ -245,7 +245,7 @@ func (b *builder) createRuntimeAssert(assert llvm.Value, blockPrefix, assertFunc
 	// current insert position.
 	faultBlock := b.ctx.AddBasicBlock(b.llvmFn, blockPrefix+".throw")
 	nextBlock := b.insertBasicBlock(blockPrefix + ".next")
-	b.blockExits[b.currentBlock] = nextBlock // adjust outgoing block for phi nodes
+	b.currentBlockInfo.exit = nextBlock // adjust outgoing block for phi nodes
 
 	// Now branch to the out-of-bounds or the regular block.
 	b.CreateCondBr(assert, faultBlock, nextBlock)

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -737,7 +737,7 @@ func (b *builder) createTypeAssert(expr *ssa.TypeAssert) llvm.Value {
 	prevBlock := b.GetInsertBlock()
 	okBlock := b.insertBasicBlock("typeassert.ok")
 	nextBlock := b.insertBasicBlock("typeassert.next")
-	b.blockExits[b.currentBlock] = nextBlock // adjust outgoing block for phi nodes
+	b.currentBlockInfo.exit = nextBlock // adjust outgoing block for phi nodes
 	b.CreateCondBr(commaOk, okBlock, nextBlock)
 
 	// Retrieve the value from the interface if the type assert was

--- a/compiler/testdata/defer.go
+++ b/compiler/testdata/defer.go
@@ -18,3 +18,23 @@ func deferMultiple() {
 	}()
 	external()
 }
+
+func deferInfiniteLoop() {
+	for {
+		defer print(8)
+	}
+}
+
+func deferLoop() {
+	for i := 0; i < 10; i++ {
+		defer print(i)
+	}
+}
+
+func deferBetweenLoops() {
+	for i := 0; i < 10; i++ {
+	}
+	defer print(1)
+	for i := 0; i < 10; i++ {
+	}
+}


### PR DESCRIPTION
The compiler needs to know whether a defer is in a loop to determine whether to allocate stack or heap memory. Previously, this performed a DFS of the CFG every time a defer was found. This resulted in time complexity jointly proportional to the number of defers and the number of blocks in the function.

Now, the compiler will instead use Tarjan's strongly connected components algorithm to find cycles in linear time. The search is performed lazily, so this has minimal performance impact on functions without defers.

In order to implement Tarjan's SCC algorithm, additional state needed to be attached to the blocks. I chose to merge all of the per-block state into a single slice to simplify memory management.