### PR TITLE
targets: change default stack size for esp32c3 and esp32s3 to 8196.

### DIFF
--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -5,6 +5,7 @@
 	"serial": "usb",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
+	"default-stack-size": 8192,
 	"cflags": [
 		"-march=rv32imc"
 	],

--- a/targets/esp32s3.json
+++ b/targets/esp32s3.json
@@ -6,7 +6,7 @@
 	"scheduler": "tasks",
 	"serial": "usb",
 	"linker": "ld.lld",
-	"default-stack-size": 2048,
+	"default-stack-size": 8192,
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"linkerscript": "targets/esp32s3.ld",


### PR DESCRIPTION
This changes the default stack size for the esp32-c3 and esp32-s3 to 8kb. Since they have more onboard memory and a larger stack size is needed for any networking etc this default seems like a more sensible one, in similar way to the rp2040/rp2350 defaults.