### PR TITLE
compiler: re-enable generics test

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -50,6 +50,7 @@ func TestCompiler(t *testing.T) {
 		{"channel.go", "", ""},
 		{"gc.go", "", ""},
 		{"zeromap.go", "", ""},
+		{"generics.go", "", ""},
 	}
 	if goMinor >= 20 {
 		tests = append(tests, testCase{"go1.20.go", "", ""})

--- a/compiler/testdata/generics.ll
+++ b/compiler/testdata/generics.ll
@@ -1,144 +1,81 @@
 ; ModuleID = 'generics.go'
 source_filename = "generics.go"
-target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
-%"main.Point[int]" = type { i32, i32 }
 %"main.Point[float32]" = type { float, float }
+%"main.Point[int]" = type { i32, i32 }
 
-declare noalias nonnull i8* @runtime.alloc(i32, i8*, i8*) #0
+; Function Attrs: allockind("alloc,zeroed") allocsize(0)
+declare noalias nonnull ptr @runtime.alloc(i32, ptr, ptr) #0
 
-declare void @runtime.trackPointer(i8* nocapture readonly, i8*) #0
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #1
 
 ; Function Attrs: nounwind
-define hidden void @main.init(i8* %context) unnamed_addr #1 {
+define hidden void @main.init(ptr %context) unnamed_addr #2 {
 entry:
   ret void
 }
 
 ; Function Attrs: nounwind
-define hidden void @main.main(i8* %context) unnamed_addr #1 {
+define hidden void @main.main(ptr %context) unnamed_addr #2 {
 entry:
-  %bi = alloca %"main.Point[int]", align 8
-  %ai = alloca %"main.Point[int]", align 8
-  %bf = alloca %"main.Point[float32]", align 8
-  %af = alloca %"main.Point[float32]", align 8
-  %af.repack = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %af, i32 0, i32 0
-  store float 0.000000e+00, float* %af.repack, align 8
-  %af.repack1 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %af, i32 0, i32 1
-  store float 0.000000e+00, float* %af.repack1, align 4
-  %0 = bitcast %"main.Point[float32]"* %af to i8*
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
-  %bf.repack = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %bf, i32 0, i32 0
-  store float 0.000000e+00, float* %bf.repack, align 8
-  %bf.repack2 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %bf, i32 0, i32 1
-  store float 0.000000e+00, float* %bf.repack2, align 4
-  %1 = bitcast %"main.Point[float32]"* %bf to i8*
-  call void @runtime.trackPointer(i8* nonnull %1, i8* undef) #2
-  %.elt = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %af, i32 0, i32 0
-  %.unpack = load float, float* %.elt, align 8
-  %.elt3 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %af, i32 0, i32 1
-  %.unpack4 = load float, float* %.elt3, align 4
-  %.elt5 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %bf, i32 0, i32 0
-  %.unpack6 = load float, float* %.elt5, align 8
-  %.elt7 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %bf, i32 0, i32 1
-  %.unpack8 = load float, float* %.elt7, align 4
-  %2 = call %"main.Point[float32]" @"main.Add[float32]"(float %.unpack, float %.unpack4, float %.unpack6, float %.unpack8, i8* undef)
-  %ai.repack = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %ai, i32 0, i32 0
-  store i32 0, i32* %ai.repack, align 8
-  %ai.repack9 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %ai, i32 0, i32 1
-  store i32 0, i32* %ai.repack9, align 4
-  %3 = bitcast %"main.Point[int]"* %ai to i8*
-  call void @runtime.trackPointer(i8* nonnull %3, i8* undef) #2
-  %bi.repack = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %bi, i32 0, i32 0
-  store i32 0, i32* %bi.repack, align 8
-  %bi.repack10 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %bi, i32 0, i32 1
-  store i32 0, i32* %bi.repack10, align 4
-  %4 = bitcast %"main.Point[int]"* %bi to i8*
-  call void @runtime.trackPointer(i8* nonnull %4, i8* undef) #2
-  %.elt11 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %ai, i32 0, i32 0
-  %.unpack12 = load i32, i32* %.elt11, align 8
-  %.elt13 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %ai, i32 0, i32 1
-  %.unpack14 = load i32, i32* %.elt13, align 4
-  %.elt15 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %bi, i32 0, i32 0
-  %.unpack16 = load i32, i32* %.elt15, align 8
-  %.elt17 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %bi, i32 0, i32 1
-  %.unpack18 = load i32, i32* %.elt17, align 4
-  %5 = call %"main.Point[int]" @"main.Add[int]"(i32 %.unpack12, i32 %.unpack14, i32 %.unpack16, i32 %.unpack18, i8* undef)
+  %0 = call %"main.Point[float32]" @"main.Add[float32]"(float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, ptr undef)
+  %1 = call %"main.Point[int]" @"main.Add[int]"(i32 0, i32 0, i32 0, i32 0, ptr undef)
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr hidden %"main.Point[float32]" @"main.Add[float32]"(float %a.X, float %a.Y, float %b.X, float %b.Y, i8* %context) unnamed_addr #1 {
+define linkonce_odr hidden %"main.Point[float32]" @"main.Add[float32]"(float %a.X, float %a.Y, float %b.X, float %b.Y, ptr %context) unnamed_addr #2 {
 entry:
