### PR TITLE
build: update macOS GH actions builds to handle deprecation of macOS 13

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,14 +16,15 @@ jobs:
     name: build-macos
     strategy:
       matrix:
-        # macos-13: amd64 (oldest supported version as of 18-10-2024)
-        # macos-14: arm64 (oldest arm64 version)
-        os: [macos-13, macos-14]
+        # macos-14: arm64 (oldest supported version as of 18-11-2025)
+        # macos-15-intel: amd64 (last intel version to be supported by github runners)
+        # See https://github.com/actions/runner-images/issues/13046
+        os: [macos-14, macos-15-intel]
         include:
-          - os: macos-13
-            goarch: amd64
           - os: macos-14
             goarch: arm64
+          - os: macos-15-intel
+            goarch: amd64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
This PR updates the macOS Github actions builds to handle deprecation of macOS 13.

See https://github.com/actions/runner-images/issues/13046