### PR TITLE
runtime: improve hardfault handler and stack reporting on Cortex-M

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3817, 299, 0, 2252},
 		{"microbit", "examples/serial", 2820, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7206, 1510, 120, 7248},
+		{"wioterminal", "examples/pininterrupt", 7286, 1534, 120, 7248},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/internal/task/task_none.go
+++ b/src/internal/task/task_none.go
@@ -42,3 +42,8 @@ func SystemStack() uintptr {
 	runtimePanic("scheduler is disabled")
 	return 0 // unreachable
 }
+
+func GoroutineStack() uintptr {
+	// No separate goroutine stack without a scheduler.
+	return 0
+}

--- a/src/internal/task/task_stack_cortexm.c
+++ b/src/internal/task/task_stack_cortexm.c
@@ -11,3 +11,14 @@ uintptr_t SystemStack() {
     );
     return sp;
 }
+
+uintptr_t GoroutineStack() {
+    uintptr_t sp;
+    asm volatile(
+        "mrs %0, PSP"
+        : "=r"(sp)
+        :
+        : "memory"
+    );
+    return sp;
+}

--- a/src/internal/task/task_stack_cortexm.go
+++ b/src/internal/task/task_stack_cortexm.go
@@ -70,3 +70,10 @@ func (s *state) pause() {
 //
 //export SystemStack
 func SystemStack() uintptr
+
+// GoroutineStack returns the PSP (goroutine stack pointer). When a fault
+// occurs in goroutine context, the hardware saves the exception frame to PSP;
+// reading PSP+0x18 gives the actual faulting PC.
+//
+//export GoroutineStack
+func GoroutineStack() uintptr

--- a/src/runtime/runtime_cortexm_hardfault_debug.go
+++ b/src/runtime/runtime_cortexm_hardfault_debug.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"device/arm"
+	"internal/task"
 	"unsafe"
 )
 
@@ -106,6 +107,20 @@ func HardFault_Handler() {
 			print(" pc=", sp.PC)
 		}
 	}
+
+	// PSP holds the actual exception frame when the fault occurred in a
+	// goroutine (thread mode, PSP active). The MSP-based sp above is the
+	// scheduler's stack and its PC is garbage in that case.
+	pspVal := task.GoroutineStack()
+
+	// heapEndSymbol is defined in baremetal.go; we also ensure that the goroutine exception frame is within addressable memory.
+	if pspVal >= 0x20000000 && pspVal < (uintptr(unsafe.Pointer(&heapEndSymbol))-uintptr(unsafe.Sizeof(interruptStack{}))) {
+		pspFrame := (*interruptStack)(unsafe.Pointer(pspVal))
+		print(" psp=", pspFrame)
+		print(" psp_pc=", pspFrame.PC)
+		print(" psp_lr=", pspFrame.LR)
+	}
+
 	println()
 	abort()
 }


### PR DESCRIPTION
Add reference to the current goroutine stack (PSP) when showing the hardfault info on Cortex-M. The stack where the hardfault happens is usually the scheduler's stack (MSP), which provides no information about the goroutine that actually caused the fault.

This was required to debug random crashes (#5375). The reason was stack overflow, which trigered the `udf` instruction. The MSP only pointed to the HardFault handler and the PC initially suggested stack corruption and nil dereference, while in reality the stack canary was overwritten which triggered a panic.