### PR TITLE
machine/rp: add Close function to UART

### DIFF
--- a/src/machine/machine_rp2_uart.go
+++ b/src/machine/machine_rp2_uart.go
@@ -73,6 +73,27 @@ func (uart *UART) Configure(config UARTConfig) error {
 	return nil
 }
 
+// Close the UART and disable its interrupt/power use.
+func (uart *UART) Close() error {
+	uart.Interrupt.Disable()
+
+	// Disable UART.
+	uart.Bus.UARTCR.ClearBits(rp.UART0_UARTCR_UARTEN)
+
+	var resetVal uint32
+	switch {
+	case uart.Bus == rp.UART0:
+		resetVal = rp.RESETS_RESET_UART0
+	case uart.Bus == rp.UART1:
+		resetVal = rp.RESETS_RESET_UART1
+	}
+
+	// reset UART
+	resetBlock(resetVal)
+
+	return nil
+}
+
 // SetBaudRate sets the baudrate to be used for the UART.
 func (uart *UART) SetBaudRate(br uint32) {
 	div := 8 * CPUFrequency() / br


### PR DESCRIPTION
This PR adds a `Close()` function to the `UART` on the `rp2040/rp2350` to allow for removing all system resources/power usage.

You still call `uart.Configure()` as before. Now you can also call `uart.Close()`.

I would like to add a similar function to other peripherals such as SPI/I2C. Also I think this would be a good feature to have on other processor families.