### PR TITLE
fix: correct IOQSPI SS control mask handling on RP2040

### DIFF
--- a/src/machine/machine_rp2040_rom.go
+++ b/src/machine/machine_rp2040_rom.go
@@ -115,7 +115,7 @@ void ram_func flash_cs_force(bool high) {
 	// &ioqspi_hw->io[1].ctrl
 	uint32_t *addr = (uint32_t*)(IO_QSPI_BASE + (1 * 8) + 4);
 
-	*addr = ((*addr) & !IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_BITS)
+	*addr = ((*addr) & ~IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_BITS)
 		| (field_val << IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_LSB);
 
 }


### PR DESCRIPTION
Fix a bug where logical NOT (!) was used instead of bitwise NOT (~) when clearing the OUTOVER field in the GPIO_QSPI_SS_CTRL register.

As per the RP2040 datasheet, this register contains multiple control fields (such as OEOVER, INOVER, and IRQOVER). Using !mask evaluates to 0 or 1, which causes the entire register to be corrupted instead of just the targeted bits.

While the current behavior might appear to work by coincidence (if other fields are intended to be 0), this fix ensures proper bitwise manipulation and prevents potential side effects.

Reference: RP2040 Datasheet
https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf

