### PR TITLE
esp32c3-radion fix DRAM/IRAM region

### DIFF
--- a/src/internal/task/task_stack_tinygoriscv.go
+++ b/src/internal/task/task_stack_tinygoriscv.go
@@ -71,3 +71,8 @@ func (s *state) pause() {
 func SystemStack() uintptr {
 	return *runtime_systemStackPtr()
 }
+
+//export tinygo_task_current
+func tinygo_task_current() unsafe.Pointer {
+	return unsafe.Pointer(Current())
+}

--- a/targets/esp32c3.ld
+++ b/targets/esp32c3.ld
@@ -29,9 +29,12 @@
 
 MEMORY
 {
-    /* Note: DRAM and IRAM below are actually in the same 384K address space. */
-    DRAM (rw) : ORIGIN = 0x3FC80000, LENGTH = 384K /* Internal SRAM 1 (data bus) */
-    IRAM (x)  : ORIGIN = 0x40380000, LENGTH = 384K /* Internal SRAM 1 (instruction bus) */
+    /* Note: DRAM and IRAM below are actually in the same 384K address space.
+     * WiFi/BLE ROM variables occupy 0x3FCCE710..0x3FCDFFFC, so DRAM must
+     * stop before that boundary to prevent the Go heap from overwriting them.
+     */
+    DRAM (rw) : ORIGIN = 0x3FC80000, LENGTH = 0x4E710 /* ends at 0x3FCCE710 — WiFi/ROM boundary */
+    IRAM (x)  : ORIGIN = 0x40380000, LENGTH = 0x4E710
 
     /* Note: DROM and IROM below are actually in the same 8M address space. */
     DROM (r)  : ORIGIN = 0x3C000000, LENGTH = 8M /* Data bus (read-only) */
@@ -59,6 +62,7 @@ SECTIONS
     .rodata : ALIGN(4)
     {
         *(.rodata*)
+        *(.srodata*)
         . = ALIGN (4);
     } >DROM
 
@@ -83,6 +87,7 @@ SECTIONS
         . = ALIGN (4);
         _sbss = ABSOLUTE(.);
         *(.sbss)
+        *(.sbss.*)
         *(.bss .bss.*)
         . = ALIGN (4);
         _ebss = ABSOLUTE(.);


### PR DESCRIPTION
Limit the usable internal DRAM/IRAM region so it does not overlap with WiFi/BLE ROM variables.
Update the linker script so the DRAM/IRAM region ends exactly at 0x3FCCE710, the documented WiFi/BLE ROM boundary.
Details