### PR TITLE
runtime (avr): fix infinite longjmp loop if stack is aligned to 256 bytes

### DIFF
--- a/src/runtime/asm_avr.S
+++ b/src/runtime/asm_avr.S
@@ -78,5 +78,8 @@ tinygo_longjmp:
     ld r28, X+
     ld r29, X+
 
+	; Mark that we returned from a longjmp.
+	ldi r24, 1
+
     ; Jump to the PC (stored in the Z register)
     icall


### PR DESCRIPTION
The setjmp code sets `r24` to 0 and checks if it is still 0 when it finishes. This usually works because `tinygo_longjmp` stores the lower half of the stack pointer into `r24`. However, `r24` will be set to 0 if the stack is aligned to 256 bytes when entering the setjmp.

Manually set `r24` to 1 in `tinygo_longjmp` to fix this issue.