### PR TITLE
machine/rp: always use the blockReset() and unresetBlockWait() helper functions

### DIFF
--- a/src/machine/machine_rp2_adc.go
+++ b/src/machine/machine_rp2_adc.go
@@ -19,10 +19,8 @@ var adcAref uint32
 
 // InitADC resets the ADC peripheral.
 func InitADC() {
-	rp.RESETS.RESET.SetBits(rp.RESETS_RESET_ADC)
-	rp.RESETS.RESET.ClearBits(rp.RESETS_RESET_ADC)
-	for !rp.RESETS.RESET_DONE.HasBits(rp.RESETS_RESET_ADC) {
-	}
+	resetBlock(rp.RESETS_RESET_ADC)
+	unresetBlockWait(rp.RESETS_RESET_ADC)
 	// enable ADC
 	rp.ADC.CS.Set(rp.ADC_CS_EN)
 	adcAref = 3300

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -259,10 +259,7 @@ func (i2c *I2C) init(config I2CConfig) error {
 //go:inline
 func (i2c *I2C) reset() {
 	resetVal := i2c.deinit()
-	rp.RESETS.RESET.ClearBits(resetVal)
-	// Wait until reset is done.
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	unresetBlockWait(resetVal)
 }
 
 // deinit sets reset bit for I2C. Must call reset to reenable I2C after deinit.
@@ -276,7 +273,7 @@ func (i2c *I2C) deinit() (resetVal uint32) {
 		resetVal = rp.RESETS_RESET_I2C1
 	}
 	// Perform I2C reset.
-	rp.RESETS.RESET.SetBits(resetVal)
+	resetBlock(resetVal)
 
 	return resetVal
 }

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -212,10 +212,7 @@ func (spi *SPI) setFormat(mode uint8) {
 //go:inline
 func (spi *SPI) reset() {
 	resetVal := spi.deinit()
-	rp.RESETS.RESET.ClearBits(resetVal)
-	// Wait until reset is done.
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	unresetBlockWait(resetVal)
 }
 
 //go:inline
@@ -227,7 +224,7 @@ func (spi *SPI) deinit() (resetVal uint32) {
 		resetVal = rp.RESETS_RESET_SPI1
 	}
 	// Perform SPI reset.
-	rp.RESETS.RESET.SetBits(resetVal)
+	resetBlock(resetVal)
 	return resetVal
 }
 

--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -148,10 +148,8 @@ func initUART(uart *UART) {
 	}
 
 	// reset UART
-	rp.RESETS.RESET.SetBits(resetVal)
-	rp.RESETS.RESET.ClearBits(resetVal)
-	for !rp.RESETS.RESET_DONE.HasBits(resetVal) {
-	}
+	resetBlock(resetVal)
+	unresetBlockWait(resetVal)
 }
 
 // handleInterrupt should be called from the appropriate interrupt handler for


### PR DESCRIPTION
This PR is a minor refactor to always use the `blockReset()` and `unresetBlockWait()` helper functions for all peripheral reset/unreset operations on the rp2040/rp2350 instead of calling the `RESET` block registers directly.