-  %complit = alloca %"main.Point[float32]", align 8
-  %b = alloca %"main.Point[float32]", align 8
-  %a = alloca %"main.Point[float32]", align 8
-  %a.repack = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 0
-  store float 0.000000e+00, float* %a.repack, align 8
-  %a.repack9 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 1
-  store float 0.000000e+00, float* %a.repack9, align 4
-  %0 = bitcast %"main.Point[float32]"* %a to i8*
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
-  %a.repack10 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 0
-  store float %a.X, float* %a.repack10, align 8
-  %a.repack11 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 1
-  store float %a.Y, float* %a.repack11, align 4
-  %b.repack = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 0
-  store float 0.000000e+00, float* %b.repack, align 8
-  %b.repack13 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 1
-  store float 0.000000e+00, float* %b.repack13, align 4
-  %1 = bitcast %"main.Point[float32]"* %b to i8*
-  call void @runtime.trackPointer(i8* nonnull %1, i8* undef) #2
-  %b.repack14 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 0
-  store float %b.X, float* %b.repack14, align 8
-  %b.repack15 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 1
-  store float %b.Y, float* %b.repack15, align 4
-  call void @main.checkSize(i32 4, i8* undef) #2
-  call void @main.checkSize(i32 8, i8* undef) #2
-  %complit.repack = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %complit, i32 0, i32 0
-  store float 0.000000e+00, float* %complit.repack, align 8
-  %complit.repack17 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %complit, i32 0, i32 1
-  store float 0.000000e+00, float* %complit.repack17, align 4
-  %2 = bitcast %"main.Point[float32]"* %complit to i8*
-  call void @runtime.trackPointer(i8* nonnull %2, i8* undef) #2
-  %3 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %complit, i32 0, i32 0
+  %stackalloc = alloca i8, align 1
+  %a = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %a, ptr nonnull %stackalloc, ptr undef) #3
+  store float %a.X, ptr %a, align 4
+  %a.repack9 = getelementptr inbounds nuw i8, ptr %a, i32 4
+  store float %a.Y, ptr %a.repack9, align 4
+  %b = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %b, ptr nonnull %stackalloc, ptr undef) #3
+  store float %b.X, ptr %b, align 4
+  %b.repack11 = getelementptr inbounds nuw i8, ptr %b, i32 4
+  store float %b.Y, ptr %b.repack11, align 4
+  call void @main.checkSize(i32 4, ptr undef) #3
+  call void @main.checkSize(i32 8, ptr undef) #3
+  %complit = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #3
   br i1 false, label %deref.throw, label %deref.next
 
 deref.next:                                       ; preds = %entry
   br i1 false, label %deref.throw1, label %deref.next2
 
 deref.next2:                                      ; preds = %deref.next
-  %4 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 0
-  %5 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 0
-  %6 = load float, float* %5, align 8
-  %7 = load float, float* %4, align 8
-  %8 = fadd float %6, %7
+  %0 = load float, ptr %a, align 4
+  %1 = load float, ptr %b, align 4
+  %2 = fadd float %0, %1
   br i1 false, label %deref.throw3, label %deref.next4
 
 deref.next4:                                      ; preds = %deref.next2
   br i1 false, label %deref.throw5, label %deref.next6
 
 deref.next6:                                      ; preds = %deref.next4
