### PR TITLE
runtime (gc_blocks.go): use a linked stack to scan marked objects

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,9 +42,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 3756, 280, 0, 2268},
-		{"microbit", "examples/serial", 2756, 340, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7297, 1491, 116, 6912},
+		{"hifive1b", "examples/echo", 3568, 280, 0, 2268},
+		{"microbit", "examples/serial", 2630, 342, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7175, 1493, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,9 +42,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 3896, 280, 0, 2268},
-		{"microbit", "examples/serial", 2860, 360, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7361, 1491, 116, 6912},
+		{"hifive1b", "examples/echo", 3756, 280, 0, 2268},
+		{"microbit", "examples/serial", 2756, 340, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7297, 1491, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -6,13 +6,25 @@
 
 package runtime
 
-const preciseHeap = false
+import "unsafe"
 
-type gcObjectScanner struct {
+// gcLayout tracks pointer locations in a heap object.
+// The conservative GC treats all locations as potential pointers, so this doesn't need to store anything.
+type gcLayout struct {
 }
 
-func newGCObjectScanner(block gcBlock) gcObjectScanner {
+// parseGCLayout stores the layout information passed to alloc into a gcLayout value.
+// The conservative GC discards this information.
+func parseGCLayout(layout unsafe.Pointer) gcLayout {
+	return gcLayout{}
+}
+
+// scanner creates a gcObjectScanner with this layout.
+func (l gcLayout) scanner() gcObjectScanner {
 	return gcObjectScanner{}
+}
+
+type gcObjectScanner struct {
 }
 
 func (scanner *gcObjectScanner) pointerFree() bool {

--- a/src/runtime/gc_conservative.go
+++ b/src/runtime/gc_conservative.go
@@ -8,34 +8,23 @@ package runtime
 
 import "unsafe"
 
-// gcLayout tracks pointer locations in a heap object.
-// The conservative GC treats all locations as potential pointers, so this doesn't need to store anything.
-type gcLayout struct {
-}
-
 // parseGCLayout stores the layout information passed to alloc into a gcLayout value.
 // The conservative GC discards this information.
 func parseGCLayout(layout unsafe.Pointer) gcLayout {
 	return gcLayout{}
 }
 
-// scanner creates a gcObjectScanner with this layout.
-func (l gcLayout) scanner() gcObjectScanner {
-	return gcObjectScanner{}
+// gcLayout tracks pointer locations in a heap object.
+// The conservative GC treats all locations as potential pointers, so this doesn't need to store anything.
+type gcLayout struct {
 }
 
-type gcObjectScanner struct {
-}
-
-func (scanner *gcObjectScanner) pointerFree() bool {
+func (l gcLayout) pointerFree() bool {
 	// We don't know whether this object contains pointers, so conservatively
 	// return false.
 	return false
 }
 
-// nextIsPointer returns whether this could be a pointer. Because the GC is
-// conservative, we can't do much more than check whether the object lies
-// somewhere in the heap.
-func (scanner gcObjectScanner) nextIsPointer(ptr, parent, addrOfWord uintptr) bool {
-	return isOnHeap(ptr)
+func (l gcLayout) scan(start, len uintptr) {
+	scanConservative(start, len)
 }


### PR DESCRIPTION
The blocks GC originally used a fixed-size stack to hold objects to scan. When this stack overflowed, the GC would fully rescan all marked objects. This could cause the GC to degrade to O(n^2) when scanning large linked data structures.

Instead of using a fixed-size stack, we now add a pointer field to the start of each object. This pointer field is used to implement an unbounded linked stack. This also consolidates the heap object scanning into one place, which simplifies the process.

This comes at the cost of introducing a pointer field to the start of the object, plus the cost of aligning the result. This translates to:
- 16 bytes of overhead on x86/arm64 with the conservative collector
- 0 bytes of overhead on x86/arm64 with the precise collector (the layout field cost gets aligned up to 16 bytes anyway)
- 8 bytes of overhead on other 64-bit systems
- 4 bytes of overhead on 32-bit systems
- 2 bytes of overhead on AVR