### PR TITLE
targets/wasm_exec: add runtime.getRandomData to gojs imports

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -294,6 +294,11 @@
 						return BigInt((timeOrigin + performance.now()) * 1e6);
 					},
 
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (slice_ptr, slice_len, slice_cap) => {
+						crypto.getRandomValues(loadSlice(slice_ptr, slice_len, slice_cap));
+					},
+
 					// func sleepTicks(timeout int64)
 					"runtime.sleepTicks": (timeout) => {
 						// Do not sleep, only reactivate scheduler after the given timeout.


### PR DESCRIPTION
TinyGo v0.37.0 updated the net submodule (tinygo-org/net) which introduced
a call to runtime.getRandomData in the compiled wasm binary. Without a
corresponding JS implementation in the gojs import object, instantiating
the module throws:

LinkError: WebAssembly.Instance(): Import # 17 "gojs" "runtime.getRandomData":
function import requires a callable

The addition is already present at the official go runtime package: [https://github.com/golang/go/blob/master/lib/wasm/wasm_exec.js#L306-L309](https://github.com/golang/go/blob/master/lib/wasm/wasm_exec.js#L306-L309).

Fixes #5357