### PR TITLE
interrupt/esp32c3: add Enable stub for QEMU test target

### DIFF
--- a/src/runtime/interrupt/interrupt_esp32c3_qemu.go
+++ b/src/runtime/interrupt/interrupt_esp32c3_qemu.go
@@ -1,0 +1,7 @@
+//go:build tinygo.riscv && esp32c3_qemu_target
+
+package interrupt
+
+// Enable is a no-op stub for the QEMU esp32c3 test target.
+// Hardware interrupts are not needed when running tests under qemu-system-riscv32.
+func (i Interrupt) Enable() error { return nil }


### PR DESCRIPTION
This PR to add an `Enable()` stub for QEMU test target on the esp32c3 processor.