### PR TITLE
feather-m0: export UART0 and pins

### DIFF
--- a/src/machine/board_feather-m0.go
+++ b/src/machine/board_feather-m0.go
@@ -43,6 +43,15 @@ const (
 	USBCDC_DP_PIN = PA25
 )
 
+// UART0 pins
+const (
+	UART0_TX_PIN = D1
+	UART0_RX_PIN = D0
+)
+
+// UART0 on the Feather M0.
+var UART0 = &sercomUSART0
+
 // UART1 pins
 const (
 	UART_TX_PIN = D10


### PR DESCRIPTION
Fixes #5206 

Added UART0 export and pin definitions to feather-m0 board.

```
uart0 := machine.UART0
uart0.Configure(machine.UARTConfig{
    TX: machine.UART0_TX_PIN,
    RX: machine.UART0_RX_PIN,
})
```