### PR TITLE
runtime: make timeoffset atomic

### DIFF
--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -3,6 +3,7 @@
 package runtime
 
 import (
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -69,13 +70,14 @@ const baremetal = true
 // timeOffset is how long the monotonic clock started after the Unix epoch. It
 // should be a positive integer under normal operation or zero when it has not
 // been set.
-var timeOffset int64
+var timeOffset atomic.Int64
 
 //go:linkname now time.now
 func now() (sec int64, nsec int32, mono int64) {
 	mono = nanotime()
-	sec = (mono + timeOffset) / (1000 * 1000 * 1000)
-	nsec = int32((mono + timeOffset) - sec*(1000*1000*1000))
+	to := timeOffset.Load()
+	sec = (mono + to) / (1000 * 1000 * 1000)
+	nsec = int32((mono + to) - sec*(1000*1000*1000))
 	return
 }
 
@@ -83,8 +85,7 @@ func now() (sec int64, nsec int32, mono int64) {
 // positive value adds to the time (skipping some time), a negative value moves
 // the clock into the past.
 func AdjustTimeOffset(offset int64) {
-	// TODO: do this atomically?
-	timeOffset += offset
+	timeOffset.Add(offset)
 }
 
 // Picolibc is not configured to define its own errno value, instead it calls


### PR DESCRIPTION
This PR makes the variable `timeOffset` atomic to be able to handle changing the system time. Otherwise the scheduler can gets rather confused if you call AdjustTimeOffset when there are multiple goroutines already running.