### PR TITLE
targets: update flash command for esp32 family for latest esptool

### DIFF
--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -15,7 +15,7 @@
 		"src/internal/task/task_stack_esp32.S"
 	],
 	"binary-format": "esp32",
-	"flash-command": "esptool.py --chip=esp32 --port {port} write_flash 0x1000 {bin} -ff 80m -fm dout",
+	"flash-command": "esptool --chip=esp32 --port {port} write-flash 0x1000 {bin} -ff 80m -fm dout",
 	"emulator": "qemu-system-xtensa -machine esp32 -nographic -drive file={img},if=mtd,format=raw",
 	"gdb": ["xtensa-esp32-elf-gdb"]
 }

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -13,7 +13,7 @@
 		"src/device/esp/esp32c3.S"
 	],
 	"binary-format": "esp32c3",
-	"flash-command": "esptool.py --chip=esp32c3 --port {port} write_flash 0x0 {bin}",
+	"flash-command": "esptool --chip=esp32c3 --port {port} write-flash 0x0 {bin}",
 	"serial-port": ["303a:1001"],
 	"openocd-interface": "esp_usb_jtag",
 	"openocd-target": "esp32c3",

--- a/targets/esp32s3.json
+++ b/targets/esp32s3.json
@@ -15,7 +15,7 @@
 		"src/internal/task/task_stack_esp32.S"
 	],
 	"binary-format": "esp32s3",
-	"flash-command": "esptool.py --chip=esp32s3 --port {port} write_flash 0x0000 {bin} -ff 80m -fm dout",
+	"flash-command": "esptool --chip=esp32s3 --port {port} write-flash 0x0000 {bin} -ff 80m -fm dout",
 	"emulator": "qemu-system-xtensa -machine esp32 -nographic -drive file={img},if=mtd,format=raw",
 	"gdb": ["xtensa-esp32-elf-gdb"]
 }

--- a/targets/esp8266.json
+++ b/targets/esp8266.json
@@ -14,5 +14,5 @@
 		"src/internal/task/task_stack_esp8266.S"
 	],
 	"binary-format": "esp8266",
-	"flash-command": "esptool.py --chip=esp8266 --port {port} write_flash 0x00000 {bin} -fm qio"
+	"flash-command": "esptool --chip=esp8266 --port {port} write-flash 0x00000 {bin} -fm qio"
 }


### PR DESCRIPTION
This updates the flash command used for boards in the ESP32 family to use the syntax of the most recent versions of the esptool command.

Gets rid of annoying deprecation warnings before they they become actual errors in some future release. Fixes #4991 and some related issues.