### PR TITLE
picolibc: use updated location for git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	url = https://github.com/WebAssembly/wasi-libc
 [submodule "lib/picolibc"]
 	path = lib/picolibc
-	url = https://github.com/keith-packard/picolibc.git
+	url = https://github.com/picolibc/picolibc.git
 [submodule "lib/stm32-svd"]
 	path = lib/stm32-svd
 	url = https://github.com/tinygo-org/stm32-svd


### PR DESCRIPTION
This PR is to use updated location for the picolibc git repo. :broom: 