### PR TITLE
builder: fix panic in findPackagePath when using -size flag

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -954,7 +954,11 @@ func findPackagePath(path string, packagePathMap map[string]string) (packagePath
 			libPath := strings.TrimPrefix(path, filepath.Join(goenv.Get("TINYGOROOT"), "lib")+string(os.PathSeparator))
 			parts := strings.SplitN(libPath, string(os.PathSeparator), 2)
 			packagePath = "C " + parts[0]
-			filename = parts[1]
+			if len(parts) > 1 {
+				filename = parts[1]
+			} else {
+				filename = parts[0]
+			}
 		} else if prefix := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project", "compiler-rt"); strings.HasPrefix(path, prefix) {
 			packagePath = "C compiler-rt"
 			filename = strings.TrimPrefix(path, prefix+string(os.PathSeparator))


### PR DESCRIPTION
This fixes an "index out of range" panic that occurs when calculating binary sizes. The strings.SplitN operation in findPackagePath can sometimes return a slice with only one element, so we now verify the length of the slice before attempting to access the second element.

Before:
```
$ tinygo flash -target xiao-esp32c3 -ldflags="-X main.ssid=thessid -X main.password=thepassword" -monitor -stack-size 8kb -size short ./examples/http-app/
panic: runtime error: index out of range [1] with length 1                          
                                                                                                                                                                         
goroutine 88 [running]:                                                                                                                                                  
github.com/tinygo-org/tinygo/builder.findPackagePath({0xc00b1e9e80, 0x3c}, 0xc003535b60)                                                                                 
        /home/ron/Development/tinygo/tinygo-122/builder/sizes.go:957 +0x63a                                                                                              
github.com/tinygo-org/tinygo/builder.readSection({0xc00d41d818?, 0xc00a6e7ad8?, 0x0?, 0xc0000b76f8?}, {0xc00e190000?, 0x0?, 0x0?}, 0xc0094b7020, 0x66311a8, 0xc003535b60)
        /home/ron/Development/tinygo/tinygo-122/builder/sizes.go:920 +0x585         
github.com/tinygo-org/tinygo/builder.loadProgramSize({0xc008288c40?, 0x0?}, 0xc003535b60)
        /home/ron/Development/tinygo/tinygo-122/builder/sizes.go:843 +0x1249        
github.com/tinygo-org/tinygo/builder.Build.func9(0xc006662f00?)                     
        /home/ron/Development/tinygo/tinygo-122/builder/build.go:983 +0x1c05        
github.com/tinygo-org/tinygo/builder.runJob(0xc009034cc0, 0xc003f2a310)
        /home/ron/Development/tinygo/tinygo-122/builder/jobs.go:212 +0x4d           
created by github.com/tinygo-org/tinygo/builder.runJobs in goroutine 1      
        /home/ron/Development/tinygo/tinygo-122/builder/jobs.go:113 +0x5b7
```

After:
```
$ tinygo flash -target xiao-esp32c3 -ldflags="-X main.ssid=thessid -X main.password=thepassword" -monitor -stack-size 8kb -size short ./examples/http-app/
   code    data     bss |   flash     ram
 650518   23760  264462 |  674278  288222
Connected to ESP32-C3
...
```