### PR TITLE
chore: update version to 0.41.0-dev

### DIFF
--- a/goenv/version.go
+++ b/goenv/version.go
@@ -10,7 +10,7 @@ import (
 
 // Version of TinyGo.
 // Update this value before release of new version of software.
-const version = "0.40.1"
+const version = "0.41.0-dev"
 
 // Return TinyGo version, either in the form 0.30.0 or as a development version
 // (like 0.30.0-dev-abcd012).


### PR DESCRIPTION
This PR is to update the TiinyGo version to `0.41.0-dev` for the next cycle.