### PR TITLE
machine_atmega328p_simulator: add correct build tag for arduino_uno

### DIFF
--- a/src/machine/machine_atmega328p_simulator.go
+++ b/src/machine/machine_atmega328p_simulator.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && (arduino || arduino_nano)
+//go:build !baremetal && (arduino_uno || arduino_nano)
 
 package machine
 


### PR DESCRIPTION
This PR is to modify `machine_atmega328p_simulator` to add the correct build tag for `arduino_uno` after renaming it. Tested in local playground.