### PR TITLE
runtime (gc_boehm.go): fix world already stopped check

### DIFF
--- a/src/runtime/gc_boehm.go
+++ b/src/runtime/gc_boehm.go
@@ -48,17 +48,17 @@ func gcInit()
 
 //export tinygo_runtime_bdwgc_callback
 func gcCallback() {
+	if hasParallelism && needsResumeWorld {
+		// Should never happen, check for it anyway.
+		runtimePanic("gc: world already stopped")
+	}
+
 	// Mark globals and all stacks, and stop the world if we're using threading.
 	gcMarkReachable()
 
 	// If we use a scheduler with parallelism (the threads scheduler for
 	// example), we need to call gcResumeWorld() after scanning has finished.
 	if hasParallelism {
-		if needsResumeWorld {
-			// Should never happen, check for it anyway.
-			runtimePanic("gc: world already stopped")
-		}
-
 		// Note that we need to resume the world after finishing the GC call.
 		needsResumeWorld = true
 	}


### PR DESCRIPTION
This fixes the "gc: world already stopped" check by moving it before `gcMarkReachable`. Previously the check did not work because `gcMarkReachable` would hang while waiting for `activeTaskLock`.

This does not fix the underlying issue (#5084), but it should provide necessary context when it does trigger. I still don't quite understand why this is happening.