### PR TITLE
Fix handling of derived peripherals and interrupt names

### DIFF
--- a/tools/gen-device-svd/gen-device-svd.go
+++ b/tools/gen-device-svd/gen-device-svd.go
@@ -368,7 +368,8 @@ func readSVD(path, sourceURL string) (*Device, error) {
 		}
 
 		for _, interrupt := range periphEl.Interrupts {
-			addInterrupt(interrupts, interrupt.Name, interrupt.Name, interrupt.Index, description)
+			interruptName := cleanName(strings.TrimSpace(interrupt.Name))
+			addInterrupt(interrupts, interruptName, interruptName, interrupt.Index, description)
 			// As a convenience, also use the peripheral name as the interrupt
 			// name. Only do that for the nrf for now, as the stm32 .svd files
 			// don't always put interrupts in the correct peripheral...
@@ -381,6 +382,9 @@ func readSVD(path, sourceURL string) (*Device, error) {
 			var derivedFrom *Peripheral
 			if periphEl.DerivedFrom != "" {
 				derivedFrom = peripheralDict[periphEl.DerivedFrom]
+				if derivedFrom == nil {
+					return nil, fmt.Errorf("peripheral %s derivedFrom %s not found", periphEl.Name, periphEl.DerivedFrom)
+				}
 			} else {
 				derivedFrom = groups[groupName]
 			}
@@ -489,16 +493,13 @@ func readSVD(path, sourceURL string) (*Device, error) {
 func orderPeripherals(input []SVDPeripheral) []*SVDPeripheral {
 	var sortedPeripherals []*SVDPeripheral
 	var missingBasePeripherals []*SVDPeripheral
-	knownBasePeripherals := map[string]struct{}{}
+	knownPeripherals := map[string]struct{}{}
 	for i := range input {
 		p := &input[i]
-		groupName := p.GroupName
-		if groupName == "" {
-			groupName = p.Name
-		}
-		knownBasePeripherals[groupName] = struct{}{}
+		// Track by peripheral name since derivedFrom references names, not group names
+		knownPeripherals[p.Name] = struct{}{}
 		if p.DerivedFrom != "" {
-			if _, ok := knownBasePeripherals[p.DerivedFrom]; !ok {
+			if _, ok := knownPeripherals[p.DerivedFrom]; !ok {
 				missingBasePeripherals = append(missingBasePeripherals, p)
 				continue
 			}


### PR DESCRIPTION
Background

  The lib/stm32-svd submodule was updated from e6db8e3 to 5b13c6d during https://github.com/tinygo-org/stm32-svd/pull/11. This update includes new device families and updated register definitions.

  Issue 1: orderPeripherals tracking by wrong key

  Problem: The orderPeripherals function in gen-device-svd.go is designed to reorder peripherals so that base peripherals are processed before peripherals that derive from them (via SVD's derivedFrom attribute). However, it was tracking known peripherals by their groupName, not their actual name.

  Example from stm32u595.svd:
  <peripheral>
    <name>I2C1</name>
    <groupName>I2C</groupName>
    ...
  </peripheral>
  <peripheral derivedFrom="I2C1">
    <name>I2C5</name>
    ...
  </peripheral>
  <peripheral derivedFrom="I2C5">
    <name>SEC_I2C5</name>
    ...
  </peripheral>

  The old code would:
  1. Process I2C1, add "I2C" (groupName) to known peripherals
  2. Process I2C5, check if "I2C1" exists in known peripherals → not found (only "I2C" exists)
  3. Defer I2C5 to missingBasePeripherals
  4. Process SEC_I2C5, check if "I2C5" exists → not found
  5. Eventually process deferred peripherals, but I2C5 still can't find I2C1 → nil pointer panic

  Fix: Track peripherals by their name field since that's what derivedFrom references.

  Issue 2: Whitespace in interrupt names

  Problem: Some SVD files in the updated stm32-svd contain interrupt names with leading whitespace (e.g., <name> FLASH</name> in stm32l0x1.svd). The generator was using these names directly without sanitization, producing invalid Go code:

  func interrupt FLASH() {        // Invalid: space in function name
      callHandlers(IRQ_ FLASH)    // Invalid: space in identifier
  }

  Fix: Apply strings.TrimSpace and cleanName to interrupt names before use.

  ---
  These issues only surfaced with the newer SVD files because:
  1. The new files have more complex derivedFrom chains (peripheral → derived → derived again)
  2. The upstream stm32-rs project introduced whitespace in some interrupt names
