### PR TITLE
fix interp: unknown type kind in markExternalValue when compiling libsecp256k1

### DIFF
--- a/interp/memory.go
+++ b/interp/memory.go
@@ -211,7 +211,6 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 		llvmType := llvmValue.Type()
 		switch llvmType.TypeKind() {
 		case llvm.IntegerTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind:
-		case llvm.VectorTypeKind, llvm.MetadataTypeKind:
 			// Nothing to do here. Integers and floats aren't pointers so don't
 			// need any marking.
 		case llvm.StructTypeKind:
@@ -223,7 +222,7 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 					return err
 				}
 			}
-		case llvm.ArrayTypeKind:
+		case llvm.ArrayTypeKind, llvm.VectorTypeKind:
 			numElements := llvmType.ArrayLength()
 			for i := 0; i < numElements; i++ {
 				element := mv.r.builder.CreateExtractValue(llvmValue, i, "")
@@ -232,6 +231,7 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 					return err
 				}
 			}
+		case llvm.MetadataTypeKind:
 		default:
 			return errors.New("interp: unknown type kind in markExternalValue")
 		}

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -223,6 +223,8 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 				}
 			}
 		case llvm.ArrayTypeKind:
+			fallthrough
+		case llvm.VectorTypeKind:
 			numElements := llvmType.ArrayLength()
 			for i := 0; i < numElements; i++ {
 				element := mv.r.builder.CreateExtractValue(llvmValue, i, "")
@@ -231,6 +233,7 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 					return err
 				}
 			}
+		case llvm.MetadataTypeKind:
 		default:
 			return errors.New("interp: unknown type kind in markExternalValue")
 		}

--- a/interp/memory.go
+++ b/interp/memory.go
@@ -211,6 +211,7 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 		llvmType := llvmValue.Type()
 		switch llvmType.TypeKind() {
 		case llvm.IntegerTypeKind, llvm.FloatTypeKind, llvm.DoubleTypeKind:
+		case llvm.VectorTypeKind, llvm.MetadataTypeKind:
 			// Nothing to do here. Integers and floats aren't pointers so don't
 			// need any marking.
 		case llvm.StructTypeKind:
@@ -223,8 +224,6 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 				}
 			}
 		case llvm.ArrayTypeKind:
-			fallthrough
-		case llvm.VectorTypeKind:
 			numElements := llvmType.ArrayLength()
 			for i := 0; i < numElements; i++ {
 				element := mv.r.builder.CreateExtractValue(llvmValue, i, "")
@@ -233,7 +232,6 @@ func (mv *memoryView) markExternal(llvmValue llvm.Value, mark uint8) error {
 					return err
 				}
 			}
-		case llvm.MetadataTypeKind:
 		default:
 			return errors.New("interp: unknown type kind in markExternalValue")
 		}


### PR DESCRIPTION
Fixes #5292 