### PR TITLE
reflect: pass StructOf field slice to reflectlite

### DIFF
--- a/src/reflect/type.go
+++ b/src/reflect/type.go
@@ -513,8 +513,20 @@ func ArrayOf(n int, t Type) Type {
 	return toType(reflectlite.ArrayOf(n, toRawType(t)))
 }
 
-func StructOf([]StructField) Type {
-	return toType(reflectlite.StructOf([]reflectlite.StructField{}))
+func StructOf(fields []StructField) Type {
+	rf := make([]reflectlite.StructField, len(fields))
+	for i := range fields {
+		rf[i] = reflectlite.StructField{
+			Name:      fields[i].Name,
+			PkgPath:   fields[i].PkgPath,
+			Type:      toRawType(fields[i].Type),
+			Tag:       fields[i].Tag,
+			Offset:    fields[i].Offset,
+			Index:     fields[i].Index,
+			Anonymous: fields[i].Anonymous,
+		}
+	}
+	return toType(reflectlite.StructOf(rf))
 }
 
 func MapOf(key, value Type) Type {


### PR DESCRIPTION
## Summary

`reflect.StructOf` previously discarded its `[]StructField` argument and always called `reflectlite.StructOf` with an empty slice, so dynamic struct layout never matched the requested fields.

Convert each `StructField` to `reflectlite.StructField` (including `Type` via `toRawType`), matching how `FuncOf` forwards its type slices.

## Note

`reflectlite.StructOf` remains unimplemented (panics) until that work lands; this change only fixes the forwarding bug at the `reflect` wrapper layer.

## Testing

Not run (small wrapper fix).