### PR TITLE
internal/task: create detatched threads and fix error handling

### DIFF
--- a/src/internal/task/task_threads.c
+++ b/src/internal/task/task_threads.c
@@ -120,9 +120,13 @@ int tinygo_task_start(uintptr_t fn, void *args, void *task, pthread_t *thread, u
     #endif
     pthread_attr_t attrs;
     pthread_attr_init(&attrs);
+	pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
     pthread_attr_setstacksize(&attrs, stackSize);
     int result = pthread_create(thread, &attrs, &start_wrapper, &state);
     pthread_attr_destroy(&attrs);
+	if (result != 0) {
+		return result;
+	}
 
     // Wait until the thread has been created and read all state_pass variables.
     #if __APPLE__


### PR DESCRIPTION
Previously, we created joinable threads.
As a result, all threads would be kept alive after completion so that pthread_join could wait for them. We never call pthread_join, so threads would never get cleaned up.

Additionally, the thread creation error check was performed after waiting for the thread to start. If pthread_create failed, the caller would get stuck waiting for a thread that was never created.