### PR TITLE
compileopts: add noasm default build tag

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -110,6 +110,7 @@ func (c *Config) BuildTags() []string {
 	tags = append(tags, []string{
 		"tinygo",                                     // that's the compiler
 		"purego",                                     // to get various crypto packages to work
+		"noasm",                                      // to avoid Go assembly which TinyGo can't compile
 		"osusergo",                                   // to get os/user to work
 		"math_big_pure_go",                           // to get math/big to work
 		"gc." + c.GC(), "scheduler." + c.Scheduler(), // used inside the runtime package


### PR DESCRIPTION
I don't know if this is a good idea or not, but, this affects github.com/zeebo/xxh3 and github.com/klauspost/cpuid/v2 which both fail to compile with tinygo unless their asm is disabled (at least for amd64 where I was testing). I am not 100% familiar with what asm tinygo supports, but my impression was that it handles _none_, hence setting `purego`? Unclear why these packages don't just use `purego`.

(Happy to just _not_ do this and keep the build tag to myself if that is more acceptable, I'm just splitting apart a chain of commits in the process of getting tsgo working).

Updates #4894