### PR TITLE
nrf: add support for reading VDDH on the nrf52840

### DIFF
--- a/src/machine/machine_nrf52840.go
+++ b/src/machine/machine_nrf52840.go
@@ -110,3 +110,7 @@ func eraseBlockSize() int64 {
 }
 
 const spiMaxBufferSize = 0xffff // from the datasheet: TXD.MAXCNT and RXD.MAXCNT
+
+// ADC instance for the VDDH input pin. This pin is typically connected to USB
+// input voltage (~5V) or directly to a battery.
+var ADC_VDDH = ADC{adcVDDHPin}

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -26,7 +26,7 @@ func InitADC() {
 // Samples can be 1(default), 2, 4, 8, 16, 32, 64, 128, 256 samples
 func (a *ADC) Configure(config ADCConfig) {
 	var configVal uint32 = nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESP_Pos |
-		nrf.SAADC_CH_CONFIG_RESP_Bypass<<nrf.SAADC_CH_CONFIG_RESN_Pos |
+		nrf.SAADC_CH_CONFIG_RESN_Bypass<<nrf.SAADC_CH_CONFIG_RESN_Pos |
 		nrf.SAADC_CH_CONFIG_REFSEL_Internal<<nrf.SAADC_CH_CONFIG_REFSEL_Pos |
 		nrf.SAADC_CH_CONFIG_MODE_SE<<nrf.SAADC_CH_CONFIG_MODE_Pos
 

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -116,32 +116,32 @@ func (a *ADC) Configure(config ADCConfig) {
 
 // Get returns the current value of an ADC pin in the range 0..0xffff.
 func (a *ADC) Get() uint16 {
-	var pwmPin uint32
+	var adcPin uint32
 	var rawValue volatile.Register16
 
 	switch a.Pin {
 	case 2:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput0
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput0
 	case 3:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput1
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput1
 	case 4:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput2
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput2
 	case 5:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput3
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput3
 	case 28:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput4
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput4
 	case 29:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput5
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput5
 	case 30:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
 	case 31:
-		pwmPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
+		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
 	default:
 		return 0
 	}
 
 	// Set pin to read.
-	nrf.SAADC.CH[0].PSELP.Set(pwmPin)
+	nrf.SAADC.CH[0].PSELP.Set(adcPin)
 
 	// Destination for sample result.
 	// Note: rawValue doesn't need to be kept alive for the GC, since the

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -12,6 +12,8 @@ func CPUFrequency() uint32 {
 	return 64000000
 }
 
+var adcVDDHPin = Pin(254) // special pin number for VDDH on the nrf52840
+
 // InitADC initializes the registers needed for ADC.
 func InitADC() {
 	// Enable ADC.
@@ -136,6 +138,12 @@ func (a *ADC) Get() uint16 {
 		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput6
 	case 31:
 		adcPin = nrf.SAADC_CH_PSELP_PSELP_AnalogInput7
+	case adcVDDHPin:
+		if Device == "nrf52840" {
+			adcPin = 0x0D // VDDHDIV5 on the nrf52840
+		} else {
+			return 0
+		}
 	default:
 		return 0
 	}

--- a/src/machine/machine_nrf52xxx.go
+++ b/src/machine/machine_nrf52xxx.go
@@ -141,7 +141,6 @@ func (a *ADC) Get() uint16 {
 	}
 
 	// Set pin to read.
-	nrf.SAADC.CH[0].PSELN.Set(pwmPin)
 	nrf.SAADC.CH[0].PSELP.Set(pwmPin)
 
 	// Destination for sample result.


### PR DESCRIPTION
VDDH is typically connected to USB (~5V) or directly to a battery. Measuring the voltage on VDDH is a way to measure the current battery voltage, which in turn can be useful to determine how much power is left in the battery.

I've special cased the nrf52840 in a somewhat unusual way, maybe there is a better way, feel free to comment!

---

This PR also contains a few small code cleanups, see the commit log for details.