### PR TITLE
wasm: add more stubbed file operations

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -237,9 +237,11 @@
 			}
 
 			const timeOrigin = Date.now() - performance.now();
+			const wasi_EBADF = 8;
+			const wasi_ENOSYS = 52;
 			this.importObject = {
 				wasi_snapshot_preview1: {
-					// https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fd_write
+					// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 					fd_write: function(fd, iovs_ptr, iovs_len, nwritten_ptr) {
 						let nwritten = 0;
 						if (fd == 1) {
@@ -268,9 +270,13 @@
 						mem().setUint32(nwritten_ptr, nwritten, true);
 						return 0;
 					},
-					fd_close: () => 0,      // dummy
-					fd_fdstat_get: () => 0, // dummy
-					fd_seek: () => 0,       // dummy
+					fd_read: () => wasi_ENOSYS,
+					fd_close: () => wasi_ENOSYS,
+					fd_fdstat_get: () => wasi_ENOSYS,
+					fd_prestat_get: () => wasi_EBADF, // wasi-libc relies on this errno value
+					fd_prestat_dir_name: () => wasi_ENOSYS,
+					fd_seek: () => wasi_ENOSYS,
+					path_open: () => wasi_ENOSYS,
 					proc_exit: (code) => {
 						this.exited = true;
 						this.exitCode = code;

--- a/testdata/stdlib.go
+++ b/testdata/stdlib.go
@@ -33,6 +33,7 @@ func main() {
 	// package time
 	time.Sleep(time.Millisecond)
 	time.Sleep(-1) // negative sleep should return immediately
+	time.LoadLocation("UTC")
 
 	// Exit the program normally.
 	os.Exit(0)


### PR DESCRIPTION
This fixes issue #5037. A few more wasip1 syscalls needed to be present, and in particular fd_prestat_get needed to return EBADF on invalid file descriptors.