### PR TITLE
machine/esp32: default SPI CS pin to NoPin when unset

### DIFF
--- a/src/machine/machine_esp32c3_spi.go
+++ b/src/machine/machine_esp32c3_spi.go
@@ -137,6 +137,12 @@ func (spi *SPI) Configure(config SPIConfig) error {
 	// configure SPI bus clock
 	spi.Bus.CLOCK.Set(freqToClockDiv(config.Frequency))
 
+	// Default CS to NoPin so that an unset CS field (zero value = GPIO0)
+	// does not accidentally configure GPIO0 as the chip select output.
+	if config.CS == 0 {
+		config.CS = NoPin
+	}
+
 	// configure esp32c3 gpio pin matrix
 	config.SDI.Configure(PinConfig{Mode: PinInput})
 	inFunc(FSPIQ_IN_IDX).Set(esp.GPIO_FUNC_IN_SEL_CFG_SEL | uint32(config.SDI))

--- a/src/machine/machine_esp32s3_spi.go
+++ b/src/machine/machine_esp32s3_spi.go
@@ -67,6 +67,12 @@ func (spi *SPI) Configure(config SPIConfig) error {
 		config.Frequency = SPI_DEFAULT_FREQUENCY
 	}
 
+	// Default CS to NoPin so that an unset CS field (zero value = GPIO0)
+	// does not accidentally configure GPIO0 as the chip select output.
+	if config.CS == 0 {
+		config.CS = NoPin
+	}
+
 	switch spi.busID {
 	case 2: // SPI2 (FSPI)
 		if config.SCK == 0 {


### PR DESCRIPTION
SPIConfig.CS has a zero value of Pin(0) (GPIO0), but NoPin is Pin(0xff). When the user does not set CS, the SPI driver sees Pin(0) != NoPin and configures GPIO0 as the chip select output, hijacking whatever function that pin was serving such as a button interrupt.

Default config.CS to NoPin when it is the zero value, so an omitted CS field correctly means "no hardware CS pin". Applied to both ESP32-S3 and ESP32-C3 SPI drivers.