### PR TITLE
build: use Go 1.26 for all builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
     # This tests the latest supported LLVM version when linking against system
     # libraries.
     docker:
-      - image: golang:1.26rc1-bookworm
+      - image: golang:1.26rc2-bookworm
     steps:
       - test-linux:
           llvm: "20"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
     # This tests the latest supported LLVM version when linking against system
     # libraries.
     docker:
-      - image: golang:1.26rc2-bookworm
+      - image: golang:1.26-bookworm
     steps:
       - test-linux:
           llvm: "20"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
     # This tests the latest supported LLVM version when linking against system
     # libraries.
     docker:
-      - image: golang:1.25-bullseye
+      - image: golang:1.26rc1-bookworm
     steps:
       - test-linux:
           llvm: "20"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Build TinyGo (LLVM ${{ matrix.version }})
         run: go install -tags=llvm${{ matrix.version }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.25-alpine
+      image: golang:1.26rc1-alpine
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: Cache Go
         uses: actions/cache@v4
         with:
-          key: go-cache-linux-alpine-v1-${{ hashFiles('go.mod') }}
+          key: go-cache-linux-alpine-v2-${{ hashFiles('go.mod') }}
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-source
         with:
-          key: llvm-source-20-linux-alpine-v1
+          key: llvm-source-20-linux-alpine-v2
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-llvm-build
         with:
-          key: llvm-build-20-linux-alpine-v1
+          key: llvm-build-20-linux-alpine-v2
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-binaryen
         with:
-          key: binaryen-linux-alpine-v1
+          key: binaryen-linux-alpine-v2
           path: build/wasm-opt
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.26rc1-alpine
+      image: golang:1.26rc2-alpine
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     # statically linked binary.
     runs-on: ubuntu-latest
     container:
-      image: golang:1.26rc2-alpine
+      image: golang:1.26-alpine
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -137,7 +137,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -181,7 +181,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Restore LLVM source cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
             llvm-project/compiler-rt
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31
       - name: Test
         run: |
           nix develop --ignore-environment --keep HOME --command bash -c "go install && ~/go/bin/tinygo version && ~/go/bin/tinygo build -o test ./testdata/cgo"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.2'
+          go-version: '1.26.0'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0-rc.1'
+          go-version: '1.26.0-rc.2'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Restore cached LLVM source
         uses: actions/cache/restore@v4
@@ -94,7 +94,7 @@ jobs:
       - name: Cache Go cache
         uses: actions/cache@v4
         with:
-          key: go-cache-windows-v1-${{ hashFiles('go.mod') }}
+          key: go-cache-windows-v2-${{ hashFiles('go.mod') }}
           path: |
             C:/Users/runneradmin/AppData/Local/go-build
             C:/Users/runneradmin/go/pkg/mod
@@ -147,7 +147,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -177,7 +177,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4
@@ -213,7 +213,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0-rc.1'
           cache: true
       - name: Download TinyGo build
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.26rc1 AS tinygo-llvm
+FROM golang:1.26rc2 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-17 ninja-build && \
@@ -33,7 +33,7 @@ RUN cd /tinygo/ && \
 
 # tinygo-compiler copies the compiler build over to a base Go container (without
 # all the build tools etc).
-FROM golang:1.26rc1 AS tinygo-compiler
+FROM golang:1.26rc2 AS tinygo-compiler
 
 # Copy tinygo build.
 COPY --from=tinygo-compiler-build /tinygo/build/release/tinygo /tinygo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.26rc2 AS tinygo-llvm
+FROM golang:1.26 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-17 ninja-build && \
@@ -33,7 +33,7 @@ RUN cd /tinygo/ && \
 
 # tinygo-compiler copies the compiler build over to a base Go container (without
 # all the build tools etc).
-FROM golang:1.26rc2 AS tinygo-compiler
+FROM golang:1.26 AS tinygo-compiler
 
 # Copy tinygo build.
 COPY --from=tinygo-compiler-build /tinygo/build/release/tinygo /tinygo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # tinygo-llvm stage obtains the llvm source for TinyGo
-FROM golang:1.25 AS tinygo-llvm
+FROM golang:1.26rc1 AS tinygo-llvm
 
 RUN apt-get update && \
     apt-get install -y apt-utils make cmake clang-17 ninja-build && \
@@ -33,7 +33,7 @@ RUN cd /tinygo/ && \
 
 # tinygo-compiler copies the compiler build over to a base Go container (without
 # all the build tools etc).
-FROM golang:1.25 AS tinygo-compiler
+FROM golang:1.26rc1 AS tinygo-compiler
 
 # Copy tinygo build.
 COPY --from=tinygo-compiler-build /tinygo/build/release/tinygo /tinygo

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -898,6 +898,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark           examples/pwm
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=digispark           examples/mcp3008
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark -gc=leaking examples/blinky1
 	@$(MD5SUM) test.hex
 ifneq ($(XTENSA), 0)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -896,6 +896,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark           examples/blinky1
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=digispark           examples/pwm
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark -gc=leaking examples/blinky1
 	@$(MD5SUM) test.hex
 ifneq ($(XTENSA), 0)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -814,6 +814,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=waveshare-rp2040-tiny examples/echo
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=vicharak_shrike-lite examples/echo
+	@$(MD5SUM) test.hex
 	# test pwm
 	$(TINYGO) build -size short -o test.hex -target=itsybitsy-m0        examples/pwm
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tinygo build -buildmode=c-shared -o add.wasm -target=wasip1 add.go
 You can also use the same syntax as Go 1.24+:
 
 ```shell
-GOARCH=wasip1 GOOS=wasm tinygo build -buildmode=c-shared -o add.wasm add.go
+GOOS=wasip1 GOARCH=wasm tinygo build -buildmode=c-shared -o add.wasm add.go
 ```
 
 ## Installation

--- a/builder/build.go
+++ b/builder/build.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -281,9 +282,13 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				allFiles[file.Name] = append(allFiles[file.Name], file)
 			}
 		}
