### PR TITLE
machine/esp32c3: correct pin interrupt setup call that was overlooked

### DIFF
--- a/src/machine/machine_esp32c3.go
+++ b/src/machine/machine_esp32c3.go
@@ -262,7 +262,7 @@ func setupPinInterrupt() error {
 	return interrupt.New(cpuInterruptFromPin, func(interrupt.Interrupt) {
 		status := esp.GPIO.STATUS.Get()
 		// Clear before processing so new edges during callbacks are not lost.
-		esp.GPIO.STATUS_W1TC.SetBits(status)
+		esp.GPIO.STATUS_W1TC.Set(status)
 		for i, mask := 0, uint32(1); i < maxPin; i, mask = i+1, mask<<1 {
 			if (status&mask) != 0 && pinCallbacks[i] != nil {
 				pinCallbacks[i](Pin(i))


### PR DESCRIPTION
This PR is to correct the `esp32c3` pin interrupt setup call that was overlooked from #5320