### PR TITLE
ci: don't double zip release artifacts

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -101,16 +101,11 @@ jobs:
       - name: Make release artifact
         run: cp -p build/release.tar.gz build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
-        # Note: this release artifact is double-zipped, see:
-        # https://github.com/actions/upload-artifact/issues/39
-        # We can essentially pick one of these:
-        # - have a double-zipped artifact when downloaded from the UI
-        # - have a very slow artifact upload
-        # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v7
         with:
           name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
           path: build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
+          archive: false
       - name: Smoke tests
         run: make smoketest TINYGO=$(PWD)/build/tinygo
   test-macos-homebrew:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,13 +118,18 @@ jobs:
           make release deb -j3 STATIC=1
           cp -p build/release.tar.gz /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
           cp -p build/release.deb    /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
-      - name: Publish release artifact
+      - name: "Publish release artifact: tarball"
         uses: actions/upload-artifact@v7
         with:
-          name: linux-amd64-double-zipped-${{ steps.version.outputs.version }}
-          path: |
-            /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
-            /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
+          name: tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
+          path: /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
+          archive: false
+      - name: "Publish release artifact: Debian package"
+        uses: actions/upload-artifact@v7
+        with:
+          name: tinygo_${{ steps.version.outputs.version }}_amd64.deb
+          path: /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
+          archive: false
   test-linux-build:
     # Test the binaries built in the build-linux job by running the smoke tests.
     runs-on: ubuntu-latest
@@ -146,9 +151,9 @@ jobs:
       - name: Install wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
       - name: Download release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: linux-amd64-double-zipped-${{ needs.build-linux.outputs.version }}
+          name: tinygo${{ needs.build-linux.outputs.version }}.linux-amd64.tar.gz
       - name: Extract release tarball
         run: |
           mkdir -p ~/lib
@@ -370,9 +375,9 @@ jobs:
         run: |
           make CROSS=${{ matrix.toolchain }}
       - name: Download amd64 release
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: linux-amd64-double-zipped-${{ needs.build-linux.outputs.version }}
+          name: tinygo${{ needs.build-linux.outputs.version }}.linux-amd64.tar.gz
       - name: Extract amd64 release
         run: |
           mkdir -p build/release
@@ -384,12 +389,17 @@ jobs:
       - name: Create ${{ matrix.goarch }} release
         run: |
           make release deb RELEASEONLY=1 DEB_ARCH=${{ matrix.libc }}
-          cp -p build/release.tar.gz /tmp/tinygo${{ steps.version.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
-          cp -p build/release.deb    /tmp/tinygo_${{ steps.version.outputs.version }}_${{ matrix.libc }}.deb
-      - name: Publish release artifact
+          cp -p build/release.tar.gz /tmp/tinygo${{ needs.build-linux.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
+          cp -p build/release.deb    /tmp/tinygo_${{ needs.build-linux.outputs.version }}_${{ matrix.libc }}.deb
+      - name: "Publish release artifact: tarball"
         uses: actions/upload-artifact@v7
         with:
-          name: linux-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
-          path: |
-            /tmp/tinygo${{ steps.version.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
-            /tmp/tinygo_${{ steps.version.outputs.version }}_${{ matrix.libc }}.deb
+          name: linux-${{ matrix.goarch }}-double-zipped-${{ needs.build-linux.outputs.version }}
+          path: /tmp/tinygo${{ needs.build-linux.outputs.version }}.linux-${{ matrix.goarch }}.tar.gz
+          archive: false
+      - name: "Publish release artifact: Debian package"
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-${{ matrix.goarch }}-double-zipped-${{ needs.build-linux.outputs.version }}
+          path: /tmp/tinygo_${{ needs.build-linux.outputs.version }}_${{ matrix.libc }}.deb
+          archive: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,16 +114,11 @@ jobs:
         working-directory: build/release
         run: 7z -tzip a tinygo${{ steps.version.outputs.version }}.windows-amd64.zip tinygo
       - name: Publish release artifact
-        # Note: this release artifact is double-zipped, see:
-        # https://github.com/actions/upload-artifact/issues/39
-        # We can essentially pick one of these:
-        # - have a dobule-zipped artifact when downloaded from the UI
-        # - have a very slow artifact upload
-        # We're doing the former here, to keep artifact uploads fast.
         uses: actions/upload-artifact@v7
         with:
-          name: windows-amd64-double-zipped-${{ steps.version.outputs.version }}
+          name: tinygo${{ steps.version.outputs.version }}.windows-amd64.zip
           path: build/release/tinygo${{ steps.version.outputs.version }}.windows-amd64.zip
+          archive: false
 
   smoke-test-windows:
     runs-on: windows-2022
@@ -149,14 +144,11 @@ jobs:
           go-version: '1.26.2'
           cache: true
       - name: Download TinyGo build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
+          name: tinygo${{ needs.build-windows.outputs.version }}.windows-amd64.zip
           path: build/
-      - name: Unzip TinyGo build
-        shell: bash
-        working-directory: build
-        run: 7z x tinygo*.windows-amd64.zip -r
+        # This build is already unzipped.
       - name: Smoke tests
         shell: bash
         run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo
@@ -179,14 +171,11 @@ jobs:
           go-version: '1.26.2'
           cache: true
       - name: Download TinyGo build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
+          name: tinygo${{ needs.build-windows.outputs.version }}.windows-amd64.zip
           path: build/
-      - name: Unzip TinyGo build
-        shell: bash
-        working-directory: build
-        run: 7z x tinygo*.windows-amd64.zip -r
+        # This build is already unzipped.
       - name: Test stdlib packages
         run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
@@ -214,13 +203,10 @@ jobs:
           go-version: '1.26.2'
           cache: true
       - name: Download TinyGo build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: windows-amd64-double-zipped-${{ needs.build-windows.outputs.version }}
+          name: tinygo${{ needs.build-windows.outputs.version }}.windows-amd64.zip
           path: build/
-      - name: Unzip TinyGo build
-        shell: bash
-        working-directory: build
-        run: 7z x tinygo*.windows-amd64.zip -r
+        # This build is already unzipped.
       - name: Test stdlib packages on wasip1
         run: make tinygo-test-wasip1-fast TINYGO=$(PWD)/build/tinygo/bin/tinygo


### PR DESCRIPTION
See: https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/

~Let's see how well this works on the first try.~ of course it didn't.