### PR TITLE
fix: init heap before random number seed on wasm platforms

### DIFF
--- a/src/runtime/runtime_wasmentry.go
+++ b/src/runtime/runtime_wasmentry.go
@@ -34,8 +34,8 @@ func wasmEntryReactor() {
 	// Initialize the heap.
 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	initRand()
 	initHeap()
+	initRand()
 
 	if hasScheduler {
 		// A package initializer might do funky stuff like start a goroutine and


### PR DESCRIPTION
This changes the order for initialization of the random number seed generation on wasm platforms until after the heap has been initialized. Should fix #5198