### PR TITLE
fix: ESP32-C3 needs to clear MCAUSE after handling interrupt

### DIFF
--- a/src/runtime/interrupt/interrupt_esp32c3.go
+++ b/src/runtime/interrupt/interrupt_esp32c3.go
@@ -201,6 +201,11 @@ func handleInterrupt() {
 		reg.Set(thresholdSave)
 		riscv.Asm("fence")
 
+		// Zero MCAUSE so that interrupt.In() returns false once we
+		// return to normal (non-interrupt) code.  Other RISC-V targets
+		// (FE310, K210) do the same.
+		riscv.MCAUSE.Set(0)
+
 		// restore MSTATUS & MEPC
 		riscv.MSTATUS.Set(mstatus)
 		riscv.MEPC.Set(mepc)


### PR DESCRIPTION
This PR corrects a big bug with the interrupt handling on ESP32-C3

MCAUSE was never being cleared after handling an interrupt. On RISC-V, mret does NOT zero MCAUSE — it retains the last trap cause. Every other TinyGo RISC-V target (FE310, K210, QEMU) explicitly does riscv.MCAUSE.Set(0) after handling. The ESP32-C3 was missing this.