### PR TITLE
internal/task: prevent semaphore resource leak for threads scheduler

### DIFF
--- a/src/internal/task/task_threads.c
+++ b/src/internal/task/task_threads.c
@@ -131,8 +131,10 @@ int tinygo_task_start(uintptr_t fn, void *args, void *task, pthread_t *thread, u
     // Wait until the thread has been created and read all state_pass variables.
     #if __APPLE__
     dispatch_semaphore_wait(state.startlock, DISPATCH_TIME_FOREVER);
+    dispatch_release(state.startlock);
     #else
     sem_wait(&state.startlock);
+    sem_destroy(&state.startlock);
     #endif
 
     return result;


### PR DESCRIPTION
Previously, https://github.com/gonum/gonum/tree/master/optimize/convex/lp test would fail on Darwin with
`Killed 9` and 
```
[2610029.422758]: process lp.test[22584] caught allocating too many mach ports.             Num of ports allocated 267611;
[2610029.422765]: [lp.test: killed] sending signal 9 and force exiting process
[2610029.422863]: lp.test[22584] Corpse allowed 1 of 5
```
in the `dmesg` log.  This prevents the resource leak and the test now passes.

```
~/go/src/github.com/dgryski/tinygo-test-corpus/_corpus/gonum/gonum/optimize/convex/lp $ ./lp.test  -test.v
=== RUN   TestSimplex
--- PASS: TestSimplex (157.64s)
PASS
```