### PR TITLE
all: support LLVM 19 and LLVM 20 on Fedora 43

### DIFF
--- a/cgo/libclang_config_llvm19.go
+++ b/cgo/libclang_config_llvm19.go
@@ -3,7 +3,7 @@
 package cgo
 
 /*
-#cgo linux        CFLAGS:  -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -I/usr/lib/llvm-19/include
+#cgo linux        CFLAGS:  -I/usr/include/llvm-19 -I/usr/include/llvm-c-19 -I/usr/lib/llvm-19/include -I/usr/lib64/llvm19/include
 #cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@19/include
 #cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@19/include
 #cgo freebsd      CFLAGS:  -I/usr/local/llvm19/include

--- a/cgo/libclang_config_llvm20.go
+++ b/cgo/libclang_config_llvm20.go
@@ -3,7 +3,7 @@
 package cgo
 
 /*
-#cgo linux        CFLAGS:  -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -I/usr/lib/llvm-20/include
+#cgo linux        CFLAGS:  -I/usr/include/llvm-20 -I/usr/include/llvm-c-20 -I/usr/lib/llvm-20/include -I/usr/lib64/llvm20/include
 #cgo darwin,amd64 CFLAGS:  -I/usr/local/opt/llvm@20/include
 #cgo darwin,arm64 CFLAGS:  -I/opt/homebrew/opt/llvm@20/include
 #cgo freebsd      CFLAGS:  -I/usr/local/llvm20/include

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/tools v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
 	tinygo.org/x/espflasher v0.6.0
-	tinygo.org/x/go-llvm v0.0.0-20250422114502-b8f170971e74
+	tinygo.org/x/go-llvm v0.0.0-20260422095634-06c6725fe5e6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -120,5 +120,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tinygo.org/x/espflasher v0.6.0 h1:CHbGMHAIWq1tB8FKd/QwBpNFw1jvHHxpmvZiF+QOYUo=
 tinygo.org/x/espflasher v0.6.0/go.mod h1:tr5u08HoE67WD5zxJesCiiVF/R1b6Akz3yXwh5zah8U=
-tinygo.org/x/go-llvm v0.0.0-20250422114502-b8f170971e74 h1:ovavgTdIBWCH8YWlcfq9gkpoyT1+IxMKSn+Df27QwE8=
-tinygo.org/x/go-llvm v0.0.0-20250422114502-b8f170971e74/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20260422095634-06c6725fe5e6 h1:QSnqFgNV2Ij0T4hM2qKv53fcDAFElxClPjVUZXzYkWU=
+tinygo.org/x/go-llvm v0.0.0-20260422095634-06c6725fe5e6/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
The system LLVM paths on Fedora 43 are slightly different from other systems like Debian, so adding those paths in this patch. This makes my life slightly easier.

This uses https://github.com/tinygo-org/go-llvm/pull/73 ~which has not yet been merged~ (done).

This doesn't need to be part of the upcoming release - it's mostly useful to TinyGo developers on Fedora.