### PR TITLE
runtime: add calls to initRand() during run() for all schedulers.

### DIFF
--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -34,8 +34,8 @@ func wasmEntryReactor() {
 	// Initialize the heap.
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	initHeap()
 	initRand()
+	initHeap()
 
 	if hasScheduler {
 		// A package initializer might do funky stuff like start a goroutine and

--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -243,8 +243,8 @@ func sleep(duration int64) {
 // run is called by the program entry point to execute the go program.
 // With a scheduler, init and the main function are invoked in a goroutine before starting the scheduler.
 func run() {
-	initHeap()
 	initRand()
+	initHeap()
 	go func() {
 		initAll()
 		callMain()

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -136,6 +136,7 @@ func sleep(duration int64) {
 // other cores when ready.
 func run() {
 	initHeap()
+	initRand()
 
 	go func() {
 		// Package initializers are currently run single-threaded.

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -135,8 +135,8 @@ func sleep(duration int64) {
 // This function is called on the first core in the system. It will wake up the
 // other cores when ready.
 func run() {
-	initHeap()
 	initRand()
+	initHeap()
 
 	go func() {
 		// Package initializers are currently run single-threaded.

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -21,8 +21,8 @@ var schedulerExit bool
 // run is called by the program entry point to execute the go program.
 // With the "none" scheduler, init and the main function are invoked directly.
 func run() {
-	initHeap()
 	initRand()
+	initHeap()
 	initAll()
 	callMain()
 	mainExited = true

--- a/src/runtime/scheduler_threads.go
+++ b/src/runtime/scheduler_threads.go
@@ -21,8 +21,8 @@ var (
 // Because we just use OS threads, we don't need to do anything special here. We
 // can just initialize everything and run main.main on the main thread.
 func run() {
-	initHeap()
 	initRand()
+	initHeap()
 	task.Init(stackTop)
 	initAll()
 	callMain()

--- a/src/runtime/scheduler_threads.go
+++ b/src/runtime/scheduler_threads.go
@@ -22,6 +22,7 @@ var (
 // can just initialize everything and run main.main on the main thread.
 func run() {
 	initHeap()
+	initRand()
 	task.Init(stackTop)
 	initAll()
 	callMain()


### PR DESCRIPTION
This PR alters the runtime initialization to add a call to `initRand()` during `run()` for all schedulers. It is intended to ensure that the random number seed used is always initialized on startup.