-  %9 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %b, i32 0, i32 1
-  %10 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %a, i32 0, i32 1
-  %11 = load float, float* %10, align 4
-  %12 = load float, float* %9, align 4
+  %3 = getelementptr inbounds nuw i8, ptr %b, i32 4
+  %4 = getelementptr inbounds nuw i8, ptr %a, i32 4
+  %5 = load float, ptr %4, align 4
+  %6 = load float, ptr %3, align 4
   br i1 false, label %store.throw, label %store.next
 
 store.next:                                       ; preds = %deref.next6
-  store float %8, float* %3, align 8
+  store float %2, ptr %complit, align 4
   br i1 false, label %store.throw7, label %store.next8
 
 store.next8:                                      ; preds = %store.next
-  %13 = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %complit, i32 0, i32 1
-  %14 = fadd float %11, %12
-  store float %14, float* %13, align 4
-  %.elt = getelementptr inbounds %"main.Point[float32]", %"main.Point[float32]"* %complit, i32 0, i32 0
-  %.unpack = load float, float* %.elt, align 8
-  %15 = insertvalue %"main.Point[float32]" undef, float %.unpack, 0
-  %16 = insertvalue %"main.Point[float32]" %15, float %14, 1
-  ret %"main.Point[float32]" %16
+  %7 = getelementptr inbounds nuw i8, ptr %complit, i32 4
+  %8 = fadd float %5, %6
+  store float %8, ptr %7, align 4
+  %.unpack = load float, ptr %complit, align 4
+  %9 = insertvalue %"main.Point[float32]" poison, float %.unpack, 0
+  %10 = insertvalue %"main.Point[float32]" %9, float %8, 1
+  ret %"main.Point[float32]" %10
 
 deref.throw:                                      ; preds = %entry
   unreachable
@@ -159,81 +96,61 @@ store.throw7:                                     ; preds = %store.next
   unreachable
 }
 
-declare void @main.checkSize(i32, i8*) #0
+declare void @main.checkSize(i32, ptr) #1
 
-declare void @runtime.nilPanic(i8*) #0
+declare void @runtime.nilPanic(ptr) #1
 
 ; Function Attrs: nounwind
-define linkonce_odr hidden %"main.Point[int]" @"main.Add[int]"(i32 %a.X, i32 %a.Y, i32 %b.X, i32 %b.Y, i8* %context) unnamed_addr #1 {
+define linkonce_odr hidden %"main.Point[int]" @"main.Add[int]"(i32 %a.X, i32 %a.Y, i32 %b.X, i32 %b.Y, ptr %context) unnamed_addr #2 {
 entry:
-  %complit = alloca %"main.Point[int]", align 8
-  %b = alloca %"main.Point[int]", align 8
-  %a = alloca %"main.Point[int]", align 8
-  %a.repack = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 0
-  store i32 0, i32* %a.repack, align 8
-  %a.repack9 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 1
-  store i32 0, i32* %a.repack9, align 4
-  %0 = bitcast %"main.Point[int]"* %a to i8*
-  call void @runtime.trackPointer(i8* nonnull %0, i8* undef) #2
-  %a.repack10 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 0
-  store i32 %a.X, i32* %a.repack10, align 8
-  %a.repack11 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 1
-  store i32 %a.Y, i32* %a.repack11, align 4
-  %b.repack = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 0
-  store i32 0, i32* %b.repack, align 8
-  %b.repack13 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 1
-  store i32 0, i32* %b.repack13, align 4
-  %1 = bitcast %"main.Point[int]"* %b to i8*
-  call void @runtime.trackPointer(i8* nonnull %1, i8* undef) #2
-  %b.repack14 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 0
-  store i32 %b.X, i32* %b.repack14, align 8
-  %b.repack15 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 1
-  store i32 %b.Y, i32* %b.repack15, align 4
-  call void @main.checkSize(i32 4, i8* undef) #2
-  call void @main.checkSize(i32 8, i8* undef) #2
-  %complit.repack = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %complit, i32 0, i32 0
-  store i32 0, i32* %complit.repack, align 8
-  %complit.repack17 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %complit, i32 0, i32 1
-  store i32 0, i32* %complit.repack17, align 4
-  %2 = bitcast %"main.Point[int]"* %complit to i8*
-  call void @runtime.trackPointer(i8* nonnull %2, i8* undef) #2
-  %3 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %complit, i32 0, i32 0
+  %stackalloc = alloca i8, align 1
+  %a = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %a, ptr nonnull %stackalloc, ptr undef) #3
+  store i32 %a.X, ptr %a, align 4
+  %a.repack9 = getelementptr inbounds nuw i8, ptr %a, i32 4
+  store i32 %a.Y, ptr %a.repack9, align 4
+  %b = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %b, ptr nonnull %stackalloc, ptr undef) #3
+  store i32 %b.X, ptr %b, align 4
+  %b.repack11 = getelementptr inbounds nuw i8, ptr %b, i32 4
+  store i32 %b.Y, ptr %b.repack11, align 4
+  call void @main.checkSize(i32 4, ptr undef) #3
+  call void @main.checkSize(i32 8, ptr undef) #3
+  %complit = call align 4 dereferenceable(8) ptr @runtime.alloc(i32 8, ptr nonnull inttoptr (i32 3 to ptr), ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull %complit, ptr nonnull %stackalloc, ptr undef) #3
   br i1 false, label %deref.throw, label %deref.next
 
 deref.next:                                       ; preds = %entry
   br i1 false, label %deref.throw1, label %deref.next2
 
 deref.next2:                                      ; preds = %deref.next
