### PR TITLE
test: increase default timeout from 1 to 2 minutes

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -454,7 +454,7 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 
 	// Build the test binary.
 	stdout := &bytes.Buffer{}
-	_, err = buildAndRun(pkgName, config, stdout, cmdArgs, environmentVars, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+	_, err = buildAndRun(pkgName, config, stdout, cmdArgs, environmentVars, 2*time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
 		return cmd.Run()
 	})
 	if err != nil {


### PR DESCRIPTION
This PR increases the test default timeout from 1 to 2 minutes to prevent spurious fails in CI from slow GH runners.