### PR TITLE
runtime/esp32s3: wait for TIMG0 update register to clear before reading timer registers

### DIFF
--- a/src/runtime/runtime_esp32sx.go
+++ b/src/runtime/runtime_esp32sx.go
@@ -58,7 +58,10 @@ func initTimer() {
 func ticks() timeUnit {
 	// First, update the LO and HI register pair by writing any value to the
 	// register. This allows reading the pair atomically.
-	esp.TIMG0.T0UPDATE.Set(0)
+	esp.TIMG0.T0UPDATE.Set(1)
+	for esp.TIMG0.T0UPDATE.Get() != 0 {
+		// Register is cleared when the update is complete.
+	}
 	// Then read the two 32-bit parts of the timer.
 	return timeUnit(uint64(esp.TIMG0.T0LO.Get()) | uint64(esp.TIMG0.T0HI.Get())<<32)
 }


### PR DESCRIPTION
according to the ESP32S3 technical reference the timer HI/LO registers are not ready until the update register has been cleared

**Section 12.2.2 (Page 644)**

<img width="961" height="234" alt="Screenshot From 2026-04-21 08-46-52" src="https://github.com/user-attachments/assets/f671f6cb-e489-4a58-aea1-481346d27196" />

This would cause stale value in the timer registers especially in cases when LO would overflow an cause HI to increment causing drastic spikes in the read `ticks()` value

Note the jump in the read ticks value from an example before this fix were the `ticks()` value is wrapping around the LO register but the the second to last line was returned an "unsettled" value from `ticks()` with the HI register incremented but the LO "stale"

```
waiting before transmitting number 416 ...
addSleepTask ticks(): 4281525514
scheduler ticks(): 4287514450
scheduler ticks(): 4291528085
transmit started
waiting before transmitting number 417 ...
addSleepTask ticks(): 8586496200
scheduler ticks(): 4297517855
```

The ESP32C3 technical reference manual says this is also the case, that implementation was not update as it is currently combined with the regular ESP32 implementation and I can not find mention of the update register being cleared in the ESP32 manual only that after writing to the UPDATE register the values are "instantly" available. I did test however waiting for the update register to clear and it is cleared and things behave as they should I can update that implementation as well!
