### PR TITLE
sync: add WaitGroup.Go

### DIFF
--- a/src/sync/waitgroup.go
+++ b/src/sync/waitgroup.go
@@ -83,3 +83,11 @@ func (wg *WaitGroup) Wait() {
 		}
 	}
 }
+
+func (wg *WaitGroup) Go(f func()) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f()
+	}()
+}


### PR DESCRIPTION
This function was missing from tinygo's implementation of WaitGroup.