### PR TITLE
builder, cgo, syscall: replace fixed-size array casts with unsafe.Slice

### DIFF
--- a/builder/tools-builtin.go
+++ b/builder/tools-builtin.go
@@ -28,7 +28,7 @@ func RunTool(tool string, args ...string) error {
 	var cflag *C.char
 	buf := C.calloc(C.size_t(len(args)), C.size_t(unsafe.Sizeof(cflag)))
 	defer C.free(buf)
-	cflags := (*[1 << 10]*C.char)(unsafe.Pointer(buf))[:len(args):len(args)]
+	cflags := unsafe.Slice((**C.char)(buf), len(args))
 	for i, flag := range args {
 		cflag := C.CString(flag)
 		cflags[i] = cflag

--- a/cgo/libclang.go
+++ b/cgo/libclang.go
@@ -130,7 +130,7 @@ func (f *cgoFile) readNames(fragment string, cflags []string, filename string, c
 	// convert Go slice of strings to C array of strings.
 	cmdargsC := C.malloc(C.size_t(len(cflags)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 	defer C.free(cmdargsC)
-	cmdargs := (*[1 << 16]*C.char)(cmdargsC)
+	cmdargs := unsafe.Slice((**C.char)(cmdargsC), len(cflags))
 	for i, cflag := range cflags {
 		s := C.CString(cflag)
 		cmdargs[i] = s
@@ -190,7 +190,7 @@ func (f *cgoFile) readNames(fragment string, cflags []string, filename string, c
 			// Sanity check. This should (hopefully) never trigger.
 			panic("libclang: file contents was not loaded")
 		}
-		data := (*[1 << 24]byte)(unsafe.Pointer(rawData))[:size]
+		data := unsafe.Slice((*byte)(unsafe.Pointer(rawData)), size)
 
 		// Hash the contents if it isn't hashed yet.
 		if _, ok := f.visitedFiles[path]; !ok {
@@ -624,7 +624,7 @@ func (p *cgoPackage) getClangLocationPosition(location C.CXSourceLocation, tu C.
 		// now by reading the file from libclang.
 		var size C.size_t
 		sourcePtr := C.clang_getFileContents(tu, file, &size)
-		source := ((*[1 << 28]byte)(unsafe.Pointer(sourcePtr)))[:size:size]
+		source := unsafe.Slice((*byte)(unsafe.Pointer(sourcePtr)), size)
 		lines := []int{0}
 		for i := 0; i < len(source)-1; i++ {
 			if source[i] == '\n' {

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -256,7 +256,7 @@ func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, e
 	if addr == unsafe.Pointer(^uintptr(0)) {
 		return nil, getErrno()
 	}
-	return (*[1 << 30]byte)(addr)[:length:length], nil
+	return unsafe.Slice((*byte)(addr), length), nil
 }
 
 func Munmap(b []byte) (err error) {


### PR DESCRIPTION
Fixes #4348

This is like http://go.dev/cl/435285 and similar; `unsafe.Slice` has provided a way to do this for a while now.

The builder change is #4348, but no reason not to do the rest.