### PR TITLE
crypto/rand: return correct count on hardware RNG read error

### DIFF
--- a/src/crypto/rand/rand_baremetal.go
+++ b/src/crypto/rand/rand_baremetal.go
@@ -26,7 +26,7 @@ func (r *reader) Read(b []byte) (n int, err error) {
 		if i%4 == 0 {
 			randomByte, err = machine.GetRNG()
 			if err != nil {
-				return n, err
+				return i, err
 			}
 		} else {
 			randomByte >>= 8


### PR DESCRIPTION
## Summary

Fix the baremetal `crypto/rand` reader so that when `machine.GetRNG()` fails after some bytes were already written, `Read` returns `(i, err)` instead of `(n, err)`. Previously `n` was still zero, so callers could not tell how many bytes were valid.

## Testing

Not run (small one-line semantic fix; hardware RNG path).