### PR TITLE
targets: correct name/tag use for esp32s3-wroom1 board

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -927,8 +927,6 @@ ifneq ($(XTENSA), 0)
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=esp32s3-wroom1	    examples/mcp3008
 	@$(MD5SUM) test.bin
-	$(TINYGO) build -size short -o test.bin -target=esp32s3   		    examples/mcp3008
-	@$(MD5SUM) test.bin
 endif
 	$(TINYGO) build -size short -o test.bin -target=esp-c3-32s-kit      examples/blinky1
 	@$(MD5SUM) test.bin

--- a/src/machine/board_esp32s3-wroom1.go
+++ b/src/machine/board_esp32s3-wroom1.go
@@ -1,4 +1,4 @@
-//go:build esp32s3 && !xiao_esp32s3
+//go:build esp32s3_wroom1
 
 package machine
 


### PR DESCRIPTION
This PR is to correct name/tag use for the `esp32s3-wroom1` board by renaming the file and using the correct board tag.

I also removed the bare `esp32s3` build from the smoketest, since that should not be build against a machine without an associated board file. See #5178 for more about this.