### PR TITLE
Update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
-Copyright (c) 2018-2025 The TinyGo Authors. All rights reserved.
+Copyright (c) 2018-2026 The TinyGo Authors. All rights reserved.
 
 TinyGo includes portions of the Go standard library.
-Copyright (c) 2009-2024 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+See https://github.com/golang/go/blob/master/LICENSE for license information.
 
 TinyGo includes portions of LLVM, which is under the Apache License v2.0 with
 LLVM Exceptions. See https://llvm.org/LICENSE.txt for license information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2018-2026 The TinyGo Authors. All rights reserved.
 
 TinyGo includes portions of the Go standard library.
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 See https://github.com/golang/go/blob/master/LICENSE for license information.
 
 TinyGo includes portions of LLVM, which is under the Apache License v2.0 with


### PR DESCRIPTION
1. Update the copyright range end to 2026.
2. Change the Go copyright from range to year to have it verbatim as specified in their license.
3. Link the Go license the same way as you link the LLVM license.