### PR TITLE
fix interp: swap operands if the pointer operand is second

### DIFF
--- a/interp/interpreter.go
+++ b/interp/interpreter.go
@@ -768,6 +768,9 @@ func (r *runner) run(fn *function, params []value, parentMem *memoryView, indent
 			// Integer binary operations.
 			lhs := operands[0]
 			rhs := operands[1]
+			if _, err := rhs.asPointer(r); err == nil {
+				lhs, rhs = rhs, lhs
+			}
 			lhsPtr, err := lhs.asPointer(r)
 			if err == nil {
 				// The lhs is a pointer. This sometimes happens for particular


### PR DESCRIPTION
On the xtensa backend, it may have the second operand as the pointer and the first as the integer. Don't fail - swap them before the regular code path.