### PR TITLE
runtime (gc_blocks.go): use best-fit allocation

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,9 +42,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 3568, 280, 0, 2268},
-		{"microbit", "examples/serial", 2630, 342, 8, 2272},
-		{"wioterminal", "examples/pininterrupt", 7175, 1493, 116, 6912},
+		{"hifive1b", "examples/echo", 3808, 280, 0, 2268},
+		{"microbit", "examples/serial", 2790, 342, 8, 2272},
+		{"wioterminal", "examples/pininterrupt", 7327, 1493, 116, 6912},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the


### PR DESCRIPTION
The allocator originally just looped through the blocks until it found a sufficiently-long range. This is simple, but it fragments very easily and can degrade to a full heap scan for long requests.

Instead, we now maintain a sorted nested list of free ranges by size. The allocator will select the shortest sufficient-length range, generally reducing fragmentation. This data structure can find a range in time directly proportional to the requested length.

Performance in the problematic `go/format` benchmark:
```
                    │ linear.txt  │            best-fit.txt             │
                    │   sec/op    │   sec/op     vs base                │
Format/array1-10000   31.77m ± 4%   25.71m ± 2%  -19.08% (p=0.000 n=20)

                    │  linear.txt  │             best-fit.txt             │
                    │     B/s      │     B/s       vs base                │
Format/array1-10000   1.945Mi ± 4%   2.403Mi ± 2%  +23.53% (p=0.000 n=20)
```