### PR TITLE
fix: separate host expected bytes from device intended bytes

### DIFF
--- a/src/machine/usb/msc/scsi.go
+++ b/src/machine/usb/msc/scsi.go
@@ -72,6 +72,7 @@ func (m *msc) scsiCmdBegin() {
 			if m.cbw.transferLength() < uint32(len(m.buf)) {
 				m.buf = m.buf[:m.cbw.transferLength()]
 			}
+			m.queuedBytes = uint32(len(m.buf))
 			m.sendUSBPacket(m.buf)
 		}
 	}

--- a/src/machine/usb/msc/scsi_inquiry.go
+++ b/src/machine/usb/msc/scsi_inquiry.go
@@ -136,13 +136,13 @@ func (m *msc) scsiEvpdInquiry(cmd scsi.Cmd, pageCode uint8) {
 
 	// Set total bytes to the length of our response
 	m.queuedBytes = uint32(len(m.buf))
-	m.totalBytes = uint32(len(m.buf))
+	m.transferBytes = uint32(len(m.buf))
 }
 
 func (m *msc) scsiStdInquiry(cmd scsi.Cmd) {
 	m.resetBuffer(scsi.InquiryRespLen)
 	m.queuedBytes = scsi.InquiryRespLen
-	m.totalBytes = scsi.InquiryRespLen
+	m.transferBytes = scsi.InquiryRespLen
 
 	// byte 0 - Device Type (0x00 for direct access block device)
 	// byte 1 - Removable media bit

--- a/src/machine/usb/msc/scsi_unmap.go
+++ b/src/machine/usb/msc/scsi_unmap.go
@@ -60,7 +60,7 @@ func (m *msc) scsiUnmap(b []byte) {
 	// FIXME: We need to handle erase block alignment
 
 	m.sentBytes += uint32(len(b))
-	if m.sentBytes >= m.totalBytes {
+	if m.sentBytes >= m.transferBytes {
 		// Order 66 complete, send CSW to establish galactic empire
 		m.state = mscStateStatus
 		m.run([]byte{}, true)


### PR DESCRIPTION
Here's a few bugfixes for issues I came across working on the nrf52840 usb msc support in #5011. I kept chasing a failure to return a CSW (post-command status report) after the host requested one of a few different unsupported commands. Fixing one broke the other and so I did some digging into places where the code was diverging from the original TinyUSB reference logic. I'm still working on the nrf52840 bit, but I want to make sure the msc library itself is correct and testable so I don't just shift the bug around.

> fix: separate host expected bytes from device intended bytes

This first commit solves a bug I introduced while porting the TinyUSB stack over. I naively assumed `p_msc->cbw.total_bytes` (the host's expected transfer size) and `p_msc->total_len` (the device's expected transfer size) could be combined into one variable, originally `m.totalBytes`. As it turns out, the device's transfer size is routinely smaller than what the host provides for, such as in the case of inquiry commands where the host sends a large expected transfer size to give the device plenty of room to provide all the data it needs, while less complex devices like this usb msc stack will only return a small fraction of that, and the difference (referred to as residue in usb) needs to be kept track of in case of errors. This change separates the usage more clearly, always referencing the host's expected total byte value through the CBW.

> fix: update m.queuedBytes when clamping output to avoid corrupting sentBytes

This one handles the situation where the device is returning less data than the host expects such as during inquiry or vpd commands where the returned output can vary greatly in length depending on the device.

> fix: don't hardcode success return state

This one's pretty self-explanatory, just ensure we don't override an error state set earlier when a CSW is sent after the endpoints are un-stalled.