-		for name, files := range allFiles {
-			name := name
-			files := files
+		// Sort embedded files by name to maintain output determinism.
+		embedNames := make([]string, 0, len(allFiles))
+		for _, files := range allFiles {
+			embedNames = append(embedNames, files[0].Name)
+		}
+		slices.Sort(embedNames)
+		for _, name := range embedNames {
 			job := &compileJob{
 				description: "make object file for " + name,
 				run: func(job *compileJob) error {
@@ -298,7 +303,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					sum := sha256.Sum256(data)
 					hexSum := hex.EncodeToString(sum[:16])
 
-					for _, file := range files {
+					for _, file := range allFiles[name] {
 						file.Size = uint64(len(data))
 						file.Hash = hexSum
 						if file.NeedsData {

--- a/compiler/gc.go
+++ b/compiler/gc.go
@@ -99,6 +99,9 @@ func typeHasPointers(t llvm.Type) bool {
 		}
 		return false
 	case llvm.ArrayTypeKind:
+		if t.ArrayLength() == 0 {
+			return false
+		}
 		if typeHasPointers(t.ElementType()) {
 			return true
 		}

--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -1,10 +1,10 @@
 package compiler
 
 import (
+	"encoding/binary"
 	"fmt"
 	"go/token"
 	"go/types"
-	"math/big"
 	"strings"
 
 	"github.com/tinygo-org/tinygo/compileopts"
@@ -231,6 +231,12 @@ func (c *compilerContext) makeGlobalArray(buf []byte, name string, elementType l
 //
 // For details on what's in this value, see src/runtime/gc_precise.go.
 func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Value {
+	if !typeHasPointers(t) {
+		// There are no pointers in this type, so we can simplify the layout.
+		layout := (uint64(1) << 1) | 1
+		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.dataPtrType)
+	}
+
 	// Use the element type for arrays. This works even for nested arrays.
 	for {
 		kind := t.TypeKind()
@@ -248,54 +254,29 @@ func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Va
 		break
 	}
 
-	// Do a few checks to see whether we need to generate any object layout
-	// information at all.
+	// Create the pointer bitmap.
 	objectSizeBytes := c.targetData.TypeAllocSize(t)
+	pointerAlignment := uint64(c.targetData.PrefTypeAlignment(c.dataPtrType))
+	bitmapLen := objectSizeBytes / pointerAlignment
+	bitmapBytes := (bitmapLen + 7) / 8
+	bitmap := make([]byte, bitmapBytes, max(bitmapBytes, 8))
+	c.buildPointerBitmap(bitmap, pointerAlignment, pos, t, 0)
+
+	// Try to encode the layout inline.
 	pointerSize := c.targetData.TypeAllocSize(c.dataPtrType)
-	pointerAlignment := c.targetData.PrefTypeAlignment(c.dataPtrType)
-	if objectSizeBytes < pointerSize {
-		// Too small to contain a pointer.
-		layout := (uint64(1) << 1) | 1
-		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.dataPtrType)
-	}
-	bitmap := c.getPointerBitmap(t, pos)
-	if bitmap.BitLen() == 0 {
-		// There are no pointers in this type, so we can simplify the layout.
-		// TODO: this can be done in many other cases, e.g. when allocating an
-		// array (like [4][]byte, which repeats a slice 4 times).
-		layout := (uint64(1) << 1) | 1
-		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.dataPtrType)
-	}
-	if objectSizeBytes%uint64(pointerAlignment) != 0 {
-		// This shouldn't happen except for packed structs, which aren't
-		// currently used.
-		c.addError(pos, "internal error: unexpected object size for object with pointer field")
-		return llvm.ConstNull(c.dataPtrType)
-	}
-	objectSizeWords := objectSizeBytes / uint64(pointerAlignment)
-
 	pointerBits := pointerSize * 8
-	var sizeFieldBits uint64
-	switch pointerBits {
-	case 16:
-		sizeFieldBits = 4
-	case 32:
-		sizeFieldBits = 5
-	case 64:
-		sizeFieldBits = 6
-	default:
-		panic("unknown pointer size")
-	}
-	layoutFieldBits := pointerBits - 1 - sizeFieldBits
+	if bitmapLen < pointerBits {
+		rawMask := binary.LittleEndian.Uint64(bitmap[0:8])
+		layout := rawMask*pointerBits + bitmapLen
+		layout <<= 1
+		layout |= 1
 
-	// Try to emit the value as an inline integer. This is possible in most
-	// cases.
-	if objectSizeWords < layoutFieldBits {
-		// If it can be stored directly in the pointer value, do so.
-		// The runtime knows that if the least significant bit of the pointer is
-		// set, the pointer contains the value itself.
-		layout := bitmap.Uint64()<<(sizeFieldBits+1) | (objectSizeWords << 1) | 1
-		return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.dataPtrType)
+		// Check if the layout fits.
+		layout &= 1<<pointerBits - 1
+		if (layout>>1)/pointerBits == rawMask {
+			// No set bits were shifted off.
+			return llvm.ConstIntToPtr(llvm.ConstInt(c.uintptrType, layout, false), c.dataPtrType)
+		}
 	}
 
 	// Unfortunately, the object layout is too big to fit in a pointer-sized
@@ -303,25 +284,24 @@ func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Va
 
 	// Try first whether the global already exists. All objects with a
 	// particular name have the same type, so this is possible.
-	globalName := "runtime/gc.layout:" + fmt.Sprintf("%d-%0*x", objectSizeWords, (objectSizeWords+15)/16, bitmap)
+	globalName := "runtime/gc.layout:" + fmt.Sprintf("%d-%0*x", bitmapLen, (bitmapLen+15)/16, bitmap)
 	global := c.mod.NamedGlobal(globalName)
 	if !global.IsNil() {
 		return global
 	}
 
 	// Create the global initializer.
-	bitmapBytes := make([]byte, int(objectSizeWords+7)/8)
-	bitmap.FillBytes(bitmapBytes)
-	reverseBytes(bitmapBytes) // big-endian to little-endian
-	var bitmapByteValues []llvm.Value
-	for _, b := range bitmapBytes {
-		bitmapByteValues = append(bitmapByteValues, llvm.ConstInt(c.ctx.Int8Type(), uint64(b), false))
+	bitmapByteValues := make([]llvm.Value, bitmapBytes)
+	i8 := c.ctx.Int8Type()
+	for i, b := range bitmap {
+		bitmapByteValues[i] = llvm.ConstInt(i8, uint64(b), false)
 	}
 	initializer := c.ctx.ConstStruct([]llvm.Value{
-		llvm.ConstInt(c.uintptrType, objectSizeWords, false),
-		llvm.ConstArray(c.ctx.Int8Type(), bitmapByteValues),
+		llvm.ConstInt(c.uintptrType, bitmapLen, false),
+		llvm.ConstArray(i8, bitmapByteValues),
 	}, false)
 
+	// Create the actual global.
 	global = llvm.AddGlobal(c.mod, initializer.Type(), globalName)
 	global.SetInitializer(initializer)
 	global.SetUnnamedAddr(true)
@@ -329,6 +309,7 @@ func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Va
 	global.SetLinkage(llvm.LinkOnceODRLinkage)
 	if c.targetData.PrefTypeAlignment(c.uintptrType) < 2 {
 		// AVR doesn't have alignment by default.
+		// The lowest bit must be unset to distinguish this from an inline layout.
 		global.SetAlignment(2)
 	}
 	if c.Debug && pos != token.NoPos {
@@ -360,52 +341,71 @@ func (c *compilerContext) createObjectLayout(t llvm.Type, pos token.Pos) llvm.Va
 	return global
 }
 
-// getPointerBitmap scans the given LLVM type for pointers and sets bits in a
-// bigint at the word offset that contains a pointer. This scan is recursive.
-func (c *compilerContext) getPointerBitmap(typ llvm.Type, pos token.Pos) *big.Int {
-	alignment := c.targetData.PrefTypeAlignment(c.dataPtrType)
-	switch typ.TypeKind() {
+// buildPointerBitmap scans the given LLVM type for pointers and sets bits in a
+// bitmap at the word offset that contains a pointer. This scan is recursive.
+func (c *compilerContext) buildPointerBitmap(
+	dst []byte,
+	ptrAlign uint64,
+	pos token.Pos,
+	t llvm.Type,
+	offset uint64,
+) {
+	switch t.TypeKind() {
 	case llvm.IntegerTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind:
-		return big.NewInt(0)
+		// These types do not contain pointers.
+
 	case llvm.PointerTypeKind:
-		return big.NewInt(1)
+		// Set the corresponding position in the bitmap.
+		dst[offset/8] |= 1 << (offset % 8)
+
 	case llvm.StructTypeKind:
-		ptrs := big.NewInt(0)
-		for i, subtyp := range typ.StructElementTypes() {
-			subptrs := c.getPointerBitmap(subtyp, pos)
-			if subptrs.BitLen() == 0 {
+		// Recurse over struct elements.
+		for i, et := range t.StructElementTypes() {
+			eo := c.targetData.ElementOffset(t, i)
+			if eo%uint64(ptrAlign) != 0 {
+				if typeHasPointers(et) {
+					// This error will let the compilation fail, but by continuing
+					// the error can still easily be shown.
+					c.addError(pos, "internal error: allocated struct contains unaligned pointer")
+				}
 				continue
 			}
-			offset := c.targetData.ElementOffset(typ, i)
-			if offset%uint64(alignment) != 0 {
-				// This error will let the compilation fail, but by continuing
-				// the error can still easily be shown.
-				c.addError(pos, "internal error: allocated struct contains unaligned pointer")
-				continue
-			}
-			subptrs.Lsh(subptrs, uint(offset)/uint(alignment))
-			ptrs.Or(ptrs, subptrs)
+			c.buildPointerBitmap(
+				dst,
+				ptrAlign,
+				pos,
+				et,
+				offset+(eo/ptrAlign),
+			)
 		}
-		return ptrs
+
 	case llvm.ArrayTypeKind:
-		subtyp := typ.ElementType()
-		subptrs := c.getPointerBitmap(subtyp, pos)
-		ptrs := big.NewInt(0)
-		if subptrs.BitLen() == 0 {
-			return ptrs
+		// Recurse over array elements.
+		len := t.ArrayLength()
+		if len <= 0 {
+			return
 		}
-		elementSize := c.targetData.TypeAllocSize(subtyp)
-		if elementSize%uint64(alignment) != 0 {
-			// This error will let the compilation fail (but continues so that
-			// other errors can be shown).
-			c.addError(pos, "internal error: allocated array contains unaligned pointer")
-			return ptrs
+		et := t.ElementType()
+		elementSize := c.targetData.TypeAllocSize(et)
+		if elementSize%ptrAlign != 0 {
+			if typeHasPointers(et) {
+				// This error will let the compilation fail (but continues so that
+				// other errors can be shown).
+				c.addError(pos, "internal error: allocated array contains unaligned pointer")
+			}
+			return
 		}
-		for i := 0; i < typ.ArrayLength(); i++ {
-			ptrs.Lsh(ptrs, uint(elementSize)/uint(alignment))
-			ptrs.Or(ptrs, subptrs)
+		elementSize /= ptrAlign
+		for i := 0; i < len; i++ {
+			c.buildPointerBitmap(
+				dst,
+				ptrAlign,
+				pos,
+				et,
+				offset+uint64(i)*elementSize,
+			)
 		}
-		return ptrs
+
 	default:
 		// Should not happen.
 		panic("unknown LLVM type")

--- a/compiler/testdata/gc.go
+++ b/compiler/testdata/gc.go
@@ -24,6 +24,10 @@ var (
 		x *byte
 		y [61]uintptr
 	}
+	struct5 *struct {
+		x *byte
+		y [30]uintptr
+	}
 
 	slice1 []byte
 	slice2 []*int
@@ -57,6 +61,10 @@ func newStruct() {
 	struct4 = new(struct {
 		x *byte
 		y [61]uintptr
+	})
+	struct5 = new(struct {
+		x *byte
+		y [30]uintptr
 	})
 }
 

--- a/compiler/testdata/gc.ll
+++ b/compiler/testdata/gc.ll
@@ -16,11 +16,12 @@ target triple = "wasm32-unknown-wasi"
 @main.struct2 = hidden global ptr null, align 4
 @main.struct3 = hidden global ptr null, align 4
 @main.struct4 = hidden global ptr null, align 4
+@main.struct5 = hidden global ptr null, align 4
 @main.slice1 = hidden global { ptr, i32, i32 } zeroinitializer, align 4
 @main.slice2 = hidden global { ptr, i32, i32 } zeroinitializer, align 4
 @main.slice3 = hidden global { ptr, i32, i32 } zeroinitializer, align 4
-@"runtime/gc.layout:62-2000000000000001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00 " }
-@"runtime/gc.layout:62-0001" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00\00" }
+@"runtime/gc.layout:62-0100000000000020" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00 " }
+@"runtime/gc.layout:62-0100000000000000" = linkonce_odr unnamed_addr constant { i32, [8 x i8] } { i32 62, [8 x i8] c"\01\00\00\00\00\00\00\00" }
 @"reflect/types.type:basic:complex128" = linkonce_odr constant { i8, ptr } { i8 80, ptr @"reflect/types.type:pointer:basic:complex128" }, align 4
 @"reflect/types.type:pointer:basic:complex128" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:basic:complex128" }, align 4
 
@@ -80,12 +81,15 @@ entry:
   %new1 = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
   call void @runtime.trackPointer(ptr nonnull %new1, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new1, ptr @main.struct2, align 4
-  %new2 = call align 4 dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-2000000000000001", ptr undef) #3
+  %new2 = call align 4 dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-0100000000000020", ptr undef) #3
   call void @runtime.trackPointer(ptr nonnull %new2, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new2, ptr @main.struct3, align 4
-  %new3 = call align 4 dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-0001", ptr undef) #3
+  %new3 = call align 4 dereferenceable(248) ptr @runtime.alloc(i32 248, ptr nonnull @"runtime/gc.layout:62-0100000000000000", ptr undef) #3
   call void @runtime.trackPointer(ptr nonnull %new3, ptr nonnull %stackalloc, ptr undef) #3
   store ptr %new3, ptr @main.struct4, align 4
+  %new4 = call align 4 dereferenceable(124) ptr @runtime.alloc(i32 124, ptr nonnull inttoptr (i32 127 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %new4, ptr nonnull %stackalloc, ptr undef) #3
+  store ptr %new4, ptr @main.struct5, align 4
   ret void
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747953325,
-        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
+        "lastModified": 1770136044,
+        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
+        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
   inputs = {
     # Use a recent stable release, but fix the version to make it reproducible.
     # This version should be updated from time to time.
-    nixpkgs.url = "nixpkgs/nixos-25.05";
+    nixpkgs.url = "nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:

--- a/goenv/version.go
+++ b/goenv/version.go
@@ -10,7 +10,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const version = "0.40.1"
+const version = "0.41.0-dev"
 
 // Return TinyGo version, either in the form 0.30.0 or as a development version
 // (like 0.30.0-dev-abcd012).

--- a/src/examples/pwm/digispark.go
+++ b/src/examples/pwm/digispark.go
@@ -1,0 +1,12 @@
+//go:build digispark
+
+package main
+
+import "machine"
+
+var (
+	// Use Timer1 for PWM (recommended for ATtiny85)
+	pwm  = machine.Timer1
+	pinA = machine.P1 // PB1, Timer1 channel A (LED pin)
+	pinB = machine.P4 // PB4, Timer1 channel B
+)

--- a/src/machine/board_digispark.go
+++ b/src/machine/board_digispark.go
@@ -2,17 +2,26 @@
 
 package machine
 
+// Digispark is a tiny ATtiny85-based board with 6 I/O pins.
+//
+// PWM is available on the following pins:
+//   - P0 (PB0): Timer0 channel A
+//   - P1 (PB1): Timer0 channel B or Timer1 channel A (LED pin)
+//   - P4 (PB4): Timer1 channel B
+//
+// Timer1 is recommended for PWM as it provides more flexible frequency control.
+
 // Return the current CPU frequency in hertz.
 func CPUFrequency() uint32 {
 	return 16000000
 }
 
 const (
-	P0 Pin = PB0
-	P1 Pin = PB1
+	P0 Pin = PB0 // PWM available (Timer0 OC0A)
+	P1 Pin = PB1 // PWM available (Timer0 OC0B or Timer1 OC1A)
 	P2 Pin = PB2
 	P3 Pin = PB3
-	P4 Pin = PB4
+	P4 Pin = PB4 // PWM available (Timer1 OC1B)
 	P5 Pin = PB5
 
 	LED = P1

--- a/src/machine/board_vicharak_shrike-lite.go
+++ b/src/machine/board_vicharak_shrike-lite.go
@@ -1,0 +1,118 @@
+//go:build vicharak_shrike_lite
+
+// Pin mappings for Vicharak Shrike-Lite.
+//
+// Reference: https://vicharak-in.github.io/shrike/shrike_pinouts.html
+
+package machine
+
+// Digital
+const (
+	IO0  Pin = GPIO0
+	IO1  Pin = GPIO1
+	IO2  Pin = GPIO2
+	IO3  Pin = GPIO3
+	IO4  Pin = GPIO4
+	IO5  Pin = GPIO5
+	IO6  Pin = GPIO6
+	IO7  Pin = GPIO7
+	IO8  Pin = GPIO8
+	IO9  Pin = GPIO9
+	IO10 Pin = GPIO10
+	IO11 Pin = GPIO11
+	IO12 Pin = GPIO12
+	IO13 Pin = GPIO13
+	IO14 Pin = GPIO14
+	IO15 Pin = GPIO15
+	IO16 Pin = GPIO16
+	IO17 Pin = GPIO17
+	IO18 Pin = GPIO18
+	IO19 Pin = GPIO19
+	IO20 Pin = GPIO20
+	IO21 Pin = GPIO21
+	IO22 Pin = GPIO22
+	IO23 Pin = GPIO23
+	IO24 Pin = GPIO24
+	IO25 Pin = GPIO25
+	IO26 Pin = GPIO26
+	IO27 Pin = GPIO27
+	IO28 Pin = GPIO28
+	IO29 Pin = GPIO29
+)
+
+// FPGA Pins
+const (
+	FPGA_EN  Pin = IO13
+	FPGA_PWR Pin = IO12
+	// SPI_SCLK
+	F3 Pin = IO2
+	// SPI_SS
+	F4 Pin = IO1
+	// SPI_SI (MOSI)
+	F5 Pin = IO3
+	// SPI_SO (MISO) / CONFIG
+	F6  Pin = IO0
+	F18 Pin = IO14
+	F17 Pin = IO15
+)
+
+// Analog pins
+const (
+	A0 Pin = IO26
+	A1 Pin = IO27
+	A2 Pin = IO28
+	A3 Pin = IO29
+)
+
+// LED
+const (
+	LED = IO4
+)
+
+// I2C pins
+const (
+	I2C0_SDA_PIN Pin = IO24
+	I2C0_SCL_PIN Pin = IO25
+
+	I2C1_SDA_PIN Pin = IO6
+	I2C1_SCL_PIN Pin = IO7
+)
+
+// SPI pins
+const (
+	SPI0_SCK_PIN Pin = IO18
+	SPI0_SDO_PIN Pin = IO19
+	SPI0_SDI_PIN Pin = IO20
+
+	SPI1_SCK_PIN Pin = IO10
+	SPI1_SDO_PIN Pin = IO11
+	SPI1_SDI_PIN Pin = IO8
+)
+
+// Onboard crystal oscillator frequency, in MHz.
+const (
+	xoscFreq = 12 // MHz
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = IO28
+	UART0_RX_PIN = IO29
+	UART_TX_PIN  = UART0_TX_PIN
+	UART_RX_PIN  = UART0_RX_PIN
+	UART1_TX_PIN = IO24
+	UART1_RX_PIN = IO25
+)
+
+var DefaultUART = UART0
+
+// USB CDC identifiers
+const (
+	usb_STRING_PRODUCT      = "Shrike-Lite"
+	usb_STRING_MANUFACTURER = "Vicharak"
+)
+
+var (
+	usb_VID uint16 = 0x2e8a
+	usb_PID uint16 = 0x0003
+)

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -375,3 +375,170 @@ func (pwm PWM) Set(channel uint8, value uint32) {
 		}
 	}
 }
+
+// SPIConfig is used to store config info for SPI.
+type SPIConfig struct {
+	Frequency uint32
+	LSBFirst  bool
+	Mode      uint8
+}
+
+// SPI is the USI-based SPI implementation for ATTiny85.
+// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI
+// (Universal Serial Interface) in three-wire mode.
+//
+// Fixed pin mapping (directly controlled by USI hardware):
+//   - PB2: SCK (clock)
+//   - PB1: DO/MOSI (data out)
+//   - PB0: DI/MISO (data in)
+//
+// Note: CS pin must be managed by the user.
+type SPI struct {
+	// Delay cycles for frequency control (0 = max speed)
+	delayCycles uint16
+
+	// USICR value configured for the selected SPI mode
+	usicrValue uint8
+
+	// LSB-first mode (requires software bit reversal)
+	lsbFirst bool
+}
+
+// SPI0 is the USI-based SPI interface on the ATTiny85
+var SPI0 = SPI{}
+
+// Configure sets up the USI for SPI communication.
+// Note: The user must configure and control the CS pin separately.
+func (s *SPI) Configure(config SPIConfig) error {
+	// Configure USI pins (fixed by hardware)
+	// PB1 (DO/MOSI) -> OUTPUT
+	// PB2 (USCK/SCK) -> OUTPUT
+	// PB0 (DI/MISO) -> INPUT
+	PB1.Configure(PinConfig{Mode: PinOutput})
+	PB2.Configure(PinConfig{Mode: PinOutput})
+	PB0.Configure(PinConfig{Mode: PinInput})
+
+	// Reset USI registers
+	avr.USIDR.Set(0)
+	avr.USISR.Set(0)
+
+	// Configure USI for SPI mode:
+	// - USIWM0: Three-wire mode (SPI)
+	// - USICS1: External clock source (software controlled via USITC)
+	// - USICLK: Clock strobe - enables counter increment on USITC toggle
+	// - USICS0: Controls clock phase (CPHA)
+	//
+	// SPI Modes:
+	//   Mode 0 (CPOL=0, CPHA=0): Clock idle low, sample on rising edge
+	//   Mode 1 (CPOL=0, CPHA=1): Clock idle low, sample on falling edge
+	//   Mode 2 (CPOL=1, CPHA=0): Clock idle high, sample on falling edge
+	//   Mode 3 (CPOL=1, CPHA=1): Clock idle high, sample on rising edge
+	//
+	// For USI, USICS0 controls the sampling edge when USICS1=1:
+	//   USICS0=0: Positive edge (rising)
+	//   USICS0=1: Negative edge (falling)
+	switch config.Mode {
+	case Mode0: // CPOL=0, CPHA=0: idle low, sample rising
+		PB2.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	case Mode1: // CPOL=0, CPHA=1: idle low, sample falling
+		PB2.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode2: // CPOL=1, CPHA=0: idle high, sample falling
+		PB2.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode3: // CPOL=1, CPHA=1: idle high, sample rising
+		PB2.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	default: // Default to Mode 0
+		PB2.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	}
+	avr.USICR.Set(s.usicrValue)
+
+	// Calculate delay cycles for frequency control
+	// Each bit transfer requires 2 clock toggles (rising + falling edge)
+	// The loop overhead is approximately 10-15 cycles per toggle on AVR
+	// We calculate additional delay cycles needed to achieve the target frequency
+	if config.Frequency > 0 && config.Frequency < CPUFrequency()/2 {
+		// Cycles per half-period = CPUFrequency / (2 * Frequency)
+		// Subtract loop overhead (~15 cycles) to get delay cycles
+		cyclesPerHalfPeriod := CPUFrequency() / (2 * config.Frequency)
+		const loopOverhead = 15
+		if cyclesPerHalfPeriod > loopOverhead {
+			s.delayCycles = uint16(cyclesPerHalfPeriod - loopOverhead)
+		} else {
+			s.delayCycles = 0
+		}
+	} else {
+		// Max speed - no delay
+		s.delayCycles = 0
+	}
+
+	// Store LSBFirst setting for use in Transfer
+	s.lsbFirst = config.LSBFirst
+
+	return nil
+}
+
+// reverseByte reverses the bit order of a byte (MSB <-> LSB)
+// Used for LSB-first SPI mode since USI hardware only supports MSB-first
+func reverseByte(b byte) byte {
+	b = (b&0xF0)>>4 | (b&0x0F)<<4
+	b = (b&0xCC)>>2 | (b&0x33)<<2
+	b = (b&0xAA)>>1 | (b&0x55)<<1
+	return b
+}
+
+// Transfer performs a single byte SPI transfer (send and receive simultaneously)
+// This implements the USI-based SPI transfer using the "clock strobing" technique
+func (s *SPI) Transfer(b byte) (byte, error) {
+	// For LSB-first mode, reverse the bits before sending
+	// USI hardware only supports MSB-first, so we do it in software
+	if s.lsbFirst {
+		b = reverseByte(b)
+	}
+
+	// Load the byte to transmit into the USI Data Register
+	avr.USIDR.Set(b)
+
+	// Clear the counter overflow flag by writing 1 to it (AVR quirk)
+	// This also resets the 4-bit counter to 0
+	avr.USISR.Set(avr.USISR_USIOIF)
+
+	// Clock the data out/in
+	// We need 16 clock toggles (8 bits × 2 edges per bit)
+	// The USI counter counts each clock edge, so it overflows at 16
+	// After 16 toggles, the clock returns to its idle state (set by CPOL in Configure)
+	//
+	// IMPORTANT: Only toggle USITC here!
+	// - USITC toggles the clock pin
+	// - The USICR mode bits (USIWM0, USICS1, USICS0, USICLK) were set in Configure()
+	// - SetBits preserves those bits and only sets USITC
+	if s.delayCycles == 0 {
+		// Fast path: no delay, run at maximum speed
+		for !avr.USISR.HasBits(avr.USISR_USIOIF) {
+			avr.USICR.SetBits(avr.USICR_USITC)
+		}
+	} else {
+		// Frequency-controlled path: add delay between clock toggles
+		for !avr.USISR.HasBits(avr.USISR_USIOIF) {
+			avr.USICR.SetBits(avr.USICR_USITC)
+			// Delay loop for frequency control
+			// Each iteration is approximately 3 cycles on AVR (dec, brne)
+			for i := s.delayCycles; i > 0; i-- {
+				avr.Asm("nop")
+			}
+		}
+	}
+
+	// Get the received byte
+	result := avr.USIDR.Get()
+
+	// For LSB-first mode, reverse the received bits
+	if s.lsbFirst {
+		result = reverseByte(result)
+	}
+
+	return result, nil
+}

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -21,3 +21,357 @@ func (p Pin) getPortMask() (*volatile.Register8, uint8) {
 	// Very simple for the attiny85, which only has a single port.
 	return avr.PORTB, 1 << uint8(p)
 }
+
+// PWM is one PWM peripheral, which consists of a counter and two output
+// channels (that can be connected to two fixed pins). You can set the frequency
+// using SetPeriod, but only for all the channels in this PWM peripheral at
+// once.
+type PWM struct {
+	num uint8
+}
+
+var (
+	Timer0 = PWM{0} // 8 bit timer for PB0 and PB1
+	Timer1 = PWM{1} // 8 bit high-speed timer for PB1 and PB4
+)
+
+// GTCCR bits for Timer1 that are not defined in the device file
+const (
+	gtccrPWM1B  = 0x40 // Pulse Width Modulator B Enable
+	gtccrCOM1B0 = 0x10 // Comparator B Output Mode bit 0
+	gtccrCOM1B1 = 0x20 // Comparator B Output Mode bit 1
+)
+
+// Configure enables and configures this PWM.
+//
+// For Timer0, there is only a limited number of periods available, namely the
+// CPU frequency divided by 256 and again divided by 1, 8, 64, 256, or 1024.
+// For a MCU running at 8MHz, this would be a period of 32µs, 256µs, 2048µs,
+// 8192µs, or 32768µs.
+//
+// For Timer1, the period is more flexible as it uses OCR1C as the top value.
+// Timer1 also supports more prescaler values (1 to 16384).
+func (pwm PWM) Configure(config PWMConfig) error {
+	switch pwm.num {
+	case 0: // Timer/Counter 0 (8-bit)
+		// Calculate the timer prescaler.
+		var prescaler uint8
+		switch config.Period {
+		case 0, (uint64(1e9) * 256 * 1) / uint64(CPUFrequency()):
+			prescaler = 1
+		case (uint64(1e9) * 256 * 8) / uint64(CPUFrequency()):
+			prescaler = 2
+		case (uint64(1e9) * 256 * 64) / uint64(CPUFrequency()):
+			prescaler = 3
+		case (uint64(1e9) * 256 * 256) / uint64(CPUFrequency()):
+			prescaler = 4
+		case (uint64(1e9) * 256 * 1024) / uint64(CPUFrequency()):
+			prescaler = 5
+		default:
+			return ErrPWMPeriodTooLong
+		}
+
+		avr.TCCR0B.Set(prescaler)
+		// Set the PWM mode to fast PWM (mode = 3).
+		avr.TCCR0A.Set(avr.TCCR0A_WGM00 | avr.TCCR0A_WGM01)
+
+	case 1: // Timer/Counter 1 (8-bit high-speed)
+		// Timer1 on ATtiny85 is different from ATmega328:
+		// - It's 8-bit with configurable top (OCR1C)
+		// - Has more prescaler options (1-16384)
+		// - PWM mode is enabled per-channel via PWM1A/PWM1B bits
+		var top uint64
+		if config.Period == 0 {
+			// Use a top appropriate for LEDs.
+			top = 0xff
+		} else {
+			// Calculate top value: top = period * (CPUFrequency / 1e9)
+			top = config.Period * (uint64(CPUFrequency()) / 1000000) / 1000
+		}
+
+		// Timer1 prescaler values: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384
+		const maxTop = 256
+		var prescaler uint8
+		switch {
+		case top <= maxTop:
+			prescaler = 1 // prescaler 1
+		case top/2 <= maxTop:
+			prescaler = 2 // prescaler 2
+			top /= 2
+		case top/4 <= maxTop:
+			prescaler = 3 // prescaler 4
+			top /= 4
+		case top/8 <= maxTop:
+			prescaler = 4 // prescaler 8
+			top /= 8
+		case top/16 <= maxTop:
+			prescaler = 5 // prescaler 16
+			top /= 16
+		case top/32 <= maxTop:
+			prescaler = 6 // prescaler 32
+			top /= 32
+		case top/64 <= maxTop:
+			prescaler = 7 // prescaler 64
+			top /= 64
+		case top/128 <= maxTop:
+			prescaler = 8 // prescaler 128
+			top /= 128
+		case top/256 <= maxTop:
+			prescaler = 9 // prescaler 256
+			top /= 256
+		case top/512 <= maxTop:
+			prescaler = 10 // prescaler 512
+			top /= 512
+		case top/1024 <= maxTop:
+			prescaler = 11 // prescaler 1024
+			top /= 1024
+		case top/2048 <= maxTop:
+			prescaler = 12 // prescaler 2048
+			top /= 2048
+		case top/4096 <= maxTop:
+			prescaler = 13 // prescaler 4096
+			top /= 4096
+		case top/8192 <= maxTop:
+			prescaler = 14 // prescaler 8192
+			top /= 8192
+		case top/16384 <= maxTop:
+			prescaler = 15 // prescaler 16384
+			top /= 16384
+		default:
+			return ErrPWMPeriodTooLong
+		}
+
+		// Set prescaler (CS1[3:0] bits)
+		avr.TCCR1.Set(prescaler)
+		// Set top value
+		avr.OCR1C.Set(uint8(top - 1))
+	}
+	return nil
+}
+
+// SetPeriod updates the period of this PWM peripheral.
+// To set a particular frequency, use the following formula:
+//
+//	period = 1e9 / frequency
+//
+// If you use a period of 0, a period that works well for LEDs will be picked.
+//
+// SetPeriod will not change the prescaler, but also won't change the current
+// value in any of the channels. This means that you may need to update the
+// value for the particular channel.
+//
+// Note that you cannot pick any arbitrary period after the PWM peripheral has
+// been configured. If you want to switch between frequencies, pick the lowest
+// frequency (longest period) once when calling Configure and adjust the
+// frequency here as needed.
+func (pwm PWM) SetPeriod(period uint64) error {
+	if pwm.num == 0 {
+		return ErrPWMPeriodTooLong // Timer0 doesn't support dynamic period
+	}
+
+	// Timer1 can adjust period via OCR1C
+	var top uint64
+	if period == 0 {
+		top = 0xff
+	} else {
+		top = period * (uint64(CPUFrequency()) / 1000000) / 1000
+	}
+
+	// Get current prescaler
+	prescaler := avr.TCCR1.Get() & 0x0f
+	// Timer1 prescaler values follow a power-of-2 pattern:
+	// prescaler n maps to divisor 2^(n-1), so we can use a simple shift
+	if prescaler > 0 && prescaler <= 15 {
+		top >>= (prescaler - 1)
+	}
+
+	if top > 256 {
+		return ErrPWMPeriodTooLong
+	}
+
+	avr.OCR1C.Set(uint8(top - 1))
+	avr.TCNT1.Set(0)
+
+	return nil
+}
+
+// Top returns the current counter top, for use in duty cycle calculation. It
+// will only change with a call to Configure or SetPeriod, otherwise it is
+// constant.
+//
+// The value returned here is hardware dependent. In general, it's best to treat
+// it as an opaque value that can be divided by some number and passed to Set
+// (see Set documentation for more information).
+func (pwm PWM) Top() uint32 {
+	if pwm.num == 1 {
+		// Timer1 has configurable top via OCR1C
+		return uint32(avr.OCR1C.Get()) + 1
+	}
+	// Timer0 goes from 0 to 0xff (256 in total)
+	return 256
+}
+
+// Counter returns the current counter value of the timer in this PWM
+// peripheral. It may be useful for debugging.
+func (pwm PWM) Counter() uint32 {
+	switch pwm.num {
+	case 0:
+		return uint32(avr.TCNT0.Get())
+	case 1:
+		return uint32(avr.TCNT1.Get())
+	}
+	return 0
+}
+
+// Prescaler lookup tables using uint16 (more efficient than uint64 on AVR)
+// Timer0 prescaler lookup table (index 0-7 maps to prescaler bits)
+var timer0Prescalers = [8]uint16{0, 1, 8, 64, 256, 1024, 0, 0}
+
+// Timer1 prescaler lookup table (index 0-15 maps to prescaler bits)
+var timer1Prescalers = [16]uint16{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}
+
+// Period returns the used PWM period in nanoseconds. It might deviate slightly
+// from the configured period due to rounding.
+func (pwm PWM) Period() uint64 {
+	var prescaler uint64
+	switch pwm.num {
+	case 0:
+		prescalerBits := avr.TCCR0B.Get() & 0x7
+		prescaler = uint64(timer0Prescalers[prescalerBits])
+		if prescaler == 0 {
+			return 0
+		}
+	case 1:
+		prescalerBits := avr.TCCR1.Get() & 0x0f
+		prescaler = uint64(timer1Prescalers[prescalerBits])
+		if prescaler == 0 {
+			return 0
+		}
+	}
+	top := uint64(pwm.Top())
+	return prescaler * top * 1000 / uint64(CPUFrequency()/1e6)
+}
+
+// Channel returns a PWM channel for the given pin.
+func (pwm PWM) Channel(pin Pin) (uint8, error) {
+	pin.Configure(PinConfig{Mode: PinOutput})
+	pin.Low()
+	switch pwm.num {
+	case 0:
+		switch pin {
+		case PB0: // OC0A
+			avr.TCCR0A.SetBits(avr.TCCR0A_COM0A1)
+			return 0, nil
+		case PB1: // OC0B
+			avr.TCCR0A.SetBits(avr.TCCR0A_COM0B1)
+			return 1, nil
+		}
+	case 1:
+		switch pin {
+		case PB1: // OC1A
+			// Enable PWM on channel A
+			avr.TCCR1.SetBits(avr.TCCR1_PWM1A | avr.TCCR1_COM1A1)
+			return 0, nil
+		case PB4: // OC1B
+			// Enable PWM on channel B (controlled via GTCCR)
+			avr.GTCCR.SetBits(gtccrPWM1B | gtccrCOM1B1)
+			return 1, nil
+		}
+	}
+	return 0, ErrInvalidOutputPin
+}
+
+// SetInverting sets whether to invert the output of this channel.
+// Without inverting, a 25% duty cycle would mean the output is high for 25% of
+// the time and low for the rest. Inverting flips the output as if a NOT gate
+// was placed at the output, meaning that the output would be 25% low and 75%
+// high with a duty cycle of 25%.
+func (pwm PWM) SetInverting(channel uint8, inverting bool) {
+	switch pwm.num {
+	case 0:
+		switch channel {
+		case 0: // channel A, PB0
+			if inverting {
+				avr.PORTB.SetBits(1 << 0)
+				avr.TCCR0A.SetBits(avr.TCCR0A_COM0A0)
+			} else {
+				avr.PORTB.ClearBits(1 << 0)
+				avr.TCCR0A.ClearBits(avr.TCCR0A_COM0A0)
+			}
+		case 1: // channel B, PB1
+			if inverting {
+				avr.PORTB.SetBits(1 << 1)
+				avr.TCCR0A.SetBits(avr.TCCR0A_COM0B0)
+			} else {
+				avr.PORTB.ClearBits(1 << 1)
+				avr.TCCR0A.ClearBits(avr.TCCR0A_COM0B0)
+			}
+		}
+	case 1:
+		switch channel {
+		case 0: // channel A, PB1
+			if inverting {
+				avr.PORTB.SetBits(1 << 1)
+				avr.TCCR1.SetBits(avr.TCCR1_COM1A0)
+			} else {
+				avr.PORTB.ClearBits(1 << 1)
+				avr.TCCR1.ClearBits(avr.TCCR1_COM1A0)
+			}
+		case 1: // channel B, PB4
+			if inverting {
+				avr.PORTB.SetBits(1 << 4)
+				avr.GTCCR.SetBits(gtccrCOM1B0)
+			} else {
+				avr.PORTB.ClearBits(1 << 4)
+				avr.GTCCR.ClearBits(gtccrCOM1B0)
+			}
+		}
+	}
+}
+
+// Set updates the channel value. This is used to control the channel duty
+// cycle, in other words the fraction of time the channel output is high (or low
+// when inverted). For example, to set it to a 25% duty cycle, use:
+//
+//	pwm.Set(channel, pwm.Top() / 4)
+//
+// pwm.Set(channel, 0) will set the output to low and pwm.Set(channel,
+// pwm.Top()) will set the output to high, assuming the output isn't inverted.
+func (pwm PWM) Set(channel uint8, value uint32) {
+	switch pwm.num {
+	case 0:
+		switch channel {
+		case 0: // channel A, PB0
+			if value == 0 {
+				avr.TCCR0A.ClearBits(avr.TCCR0A_COM0A1)
+			} else {
+				avr.OCR0A.Set(uint8(value - 1))
+				avr.TCCR0A.SetBits(avr.TCCR0A_COM0A1)
+			}
+		case 1: // channel B, PB1
+			if value == 0 {
+				avr.TCCR0A.ClearBits(avr.TCCR0A_COM0B1)
+			} else {
+				avr.OCR0B.Set(uint8(value - 1))
+				avr.TCCR0A.SetBits(avr.TCCR0A_COM0B1)
+			}
+		}
+	case 1:
+		switch channel {
+		case 0: // channel A, PB1
+			if value == 0 {
+				avr.TCCR1.ClearBits(avr.TCCR1_COM1A1)
+			} else {
+				avr.OCR1A.Set(uint8(value - 1))
+				avr.TCCR1.SetBits(avr.TCCR1_COM1A1)
+			}
+		case 1: // channel B, PB4
+			if value == 0 {
+				avr.GTCCR.ClearBits(gtccrCOM1B1)
+			} else {
+				avr.OCR1B.Set(uint8(value - 1))
+				avr.GTCCR.SetBits(gtccrCOM1B1)
+			}
+		}
+	}
+}

--- a/src/machine/machine_rp2_adc.go
+++ b/src/machine/machine_rp2_adc.go
@@ -19,10 +19,8 @@ var adcAref uint32
 
 // InitADC resets the ADC peripheral.
 func InitADC() {
-	rp.RESETS.RESET.SetBits(rp.RESETS_RESET_ADC)
-	rp.RESETS.RESET.ClearBits(rp.RESETS_RESET_ADC)
-	for !rp.RESETS.RESET_DONE.HasBits(rp.RESETS_RESET_ADC) {
-	}
+	resetBlock(rp.RESETS_RESET_ADC)
+	unresetBlockWait(rp.RESETS_RESET_ADC)
 	// enable ADC
 	rp.ADC.CS.Set(rp.ADC_CS_EN)
 	adcAref = 3300

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -259,10 +259,7 @@ func (i2c *I2C) init(config I2CConfig) error {
 //go:inline
 func (i2c *I2C) reset() {
 	resetVal := i2c.deinit()
-	rp.RESETS.RESET.ClearBits(resetVal)
-	// Wait until reset is done.
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	unresetBlockWait(resetVal)
 }
 
 // deinit sets reset bit for I2C. Must call reset to reenable I2C after deinit.
@@ -276,7 +273,7 @@ func (i2c *I2C) deinit() (resetVal uint32) {
 		resetVal = rp.RESETS_RESET_I2C1
 	}
 	// Perform I2C reset.
-	rp.RESETS.RESET.SetBits(resetVal)
+	resetBlock(resetVal)
 
 	return resetVal
 }

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -280,8 +280,6 @@ func (i2c *I2C) deinit() (resetVal uint32) {
 
 // tx performs blocking write followed by read to I2C bus.
 func (i2c *I2C) tx(addr uint8, tx, rx []byte) (err error) {
-	const timeout_us = 4_000
-	deadline := ticks() + timeout_us
 	if addr >= 0x80 || isReservedI2CAddr(addr) {
 		return errInvalidTgtAddr
 	}
@@ -291,6 +289,14 @@ func (i2c *I2C) tx(addr uint8, tx, rx []byte) (err error) {
 	if txlen == 0 && rxlen == 0 {
 		return nil
 	}
+
+	// Base 4ms for small register pokes.
+	// Add per-byte budget. 100us/byte is conservative at 400kHz and still ok at 100kHz for modest sizes.
+	timeout_us := uint64(4_000) + uint64(txlen+rxlen)*100
+	// Cap so it doesn't go insane:
+	timeout_us = min(timeout_us, 500_000)
+
+	deadline := ticks() + timeout_us
 
 	err = i2c.disable()
 	if err != nil {

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -212,10 +212,7 @@ func (spi *SPI) setFormat(mode uint8) {
 //go:inline
 func (spi *SPI) reset() {
 	resetVal := spi.deinit()
-	rp.RESETS.RESET.ClearBits(resetVal)
-	// Wait until reset is done.
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	unresetBlockWait(resetVal)
 }
 
 //go:inline
@@ -227,7 +224,7 @@ func (spi *SPI) deinit() (resetVal uint32) {
 		resetVal = rp.RESETS_RESET_SPI1
 	}
 	// Perform SPI reset.
-	rp.RESETS.RESET.SetBits(resetVal)
+	resetBlock(resetVal)
 	return resetVal
 }
 

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -148,10 +148,8 @@ func initUART(uart *UART) {
 	}
 
 	// reset UART
-	rp.RESETS.RESET.SetBits(resetVal)
-	rp.RESETS.RESET.ClearBits(resetVal)
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	resetBlock(resetVal)
+	unresetBlockWait(resetVal)
 }
 
 // handleInterrupt should be called from the appropriate interrupt handler for

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -73,6 +73,27 @@ func (uart *UART) Configure(config UARTConfig) error {
 	return nil
 }
 
+// Close the UART and disable its interrupt/power use.
+func (uart *UART) Close() error {
+	uart.Interrupt.Disable()
+
+	// Disable UART.
+	uart.Bus.UARTCR.ClearBits(rp.UART0_UARTCR_UARTEN)
+
+	var resetVal uint32
+	switch {
+	case uart.Bus == rp.UART0:
+		resetVal = rp.RESETS_RESET_UART0
+	case uart.Bus == rp.UART1:
+		resetVal = rp.RESETS_RESET_UART1
+	}
+
+	// reset UART
+	resetBlock(resetVal)
+
+	return nil
+}
+
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
 	div := 8 * CPUFrequency() / br

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || rp2350 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build !baremetal || atmega || attiny85 || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || rp2350 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 package machine
 

--- a/src/machine/spi_tx.go
+++ b/src/machine/spi_tx.go
@@ -1,4 +1,4 @@
-//go:build atmega || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build atmega || attiny85 || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 // This file implements the SPI Tx function for targets that don't have a custom
 // (faster) implementation for it.

--- a/targets/vicharak_shrike-lite.json
+++ b/targets/vicharak_shrike-lite.json
@@ -1,0 +1,14 @@
+{
+    "inherits": [
+        "rp2040"
+    ],
+    "serial-port": ["2e8a:0003"],
+    "default-stack-size": 8192,
+    "build-tags": ["vicharak_shrike_lite"],
+    "ldflags": [
+        "--defsym=__flash_size=4M"
+    ],
+    "extra-files": [
+        "targets/pico-boot-stage2.S"
+    ]
+}

--- a/testdata/corpus.yaml
+++ b/testdata/corpus.yaml
@@ -29,8 +29,7 @@
 - repo: github.com/dgryski/go-camellia
 - repo: github.com/dgryski/go-change
 - repo: github.com/dgryski/go-chaskey
-  tags: appengine noasm
-  skipwasi: true # siphash has build tag issues
+  tags: appengine noasm # for dchest/siphash
 - repo: github.com/dgryski/go-clefia
 - repo: github.com/dgryski/go-clockpro
 - repo: github.com/dgryski/go-cobs
@@ -56,7 +55,6 @@
 - repo: github.com/dgryski/go-linlog
 - repo: github.com/dgryski/go-maglev
   tags: appengine # for dchest/siphash
-  skipwasi: true
 - repo: github.com/dgryski/go-marvin32
 - repo: github.com/dgryski/go-md5crypt
 - repo: github.com/dgryski/go-metro
@@ -66,7 +64,6 @@
   tags: noasm
 - repo: github.com/dgryski/go-mpchash
   tags: appengine # for dchest/siphash
-  skipwasi: true
 - repo: github.com/dgryski/go-neeva
 - repo: github.com/dgryski/go-nibz
 - repo: github.com/dgryski/go-nibblesort
@@ -289,3 +286,8 @@
 - repo: github.com/philhofer/fwd
 - repo: github.com/blevesearch/sear
 - repo: github.com/steveyen/gtreap
+- repo: github.com/orsinium-labs/tinymath
+- repo: github.com/orsinium-labs/jsony
+- repo: github.com/tidwall/gjson
+- repo: github.com/dchest/siphash
+  tags: appengine


### PR DESCRIPTION
A test of using Go 1.26rc1 for all builds.

**UPDATE: now testing against Go 1.26rc2**

**FURTHER UPDATE: now testing against Go 1.26 release**