### PR TITLE
Add goroutine core affinity support for RP2040/RP2350 systems 

### DIFF
--- a/src/examples/core-pinning/main.go
+++ b/src/examples/core-pinning/main.go
@@ -1,47 +1,60 @@
 // This example demonstrates goroutine core pinning on multi-core systems (RP2040/RP2350).
 // It shows how to pin goroutines to specific CPU cores and verify their execution.
-//
 
 //go:build rp2040 || rp2350
 
 package main
 
 import (
+	"machine"
 	"runtime"
 	"time"
 )
 
 func main() {
+	time.Sleep(5 * time.Second)
 	println("=== Core Pinning Example ===")
 	println("Number of CPU cores:", runtime.NumCPU())
-	println("Main starting on core:", runtime.CurrentCPU())
+	println("[main] Main starting on core:", machine.CurrentCore())
 	println()
 
-	// Pin main goroutine to core 0
-	runtime.LockToCore(0)
-	println("Main pinned to core:", runtime.GetAffinity())
+	// Example 1: Pin using standard Go API (LockOSThread)
+	// This pins to whichever core this goroutine is currently running on
+	runtime.LockOSThread()
+	println("[main] Pinned using runtime.LockOSThread()")
+	println("[main] Running on core:", machine.CurrentCore())
+	runtime.UnlockOSThread()
+	println("[main] Unpinned using runtime.UnlockOSThread()")
+	println()
+
+	// Example 2: Pin to a specific core using machine package
+	machine.LockCore(0)
+	println("[main] Explicitly pinned to core 0 using machine.LockCore()")
 	println()
 
 	// Start a goroutine pinned to core 1
 	go core1Worker()
+
+	// Start a goroutine using standard LockOSThread
+	go standardLockWorker()
 
 	// Start an unpinned goroutine (can run on either core)
 	go unpinnedWorker()
 
 	// Main loop on core 0
 	for i := 0; i < 10; i++ {
-		println("Core 0 (main):", i, "on CPU", runtime.CurrentCPU())
+		println("[main] loop", i, "on CPU", machine.CurrentCore())
 		time.Sleep(500 * time.Millisecond)
 	}
 
 	// Unpin and let main run on any core
-	runtime.UnlockFromCore()
+	machine.UnlockCore()
 	println()
-	println("Main unpinned, affinity:", runtime.GetAffinity())
+	println("[main] Unpinned using machine.UnlockCore()")
 
-	// Continue running for a bit to show migration
+	// Continue running for a bit to show potential migration
 	for i := 0; i < 5; i++ {
-		println("Unpinned main on CPU", runtime.CurrentCPU())
+		println("[main] unpinned loop on CPU", machine.CurrentCore())
 		time.Sleep(500 * time.Millisecond)
 	}
 
@@ -49,32 +62,50 @@ func main() {
 	println("Example complete!")
 }
 
-// Worker function that runs on core 1
+// Worker function that pins to core 1 using explicit core selection
 func core1Worker() {
-	// Pin this goroutine to core 1
-	runtime.LockToCore(1)
-	println("Worker pinned to core:", runtime.GetAffinity())
+	// Pin this goroutine to core 1 explicitly
+	machine.LockCore(1)
+	println("[core1-worker] Worker pinned to core 1 using machine.LockCore()")
 
 	for i := 0; i < 10; i++ {
-		println("  Core 1 (worker):", i, "on CPU", runtime.CurrentCPU())
+		println("[core1-worker] loop", i, "on CPU", machine.CurrentCore())
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	println("  Core 1 worker finished")
+	println("[core1-worker] Finished")
+}
+
+// Worker function that uses standard Go LockOSThread()
+func standardLockWorker() {
+	// Pin this goroutine to whichever core it starts on
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	core := machine.CurrentCore()
+	println("[std-lock-worker] Worker locked using runtime.LockOSThread()")
+	println("[std-lock-worker] Running on core:", core)
+
+	for i := 0; i < 10; i++ {
+		println("[std-lock-worker] loop", i, "on CPU", machine.CurrentCore())
+		time.Sleep(600 * time.Millisecond)
+	}
+
+	println("[std-lock-worker] Finished")
 }
 
 // Worker function that is not pinned (can run on any core)
 func unpinnedWorker() {
-	println("Unpinned worker starting, affinity:", runtime.GetAffinity())
+	println("[unpinned-worker] Starting")
 
 	for i := 0; i < 10; i++ {
-		cpu := runtime.CurrentCPU()
-		println("    Unpinned worker:", i, "on CPU", cpu)
+		cpu := machine.CurrentCore()
+		println("[unpinned-worker] loop", i, "on CPU", cpu)
 		time.Sleep(700 * time.Millisecond)
 
 		// Yield to potentially migrate to another core
 		runtime.Gosched()
 	}
 
-	println("    Unpinned worker finished")
+	println("[unpinned-worker] Finished")
 }

--- a/src/examples/core-pinning/main.go
+++ b/src/examples/core-pinning/main.go
@@ -1,0 +1,80 @@
+// This example demonstrates goroutine core pinning on multi-core systems (RP2040/RP2350).
+// It shows how to pin goroutines to specific CPU cores and verify their execution.
+//
+
+//go:build rp2040 || rp2350
+
+package main
+
+import (
+	"runtime"
+	"time"
+)
+
+func main() {
+	println("=== Core Pinning Example ===")
+	println("Number of CPU cores:", runtime.NumCPU())
+	println("Main starting on core:", runtime.CurrentCPU())
+	println()
+
+	// Pin main goroutine to core 0
+	runtime.LockToCore(0)
+	println("Main pinned to core:", runtime.GetAffinity())
+	println()
+
+	// Start a goroutine pinned to core 1
+	go core1Worker()
+
+	// Start an unpinned goroutine (can run on either core)
+	go unpinnedWorker()
+
+	// Main loop on core 0
+	for i := 0; i < 10; i++ {
+		println("Core 0 (main):", i, "on CPU", runtime.CurrentCPU())
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Unpin and let main run on any core
+	runtime.UnlockFromCore()
+	println()
+	println("Main unpinned, affinity:", runtime.GetAffinity())
+
+	// Continue running for a bit to show migration
+	for i := 0; i < 5; i++ {
+		println("Unpinned main on CPU", runtime.CurrentCPU())
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	println()
+	println("Example complete!")
+}
+
+// Worker function that runs on core 1
+func core1Worker() {
+	// Pin this goroutine to core 1
+	runtime.LockToCore(1)
+	println("Worker pinned to core:", runtime.GetAffinity())
+
+	for i := 0; i < 10; i++ {
+		println("  Core 1 (worker):", i, "on CPU", runtime.CurrentCPU())
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	println("  Core 1 worker finished")
+}
+
+// Worker function that is not pinned (can run on any core)
+func unpinnedWorker() {
+	println("Unpinned worker starting, affinity:", runtime.GetAffinity())
+
+	for i := 0; i < 10; i++ {
+		cpu := runtime.CurrentCPU()
+		println("    Unpinned worker:", i, "on CPU", cpu)
+		time.Sleep(700 * time.Millisecond)
+
+		// Yield to potentially migrate to another core
+		runtime.Gosched()
+	}
+
+	println("    Unpinned worker finished")
+}

--- a/src/internal/task/task.go
+++ b/src/internal/task/task.go
@@ -29,6 +29,14 @@ type Task struct {
 	// since it falls into the padding of the FipsIndicator bit above.
 	RunState uint8
 
+	// Affinity specifies which CPU core this task should run on.
+	// -1 means no affinity (can run on any core)
+	// 0, 1, etc. means pinned to that specific core
+	// To be used ONLY with the "cores" scheduler.
+	// By default, all goroutines are unpinned (Affinity = -1)
+	// Pinning takes effect at the next scheduling point (e.g., after time.Sleep(), channel operations, or runtime.Gosched())
+	Affinity int8
+
 	// DeferFrame stores a pointer to the (stack allocated) defer frame of the
 	// goroutine that is used for the recover builtin.
 	DeferFrame unsafe.Pointer

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -28,7 +28,6 @@ func LockCore(core int) {
 		panic("machine: core out of range")
 	}
 	machineLockCore(core)
-	runtime.Gosched()
 }
 
 // UnlockCore unpins the calling goroutine, allowing it to run on any available core.

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -1,0 +1,26 @@
+//go:build (rp2040 || rp2350) && scheduler.cores
+
+package machine
+
+const numCPU = 2 // RP2040 and RP2350 both have 2 cores
+
+// LockCore implementation for the cores scheduler.
+func LockCore(core int) {
+	if core < 0 || core >= numCPU {
+		panic("machine: core out of range")
+	}
+	machineLockCore(core)
+}
+
+// UnlockCore implementation for the cores scheduler.
+func UnlockCore() {
+	machineUnlockCore()
+}
+
+// Internal functions implemented in runtime/scheduler_cores.go
+//
+//go:linkname machineLockCore runtime.machineLockCore
+func machineLockCore(core int)
+
+//go:linkname machineUnlockCore runtime.machineUnlockCore
+func machineUnlockCore()

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -4,7 +4,32 @@ package machine
 
 const numCPU = 2 // RP2040 and RP2350 both have 2 cores
 
-// LockCore implementation for the cores scheduler.
+// LockCore sets the affinity for the current goroutine to the specified core.
+// This does not immediately migrate the goroutine; migration occurs at the next
+// scheduling point. See machine_rp2.go for full documentation.
+// Important: LockCore sets the affinity but does not immediately migrate the
+// goroutine to the target core. The actual migration happens at the next
+// scheduling point (e.g., channel operation, time.Sleep, or Gosched). After
+// that point, the goroutine will wait in the target core's queue if that core
+// is busy running another goroutine.
+//
+// To avoid potential blocking on a busy core, consider calling LockCore in an
+// init function before any other goroutines have started. This guarantees the
+// target core is available.
+//
+// This is useful for:
+//   - Isolating time-critical operations to a dedicated core
+//   - Improving cache locality for performance-sensitive code
+//   - Exclusive access to core-local resources
+//
+// Warning: Pinning goroutines can lead to load imbalance. The goroutine will
+// wait in the specified core's queue even if other cores are idle. If a
+// long-running goroutine occupies the target core, LockCore may appear to
+// block indefinitely (until the next scheduling point on the target core).
+//
+// Valid core values are 0 and 1. Panics if core is out of range.
+//
+// Only available on RP2040 and RP2350 with the "cores" scheduler.
 func LockCore(core int) {
 	if core < 0 || core >= numCPU {
 		panic("machine: core out of range")
@@ -12,7 +37,13 @@ func LockCore(core int) {
 	machineLockCore(core)
 }
 
-// UnlockCore implementation for the cores scheduler.
+// UnlockCore unpins the calling goroutine, allowing it to run on any available core.
+// This undoes a previous call to LockCore.
+//
+// After calling UnlockCore, the scheduler is free to schedule the goroutine on
+// any core for automatic load balancing.
+//
+// Only available on RP2040 and RP2350 with the "cores" scheduler.
 func UnlockCore() {
 	machineUnlockCore()
 }

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -2,8 +2,6 @@
 
 package machine
 
-import "runtime"
-
 const numCPU = 2 // RP2040 and RP2350 both have 2 cores
 
 // LockCore sets the affinity for the current goroutine to the specified core.

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -9,11 +9,6 @@ const numCPU = 2 // RP2040 and RP2350 both have 2 cores
 // LockCore sets the affinity for the current goroutine to the specified core.
 // This does not immediately migrate the goroutine; migration occurs at the next
 // scheduling point. See machine_rp2.go for full documentation.
-// Important: LockCore sets the affinity but does not immediately migrate the
-// goroutine to the target core. The actual migration happens at the next
-// scheduling point (e.g., channel operation, time.Sleep, or Gosched). After
-// that point, the goroutine will wait in the target core's queue if that core
-// is busy running another goroutine.
 //
 // To avoid potential blocking on a busy core, consider calling LockCore in an
 // init function before any other goroutines have started. This guarantees the
@@ -28,10 +23,6 @@ const numCPU = 2 // RP2040 and RP2350 both have 2 cores
 // wait in the specified core's queue even if other cores are idle. If a
 // long-running goroutine occupies the target core, LockCore may appear to
 // block indefinitely (until the next scheduling point on the target core).
-//
-// Valid core values are 0 and 1. Panics if core is out of range.
-//
-// Only available on RP2040 and RP2350 with the "cores" scheduler.
 func LockCore(core int) {
 	if core < 0 || core >= numCPU {
 		panic("machine: core out of range")

--- a/src/machine/machine_rp2_cores.go
+++ b/src/machine/machine_rp2_cores.go
@@ -2,6 +2,8 @@
 
 package machine
 
+import "runtime"
+
 const numCPU = 2 // RP2040 and RP2350 both have 2 cores
 
 // LockCore sets the affinity for the current goroutine to the specified core.
@@ -35,6 +37,7 @@ func LockCore(core int) {
 		panic("machine: core out of range")
 	}
 	machineLockCore(core)
+	runtime.Gosched()
 }
 
 // UnlockCore unpins the calling goroutine, allowing it to run on any available core.

--- a/src/machine/machine_rp2_nocores.go
+++ b/src/machine/machine_rp2_nocores.go
@@ -1,0 +1,15 @@
+//go:build (rp2040 || rp2350) && !scheduler.cores
+
+package machine
+
+// LockCore is not available without the cores scheduler.
+// This is a stub that panics.
+func LockCore(core int) {
+	panic("machine.LockCore: not available without scheduler.cores")
+}
+
+// UnlockCore is not available without the cores scheduler.
+// This is a stub that panics.
+func UnlockCore() {
+	panic("machine.UnlockCore: not available without scheduler.cores")
+}

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -100,6 +100,9 @@ func os_sigpipe() {
 // LockOSThread wires the calling goroutine to its current operating system thread.
 // On microcontrollers with multiple cores (e.g., RP2040/RP2350), this pins the
 // goroutine to the core it's currently running on.
+// With the "cores" scheduler on RP2040/RP2350, this pins the goroutine to the
+// core it's currently running on. The pinning takes effect at the next
+// scheduling point (e.g., channel operation, time.Sleep, or Gosched).
 // Called by go1.18 standard library on windows, see https://github.com/golang/go/issues/49320
 func LockOSThread() {
 	lockOSThreadImpl()
@@ -108,6 +111,8 @@ func LockOSThread() {
 // UnlockOSThread undoes an earlier call to LockOSThread.
 // On microcontrollers with multiple cores, this unpins the goroutine, allowing
 // it to run on any available core.
+// With the "cores" scheduler, this unpins the goroutine, allowing it to run on
+// any available core.
 func UnlockOSThread() {
 	unlockOSThreadImpl()
 }

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -98,14 +98,18 @@ func os_sigpipe() {
 }
 
 // LockOSThread wires the calling goroutine to its current operating system thread.
-// Stub for now
+// On microcontrollers with multiple cores (e.g., RP2040/RP2350), this pins the
+// goroutine to the core it's currently running on.
 // Called by go1.18 standard library on windows, see https://github.com/golang/go/issues/49320
 func LockOSThread() {
+	lockOSThreadImpl()
 }
 
 // UnlockOSThread undoes an earlier call to LockOSThread.
-// Stub for now
+// On microcontrollers with multiple cores, this unpins the goroutine, allowing
+// it to run on any available core.
 func UnlockOSThread() {
+	unlockOSThreadImpl()
 }
 
 // KeepAlive makes sure the value in the interface is alive until at least the

--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -261,6 +261,16 @@ func unlockAtomics(mask interrupt.State) {
 	interrupt.Restore(mask)
 }
 
+// lockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func lockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}
+
+// unlockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func unlockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}
+
 func printlock() {
 	// nothing to do
 }

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -22,8 +22,9 @@ var secondaryCoresStarted bool
 var cpuTasks [numCPU]*task.Task
 
 var (
-	sleepQueue *task.Task
-	runqueue   task.Queue
+	sleepQueue     *task.Task
+	runqueueShared task.Queue         // For unpinned tasks (affinity = -1)
+	runqueueCore   [numCPU]task.Queue // Per-core queues for pinned tasks
 )
 
 func deadlock() {
@@ -39,8 +40,14 @@ func scheduleTask(t *task.Task) {
 	switch t.RunState {
 	case task.RunStatePaused:
 		// Paused, state is saved on the stack.
-		// Add it to the runqueue...
-		runqueue.Push(t)
+		// Route to appropriate queue based on affinity.
+		if t.Affinity >= 0 && t.Affinity < numCPU {
+			// Pinned to specific core
+			runqueueCore[t.Affinity].Push(t)
+		} else {
+			// Not pinned, use shared queue
+			runqueueShared.Push(t)
+		}
 		// ...and wake up a sleeping core, if there is one.
 		// (If all cores are already busy, this is a no-op).
 		schedulerWake()
@@ -86,13 +93,68 @@ func addSleepTask(t *task.Task, wakeup timeUnit) {
 
 func Gosched() {
 	schedulerLock.Lock()
-	runqueue.Push(task.Current())
+	t := task.Current()
+
+	// Respect affinity when re-queueing.
+	if t.Affinity >= 0 && t.Affinity < numCPU {
+		runqueueCore[t.Affinity].Push(t)
+	} else {
+		runqueueShared.Push(t)
+	}
+
 	task.PauseLocked()
 }
 
 // NumCPU returns the number of CPU cores on this system.
 func NumCPU() int {
 	return numCPU
+}
+
+// CurrentCPU returns the current CPU core number.
+// On RP2040/RP2350, this returns 0 or 1.
+func CurrentCPU() int {
+	return int(currentCPU())
+}
+
+// LockToCore pins the current goroutine to the specified CPU core.
+// Use core = -1 to unpin (allow running on any core).
+// Use core = 0 or 1 to pin to a specific core.
+// Panics if core is invalid (not -1, 0, or 1 on RP2040/RP2350).
+func LockToCore(core int) {
+	if core < -1 || core >= numCPU {
+		panic("runtime: invalid core number")
+	}
+
+	schedulerLock.Lock()
+	t := task.Current()
+	if t != nil {
+		t.Affinity = int8(core)
+	}
+	schedulerLock.Unlock()
+}
+
+// UnlockFromCore unpins the current goroutine, allowing it to run on any core.
+// This is equivalent to LockToCore(-1).
+func UnlockFromCore() {
+	schedulerLock.Lock()
+	t := task.Current()
+	if t != nil {
+		t.Affinity = -1
+	}
+	schedulerLock.Unlock()
+}
+
+// GetAffinity returns the CPU core affinity of the current goroutine.
+// Returns -1 if not pinned, or 0/1 if pinned to a specific core.
+func GetAffinity() int {
+	schedulerLock.Lock()
+	t := task.Current()
+	affinity := -1
+	if t != nil {
+		affinity = int(t.Affinity)
+	}
+	schedulerLock.Unlock()
+	return affinity
 }
 
 func addTimer(tn *timerNode) {
@@ -110,7 +172,7 @@ func removeTimer(t *timer) *timerNode {
 }
 
 func schedulerRunQueue() *task.Queue {
-	return &runqueue
+	return &runqueueShared
 }
 
 // Pause the current task for a given time.
@@ -160,9 +222,33 @@ func run() {
 }
 
 func scheduler(_ bool) {
+	currentCore := int(currentCPU())
+
 	for mainExited.Load() == 0 {
 		// Check for ready-to-run tasks.
-		if runnable := runqueue.Pop(); runnable != nil {
+		// First, try to get a task pinned to this core.
+		var runnable *task.Task
+		if currentCore < numCPU {
+			runnable = runqueueCore[currentCore].Pop()
+		}
+
+		// If no pinned tasks, try the shared queue.
+		if runnable == nil {
+			runnable = runqueueShared.Pop()
+		}
+
+		if runnable != nil {
+			// Verify affinity constraint (sanity check).
+			if runnable.Affinity >= 0 && runnable.Affinity != int8(currentCore) {
+				// Shouldn't happen, but put it back on correct queue.
+				if runnable.Affinity < numCPU {
+					runqueueCore[runnable.Affinity].Push(runnable)
+				} else {
+					runqueueShared.Push(runnable)
+				}
+				continue
+			}
+
 			// Resume it now.
 			setCurrentTask(runnable)
 			runnable.RunState = task.RunStateRunning
@@ -182,6 +268,19 @@ func scheduler(_ bool) {
 				// It is, pop it from the queue.
 				sleepQueue = sleepQueue.Next
 				sleepingTask.Next = nil
+
+				// Check affinity before running.
+				if sleepingTask.Affinity >= 0 && sleepingTask.Affinity != int8(currentCore) {
+					// Task is pinned to a different core, re-queue it.
+					sleepingTask.RunState = task.RunStatePaused
+					if sleepingTask.Affinity < numCPU {
+						runqueueCore[sleepingTask.Affinity].Push(sleepingTask)
+					} else {
+						runqueueShared.Push(sleepingTask)
+					}
+					schedulerWake()
+					continue
+				}
 
 				// Run it now.
 				setCurrentTask(sleepingTask)

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -128,6 +128,7 @@ func machineLockCore(core int) {
 		t.Affinity = int8(core)
 	}
 	schedulerLock.Unlock()
+	Gosched()
 }
 
 // machineUnlockCore unpins the current goroutine.

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -110,21 +110,18 @@ func NumCPU() int {
 	return numCPU
 }
 
-// CurrentCPU returns the current CPU core number.
-// On RP2040/RP2350, this returns 0 or 1.
-func CurrentCPU() int {
-	return int(currentCPU())
-}
+//
+// Warning: Pinning goroutines can lead to load imbalance. The goroutine will
+// wait in the specified core's queue even if other cores are idle. Use this
+// feature carefully and only when you need explicit core affinity.
+//
+// Valid core values are 0 and 1. Panics if core is out of range.
+//
 
-// LockToCore pins the current goroutine to the specified CPU core.
-// Use core = -1 to unpin (allow running on any core).
-// Use core = 0 or 1 to pin to a specific core.
-// Panics if core is invalid (not -1, 0, or 1 on RP2040/RP2350).
-func LockToCore(core int) {
-	if core < -1 || core >= numCPU {
-		panic("runtime: invalid core number")
-	}
-
+// machineLockCore pins the current goroutine to the specified CPU core.
+// This is called by machine.LockCore() on RP2040/RP2350.
+// It does not validate the core number - validation is done in machine package.
+func machineLockCore(core int) {
 	schedulerLock.Lock()
 	t := task.Current()
 	if t != nil {
@@ -133,9 +130,9 @@ func LockToCore(core int) {
 	schedulerLock.Unlock()
 }
 
-// UnlockFromCore unpins the current goroutine, allowing it to run on any core.
-// This is equivalent to LockToCore(-1).
-func UnlockFromCore() {
+// machineUnlockCore unpins the current goroutine.
+// This is called by machine.UnlockCore() on RP2040/RP2350.
+func machineUnlockCore() {
 	schedulerLock.Lock()
 	t := task.Current()
 	if t != nil {
@@ -144,17 +141,16 @@ func UnlockFromCore() {
 	schedulerLock.Unlock()
 }
 
-// GetAffinity returns the CPU core affinity of the current goroutine.
-// Returns -1 if not pinned, or 0/1 if pinned to a specific core.
-func GetAffinity() int {
-	schedulerLock.Lock()
-	t := task.Current()
-	affinity := -1
-	if t != nil {
-		affinity = int(t.Affinity)
-	}
-	schedulerLock.Unlock()
-	return affinity
+// lockOSThreadImpl implements LockOSThread for the cores scheduler.
+// It pins the current goroutine to whichever core it's currently running on.
+func lockOSThreadImpl() {
+	core := int(currentCPU())
+	machineLockCore(core)
+}
+
+// unlockOSThreadImpl implements UnlockOSThread for the cores scheduler.
+func unlockOSThreadImpl() {
+	machineUnlockCore()
 }
 
 func addTimer(tn *timerNode) {

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -85,6 +85,16 @@ func unlockAtomics(mask interrupt.State) {
 	interrupt.Restore(mask)
 }
 
+// lockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func lockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}
+
+// unlockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func unlockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}
+
 func printlock() {
 	// nothing to do
 }

--- a/src/runtime/scheduler_threads.go
+++ b/src/runtime/scheduler_threads.go
@@ -157,3 +157,13 @@ func lockAtomics() interrupt.State {
 func unlockAtomics(mask interrupt.State) {
 	atomicsLock.Unlock()
 }
+
+// lockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func lockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}
+
+// unlockOSThreadImpl is a no-op for the cooperative scheduler (single-threaded).
+func unlockOSThreadImpl() {
+	// Single-threaded, nothing to do.
+}


### PR DESCRIPTION
This PR proposes
- Support for CPU core pinning and affinity for tasks and goroutines.
- Updated the scheduler to respect affinity constraints with separate queues for pinned and shared tasks.
- Added new runtime API functions `LockToCore`, `UnlockFromCore`, `GetAffinity`, and `CurrentCPU`.
- Example program demonstrates core pinning and unpinned execution behavior.

## API Functions
 
### `runtime.NumCPU() int`
Returns the number of CPU cores available (returns 2 on RP2040/RP2350).
 
### `runtime.CurrentCPU() int`
Returns the current CPU core number (0 or 1).
 
### `runtime.LockToCore(core int)`
Pins the current goroutine to the specified core:
- `core = 0` - Pin to core 0
- `core = 1` - Pin to core 1
- `core = -1` - Unpin (allow running on any core)
 
Panics if core is invalid (not -1, 0, or 1).
 
### `runtime.UnlockFromCore()`
Unpins the current goroutine, allowing it to run on any core.
Equivalent to `runtime.LockToCore(-1)`.
 
### `runtime.GetAffinity() int`
Returns the current goroutine's CPU affinity:
- Returns `-1` if not pinned (can run on any core)
- Returns `0` or `1` if pinned to that specific core
 
###  Example program included in the examples directory
- Tested on both pico and pico2

- Output of example program

```
=== Core Pinning Example ===                                             
Number of CPU cores: 2                                                   
Main starting on core: 0                                                 
                                                                         
Main pinned to core: 0

Core 0 (main): 0 on CPU 0
Worker pinned to core: 1
  Core 1 (worker): 0 on CPU 0
Unpinned worker starting, affinity: 0
    Unpinned worker: 0 on CPU 0
Core 0 (main): 1 on CPU 0
    Unpinned worker: 1 on CPU 0
Core 0 (main): 2 on CPU 0
  Core 1 (worker): 2 on CPU 1
    Unpinned worker: 2 on CPU 0                                                 
Core 0 (main): 3 on CPU 0                                                       
  Core 1 (worker): 3 onCPU 1                                                    
Core 0 (main): 4 on CPU 0                                                       
  Core 1 (worker): 4 on CPU 1                                                   
    Unpinned worker: 3 on CPU 0                                                 
Core 0 (main): 5 on CPU 0                                                       
  Core 1 (worker): 5 on CPU 1                                                   
    Unpinned worker: 4 on CPU 0                                                 
Core 0 (main): 6 on CPU 0                                                       
  Core 1 (worker): 6 on CPU 1                                                   
Core 0 (main): 7 on CPU 0                                                       
  Core 1 (worker): 7 on CPU 1                                                   
    Unpinned worker: 5 on CPU 0                                                 
Core 0 (main): 8 on CPU 0                                                       
  Core 1 (worker): 8 on CPU 1                                                   
    Unpinned worker: 6 on CPU 0                                                 
Core 0 (main): 9 on CPU 0                                                       
  Core 1 (worker): 9 on CPU 1                                                   
    Unpinned worker: 7 on CPU 0                                                 
                                                                                
Main unpinned, affinity: -1                                                     
Unpinned main on CPU 0                                                          
  Core 1 worker finished                                                        
Unpinned main on CPU 0                                                          
    Unpinned worker: 8 on CPU 0                                                 
Unpinned main on CPU 0                                                          
    Unpinned worker: 9 on CPU 0                                                 
Unpinned main on CPU 0                                                          
Unpinned main on CPU 1                                                          
    Unpinned worker finished                                                    
                                                                                
Example complte!   
```