### PR TITLE
targets: rename arduino target to arduino-uno

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -634,7 +634,7 @@ smoketest: testchdir
 	@$(MD5SUM) test.hex
 	# test simulated boards on play.tinygo.org
 ifneq ($(WASM), 0)
-	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=arduino              examples/blinky1
+	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=arduino_uno          examples/blinky1
 	@$(MD5SUM) test.wasm
 	GOOS=js GOARCH=wasm $(TINYGO) build -size short -o test.wasm -tags=hifive1b             examples/blinky1
 	@$(MD5SUM) test.wasm
@@ -898,13 +898,13 @@ endif
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=atmega1284p         examples/machinetest
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=arduino             examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=arduino-uno         examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=arduino-leonardo    examples/blinky1
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=arduino             examples/pwm
+	$(TINYGO) build -size short -o test.hex -target=arduino-uno         examples/pwm
 	@$(MD5SUM) test.hex
-	$(TINYGO) build -size short -o test.hex -target=arduino -scheduler=tasks  examples/blinky1
+	$(TINYGO) build -size short -o test.hex -target=arduino-uno -scheduler=tasks  examples/blinky1
 	@$(MD5SUM) test.hex
 	$(TINYGO) build -size short -o test.hex -target=arduino-mega1280    examples/blinky1
 	@$(MD5SUM) test.hex

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 The above program can be compiled and run without modification on an Arduino Uno, an Adafruit ItsyBitsy M0, or any of the supported boards that have a built-in LED, just by setting the correct TinyGo compiler target. For example, this compiles and flashes an Arduino Uno:
 
 ```shell
-tinygo flash -target arduino examples/blinky1
+tinygo flash -target arduino-uno examples/blinky1
 ```
 
 ## WebAssembly

--- a/src/examples/pininterrupt/arduino-uno.go
+++ b/src/examples/pininterrupt/arduino-uno.go
@@ -1,4 +1,4 @@
-//go:build arduino
+//go:build arduino_uno
 
 package main
 

--- a/src/examples/pwm/arduino-uno.go
+++ b/src/examples/pwm/arduino-uno.go
@@ -1,4 +1,4 @@
-//go:build arduino
+//go:build arduino_uno
 
 package main
 

--- a/src/examples/pwm/pico2.go
+++ b/src/examples/pwm/pico2.go
@@ -1,0 +1,11 @@
+//go:build pico2 || pico_plus2
+
+package main
+
+import "machine"
+
+var (
+	pwm = machine.PWM0 // Pin 25 (LED on pico2) corresponds to PWM0.
+	//pinA = machine.LED
+	pinA = machine.GPIO16
+)

--- a/src/machine/board_arduino_uno.go
+++ b/src/machine/board_arduino_uno.go
@@ -1,4 +1,4 @@
-//go:build arduino
+//go:build arduino_uno
 
 package machine
 

--- a/src/machine/board_atmega328p.go
+++ b/src/machine/board_atmega328p.go
@@ -1,4 +1,4 @@
-//go:build (avr && atmega328p) || arduino || arduino_nano
+//go:build (avr && atmega328p) || arduino_uno || arduino_nano
 
 package machine
 

--- a/targets/arduino-uno.json
+++ b/targets/arduino-uno.json
@@ -1,0 +1,11 @@
+{
+	"inherits": ["atmega328p"],
+	"build-tags": ["arduino_uno"],
+	"ldflags": [
+		"--defsym=_bootloader_size=512",
+		"--defsym=_stack_size=512"
+	],
+	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
+	"serial-port": ["2341:0043", "2341:0001", "2a03:0043", "2341:0243"],
+	"emulator": "simavr -m atmega328p -f 16000000 {}"
+}

--- a/targets/arduino.json
+++ b/targets/arduino.json
@@ -1,11 +1,3 @@
 {
-	"inherits": ["atmega328p"],
-	"build-tags": ["arduino"],
-	"ldflags": [
-		"--defsym=_bootloader_size=512",
-		"--defsym=_stack_size=512"
-	],
-	"flash-command": "avrdude -c arduino -p atmega328p -P {port} -U flash:w:{hex}:i",
-	"serial-port": ["2341:0043", "2341:0001", "2a03:0043", "2341:0243"],
-	"emulator": "simavr -m atmega328p -f 16000000 {}"
+	"inherits": ["arduino-uno"]
 }


### PR DESCRIPTION
Rename the "arduino" target to "arduino-uno" to better reflect the board it represents. The "arduino" name is kept as an alias that inherits from "arduino-uno" for backward compatibility.

- Rename targets/arduino.json to targets/arduino-uno.json
- Create targets/arduino.json as alias inheriting from arduino-uno
- Rename board_arduino.go to board_arduino_uno.go
- Update build tag from "arduino" to "arduino_uno"
- Rename corresponding example files