### PR TITLE
targets: add "adb" flash method using Android Debug Bridge

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -536,7 +536,7 @@ func (c *Config) Programmer() (method, openocdInterface string) {
 	case "":
 		// No configuration supplied.
 		return c.Target.FlashMethod, c.Target.OpenOCDInterface
-	case "openocd", "msd", "command":
+	case "openocd", "msd", "command", "adb":
 		// The -programmer flag only specifies the flash method.
 		return c.Options.Programmer, c.Target.OpenOCDInterface
 	case "bmp":

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -64,6 +64,9 @@ type TargetSpec struct {
 	OpenOCDCommands  []string `json:"openocd-commands,omitempty"`
 	OpenOCDVerify    *bool    `json:"openocd-verify,omitempty"` // enable verify when flashing with openocd
 	JLinkDevice      string   `json:"jlink-device,omitempty"`
+	ADBPreCommands   []string `json:"adb-pre-commands,omitempty"`
+	ADBPushRemote    string   `json:"adb-push-remote,omitempty"`
+	ADBPostCommands  []string `json:"adb-post-commands,omitempty"`
 	CodeModel        string   `json:"code-model,omitempty"`
 	RelocationModel  string   `json:"relocation-model,omitempty"`
 	WITPackage       string   `json:"wit-package,omitempty"`

--- a/main.go
+++ b/main.go
@@ -396,6 +396,8 @@ func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 		fileExt = ".hex"
 	case "bmp":
 		fileExt = ".elf"
+	case "adb":
+		fileExt = ".hex"
 	case "esp32flash", "esp32jtag":
 		fileExt = ".bin"
 	case "native":
@@ -531,6 +533,38 @@ func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 		err = cmd.Run()
 		if err != nil {
 			return &commandError{"failed to flash", result.Binary, err}
+		}
+	case "adb":
+		// Run pre-flash adb shell commands.
+		for _, preCmd := range config.Target.ADBPreCommands {
+			cmd := executeCommand(config.Options, "adb", "shell", preCmd)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return &commandError{"failed to run adb pre-command", preCmd, err}
+			}
+		}
+
+		// Push the binary to the device.
+		if config.Target.ADBPushRemote == "" {
+			return errors.New("invalid target file: flash-method was set to \"adb\" but no adb-push-remote was set")
+		}
+		cmd := executeCommand(config.Options, "adb", "push", result.Binary, config.Target.ADBPushRemote)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return &commandError{"adb push failed to " + config.Target.ADBPushRemote, result.Binary, err}
+		}
+
+		// Run post-flash adb shell commands.
+		for _, postCmd := range config.Target.ADBPostCommands {
+			postCmd = strings.ReplaceAll(postCmd, "{remote}", config.Target.ADBPushRemote)
+			cmd := executeCommand(config.Options, "adb", "shell", postCmd)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return &commandError{"failed to run adb post-command", postCmd, err}
+			}
 		}
 	case "esp32flash":
 		port, err := getDefaultPort(port, config.Target.SerialPort)

--- a/targets/arduino-uno-q.json
+++ b/targets/arduino-uno-q.json
@@ -2,7 +2,9 @@
   "inherits": ["stm32u585"],
   "build-tags": ["arduino_uno_q"],
   "serial": "uart",
-  "openocd-interface": "stlink",
-  "openocd-target": "stm32u5x",
-  "openocd-commands": ["adapter driver linuxgpiod adapter gpio swclk -chip 1 26 adapter gpio swdio -chip 1 25 adapter gpio srst -chip 1 38 transport select swd adapter speed 1000 reset_config srst_only srst_push_pull"]
+  "flash-method": "adb",
+  "adb-push-remote": "/tmp/firmware.hex",
+  "adb-post-commands": [
+    "/opt/openocd/bin/openocd -s /opt/openocd/share/openocd/scripts -s /opt/openocd -c \"adapter driver linuxgpiod\" -c \"adapter gpio swclk -chip 1 26\" -c \"adapter gpio swdio -chip 1 25\" -c \"adapter gpio srst -chip 1 38\" -c \"transport select swd\" -c \"adapter speed 1000\" -c \"reset_config srst_only srst_push_pull\" -f /opt/openocd/stm32u5x.cfg -c \"program {remote} verify reset exit\""
+  ]
 }


### PR DESCRIPTION
Add a new flash method that uses adb to flash boards over Android Debug Bridge. The method supports running pre-flash shell commands via "adb shell", pushing the firmware binary via "adb push", and running post-flash shell commands with a {remote} token for the remote path.

New target JSON fields:
- adb-pre-commands: shell commands to run before pushing firmware
- adb-push-remote: remote device path for adb push
- adb-post-commands: shell commands to run after pushing firmware

Switch arduino-uno-q target to use the new adb flash method with openocd running on the remote device.

You must install the adb command line tool for your platform here: https://developer.android.com/tools/releases/platform-tools

Here it is in action flashing the `blinky1` program from my machine onto the connected Arduino UNO Q board:

```
$ tinygo flash -target arduino-uno-q -size short examples/blinky1                   
   code    data     bss |   flash     ram
   6004    1452    4328 |    7456    5780                                           
/tmp/tinygo2117185289/main.hex: 1 file pushed, 0 skipped. 82.9 MB/s (20532 bytes in 0.000s)                                                                              
Open On-Chip Debugger 0.12.0+dev-ge6a2c12f4 (2025-05-22-15:51)                      
Licensed under GNU GPL v2                                                                                                                                                
For bug reports, read                                                               
        http://openocd.org/doc/doxygen/bugs.html
adapter speed: 1000 kHz                                                             
srst_only separate srst_gates_jtag srst_push_pull connect_deassert_srst             
clock_config                                                                                                                                                             
Info : Linux GPIOD JTAG/SWD bitbang driver (libgpiod v2)                                                                                                                 
Info : Note: The adapter "linuxgpiod" doesn't support configurable speed            
Info : SWD DPIDR 0x0be12477                                                         
Info : [stm32u5.ap0] Examination succeed                                                                                                                                 
Info : [stm32u5.cpu] Cortex-M33 r0p4 processor detected                             
Info : [stm32u5.cpu] target has 8 breakpoints, 4 watchpoints
Info : [stm32u5.cpu] Examination succeed                                            
Info : [stm32u5.ap0] gdb port disabled                                              
Info : [stm32u5.cpu] starting gdb server on 3333                                    
Info : Listening on port 3333 for gdb connections                                                                                                                        
CPU in Non-Secure state                                                             
[stm32u5.cpu] halted due to breakpoint, current mode: Thread                                                                                                             
xPSR: 0xf9000000 pc: 0x08002f80 msp: 0x20001000                                                                                                                          
Error: Translation from khz to adapter speed not implemented     
Error: [stm32u5.cpu] Execution of event reset-init failed:           
                                                                                    
** Programming Started **                                                           
Info : device idcode = 0x30076482 (STM32U57/U58xx - Rev U : 0x3007)                 
Info : TZEN = 0 : TrustZone disabled by option bytes                                
Info : RDP level 0 (0xAA)                                                           
Info : flash size = 2048 KiB                                                                                                                                             
Info : flash mode : dual-bank                                                                                                                                            
Warn : Adding extra erase range, 0x08001d20 .. 0x08001fff                           
** Programming Finished **                                                          
** Verify Started **                                                                
** Verified OK **                                                                                                                                                        
** Resetting Target **                                                              
shutdown command invoked
```