### PR TITLE
build: go back to normal scheduler instead of tasks scheduler for macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build TinyGo release tarball
         run: make release -j3
       - name: Test stdlib packages
-        run: make tinygo-test TEST_ADDITIONAL_FLAGS="-scheduler=tasks"
+        run: make tinygo-test
       - name: Make release artifact
         run: cp -p build/release.tar.gz build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact


### PR DESCRIPTION
This PR is to go back to normal scheduler instead of tasks scheduler for macOS.

Basically revert https://github.com/tinygo-org/tinygo/pull/5080 since we should no longer have that problem.