### PR TITLE
machine/attiny85: add USI-based SPI support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -898,6 +898,8 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark           examples/pwm
 	@$(MD5SUM) test.hex
+	$(TINYGO) build -size short -o test.hex -target=digispark           examples/mcp3008
+	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=digispark -gc=leaking examples/blinky1
 	@$(MD5SUM) test.hex
 ifneq ($(XTENSA), 0)

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -405,6 +405,9 @@ type SPI struct {
 
 	// USICR value configured for the selected SPI mode
 	usicrValue uint8
+
+	// LSB-first mode (requires software bit reversal)
+	lsbFirst bool
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
@@ -500,15 +503,30 @@ func (s *SPI) Configure(config SPIConfig) error {
 		s.delayCycles = 0
 	}
 
-	// Note: LSBFirst is not directly supported by USI hardware
-	// It would need to be implemented in software if required
+	// Store LSBFirst setting for use in Transfer
+	s.lsbFirst = config.LSBFirst
 
 	return nil
+}
+
+// reverseByte reverses the bit order of a byte (MSB <-> LSB)
+// Used for LSB-first SPI mode since USI hardware only supports MSB-first
+func reverseByte(b byte) byte {
+	b = (b&0xF0)>>4 | (b&0x0F)<<4
+	b = (b&0xCC)>>2 | (b&0x33)<<2
+	b = (b&0xAA)>>1 | (b&0x55)<<1
+	return b
 }
 
 // Transfer performs a single byte SPI transfer (send and receive simultaneously)
 // This implements the USI-based SPI transfer using the "clock strobing" technique
 func (s *SPI) Transfer(b byte) (byte, error) {
+	// For LSB-first mode, reverse the bits before sending
+	// USI hardware only supports MSB-first, so we do it in software
+	if s.lsbFirst {
+		b = reverseByte(b)
+	}
+
 	// Load the byte to transmit into the USI Data Register
 	s.usidr.Set(b)
 
@@ -542,6 +560,13 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 		}
 	}
 
