### PR TITLE
runtime: call initRand() on RP2040/RP2350

### DIFF
--- a/src/runtime/rand_rp2.go
+++ b/src/runtime/rand_rp2.go
@@ -11,10 +11,11 @@ func hardwareRand() (n uint64, ok bool) {
 		n1, _ := machine.GetRNG()
 		n2, _ := machine.GetRNG()
 		hardwareRandValue = uint64(n1)<<32 | uint64(n2)
+		initRand() // seeding for fastrand64()
 	}
 
 	// Return ok=false to keep using fastrand64(),
-	// with hardwareRandVal used only as its initial random state.
+	// with hardwareRandValue used only as its initial random state via initRand().
 
 	return hardwareRandValue, false
 }

--- a/src/runtime/rand_rp2.go
+++ b/src/runtime/rand_rp2.go
@@ -11,7 +11,6 @@ func hardwareRand() (n uint64, ok bool) {
 		n1, _ := machine.GetRNG()
 		n2, _ := machine.GetRNG()
 		hardwareRandValue = uint64(n1)<<32 | uint64(n2)
-		initRand() // seeding for fastrand64()
 	}
 
 	// Return ok=false to keep using fastrand64(),

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -141,6 +141,7 @@ func run() {
 		// Package initializers are currently run single-threaded.
 		// This might help with registering interrupts and such.
 		initAll()
+		initRand()
 
 		// After package initializers have finished, start all the other cores.
 		startSecondaryCores()


### PR DESCRIPTION
This is a follow-up to #5124.
I apologize for the incomplete fix in the previous PR.

This PR fixes the missing call to `initRand()` on RP2040/RP2350.
In the previous change, entropy was prepared for `fastrand64()`,
but `initRand()` was never invoked, so the global RNG still started from a fixed state.

This ensures `initRand()` is called so the prepared randomness is actually used.

Sorry for the oversight, and thank you for reviewing this follow-up.