### PR TITLE
fix baremetal runtime: rename malloc and co. export names

### DIFF
--- a/src/runtime/baremetal.go
+++ b/src/runtime/baremetal.go
@@ -37,20 +37,20 @@ func growHeap() bool {
 	return false
 }
 
-//export malloc
+//export tinygo_malloc
 func libc_malloc(size uintptr) unsafe.Pointer {
 	// Note: this zeroes the returned buffer which is not necessary.
 	// The same goes for bytealg.MakeNoZero.
 	return alloc(size, nil)
 }
 
-//export calloc
+//export tinygo_calloc
 func libc_calloc(nmemb, size uintptr) unsafe.Pointer {
 	// No difference between calloc and malloc.
 	return libc_malloc(nmemb * size)
 }
 
-//export free
+//export tinygo_free
 func libc_free(ptr unsafe.Pointer) {
 	free(ptr)
 }


### PR DESCRIPTION
The original intention was the Go code would use CGo to call into C code, and the exports would allow C code to call malloc without needing modification. But calling the export malloc is wrong as it clashes when linking the Go code as a static library to esp-idf C environment. Moreover, C.CString calls malloc to allocate memory to return to C. I have found that it links the libc_malloc function instead. This means C.CString returns GC-allocated memory to C, so if C calls free on that, it bombs. I think a better name would be tinygo_malloc. And if the aim was to avoid modification of existing C code, it is very easy for the developer to add the aliasing function on the C side.