-	// After 8 bits are transferred, return the received byte
-	return s.usidr.Get(), nil
+	// Get the received byte
+	result := s.usidr.Get()
+
+	// For LSB-first mode, reverse the received bits
+	if s.lsbFirst {
+		result = reverseByte(result)
+	}
+
+	return result, nil
 }

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -5,7 +5,6 @@ package machine
 import (
 	"device/avr"
 	"runtime/volatile"
-	"unsafe"
 )
 
 const (
@@ -384,189 +383,75 @@ type SPIConfig struct {
 	Mode      uint8
 }
 
-// SPI is the USI-based SPI implementation for ATTiny85
-// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI (Universal Serial Interface)
-// which can be configured to work as SPI in "Three-wire mode"
+// SPI is the USI-based SPI implementation for ATTiny85.
+// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI
+// (Universal Serial Interface) in three-wire mode.
+//
+// Fixed pin mapping (directly controlled by USI hardware):
+//   - PB2: SCK (clock)
+//   - PB1: DO/MOSI (data out)
+//   - PB0: DI/MISO (data in)
+//
+// Note: CS pin must be managed by the user.
 type SPI struct {
-	// USI registers
-	usidr *volatile.Register8 // Data Register
-	usisr *volatile.Register8 // Status Register
-	usicr *volatile.Register8 // Control Register
-
-	// The io pins for the USI-SPI
-	// Note: Pin mapping is different from ISP programming pins
-	sck Pin // PB2 (USCK) - Clock
-	sdo Pin // PB1 (DO) - MOSI (Master Out Slave In)
-	sdi Pin // PB0 (DI) - MISO (Master In Slave Out)
-	cs  Pin // User-defined CS pin (USI doesn't manage CS)
-
-	// Delay cycles for frequency control (0 = max speed)
-	delayCycles uint16
-
-	// USICR value configured for the selected SPI mode
+	// Single byte stores USICR configuration value
 	usicrValue uint8
-
-	// LSB-first mode (requires software bit reversal)
-	lsbFirst bool
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
-var SPI0 = &SPI{
-	usidr: avr.USIDR,
-	usisr: avr.USISR,
-	usicr: avr.USICR,
+var SPI0 = SPI{}
 
-	sck: PB2, // USCK
-	sdo: PB1, // DO (MOSI)
-	sdi: PB0, // DI (MISO)
-	cs:  PB3, // Default CS pin (can be any available pin)
-}
-
-// Configure sets up the USI for SPI communication
-func (s *SPI) Configure(config SPIConfig) error {
-	// Validate configuration - check that USI registers are set
-	if s.usicr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
-		s.usisr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
-		s.usidr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) {
-		return errSPIInvalidMachineConfig
-	}
-
-	// Configure pins
+// Configure sets up the USI for SPI communication.
+// Note: The user must configure and control the CS pin separately.
+func (spi *SPI) Configure(config SPIConfig) error {
+	// Configure USI pins (directly, not via struct fields)
 	// PB1 (DO/MOSI) -> OUTPUT
 	// PB2 (USCK/SCK) -> OUTPUT
-	// PB0 (DI/MISO) -> INPUT with pull-up
-	s.sdo.Configure(PinConfig{Mode: PinOutput})
-	s.sck.Configure(PinConfig{Mode: PinOutput})
-	s.sdi.Configure(PinConfig{Mode: PinInput})
+	// PB0 (DI/MISO) -> INPUT
+	PB1.Configure(PinConfig{Mode: PinOutput})
+	PB2.Configure(PinConfig{Mode: PinOutput})
+	PB0.Configure(PinConfig{Mode: PinInput})
 
-	// Enable pull-up on MISO (PB0) for better signal integrity
-	avr.PORTB.SetBits(1 << uint8(s.sdi))
-
-	// Configure CS pin - prevent glitches by setting HIGH first
-	s.cs.High()
-	s.cs.Configure(PinConfig{Mode: PinOutput})
-
-	// Reset USI data register
-	s.usidr.Set(0)
-	s.usisr.Set(0)
+	// Reset USI registers
+	avr.USIDR.Set(0)
+	avr.USISR.Set(0)
 
 	// Configure USI for SPI mode:
 	// - USIWM0: Three-wire mode (SPI)
 	// - USICS1: External clock source (software controlled via USITC)
-	// - USICLK: Clock strobe - enables counter increment on USITC toggle
+	// - USICLK: Clock strobe
 	// - USICS0: Controls clock phase (CPHA)
-	//
-	// SPI Modes:
-	//   Mode 0 (CPOL=0, CPHA=0): Clock idle low, sample on rising edge
-	//   Mode 1 (CPOL=0, CPHA=1): Clock idle low, sample on falling edge
-	//   Mode 2 (CPOL=1, CPHA=0): Clock idle high, sample on falling edge
-	//   Mode 3 (CPOL=1, CPHA=1): Clock idle high, sample on rising edge
-	//
-	// For USI, USICS0 controls the sampling edge when USICS1=1:
-	//   USICS0=0: Positive edge (rising)
-	//   USICS0=1: Negative edge (falling)
 	switch config.Mode {
-	case Mode0: // CPOL=0, CPHA=0: idle low, sample rising
-		s.sck.Low()
-		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
-	case Mode1: // CPOL=0, CPHA=1: idle low, sample falling
-		s.sck.Low()
-		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
-	case Mode2: // CPOL=1, CPHA=0: idle high, sample falling
-		s.sck.High()
-		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
-	case Mode3: // CPOL=1, CPHA=1: idle high, sample rising
-		s.sck.High()
-		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
-	default: // Default to Mode 0
-		s.sck.Low()
-		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	case Mode1: // CPOL=0, CPHA=1
+		PB2.Low()
+		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode2: // CPOL=1, CPHA=0
+		PB2.High()
+		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode3: // CPOL=1, CPHA=1
+		PB2.High()
+		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	default: // Mode0: CPOL=0, CPHA=0
+		PB2.Low()
+		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
 	}
-	s.usicr.Set(s.usicrValue)
-
-	// Calculate delay cycles for frequency control
-	// Each bit transfer requires 2 clock toggles (rising + falling edge)
-	// The loop overhead is approximately 10-15 cycles per toggle on AVR
-	// We calculate additional delay cycles needed to achieve the target frequency
-	if config.Frequency > 0 && config.Frequency < CPUFrequency()/2 {
-		// Cycles per half-period = CPUFrequency / (2 * Frequency)
-		// Subtract loop overhead (~15 cycles) to get delay cycles
-		cyclesPerHalfPeriod := CPUFrequency() / (2 * config.Frequency)
-		const loopOverhead = 15
-		if cyclesPerHalfPeriod > loopOverhead {
-			s.delayCycles = uint16(cyclesPerHalfPeriod - loopOverhead)
-		} else {
-			s.delayCycles = 0
-		}
-	} else {
-		// Max speed - no delay
-		s.delayCycles = 0
-	}
-
-	// Store LSBFirst setting for use in Transfer
-	s.lsbFirst = config.LSBFirst
+	avr.USICR.Set(spi.usicrValue)
 
 	return nil
 }
 
-// reverseByte reverses the bit order of a byte (MSB <-> LSB)
-// Used for LSB-first SPI mode since USI hardware only supports MSB-first
-func reverseByte(b byte) byte {
-	b = (b&0xF0)>>4 | (b&0x0F)<<4
-	b = (b&0xCC)>>2 | (b&0x33)<<2
-	b = (b&0xAA)>>1 | (b&0x55)<<1
-	return b
-}
+// Transfer performs a single byte SPI transfer (send and receive simultaneously).
+func (spi *SPI) Transfer(b byte) (byte, error) {
+	// Load byte to transmit
+	avr.USIDR.Set(b)
 
-// Transfer performs a single byte SPI transfer (send and receive simultaneously)
-// This implements the USI-based SPI transfer using the "clock strobing" technique
-func (s *SPI) Transfer(b byte) (byte, error) {
-	// For LSB-first mode, reverse the bits before sending
-	// USI hardware only supports MSB-first, so we do it in software
-	if s.lsbFirst {
-		b = reverseByte(b)
+	// Clear counter overflow flag and reset counter
+	avr.USISR.Set(avr.USISR_USIOIF)
+
+	// Clock 8 bits (16 toggles)
+	for !avr.USISR.HasBits(avr.USISR_USIOIF) {
+		avr.USICR.SetBits(avr.USICR_USITC)
 	}
 
-	// Load the byte to transmit into the USI Data Register
-	s.usidr.Set(b)
-
-	// Clear the counter overflow flag by writing 1 to it (AVR quirk)
-	// This also resets the 4-bit counter to 0
-	s.usisr.Set(avr.USISR_USIOIF)
-
-	// Clock the data out/in
-	// We need 16 clock toggles (8 bits × 2 edges per bit)
-	// The USI counter counts each clock edge, so it overflows at 16
-	// After 16 toggles, the clock returns to its idle state (set by CPOL in Configure)
-	//
-	// IMPORTANT: Only toggle USITC here!
-	// - USITC toggles the clock pin
-	// - The USICR mode bits (USIWM0, USICS1, USICS0, USICLK) were set in Configure()
-	// - SetBits preserves those bits and only sets USITC
-	if s.delayCycles == 0 {
-		// Fast path: no delay, run at maximum speed
-		for !s.usisr.HasBits(avr.USISR_USIOIF) {
-			s.usicr.SetBits(avr.USICR_USITC)
-		}
-	} else {
-		// Frequency-controlled path: add delay between clock toggles
-		for !s.usisr.HasBits(avr.USISR_USIOIF) {
-			s.usicr.SetBits(avr.USICR_USITC)
-			// Delay loop for frequency control
-			// Each iteration is approximately 3 cycles on AVR (dec, brne)
-			for i := s.delayCycles; i > 0; i-- {
-				avr.Asm("nop")
-			}
-		}
-	}
-
-	// Get the received byte
-	result := s.usidr.Get()
-
-	// For LSB-first mode, reverse the received bits
-	if s.lsbFirst {
-		result = reverseByte(result)
-	}
-
-	return result, nil
+	return avr.USIDR.Get(), nil
 }

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -5,6 +5,7 @@ package machine
 import (
 	"device/avr"
 	"runtime/volatile"
+	"unsafe"
 )
 
 const (
@@ -383,75 +384,189 @@ type SPIConfig struct {
 	Mode      uint8
 }
 
-// SPI is the USI-based SPI implementation for ATTiny85.
-// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI
-// (Universal Serial Interface) in three-wire mode.
-//
-// Fixed pin mapping (directly controlled by USI hardware):
-//   - PB2: SCK (clock)
-//   - PB1: DO/MOSI (data out)
-//   - PB0: DI/MISO (data in)
-//
-// Note: CS pin must be managed by the user.
+// SPI is the USI-based SPI implementation for ATTiny85
+// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI (Universal Serial Interface)
+// which can be configured to work as SPI in "Three-wire mode"
 type SPI struct {
-	// Single byte stores USICR configuration value
+	// USI registers
+	usidr *volatile.Register8 // Data Register
+	usisr *volatile.Register8 // Status Register
+	usicr *volatile.Register8 // Control Register
+
+	// The io pins for the USI-SPI
+	// Note: Pin mapping is different from ISP programming pins
+	sck Pin // PB2 (USCK) - Clock
+	sdo Pin // PB1 (DO) - MOSI (Master Out Slave In)
+	sdi Pin // PB0 (DI) - MISO (Master In Slave Out)
+	cs  Pin // User-defined CS pin (USI doesn't manage CS)
+
+	// Delay cycles for frequency control (0 = max speed)
+	delayCycles uint16
+
+	// USICR value configured for the selected SPI mode
 	usicrValue uint8
+
+	// LSB-first mode (requires software bit reversal)
+	lsbFirst bool
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
-var SPI0 = SPI{}
+var SPI0 = &SPI{
+	usidr: avr.USIDR,
+	usisr: avr.USISR,
+	usicr: avr.USICR,
 
-// Configure sets up the USI for SPI communication.
-// Note: The user must configure and control the CS pin separately.
-func (spi *SPI) Configure(config SPIConfig) error {
-	// Configure USI pins (directly, not via struct fields)
+	sck: PB2, // USCK
+	sdo: PB1, // DO (MOSI)
+	sdi: PB0, // DI (MISO)
+	cs:  PB3, // Default CS pin (can be any available pin)
+}
+
+// Configure sets up the USI for SPI communication
+func (s *SPI) Configure(config SPIConfig) error {
+	// Validate configuration - check that USI registers are set
+	if s.usicr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
+		s.usisr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
+		s.usidr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) {
+		return errSPIInvalidMachineConfig
+	}
+
+	// Configure pins
 	// PB1 (DO/MOSI) -> OUTPUT
 	// PB2 (USCK/SCK) -> OUTPUT
-	// PB0 (DI/MISO) -> INPUT
-	PB1.Configure(PinConfig{Mode: PinOutput})
-	PB2.Configure(PinConfig{Mode: PinOutput})
-	PB0.Configure(PinConfig{Mode: PinInput})
+	// PB0 (DI/MISO) -> INPUT with pull-up
+	s.sdo.Configure(PinConfig{Mode: PinOutput})
+	s.sck.Configure(PinConfig{Mode: PinOutput})
+	s.sdi.Configure(PinConfig{Mode: PinInput})
 
-	// Reset USI registers
-	avr.USIDR.Set(0)
-	avr.USISR.Set(0)
+	// Enable pull-up on MISO (PB0) for better signal integrity
+	avr.PORTB.SetBits(1 << uint8(s.sdi))
+
+	// Configure CS pin - prevent glitches by setting HIGH first
+	s.cs.High()
+	s.cs.Configure(PinConfig{Mode: PinOutput})
+
+	// Reset USI data register
+	s.usidr.Set(0)
+	s.usisr.Set(0)
 
 	// Configure USI for SPI mode:
 	// - USIWM0: Three-wire mode (SPI)
 	// - USICS1: External clock source (software controlled via USITC)
-	// - USICLK: Clock strobe
+	// - USICLK: Clock strobe - enables counter increment on USITC toggle
 	// - USICS0: Controls clock phase (CPHA)
+	//
+	// SPI Modes:
+	//   Mode 0 (CPOL=0, CPHA=0): Clock idle low, sample on rising edge
+	//   Mode 1 (CPOL=0, CPHA=1): Clock idle low, sample on falling edge
+	//   Mode 2 (CPOL=1, CPHA=0): Clock idle high, sample on falling edge
+	//   Mode 3 (CPOL=1, CPHA=1): Clock idle high, sample on rising edge
+	//
+	// For USI, USICS0 controls the sampling edge when USICS1=1:
+	//   USICS0=0: Positive edge (rising)
+	//   USICS0=1: Negative edge (falling)
 	switch config.Mode {
-	case Mode1: // CPOL=0, CPHA=1
-		PB2.Low()
-		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
-	case Mode2: // CPOL=1, CPHA=0
-		PB2.High()
-		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
-	case Mode3: // CPOL=1, CPHA=1
-		PB2.High()
-		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
-	default: // Mode0: CPOL=0, CPHA=0
-		PB2.Low()
-		spi.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	case Mode0: // CPOL=0, CPHA=0: idle low, sample rising
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	case Mode1: // CPOL=0, CPHA=1: idle low, sample falling
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode2: // CPOL=1, CPHA=0: idle high, sample falling
+		s.sck.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode3: // CPOL=1, CPHA=1: idle high, sample rising
+		s.sck.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	default: // Default to Mode 0
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
 	}
-	avr.USICR.Set(spi.usicrValue)
+	s.usicr.Set(s.usicrValue)
+
+	// Calculate delay cycles for frequency control
+	// Each bit transfer requires 2 clock toggles (rising + falling edge)
+	// The loop overhead is approximately 10-15 cycles per toggle on AVR
+	// We calculate additional delay cycles needed to achieve the target frequency
+	if config.Frequency > 0 && config.Frequency < CPUFrequency()/2 {
+		// Cycles per half-period = CPUFrequency / (2 * Frequency)
+		// Subtract loop overhead (~15 cycles) to get delay cycles
+		cyclesPerHalfPeriod := CPUFrequency() / (2 * config.Frequency)
+		const loopOverhead = 15
+		if cyclesPerHalfPeriod > loopOverhead {
+			s.delayCycles = uint16(cyclesPerHalfPeriod - loopOverhead)
+		} else {
+			s.delayCycles = 0
+		}
+	} else {
+		// Max speed - no delay
+		s.delayCycles = 0
+	}
+
+	// Store LSBFirst setting for use in Transfer
+	s.lsbFirst = config.LSBFirst
 
 	return nil
 }
 
-// Transfer performs a single byte SPI transfer (send and receive simultaneously).
-func (spi *SPI) Transfer(b byte) (byte, error) {
-	// Load byte to transmit
-	avr.USIDR.Set(b)
+// reverseByte reverses the bit order of a byte (MSB <-> LSB)
+// Used for LSB-first SPI mode since USI hardware only supports MSB-first
+func reverseByte(b byte) byte {
+	b = (b&0xF0)>>4 | (b&0x0F)<<4
+	b = (b&0xCC)>>2 | (b&0x33)<<2
+	b = (b&0xAA)>>1 | (b&0x55)<<1
+	return b
+}
 
-	// Clear counter overflow flag and reset counter
-	avr.USISR.Set(avr.USISR_USIOIF)
-
-	// Clock 8 bits (16 toggles)
-	for !avr.USISR.HasBits(avr.USISR_USIOIF) {
-		avr.USICR.SetBits(avr.USICR_USITC)
+// Transfer performs a single byte SPI transfer (send and receive simultaneously)
+// This implements the USI-based SPI transfer using the "clock strobing" technique
+func (s *SPI) Transfer(b byte) (byte, error) {
+	// For LSB-first mode, reverse the bits before sending
+	// USI hardware only supports MSB-first, so we do it in software
+	if s.lsbFirst {
+		b = reverseByte(b)
 	}
 
-	return avr.USIDR.Get(), nil
+	// Load the byte to transmit into the USI Data Register
+	s.usidr.Set(b)
+
+	// Clear the counter overflow flag by writing 1 to it (AVR quirk)
+	// This also resets the 4-bit counter to 0
+	s.usisr.Set(avr.USISR_USIOIF)
+
+	// Clock the data out/in
+	// We need 16 clock toggles (8 bits × 2 edges per bit)
+	// The USI counter counts each clock edge, so it overflows at 16
+	// After 16 toggles, the clock returns to its idle state (set by CPOL in Configure)
+	//
+	// IMPORTANT: Only toggle USITC here!
+	// - USITC toggles the clock pin
+	// - The USICR mode bits (USIWM0, USICS1, USICS0, USICLK) were set in Configure()
+	// - SetBits preserves those bits and only sets USITC
+	if s.delayCycles == 0 {
+		// Fast path: no delay, run at maximum speed
+		for !s.usisr.HasBits(avr.USISR_USIOIF) {
+			s.usicr.SetBits(avr.USICR_USITC)
+		}
+	} else {
+		// Frequency-controlled path: add delay between clock toggles
+		for !s.usisr.HasBits(avr.USISR_USIOIF) {
+			s.usicr.SetBits(avr.USICR_USITC)
+			// Delay loop for frequency control
+			// Each iteration is approximately 3 cycles on AVR (dec, brne)
+			for i := s.delayCycles; i > 0; i-- {
+				avr.Asm("nop")
+			}
+		}
+	}
+
+	// Get the received byte
+	result := s.usidr.Get()
+
+	// For LSB-first mode, reverse the received bits
+	if s.lsbFirst {
+		result = reverseByte(result)
+	}
+
+	return result, nil
 }

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -5,6 +5,7 @@ package machine
 import (
 	"device/avr"
 	"runtime/volatile"
+	"unsafe"
 )
 
 const (
@@ -374,4 +375,114 @@ func (pwm PWM) Set(channel uint8, value uint32) {
 			}
 		}
 	}
+}
+
+// SPIConfig is used to store config info for SPI.
+type SPIConfig struct {
+	Frequency uint32
+	LSBFirst  bool
+	Mode      uint8
+}
+
+// SPI is the USI-based SPI implementation for ATTiny85
+// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI (Universal Serial Interface)
+// which can be configured to work as SPI in "Three-wire mode"
+type SPI struct {
+	// USI registers
+	usidr *volatile.Register8 // Data Register
+	usisr *volatile.Register8 // Status Register
+	usicr *volatile.Register8 // Control Register
+
+	// The io pins for the USI-SPI
+	// Note: Pin mapping is different from ISP programming pins
+	sck Pin // PB2 (USCK) - Clock
+	sdo Pin // PB1 (DO) - MOSI (Master Out Slave In)
+	sdi Pin // PB0 (DI) - MISO (Master In Slave Out)
+	cs  Pin // User-defined CS pin (USI doesn't manage CS)
+}
+
+// SPI0 is the USI-based SPI interface on the ATTiny85
+var SPI0 = &SPI{
+	usidr: avr.USIDR,
+	usisr: avr.USISR,
+	usicr: avr.USICR,
+
+	sck: PB2, // USCK
+	sdo: PB1, // DO (MOSI)
+	sdi: PB0, // DI (MISO)
+	cs:  PB3, // Default CS pin (can be any available pin)
+}
+
+// Configure sets up the USI for SPI communication
+func (s *SPI) Configure(config SPIConfig) error {
+	// Validate configuration - check that USI registers are set
+	if s.usicr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
+		s.usisr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
+		s.usidr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) {
+		return errSPIInvalidMachineConfig
+	}
+
+	// Configure pins
+	// PB1 (DO/MOSI) -> OUTPUT
+	// PB2 (USCK/SCK) -> OUTPUT
+	// PB0 (DI/MISO) -> INPUT with pull-up
+	s.sdo.Configure(PinConfig{Mode: PinOutput})
+	s.sck.Configure(PinConfig{Mode: PinOutput})
+	s.sdi.Configure(PinConfig{Mode: PinInput})
+
+	// Enable pull-up on MISO (PB0) for better signal integrity
+	avr.PORTB.SetBits(1 << uint8(s.sdi))
+
+	// Configure CS pin - prevent glitches by setting HIGH first
+	s.cs.High()
+	s.cs.Configure(PinConfig{Mode: PinOutput})
+
+	// Reset USI data register
+	s.usidr.Set(0)
+	s.usisr.Set(0)
+
+	// Configure USI for SPI mode:
+	// - USIWM0: Three-wire mode (SPI)
+	// - USICS1: External clock source (software controlled via USITC)
+	// - USICLK: Clock strobe - enables counter increment on USITC toggle
+	//
+	// Note: ATTiny85 USI doesn't have configurable frequency dividers like dedicated SPI hardware
+	// The SPI clock speed is determined by how fast the software toggles the clock
+	// For now, we'll ignore the Frequency parameter as it runs at maximum software speed
+	//
+	// Note: LSBFirst and Mode configurations are not directly supported by USI
+	// These would need to be implemented in software if required
+	// For now, we use the standard MSB-first, Mode 0 (CPOL=0, CPHA=0)
+	s.usicr.Set(avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK)
+
+	return nil
+}
+
+// Transfer performs a single byte SPI transfer (send and receive simultaneously)
+// This implements the USI-based SPI transfer using the "clock strobing" technique
+func (s *SPI) Transfer(b byte) (byte, error) {
+	// Load the byte to transmit into the USI Data Register
+	s.usidr.Set(b)
+
+	// Clear the counter overflow flag by writing 1 to it (AVR quirk)
+	// This also resets the 4-bit counter to 0
+	s.usisr.Set(avr.USISR_USIOIF)
+
+	// Clock the data out/in
+	// We need 16 clock toggles (8 bits × 2 edges per bit)
+	// The USI counter counts each clock edge, so it overflows at 16
+	//
+	// IMPORTANT: Only toggle USITC here, not USICLK!
+	// - USITC toggles the clock pin
+	// - With USICS1 set (software clock strobe mode), the data shifts on clock edges
+	// - USICLK is a separate strobe that would cause extra shifts if set here
+	//
+	// The USICR register was configured in Configure() with USIWM0 | USICS1 | USICLK.
+	// We use SetBits to preserve that configuration and only toggle USITC.
+	for !s.usisr.HasBits(avr.USISR_USIOIF) {
+		s.usicr.SetBits(avr.USICR_USITC)
+	}
+
+	// After 8 bits are transferred, return the received byte
+	return s.usidr.Get(), nil
 }

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -5,7 +5,6 @@ package machine
 import (
 	"device/avr"
 	"runtime/volatile"
-	"unsafe"
 )
 
 const (
@@ -384,22 +383,17 @@ type SPIConfig struct {
 	Mode      uint8
 }
 
-// SPI is the USI-based SPI implementation for ATTiny85
-// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI (Universal Serial Interface)
-// which can be configured to work as SPI in "Three-wire mode"
+// SPI is the USI-based SPI implementation for ATTiny85.
+// The ATTiny85 doesn't have dedicated SPI hardware, but uses the USI
+// (Universal Serial Interface) in three-wire mode.
+//
+// Fixed pin mapping (directly controlled by USI hardware):
+//   - PB2: SCK (clock)
+//   - PB1: DO/MOSI (data out)
+//   - PB0: DI/MISO (data in)
+//
+// Note: CS pin must be managed by the user.
 type SPI struct {
-	// USI registers
-	usidr *volatile.Register8 // Data Register
-	usisr *volatile.Register8 // Status Register
-	usicr *volatile.Register8 // Control Register
-
-	// The io pins for the USI-SPI
-	// Note: Pin mapping is different from ISP programming pins
-	sck Pin // PB2 (USCK) - Clock
-	sdo Pin // PB1 (DO) - MOSI (Master Out Slave In)
-	sdi Pin // PB0 (DI) - MISO (Master In Slave Out)
-	cs  Pin // User-defined CS pin (USI doesn't manage CS)
-
 	// Delay cycles for frequency control (0 = max speed)
 	delayCycles uint16
 
@@ -411,44 +405,22 @@ type SPI struct {
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
-var SPI0 = &SPI{
-	usidr: avr.USIDR,
-	usisr: avr.USISR,
-	usicr: avr.USICR,
+var SPI0 = SPI{}
 
-	sck: PB2, // USCK
-	sdo: PB1, // DO (MOSI)
-	sdi: PB0, // DI (MISO)
-	cs:  PB3, // Default CS pin (can be any available pin)
-}
-
-// Configure sets up the USI for SPI communication
+// Configure sets up the USI for SPI communication.
+// Note: The user must configure and control the CS pin separately.
 func (s *SPI) Configure(config SPIConfig) error {
-	// Validate configuration - check that USI registers are set
-	if s.usicr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
-		s.usisr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) ||
-		s.usidr == (*volatile.Register8)(unsafe.Pointer(uintptr(0))) {
-		return errSPIInvalidMachineConfig
-	}
-
-	// Configure pins
+	// Configure USI pins (fixed by hardware)
 	// PB1 (DO/MOSI) -> OUTPUT
 	// PB2 (USCK/SCK) -> OUTPUT
-	// PB0 (DI/MISO) -> INPUT with pull-up
-	s.sdo.Configure(PinConfig{Mode: PinOutput})
-	s.sck.Configure(PinConfig{Mode: PinOutput})
-	s.sdi.Configure(PinConfig{Mode: PinInput})
+	// PB0 (DI/MISO) -> INPUT
+	PB1.Configure(PinConfig{Mode: PinOutput})
+	PB2.Configure(PinConfig{Mode: PinOutput})
+	PB0.Configure(PinConfig{Mode: PinInput})
 
-	// Enable pull-up on MISO (PB0) for better signal integrity
-	avr.PORTB.SetBits(1 << uint8(s.sdi))
-
-	// Configure CS pin - prevent glitches by setting HIGH first
-	s.cs.High()
-	s.cs.Configure(PinConfig{Mode: PinOutput})
-
-	// Reset USI data register
-	s.usidr.Set(0)
-	s.usisr.Set(0)
+	// Reset USI registers
+	avr.USIDR.Set(0)
+	avr.USISR.Set(0)
 
 	// Configure USI for SPI mode:
 	// - USIWM0: Three-wire mode (SPI)
@@ -467,22 +439,22 @@ func (s *SPI) Configure(config SPIConfig) error {
 	//   USICS0=1: Negative edge (falling)
 	switch config.Mode {
 	case Mode0: // CPOL=0, CPHA=0: idle low, sample rising
-		s.sck.Low()
+		PB2.Low()
 		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
 	case Mode1: // CPOL=0, CPHA=1: idle low, sample falling
-		s.sck.Low()
+		PB2.Low()
 		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
 	case Mode2: // CPOL=1, CPHA=0: idle high, sample falling
-		s.sck.High()
+		PB2.High()
 		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
 	case Mode3: // CPOL=1, CPHA=1: idle high, sample rising
-		s.sck.High()
+		PB2.High()
 		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
 	default: // Default to Mode 0
-		s.sck.Low()
+		PB2.Low()
 		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
 	}
-	s.usicr.Set(s.usicrValue)
+	avr.USICR.Set(s.usicrValue)
 
 	// Calculate delay cycles for frequency control
 	// Each bit transfer requires 2 clock toggles (rising + falling edge)
@@ -528,11 +500,11 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 	}
 
 	// Load the byte to transmit into the USI Data Register
-	s.usidr.Set(b)
+	avr.USIDR.Set(b)
 
 	// Clear the counter overflow flag by writing 1 to it (AVR quirk)
 	// This also resets the 4-bit counter to 0
-	s.usisr.Set(avr.USISR_USIOIF)
+	avr.USISR.Set(avr.USISR_USIOIF)
 
 	// Clock the data out/in
 	// We need 16 clock toggles (8 bits × 2 edges per bit)
@@ -545,13 +517,13 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 	// - SetBits preserves those bits and only sets USITC
 	if s.delayCycles == 0 {
 		// Fast path: no delay, run at maximum speed
-		for !s.usisr.HasBits(avr.USISR_USIOIF) {
-			s.usicr.SetBits(avr.USICR_USITC)
+		for !avr.USISR.HasBits(avr.USISR_USIOIF) {
+			avr.USICR.SetBits(avr.USICR_USITC)
 		}
 	} else {
 		// Frequency-controlled path: add delay between clock toggles
-		for !s.usisr.HasBits(avr.USISR_USIOIF) {
-			s.usicr.SetBits(avr.USICR_USITC)
+		for !avr.USISR.HasBits(avr.USISR_USIOIF) {
+			avr.USICR.SetBits(avr.USICR_USITC)
 			// Delay loop for frequency control
 			// Each iteration is approximately 3 cycles on AVR (dec, brne)
 			for i := s.delayCycles; i > 0; i-- {
@@ -561,7 +533,7 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 	}
 
 	// Get the received byte
-	result := s.usidr.Get()
+	result := avr.USIDR.Get()
 
 	// For LSB-first mode, reverse the received bits
 	if s.lsbFirst {

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -402,6 +402,9 @@ type SPI struct {
 
 	// Delay cycles for frequency control (0 = max speed)
 	delayCycles uint16
+
+	// USICR value configured for the selected SPI mode
+	usicrValue uint8
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
@@ -448,7 +451,35 @@ func (s *SPI) Configure(config SPIConfig) error {
 	// - USIWM0: Three-wire mode (SPI)
 	// - USICS1: External clock source (software controlled via USITC)
 	// - USICLK: Clock strobe - enables counter increment on USITC toggle
-	s.usicr.Set(avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK)
+	// - USICS0: Controls clock phase (CPHA)
+	//
+	// SPI Modes:
+	//   Mode 0 (CPOL=0, CPHA=0): Clock idle low, sample on rising edge
+	//   Mode 1 (CPOL=0, CPHA=1): Clock idle low, sample on falling edge
+	//   Mode 2 (CPOL=1, CPHA=0): Clock idle high, sample on falling edge
+	//   Mode 3 (CPOL=1, CPHA=1): Clock idle high, sample on rising edge
+	//
+	// For USI, USICS0 controls the sampling edge when USICS1=1:
+	//   USICS0=0: Positive edge (rising)
+	//   USICS0=1: Negative edge (falling)
+	switch config.Mode {
+	case Mode0: // CPOL=0, CPHA=0: idle low, sample rising
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	case Mode1: // CPOL=0, CPHA=1: idle low, sample falling
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode2: // CPOL=1, CPHA=0: idle high, sample falling
+		s.sck.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICS0 | avr.USICR_USICLK
+	case Mode3: // CPOL=1, CPHA=1: idle high, sample rising
+		s.sck.High()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	default: // Default to Mode 0
+		s.sck.Low()
+		s.usicrValue = avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK
+	}
+	s.usicr.Set(s.usicrValue)
 
 	// Calculate delay cycles for frequency control
 	// Each bit transfer requires 2 clock toggles (rising + falling edge)
@@ -469,9 +500,8 @@ func (s *SPI) Configure(config SPIConfig) error {
 		s.delayCycles = 0
 	}
 
-	// Note: LSBFirst and Mode configurations are not directly supported by USI
-	// These would need to be implemented in software if required
-	// For now, we use the standard MSB-first, Mode 0 (CPOL=0, CPHA=0)
+	// Note: LSBFirst is not directly supported by USI hardware
+	// It would need to be implemented in software if required
 
 	return nil
 }
@@ -489,14 +519,12 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 	// Clock the data out/in
 	// We need 16 clock toggles (8 bits × 2 edges per bit)
 	// The USI counter counts each clock edge, so it overflows at 16
+	// After 16 toggles, the clock returns to its idle state (set by CPOL in Configure)
 	//
-	// IMPORTANT: Only toggle USITC here, not USICLK!
+	// IMPORTANT: Only toggle USITC here!
 	// - USITC toggles the clock pin
-	// - With USICS1 set (software clock strobe mode), the data shifts on clock edges
-	// - USICLK is a separate strobe that would cause extra shifts if set here
-	//
-	// The USICR register was configured in Configure() with USIWM0 | USICS1 | USICLK.
-	// We use SetBits to preserve that configuration and only toggle USITC.
+	// - The USICR mode bits (USIWM0, USICS1, USICS0, USICLK) were set in Configure()
+	// - SetBits preserves those bits and only sets USITC
 	if s.delayCycles == 0 {
 		// Fast path: no delay, run at maximum speed
 		for !s.usisr.HasBits(avr.USISR_USIOIF) {

--- a/src/machine/machine_attiny85.go
+++ b/src/machine/machine_attiny85.go
@@ -399,6 +399,9 @@ type SPI struct {
 	sdo Pin // PB1 (DO) - MOSI (Master Out Slave In)
 	sdi Pin // PB0 (DI) - MISO (Master In Slave Out)
 	cs  Pin // User-defined CS pin (USI doesn't manage CS)
+
+	// Delay cycles for frequency control (0 = max speed)
+	delayCycles uint16
 }
 
 // SPI0 is the USI-based SPI interface on the ATTiny85
@@ -445,15 +448,30 @@ func (s *SPI) Configure(config SPIConfig) error {
 	// - USIWM0: Three-wire mode (SPI)
 	// - USICS1: External clock source (software controlled via USITC)
 	// - USICLK: Clock strobe - enables counter increment on USITC toggle
-	//
-	// Note: ATTiny85 USI doesn't have configurable frequency dividers like dedicated SPI hardware
-	// The SPI clock speed is determined by how fast the software toggles the clock
-	// For now, we'll ignore the Frequency parameter as it runs at maximum software speed
-	//
+	s.usicr.Set(avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK)
+
+	// Calculate delay cycles for frequency control
+	// Each bit transfer requires 2 clock toggles (rising + falling edge)
+	// The loop overhead is approximately 10-15 cycles per toggle on AVR
+	// We calculate additional delay cycles needed to achieve the target frequency
+	if config.Frequency > 0 && config.Frequency < CPUFrequency()/2 {
+		// Cycles per half-period = CPUFrequency / (2 * Frequency)
+		// Subtract loop overhead (~15 cycles) to get delay cycles
+		cyclesPerHalfPeriod := CPUFrequency() / (2 * config.Frequency)
+		const loopOverhead = 15
+		if cyclesPerHalfPeriod > loopOverhead {
+			s.delayCycles = uint16(cyclesPerHalfPeriod - loopOverhead)
+		} else {
+			s.delayCycles = 0
+		}
+	} else {
+		// Max speed - no delay
+		s.delayCycles = 0
+	}
+
 	// Note: LSBFirst and Mode configurations are not directly supported by USI
 	// These would need to be implemented in software if required
 	// For now, we use the standard MSB-first, Mode 0 (CPOL=0, CPHA=0)
-	s.usicr.Set(avr.USICR_USIWM0 | avr.USICR_USICS1 | avr.USICR_USICLK)
 
 	return nil
 }
@@ -479,8 +497,21 @@ func (s *SPI) Transfer(b byte) (byte, error) {
 	//
 	// The USICR register was configured in Configure() with USIWM0 | USICS1 | USICLK.
 	// We use SetBits to preserve that configuration and only toggle USITC.
-	for !s.usisr.HasBits(avr.USISR_USIOIF) {
-		s.usicr.SetBits(avr.USICR_USITC)
+	if s.delayCycles == 0 {
+		// Fast path: no delay, run at maximum speed
+		for !s.usisr.HasBits(avr.USISR_USIOIF) {
+			s.usicr.SetBits(avr.USICR_USITC)
+		}
+	} else {
+		// Frequency-controlled path: add delay between clock toggles
+		for !s.usisr.HasBits(avr.USISR_USIOIF) {
+			s.usicr.SetBits(avr.USICR_USITC)
+			// Delay loop for frequency control
+			// Each iteration is approximately 3 cycles on AVR (dec, brne)
+			for i := s.delayCycles; i > 0; i-- {
+				avr.Asm("nop")
+			}
+		}
 	}
 
 	// After 8 bits are transferred, return the received byte

--- a/src/machine/spi.go
+++ b/src/machine/spi.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || rp2350 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build !baremetal || atmega || attiny85 || esp32 || fe310 || k210 || nrf || (nxp && !mk66f18) || rp2040 || rp2350 || sam || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 package machine
 

--- a/src/machine/spi_tx.go
+++ b/src/machine/spi_tx.go
@@ -1,4 +1,4 @@
-//go:build atmega || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
+//go:build atmega || attiny85 || fe310 || k210 || (nxp && !mk66f18) || (stm32 && !stm32f7x2 && !stm32l5x2)
 
 // This file implements the SPI Tx function for targets that don't have a custom
 // (faster) implementation for it.


### PR DESCRIPTION
## Summary

Implement SPI communication for ATtiny85 using the USI (Universal Serial Interface) hardware in three-wire mode. The ATtiny85 lacks dedicated SPI hardware but can emulate SPI using the USI module with software clock strobing.

## Implementation

- Configure USI in three-wire mode for SPI operation
- Use clock strobing technique to shift data in/out
- Pin mapping: PB2 (SCK), PB1 (MOSI/DO), PB0 (MISO/DI)
- Support both Transfer() and Tx() methods
- Software-based frequency control via delay loops
- All 4 SPI modes supported
- LSB-first bit order supported via software bit reversal

The implementation uses the USI control register (USICR) to toggle the clock pin, which triggers automatic bit shifting in hardware.

## Frequency Configuration

The ATtiny85 USI lacks hardware prescalers, so frequency is controlled via software delay loops between clock toggles:

```go
// Configure SPI at 1 MHz
machine.SPI0.Configure(machine.SPIConfig{
    Frequency: 1000000,
})

// Configure SPI at 400 kHz (useful for SD card initialization)
machine.SPI0.Configure(machine.SPIConfig{
    Frequency: 400000,
})

// Configure SPI at maximum speed (no delay)
machine.SPI0.Configure(machine.SPIConfig{
    Frequency: 0,
})
```

## SPI Mode Configuration

All 4 SPI modes are supported:

| Mode | CPOL | CPHA | Clock Idle | Data Sampled |
|------|------|------|------------|--------------|
| 0    | 0    | 0    | Low        | Rising edge  |
| 1    | 0    | 1    | Low        | Falling edge |
| 2    | 1    | 0    | High       | Falling edge |
| 3    | 1    | 1    | High       | Rising edge  |

```go
// Configure SPI in Mode 0 (default)
machine.SPI0.Configure(machine.SPIConfig{
    Mode: machine.Mode0,
})

// Configure SPI in Mode 3
machine.SPI0.Configure(machine.SPIConfig{
    Mode: machine.Mode3,
})
```

## Bit Order Configuration

Both MSB-first (default) and LSB-first bit orders are supported:

```go
// Configure SPI with LSB-first bit order
machine.SPI0.Configure(machine.SPIConfig{
    LSBFirst: true,
})
```

LSB-first is implemented via software bit reversal since the USI hardware only supports MSB-first.

## References

- [tinySPI library](https://github.com/JChristensen/tinySPI) - reference implementation
- ATtiny85 datasheet USI section