### PR TITLE
runtime: avoid fixed math/rand sequence on RP2040/RP2350

### DIFF
--- a/src/runtime/rand_norng.go
+++ b/src/runtime/rand_norng.go
@@ -1,4 +1,4 @@
-//go:build baremetal && !(nrf || (stm32 && !(stm32f103 || stm32l0x1)) || (sam && atsamd51) || (sam && atsame5x) || esp32c3 || tkey || (tinygo.riscv32 && virt))
+//go:build baremetal && !(nrf || (stm32 && !(stm32f103 || stm32l0x1)) || (sam && atsamd51) || (sam && atsame5x) || esp32c3 || tkey || (tinygo.riscv32 && virt) || rp2040 || rp2350)
 
 package runtime
 

--- a/src/runtime/rand_rp2.go
+++ b/src/runtime/rand_rp2.go
@@ -1,4 +1,4 @@
-//go:build rp2040 || rand_rp2350
+//go:build rp2040 || rp2350
 
 package runtime
 

--- a/src/runtime/rand_rp2.go
+++ b/src/runtime/rand_rp2.go
@@ -1,0 +1,20 @@
+//go:build rp2040 || rand_rp2350
+
+package runtime
+
+import "machine"
+
+var hardwareRandValue uint64
+
+func hardwareRand() (n uint64, ok bool) {
+	if hardwareRandValue == 0 {
+		n1, _ := machine.GetRNG()
+		n2, _ := machine.GetRNG()
+		hardwareRandValue = uint64(n1)<<32 | uint64(n2)
+	}
+
+	// Return ok=false to keep using fastrand64(),
+	// with hardwareRandVal used only as its initial random state.
+
+	return hardwareRandValue, false
+}


### PR DESCRIPTION
fix: #5123 

This change provides entropy from `machine.GetRNG()` to initialize `fastrand64()` on RP2040/RP2350, 
while keeping `fastrand64()` as the random generator. 