### PR TITLE
change: remove possibly unusable syscall functions for wasm targets

### DIFF
--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -3,6 +3,7 @@
 package syscall
 
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -173,34 +174,11 @@ func Chown(path string, uid, gid int) (err error) {
 }
 
 func Fork() (err error) {
-	fail := int(libc_fork())
-	if fail < 0 {
-		err = getErrno()
-	}
-	return
+	return errors.ErrUnsupported
 }
 
 func Execve(pathname string, argv []string, envv []string) (err error) {
-	argv0 := cstring(pathname)
-
-	// transform argv and envv into the format expected by execve
-	argv1 := make([]*byte, len(argv)+1)
-	for i, arg := range argv {
-		argv1[i] = &cstring(arg)[0]
-	}
-	argv1[len(argv)] = nil
-
-	env1 := make([]*byte, len(envv)+1)
-	for i, env := range envv {
-		env1[i] = &cstring(env)[0]
-	}
-	env1[len(envv)] = nil
-
-	fail := int(libc_execve(&argv0[0], &argv1[0], &env1[0]))
-	if fail < 0 {
-		err = getErrno()
-	}
-	return
+	return errors.ErrUnsupported
 }
 
 func Truncate(path string, length int64) (err error) {
@@ -407,16 +385,6 @@ func libc_readlink(path *byte, buf *byte, count uint) int
 //
 //export unlink
 func libc_unlink(pathname *byte) int32
-
-// pid_t fork(void);
-//
-//export fork
-func libc_fork() int32
-
-// int execve(const char *filename, char *const argv[], char *const envp[]);
-//
-//export execve
-func libc_execve(filename *byte, argv **byte, envp **byte) int
 
 // int truncate(const char *path, off_t length);
 //


### PR DESCRIPTION
This removes the implementations and exported system funcs from the `syscall` package for `Fork()` and `Execve()` functions for wasm. They cannot possibly work given the builds tags in this file (except maybe on nintendoswitch?) and we do not need the export.