### PR TITLE
main (test): skips mipsle test if the emulator is missing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -222,6 +222,7 @@ func TestBuild(t *testing.T) {
 			// to be sure.
 			t.Parallel()
 			options := optionsFromOSARCH("linux/mipsle/softfloat", sema)
+			emuCheck(t, options)
 			runTest("cgo/", options, t, nil, nil)
 		})
 	} else if runtime.GOOS == "windows" {


### PR DESCRIPTION
This one specific case was missing a call to emucheck.