### PR TITLE
Add per-byte timeout budget for rp2 I2C

### DIFF
--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -280,8 +280,6 @@ func (i2c *I2C) deinit() (resetVal uint32) {
 
 // tx performs blocking write followed by read to I2C bus.
 func (i2c *I2C) tx(addr uint8, tx, rx []byte) (err error) {
-	const timeout_us = 4_000
-	deadline := ticks() + timeout_us
 	if addr >= 0x80 || isReservedI2CAddr(addr) {
 		return errInvalidTgtAddr
 	}
@@ -291,6 +289,14 @@ func (i2c *I2C) tx(addr uint8, tx, rx []byte) (err error) {
 	if txlen == 0 && rxlen == 0 {
 		return nil
 	}
+
+	// Base 4ms for small register pokes.
+	// Add per-byte budget. 100us/byte is conservative at 400kHz and still ok at 100kHz for modest sizes.
+	timeout_us := uint64(4_000) + uint64(txlen+rxlen) * 100
+	// Cap so it doesn't go insane:
+	timeout_us = min(timeout_us, 500_000)
+
+	deadline := ticks() + timeout_us
 
 	err = i2c.disable()
 	if err != nil {

--- a/src/machine/machine_rp2_i2c.go
+++ b/src/machine/machine_rp2_i2c.go
@@ -292,7 +292,7 @@ func (i2c *I2C) tx(addr uint8, tx, rx []byte) (err error) {
 
 	// Base 4ms for small register pokes.
 	// Add per-byte budget. 100us/byte is conservative at 400kHz and still ok at 100kHz for modest sizes.
-	timeout_us := uint64(4_000) + uint64(txlen+rxlen) * 100
+	timeout_us := uint64(4_000) + uint64(txlen+rxlen)*100
 	// Cap so it doesn't go insane:
 	timeout_us = min(timeout_us, 500_000)
 


### PR DESCRIPTION
I was hitting an issue with using an SSD1306 display and the tinygo.org/x/drivers/ssd1306 i2c driver. The display worked, but then after about ~20 minutes of running, I would get i2c write timeout errors, even though the screen was still updating. This was due to eventually needing GC to run and that made gosched() take long enough that we hit the i2c timeout. 

I see this is actually fixed in the dev branch: gosched() time is compensated for. But I also see that the total, fixed timeout was lowered from 40ms to 4ms. 

For the SSD1306 driver which sends the full frame buffer, about 1025 bytes, when it does an update, 4ms is not enough time. 

I2C consumes 9 clock pulses per byte (8 bits + ACK). So the wire time for N bytes is: t≈9N/f.

Any single I2C write of ~180+ bytes @ 400kHz is guaranteed to exceed 4 ms wire time.

Any single write of ~45+ bytes @ 100kHz is guaranteed to exceed 4 ms.



My proposed fix is adding a 100us budget per byte to be transfered, with a cap of 500ms.
