### PR TITLE
targets: switch rp2040/rp2350 to default to tasks scheduler

### DIFF
--- a/targets/rp2040.json
+++ b/targets/rp2040.json
@@ -1,7 +1,7 @@
 {
     "inherits": ["cortex-m0plus"],
     "build-tags": ["rp2040", "rp"],
-    "scheduler": "cores",
+    "scheduler": "tasks",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "serial": "usb",

--- a/targets/rp2350.json
+++ b/targets/rp2350.json
@@ -1,7 +1,7 @@
 {
     "inherits": ["cortex-m33"],
     "build-tags": ["rp2350", "rp"],
-    "scheduler": "cores",
+    "scheduler": "tasks",
     "flash-1200-bps-reset": "true",
     "flash-method": "msd",
     "serial": "usb",


### PR DESCRIPTION
This switches the rp2040 and rp2350 to use the tasks scheduler by default instead of using the cores scheduler. Too many race conditions at present, we need to look into exactly why. In the meantime, going back to the tasks as default will address a lot of these intermittent problems.

Address #5217 