### PR TITLE
Fix runtime on rp2350/2040 for multicore scheduler

### DIFF
--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -2,7 +2,6 @@
 
 // Used to track contribution from various authors automatically
 // SPDX-FileCopyrightText:  Copyright Hewlett Packard Enterprise Development LP
-//
 package runtime
 
 import (

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -393,8 +393,6 @@ func init() {
 	machineInit()
 
 	machine.InitSerial()
-
-	rp.PPB.SetACTLR_EXTEXCLALL(1)
 }
 
 func prerun() {

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -393,6 +393,8 @@ func init() {
 	machineInit()
 
 	machine.InitSerial()
+
+	initRP()
 }
 
 func prerun() {

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -1,6 +1,8 @@
 //go:build rp2040 || rp2350
+
 // Used to track contribution from various authors automatically
 // SPDX-FileCopyrightText:  Copyright Hewlett Packard Enterprise Development LP
+//
 package runtime
 
 import (
@@ -121,15 +123,15 @@ func startSecondaryCores() {
 
 	// Reset Core1
 	arm.DisableIRQ(uint32(sioIrqFifoProc0))
-        rp.PSM.SetFRCE_OFF_PROC1(1)
-        // Now we need to restart the core
-        for rp.PSM.GetFRCE_OFF_PROC1() == 0 {
-                // Sleep a little bit
-                sleepTicks(100)
-        }
-        rp.PSM.SetFRCE_OFF_PROC1(0)
+	rp.PSM.SetFRCE_OFF_PROC1(1)
+	// Now we need to restart the core
+	for rp.PSM.GetFRCE_OFF_PROC1() == 0 {
+		// Sleep a little bit
+		sleepTicks(100)
+	}
+	rp.PSM.SetFRCE_OFF_PROC1(0)
 	multicore_fifo_pop_blocking()
-	sleepTicks(1000)	
+	sleepTicks(1000)
 
 	// Start the second core of the RP2040/RP2350.
 	// See sections 2.8.2 and 5.3 in the datasheets for RP2040 and RP2350 respectively.
@@ -156,18 +158,18 @@ func startSecondaryCores() {
 	// We can only do this after we don't need the FIFO anymore for starting the
 	// second core.
 	intr := interrupt.New(sioIrqFifoProc0, func(intr interrupt.Interrupt) {
-                status := rp.SIO.GetFIFO_ST_VLD()
-                if status != 0 {
-                switch rp.SIO.FIFO_RD.Get() {
-                case 1:
-                        if currentCPU() == 1 {
-                                gcInterruptHandler(1)
-                        } else {
-                                gcInterruptHandler(0)
-                        }
-                }
-                }
-        })
+		status := rp.SIO.GetFIFO_ST_VLD()
+		if status != 0 {
+			switch rp.SIO.FIFO_RD.Get() {
+			case 1:
+				if currentCPU() == 1 {
+					gcInterruptHandler(1)
+				} else {
+					gcInterruptHandler(0)
+				}
+			}
+		}
+	})
 	intr.Enable()
 	intr.SetPriority(0xff)
 }
@@ -197,22 +199,22 @@ func runCore1() {
 	// the GC.
 	// Use the lowest possible priority (highest priority value), so that other
 	// interrupts can still happen while the GC is running.
-        intr := interrupt.New(sioIrqFifoProc1, func(intr interrupt.Interrupt) {
-                status := rp.SIO.GetFIFO_ST_VLD()
-                // ok we have just one interrupt vector ... sor
-                // we shall be acting based on CPU number calling in
+	intr := interrupt.New(sioIrqFifoProc1, func(intr interrupt.Interrupt) {
+		status := rp.SIO.GetFIFO_ST_VLD()
+		// ok we have just one interrupt vector ... sor
+		// we shall be acting based on CPU number calling in
 
-                if status != 0 {
-                        switch rp.SIO.FIFO_RD.Get() {
-                                case 1:
-                                        if currentCPU() == 1 {
-                                                gcInterruptHandler(1)
-                                        } else {
-                                                gcInterruptHandler(0)
-                                        }
-                        }
-                }
-        })
+		if status != 0 {
+			switch rp.SIO.FIFO_RD.Get() {
+			case 1:
+				if currentCPU() == 1 {
+					gcInterruptHandler(1)
+				} else {
+					gcInterruptHandler(0)
+				}
+			}
+		}
+	})
 	intr.Enable()
 	intr.SetPriority(0xff)
 
@@ -326,37 +328,37 @@ func coreStackTop(core uint32) uintptr {
 // These spinlocks are needed by the runtime.
 
 type spinLock struct {
-        atomic.Uint32
+	atomic.Uint32
 }
 
 var (
-        schedulerLock spinLock
-        futexLock     spinLock
-        atomicsLock   spinLock
-        printLock     spinLock
+	schedulerLock spinLock
+	futexLock     spinLock
+	atomicsLock   spinLock
+	printLock     spinLock
 )
 
 func resetSpinLocks() {
 	schedulerLock.Store(0)
-        futexLock.Store(0)
-        atomicsLock.Store(0)
-        printLock.Store(0)
+	futexLock.Store(0)
+	atomicsLock.Store(0)
+	printLock.Store(0)
 }
 
 func (l *spinLock) Lock() {
 	// Wait for the lock to be available.
 
 	for !l.Uint32.CompareAndSwap(0, 1) {
-                spinLoopWait()
-        }
+		spinLoopWait()
+	}
 
 }
 
 func (l *spinLock) Unlock() {
-        if schedulerAsserts && l.Uint32.Load() != 1 {
-                runtimePanic("unlock of unlocked spinlock")
-        }
-        l.Uint32.Store(0)
+	if schedulerAsserts && l.Uint32.Load() != 1 {
+		runtimePanic("unlock of unlocked spinlock")
+	}
+	l.Uint32.Store(0)
 }
 
 // Wait until a signal is received, indicating that it can resume from the

--- a/src/runtime/runtime_rp2.go
+++ b/src/runtime/runtime_rp2.go
@@ -1,5 +1,6 @@
 //go:build rp2040 || rp2350
-
+// Used to track contribution from various authors automatically
+// SPDX-FileCopyrightText:  Copyright Hewlett Packard Enterprise Development LP
 package runtime
 
 import (
@@ -10,6 +11,7 @@ import (
 	_ "machine/usb/cdc"
 	"runtime/interrupt"
 	"runtime/volatile"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -116,6 +118,19 @@ func currentCPU() uint32 {
 // Start the secondary cores for this chip.
 // On the RP2040/RP2350, there is only one other core to start.
 func startSecondaryCores() {
+
+	// Reset Core1
+	arm.DisableIRQ(uint32(sioIrqFifoProc0))
+        rp.PSM.SetFRCE_OFF_PROC1(1)
+        // Now we need to restart the core
+        for rp.PSM.GetFRCE_OFF_PROC1() == 0 {
+                // Sleep a little bit
+                sleepTicks(100)
+        }
+        rp.PSM.SetFRCE_OFF_PROC1(0)
+	multicore_fifo_pop_blocking()
+	sleepTicks(1000)	
+
 	// Start the second core of the RP2040/RP2350.
 	// See sections 2.8.2 and 5.3 in the datasheets for RP2040 and RP2350 respectively.
 	seq := 0
@@ -141,11 +156,18 @@ func startSecondaryCores() {
 	// We can only do this after we don't need the FIFO anymore for starting the
 	// second core.
 	intr := interrupt.New(sioIrqFifoProc0, func(intr interrupt.Interrupt) {
-		switch rp.SIO.FIFO_RD.Get() {
-		case 1:
-			gcInterruptHandler(0)
-		}
-	})
+                status := rp.SIO.GetFIFO_ST_VLD()
+                if status != 0 {
+                switch rp.SIO.FIFO_RD.Get() {
+                case 1:
+                        if currentCPU() == 1 {
+                                gcInterruptHandler(1)
+                        } else {
+                                gcInterruptHandler(0)
+                        }
+                }
+                }
+        })
 	intr.Enable()
 	intr.SetPriority(0xff)
 }
@@ -169,17 +191,28 @@ var stack1TopSymbol [0]uint32
 func runCore1() {
 	// Clear sticky bit that seems to have been set while starting this core.
 	rp.SIO.FIFO_ST.Set(rp.SIO_FIFO_ST_ROE)
+	rp.SIO.FIFO_ST.Set(rp.SIO_FIFO_ST_WOF)
 
 	// Enable the FIFO interrupt, mainly used for the stop-the-world phase of
 	// the GC.
 	// Use the lowest possible priority (highest priority value), so that other
 	// interrupts can still happen while the GC is running.
-	intr := interrupt.New(sioIrqFifoProc1, func(intr interrupt.Interrupt) {
-		switch rp.SIO.FIFO_RD.Get() {
-		case 1:
-			gcInterruptHandler(1)
-		}
-	})
+        intr := interrupt.New(sioIrqFifoProc1, func(intr interrupt.Interrupt) {
+                status := rp.SIO.GetFIFO_ST_VLD()
+                // ok we have just one interrupt vector ... sor
+                // we shall be acting based on CPU number calling in
+
+                if status != 0 {
+                        switch rp.SIO.FIFO_RD.Get() {
+                                case 1:
+                                        if currentCPU() == 1 {
+                                                gcInterruptHandler(1)
+                                        } else {
+                                                gcInterruptHandler(0)
+                                        }
+                        }
+                }
+        })
 	intr.Enable()
 	intr.SetPriority(0xff)
 
@@ -291,41 +324,39 @@ func coreStackTop(core uint32) uintptr {
 }
 
 // These spinlocks are needed by the runtime.
+
+type spinLock struct {
+        atomic.Uint32
+}
+
 var (
-	printLock     = spinLock{id: 20}
-	schedulerLock = spinLock{id: 21}
-	atomicsLock   = spinLock{id: 22}
-	futexLock     = spinLock{id: 23}
+        schedulerLock spinLock
+        futexLock     spinLock
+        atomicsLock   spinLock
+        printLock     spinLock
 )
 
 func resetSpinLocks() {
-	for i := uint8(0); i < numSpinlocks; i++ {
-		l := &spinLock{id: i}
-		l.spinlock().Set(0)
-	}
-}
-
-// A hardware spinlock, one of the 32 spinlocks defined in the SIO peripheral.
-type spinLock struct {
-	id uint8
-}
-
-// Return the spinlock register: rp.SIO.SPINLOCKx
-func (l *spinLock) spinlock() *volatile.Register32 {
-	return (*volatile.Register32)(unsafe.Add(unsafe.Pointer(&rp.SIO.SPINLOCK0), l.id*4))
+	schedulerLock.Store(0)
+        futexLock.Store(0)
+        atomicsLock.Store(0)
+        printLock.Store(0)
 }
 
 func (l *spinLock) Lock() {
 	// Wait for the lock to be available.
-	spinlock := l.spinlock()
-	for spinlock.Get() == 0 {
-		arm.Asm("wfe")
-	}
+
+	for !l.Uint32.CompareAndSwap(0, 1) {
+                spinLoopWait()
+        }
+
 }
 
 func (l *spinLock) Unlock() {
-	l.spinlock().Set(0)
-	arm.Asm("sev")
+        if schedulerAsserts && l.Uint32.Load() != 1 {
+                runtimePanic("unlock of unlocked spinlock")
+        }
+        l.Uint32.Store(0)
 }
 
 // Wait until a signal is received, indicating that it can resume from the
@@ -361,6 +392,8 @@ func init() {
 	machineInit()
 
 	machine.InitSerial()
+
+	rp.PPB.SetACTLR_EXTEXCLALL(1)
 }
 
 func prerun() {

--- a/src/runtime/runtime_rp2040.go
+++ b/src/runtime/runtime_rp2040.go
@@ -10,3 +10,6 @@ const (
 	sioIrqFifoProc0 = rp.IRQ_SIO_IRQ_PROC0
 	sioIrqFifoProc1 = rp.IRQ_SIO_IRQ_PROC1
 )
+
+func initRP() {
+}

--- a/src/runtime/runtime_rp2350.go
+++ b/src/runtime/runtime_rp2350.go
@@ -14,3 +14,7 @@ const (
 	sioIrqFifoProc0 = rp.IRQ_SIO_IRQ_FIFO
 	sioIrqFifoProc1 = rp.IRQ_SIO_IRQ_FIFO
 )
+
+func initRP() {
+	rp.PPB.SetACTLR_EXTEXCLALL(1)
+}


### PR DESCRIPTION
Address issue reported into 
GC-caused scheduler deadlock on RP2350 #5151

- Add interrupt handler per core detection to properly call the garbage collector
- Switch to software spinlock as to avoid hardware bugs on rp2350
- reset second core before running it (in some cases it stay stuck)

With these fixes I have been able to make run  https://github.com/opencomputeproject/ocp-fwupdater-PoC/ with the core scheduler. (still need to be fully updated upstream)

ps: I had to add the SPDX contribution as this work is performed during my work time at Hewlett Packard Enterprise, and has been approved to be released publicly.