### PR TITLE
builder: increase stack size margin for automatic stack allocation

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -1352,6 +1352,14 @@ func determineStackSizes(mod llvm.Module, executable string) ([]string, map[stri
 	}
 	baseStackSize, baseStackSizeType, baseStackSizeFailedAt := functions["tinygo_startTask"][0].StackSize()
 
+	// Account for the bytes that tinygo_swapTask pushes onto the goroutine stack
+	// on every context switch. The static analysis correctly traces Go calls,
+	// but it cannot see into the assembly-level register push.
+	var contextSwitchOverhead uint64
+	if swapFuncs, ok := functions["tinygo_swapTask"]; ok && len(swapFuncs) == 1 {
+		contextSwitchOverhead = swapFuncs[0].FrameSize
+	}
+
 	sizes := make(map[string]functionStackSize)
 
 	// Add the reset handler function, for convenience. The reset handler runs
@@ -1399,6 +1407,12 @@ func determineStackSizes(mod llvm.Module, executable string) ([]string, map[stri
 			// registers to start and suspend the goroutine. Otherwise a stack
 			// overflow will occur even before the goroutine is started.
 			stackSize = baseStackSize
+		}
+		if stackSizeType == stacksize.Bounded {
+			// Add the overhead of context switching. This is needed because the
+			// context switch (tinygo_swapTask) pushes callee-saved registers
+			// onto the current stack, which is not seen by the static analysis.
+			stackSize += contextSwitchOverhead
 		}
 		sizes[name] = functionStackSize{
 			stackSize:        stackSize,


### PR DESCRIPTION
When TinyGo calculates stack sizes automatically, it performs a static analysis of the call graph. While this analysis correctly identifies the stack requirements for Go functions, it cannot account for stack usage within assembly-level routines that are not visible to the high-level analysis.

Specifically, `tinygo_swapTask` pushes callee-saved registers onto the current goroutine's stack during every context switch. If this overhead is not accounted for, a goroutine might overflow its stack during a context switch even if its Go-level stack usage is within limits.

With this change in `determineStackSizes`, we now look up the `tinygo_swapTask` function in the symbol table to determine its frame size. This context switch overhead is now added to the calculated stack size for all goroutines that have a bounded stack size.

Fixes #5375 
