### PR TITLE
nrf: don't block SPI transfer

### DIFF
--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -335,6 +335,7 @@ func (spi *SPI) Tx(w, r []byte) error {
 		// finished if the transfer is send-only (a common case).
 		spi.Bus.TASKS_START.Set(1)
 		for spi.Bus.EVENTS_END.Get() == 0 {
+			gosched()
 		}
 		spi.Bus.EVENTS_END.Set(0)
 	}


### PR DESCRIPTION
Ideally we'd use something like
https://github.com/tinygo-org/tinygo/pull/5016 but that's a bit more involved. As a quick improvement, call gosched() instead.

Example where I use this: a custom WS2812 driver that uses SPI to transfer the data. It's useful to be able to switch back to the main goroutine during the transfer to render the next LED update.