-  %4 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 0
-  %5 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 0
-  %6 = load i32, i32* %5, align 8
-  %7 = load i32, i32* %4, align 8
-  %8 = add i32 %6, %7
+  %0 = load i32, ptr %a, align 4
+  %1 = load i32, ptr %b, align 4
+  %2 = add i32 %0, %1
   br i1 false, label %deref.throw3, label %deref.next4
 
 deref.next4:                                      ; preds = %deref.next2
   br i1 false, label %deref.throw5, label %deref.next6
 
 deref.next6:                                      ; preds = %deref.next4
-  %9 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %b, i32 0, i32 1
-  %10 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %a, i32 0, i32 1
-  %11 = load i32, i32* %10, align 4
-  %12 = load i32, i32* %9, align 4
+  %3 = getelementptr inbounds nuw i8, ptr %b, i32 4
+  %4 = getelementptr inbounds nuw i8, ptr %a, i32 4
+  %5 = load i32, ptr %4, align 4
+  %6 = load i32, ptr %3, align 4
   br i1 false, label %store.throw, label %store.next
 
 store.next:                                       ; preds = %deref.next6
-  store i32 %8, i32* %3, align 8
+  store i32 %2, ptr %complit, align 4
   br i1 false, label %store.throw7, label %store.next8
 
 store.next8:                                      ; preds = %store.next
-  %13 = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %complit, i32 0, i32 1
-  %14 = add i32 %11, %12
-  store i32 %14, i32* %13, align 4
-  %.elt = getelementptr inbounds %"main.Point[int]", %"main.Point[int]"* %complit, i32 0, i32 0
-  %.unpack = load i32, i32* %.elt, align 8
-  %15 = insertvalue %"main.Point[int]" undef, i32 %.unpack, 0
-  %16 = insertvalue %"main.Point[int]" %15, i32 %14, 1
-  ret %"main.Point[int]" %16
+  %7 = getelementptr inbounds nuw i8, ptr %complit, i32 4
+  %8 = add i32 %5, %6
+  store i32 %8, ptr %7, align 4
+  %.unpack = load i32, ptr %complit, align 4
+  %9 = insertvalue %"main.Point[int]" poison, i32 %.unpack, 0
+  %10 = insertvalue %"main.Point[int]" %9, i32 %8, 1
+  ret %"main.Point[int]" %10
 
 deref.throw:                                      ; preds = %entry
   unreachable
@@ -254,6 +171,7 @@ store.throw7:                                     ; preds = %store.next
   unreachable
 }
 
-attributes #0 = { "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #1 = { nounwind "target-features"="+bulk-memory,+nontrapping-fptoint,+sign-ext" }
-attributes #2 = { nounwind }
+attributes #0 = { allockind("alloc,zeroed") allocsize(0) "alloc-family"="runtime.alloc" "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
+attributes #1 = { "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
+attributes #2 = { nounwind "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
+attributes #3 = { nounwind }


### PR DESCRIPTION
This seems to have been removed by accident, but it still seems useful to me.

Needs some IR updates since of course that IR didn't get updated lately.