### PR TITLE
machine/esp32s3: use edge-triggered CPU interrupt for GPIO pin interrupts

### DIFF
--- a/src/examples/pininterrupt/xiao-esp32s3.go
+++ b/src/examples/pininterrupt/xiao-esp32s3.go
@@ -6,6 +6,6 @@ import "machine"
 
 const (
 	button          = machine.D1
-	buttonMode      = machine.PinInput
+	buttonMode      = machine.PinInputPullup
 	buttonPinChange = machine.PinFalling
 )

--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -261,13 +261,13 @@ func setupPinInterrupt() error {
 	esp.INTERRUPT_CORE0.GPIO_INTERRUPT_PRO_MAP.Set(cpuInterruptFromPin)
 	return interrupt.New(cpuInterruptFromPin, func(interrupt.Interrupt) {
 		status := esp.GPIO.STATUS.Get()
+		// Clear before processing so new edges during callbacks are not lost.
+		esp.GPIO.STATUS_W1TC.SetBits(status)
 		for i, mask := 0, uint32(1); i < maxPin; i, mask = i+1, mask<<1 {
 			if (status&mask) != 0 && pinCallbacks[i] != nil {
 				pinCallbacks[i](Pin(i))
 			}
 		}
-		// clear interrupt bit
-		esp.GPIO.STATUS_W1TC.SetBits(status)
 	}).Enable()
 }
 

--- a/src/machine/machine_esp32s3.go
+++ b/src/machine/machine_esp32s3.go
@@ -306,7 +306,12 @@ func (p Pin) pinReg() *volatile.Register32 {
 }
 
 const maxPin = 49
-const cpuInterruptFromPin = 8
+
+// cpuInterruptFromPin selects an edge-triggered CPU interrupt line for GPIO.
+// CPU interrupt 10 is edge-triggered level-1 on the Xtensa LX7, which prevents
+// the ISR from re-entering continuously when other peripherals (e.g. SPI via
+// the GPIO Matrix) keep GPIO.STATUS bits asserted.
+const cpuInterruptFromPin = 10
 
 type PinChange uint8
 
@@ -370,23 +375,28 @@ var (
 func setupPinInterrupt() error {
 	esp.INTERRUPT_CORE0.SetGPIO_INTERRUPT_PRO_MAP(cpuInterruptFromPin)
 	return interrupt.New(cpuInterruptFromPin, func(interrupt.Interrupt) {
-		// Check status for GPIO0-31
+		// Read and immediately clear interrupt status bits.
+		// Clearing before processing is critical for edge-triggered CPU
+		// interrupts: any new GPIO events that arrive during callback
+		// execution will set fresh STATUS bits, generating a new edge
+		// on the CPU interrupt line so they are not lost.
 		status := esp.GPIO.STATUS.Get()
+		status1 := esp.GPIO.STATUS1.Get()
+		esp.GPIO.STATUS_W1TC.Set(status)
+		esp.GPIO.STATUS1_W1TC.Set(status1)
+
+		// Check status for GPIO0-31
 		for i, mask := 0, uint32(1); i < 32; i, mask = i+1, mask<<1 {
 			if (status&mask) != 0 && pinCallbacks[i] != nil {
 				pinCallbacks[i](Pin(i))
 			}
 		}
 		// Check status for GPIO32-48
-		status1 := esp.GPIO.STATUS1.Get()
 		for i, mask := 32, uint32(1); i < maxPin; i, mask = i+1, mask<<1 {
 			if (status1&mask) != 0 && pinCallbacks[i] != nil {
 				pinCallbacks[i](Pin(i))
 			}
 		}
-		// Clear interrupt bits
-		esp.GPIO.STATUS_W1TC.SetBits(status)
-		esp.GPIO.STATUS1_W1TC.SetBits(status1)
 	}).Enable()
 }
 

--- a/src/runtime/interrupt/interrupt_esp32s3.go
+++ b/src/runtime/interrupt/interrupt_esp32s3.go
@@ -107,6 +107,12 @@ func handleInterrupt() {
 	enabled := readINTENABLE()
 	active := pending & enabled
 
+	// Clear edge-triggered pending bits before dispatching handlers so that
+	// new edges arriving during handler execution are not lost.  Writing to
+	// INTCLEAR is a no-op for level-triggered lines, so this is safe for all
+	// interrupt types.
+	writeINTCLEAR(active)
+
 	for i := firstCPUInt; i <= lastCPUInt; i++ {
 		if active&(1<<uint(i)) != 0 {
 			// callHandlers requires a compile-time constant, so we
@@ -210,6 +216,16 @@ func writeINTENABLE(val uint32) {
 // reflects the currently pending CPU interrupts.
 func readINTERRUPT() uint32 {
 	return uint32(device.AsmFull("rsr {}, INTERRUPT", nil))
+}
+
+// writeINTCLEAR writes the INTCLEAR special register (SR 227).
+// Setting bit N clears CPU interrupt N if it is edge-triggered or
+// software-triggered.  Bits corresponding to level-triggered interrupts
+// are ignored by hardware.
+func writeINTCLEAR(val uint32) {
+	device.AsmFull("wsr {val}, INTCLEAR", map[string]interface{}{
+		"val": val,
+	})
 }
 
 // -- Interrupt matrix helpers -----------------------------------------------


### PR DESCRIPTION
This PR modifies the recent `machine_esp32s3` changes to use `Set()` to clear interrupt bits to avoid clearing unwanted bits.

Based on feedback from @aykevl 

I tested on actual hardware, and still works as expected, presumably without side effects.

UPDATE: this PR has been heavily modified to now do the following:

When SPI is configured via the GPIO Matrix, SPI signal transitions set GPIO.STATUS bits on the routed pins. With a level-triggered CPU interrupt (line 8), the ISR re-enters continuously as long as any STATUS bit is asserted — causing user GPIO callbacks to fire spuriously.

Switch cpuInterruptFromPin to CPU interrupt 10, which is edge-triggered (level 1) on the Xtensa LX7. This ensures the ISR fires once per GPIO event rather than looping while SPI is active.

Also move STATUS_W1TC clears to before callback dispatch so that new GPIO events arriving during handler execution generate a fresh edge, and add writeINTCLEAR(active) in handleInterrupt to properly acknowledge edge-triggered CPU interrupt pending bits via the INTCLEAR register.

Fixes GPIO interrupts firing constantly when SPI and pin interrupts are used together.

FURTHER UPDATE: added another commit to correct the ordering of the pin interrupt handler for esp32c3 as well to avoid similar problem.