### PR TITLE
testdata: fix flaky timers test by draining ticker channel after Stop

### DIFF
--- a/testdata/timers.go
+++ b/testdata/timers.go
@@ -21,6 +21,11 @@ func main() {
 	<-ticker.C
 	println("waited on ticker at 1000ms")
 	ticker.Stop()
+	// Drain any tick that was already queued before Stop took effect.
+	select {
+	case <-ticker.C:
+	default:
+	}
 	time.Sleep(time.Millisecond * 750)
 	select {
 	case <-ticker.C:


### PR DESCRIPTION
Ticker.Stop does not drain already-buffered ticks from the channel, so on slow CI runners a tick may already be queued before Stop takes effect, causing a spurious "fail: ticker should have stopped!" failure.

Drain the channel immediately after Stop before checking that no new ticks arrive.