### PR TITLE
runtime (wasm): scan the system stack

### DIFF
--- a/src/internal/task/task_asyncify.go
+++ b/src/internal/task/task_asyncify.go
@@ -108,6 +108,10 @@ func (*stackState) unwind()
 func (t *Task) Resume() {
 	// The current task must be saved and restored because this can nest on WASM with JS.
 	prevTask := currentTask
+	if prevTask == nil {
+		// Save the system stack pointer.
+		saveStackPointer()
+	}
 	t.gcData.swap()
 	currentTask = t
 	if !t.state.launched {
@@ -122,6 +126,9 @@ func (t *Task) Resume() {
 		runtimePanic("stack overflow")
 	}
 }
+
+//go:linkname saveStackPointer runtime.saveStackPointer
+func saveStackPointer()
 
 //export tinygo_rewind
 func (*state) rewind()

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -73,6 +73,14 @@ func align(ptr uintptr) uintptr {
 //export tinygo_getCurrentStackPointer
 func getCurrentStackPointer() uintptr
 
+// savedStackPointer is used to save the system stack pointer while in a goroutine.
+var savedStackPointer uintptr
+
+// saveStackPointer is called by internal/task.state.Resume() to save the stack pointer before entering a goroutine from the system stack.
+func saveStackPointer() {
+	savedStackPointer = getCurrentStackPointer()
+}
+
 // growHeap tries to grow the heap size. It returns true if it succeeds, false
 // otherwise.
 func growHeap() bool {


### PR DESCRIPTION
This saves the system stack pointer into a global and uses it to scan. It should fix some use-after-free issues?