### PR TITLE
usb/cdc: fix RP2 USB CDC TX race with cores scheduler

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3817, 299, 0, 2252},
 		{"microbit", "examples/serial", 2820, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7930, 1650, 132, 7472},
+		{"wioterminal", "examples/pininterrupt", 8036, 1652, 132, 7480},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -32,9 +32,13 @@ type USBCDC struct {
 	// inflight is the number of bytes currently submitted to the USB IN endpoint.
 	inflight atomic.Uint32
 
-	// txActive serializes the USB CDC TX pump between Write and the TX
-	// completion handler. This matters on multicore targets where they can run
-	// concurrently.
+	// txActive is the TX-pump ownership flag: 0 = idle, 1 = a pump owns the TX
+	// path. Claimed once (kickTx, CAS 0->1), held across every in-flight packet
+	// and the TX-complete IRQ, and released only when the ring drains. While it
+	// is set, kickTx's CAS fails and no second pump starts, which serializes the
+	// pump against Write across cores. Same model as Linux NAPI_STATE_SCHED:
+	// held across completion, dropped only with a recheck
+	// (Documentation/networking/napi.rst).
 	txActive atomic.Uint32
 
 	rbuf [1]byte
@@ -113,7 +117,9 @@ func (usbcdc *USBCDC) Write(data []byte) (n int, err error) {
 	return n, nil
 }
 
-// kickTx starts the TX pump if it is idle.
+// kickTx claims the TX pump for a producer. This CAS is the only start-from-idle
+// edge; if it fails, a pump already owns the path and will drain what we just
+// enqueued -- see the recheck in sendFromRing.
 func (usbcdc *USBCDC) kickTx() {
 	if !usbcdc.txActive.CompareAndSwap(0, 1) {
 		return
@@ -122,6 +128,9 @@ func (usbcdc *USBCDC) kickTx() {
 }
 
 func (usbcdc *USBCDC) txhandler() {
+	// TX-complete IRQ. The pump is still owned here (txActive stayed 1 across the
+	// in-flight packet), so continue WITHOUT re-claiming -- pairs with the CAS in
+	// kickTx. A CAS here would see the flag already set, bail, and stall the chain.
 	inflight := usbcdc.inflight.Load()
 	if inflight == 0 {
 		return
@@ -131,54 +140,35 @@ func (usbcdc *USBCDC) txhandler() {
 	usbcdc.sendFromRing()
 }
 
-// sendFromRing submits one USB IN packet from the TX ring, or shuts down
-// the TX pump if the ring is empty.
-//
-// The caller must own txActive (either having just acquired it via CAS,
-// or continuing ownership from a previous packet submission).
-// For kickTx: newly acquired via CAS.
-// For txhandler: inherited from the previous packet submission.
-//
-// While the caller owns txActive:
-//   - If data is available, one packet is sent and txActive remains set
-//     for the in-flight packet (ownership continues to txhandler).
-//   - If the ring is empty, txActive is cleared and the pump shuts down
-//     (with a final re-check to avoid a missed wakeup from Write).
+// sendFromRing runs one step of the TX pump: submit one IN packet, or release the
+// pump if the ring is empty. Precondition: txActive == 1 (from kickTx's CAS, or
+// still held from the previous packet when entered via txhandler).
 func (usbcdc *USBCDC) sendFromRing() {
-	// This loop sends at most one USB IN packet per entry.
-	//
-	// If the TX ring has data, one packet is handed to the USB hardware and
-	// txActive remains set until txhandler continues the pump after
-	// completion.
-	//
-	// If the TX ring appears empty, this is the shutdown path. Clear
-	// txActive, then re-check the ring to avoid missing a Write that added
-	// data while txActive was still set.
 	for {
 		d1, _ := usbcdc.tx.Peek()
 		if len(d1) == 0 {
+			// Release the pump, then re-scan the ring: closes the missed-wakeup
+			// race where Write Put()s data and kickTx's CAS then fails (txActive
+			// still set), leaving the data for this pump to drain. The Store(0)
+			// is ordered before the Used() load -- and, in the producer, Put()
+			// before its CAS -- by the sequential consistency of Go's atomics, so
+			// neither side misses the other (assumes the ring's accesses are
+			// atomic too). cf. napi_complete_done() clearing NAPI_STATE_SCHED
+			// then rechecking.
 			usbcdc.txActive.Store(0)
-			// Avoid a missed wakeup.
-			//
-			// A concurrent Write may have appended data while txActive was
-			// still set. In that case kickTx would see an active pump and
-			// return without starting another transfer. After clearing
-			// txActive, re-check the ring and reclaim txActive if this pump
-			// must continue.
-			switch {
-			case usbcdc.tx.Used() == 0:
-				return
-			case !usbcdc.txActive.CompareAndSwap(0, 1):
-				return
+			if usbcdc.tx.Used() == 0 {
+				return // ring empty and pump released; done
 			}
-			// New data appeared during shutdown, and this caller reclaimed
-			// txActive. Continue and re-peek the ring.
-			continue
+			if !usbcdc.txActive.CompareAndSwap(0, 1) {
+				return // another producer re-claimed the pump; let it run
+			}
+			continue // re-claimed; re-peek and keep pumping
 		}
+
 		chunk := d1[:min(usb.EndpointPacketSize, len(d1))]
 		usbcdc.inflight.Store(uint32(len(chunk)))
 		machine.SendUSBInPacket(cdcEndpointIn, chunk)
-		return
+		return // in flight; txActive stays set, txhandler continues
 	}
 }
 

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -134,8 +134,14 @@ func (usbcdc *USBCDC) txhandler() {
 // sendFromRing sends one USB packet from the ring and sets inflight.
 //
 // The caller must own txActive. Ownership starts in kickTx and is kept across
-// TX completion interrupts until the TX ring is empty.
+// TX completion handling until the TX ring is empty.
 func (usbcdc *USBCDC) sendFromRing() {
+	// This is the main TX pump loop. While txActive is held, each iteration
+	// peeks the TX ring and sends one packet if data is available.
+	//
+	// The empty-ring case below is the shutdown path: release txActive, then
+	// re-check the ring to avoid missing a Write that appended data while
+	// txActive was still set.
 	for {
 		d1, _ := usbcdc.tx.Peek()
 		if len(d1) == 0 {
@@ -149,6 +155,9 @@ func (usbcdc *USBCDC) sendFromRing() {
 			case !usbcdc.txActive.CompareAndSwap(0, 1):
 				return
 			}
+
+			// New data appeared while txActive was set, and this TX pump owner
+			// re-acquired ownership. Continue the pump and re-peek the ring.
 			continue
 		}
 

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -131,36 +131,50 @@ func (usbcdc *USBCDC) txhandler() {
 	usbcdc.sendFromRing()
 }
 
-// sendFromRing sends one USB packet from the ring and sets inflight.
+// sendFromRing submits one USB IN packet from the TX ring, or shuts down
+// the TX pump if the ring is empty.
 //
-// The caller must own txActive. Ownership starts in kickTx and is kept across
-// TX completion handling until the TX ring is empty.
+// The caller must own txActive (either having just acquired it via CAS,
+// or continuing ownership from a previous packet submission).
+// For kickTx: newly acquired via CAS.
+// For txhandler: inherited from the previous packet submission.
+//
+// While the caller owns txActive:
+//   - If data is available, one packet is sent and txActive remains set
+//     for the in-flight packet (ownership continues to txhandler).
+//   - If the ring is empty, txActive is cleared and the pump shuts down
+//     (with a final re-check to avoid a missed wakeup from Write).
 func (usbcdc *USBCDC) sendFromRing() {
-	// This is the main TX pump loop. While txActive is held, each iteration
-	// peeks the TX ring and sends one packet if data is available.
+	// This loop sends at most one USB IN packet per entry.
 	//
-	// The empty-ring case below is the shutdown path: release txActive, then
-	// re-check the ring to avoid missing a Write that appended data while
-	// txActive was still set.
+	// If the TX ring has data, one packet is handed to the USB hardware and
+	// txActive remains set until txhandler continues the pump after
+	// completion.
+	//
+	// If the TX ring appears empty, this is the shutdown path. Clear
+	// txActive, then re-check the ring to avoid missing a Write that added
+	// data while txActive was still set.
 	for {
 		d1, _ := usbcdc.tx.Peek()
 		if len(d1) == 0 {
 			usbcdc.txActive.Store(0)
-
-			// Avoid a missed wakeup: Write may append data while txActive is
-			// still set, causing kickTx to return without starting a transfer.
+			// Avoid a missed wakeup.
+			//
+			// A concurrent Write may have appended data while txActive was
+			// still set. In that case kickTx would see an active pump and
+			// return without starting another transfer. After clearing
+			// txActive, re-check the ring and reclaim txActive if this pump
+			// must continue.
 			switch {
 			case usbcdc.tx.Used() == 0:
 				return
 			case !usbcdc.txActive.CompareAndSwap(0, 1):
 				return
 			}
-
-			// New data appeared while txActive was set, and this TX pump owner
-			// re-acquired ownership. Continue the pump and re-peek the ring.
+			// New data appeared during shutdown, and this caller reclaimed
+			// txActive. Continue and re-peek the ring.
 			continue
 		}
-
 		chunk := d1[:min(usb.EndpointPacketSize, len(d1))]
 		usbcdc.inflight.Store(uint32(len(chunk)))
 		machine.SendUSBInPacket(cdcEndpointIn, chunk)

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -26,11 +26,19 @@ type cdcLineInfo struct {
 
 // USBCDC is the USB CDC aka serial over USB interface.
 type USBCDC struct {
-	tx       ring512
-	rx       ring512
+	tx ring512
+	rx ring512
+
+	// inflight is the number of bytes currently submitted to the USB IN endpoint.
 	inflight atomic.Uint32
-	rbuf     [1]byte
-	wbuf     [1]byte
+
+	// txActive serializes the USB CDC TX pump between Write and the TX
+	// completion handler. This matters on multicore targets where they can run
+	// concurrently.
+	txActive atomic.Uint32
+
+	rbuf [1]byte
+	wbuf [1]byte
 }
 
 var (
@@ -81,7 +89,7 @@ func (usbcdc *USBCDC) Configure(config machine.UARTConfig) error {
 
 // Flush flushes buffered data.
 func (usbcdc *USBCDC) Flush() {
-	for usbcdc.tx.Used() > 0 {
+	for usbcdc.tx.Used() > 0 || usbcdc.txActive.Load() != 0 {
 		gosched()
 	}
 }
@@ -105,33 +113,50 @@ func (usbcdc *USBCDC) Write(data []byte) (n int, err error) {
 	return n, nil
 }
 
-// kickTx starts a transfer if none is in flight. Called from main context only.
+// kickTx starts the TX pump if it is idle.
 func (usbcdc *USBCDC) kickTx() {
-	if usbcdc.inflight.Load() > 0 {
-		return // txhandler will chain the next packet.
+	if !usbcdc.txActive.CompareAndSwap(0, 1) {
+		return
 	}
 	usbcdc.sendFromRing()
 }
 
 func (usbcdc *USBCDC) txhandler() {
 	inflight := usbcdc.inflight.Load()
-	usbcdc.inflight.Store(0)
+	if inflight == 0 {
+		return
+	}
 	usbcdc.tx.Discard(inflight)
+	usbcdc.inflight.Store(0)
 	usbcdc.sendFromRing()
 }
 
 // sendFromRing sends one USB packet from the ring and sets inflight.
-// Called from kickTx (main) or txhandler (ISR), but never concurrently
-// because kickTx only runs when inflight==0 and txhandler only runs
-// when inflight>0.
+//
+// The caller must own txActive. Ownership starts in kickTx and is kept across
+// TX completion interrupts until the TX ring is empty.
 func (usbcdc *USBCDC) sendFromRing() {
-	d1, _ := usbcdc.tx.Peek()
-	if len(d1) == 0 {
+	for {
+		d1, _ := usbcdc.tx.Peek()
+		if len(d1) == 0 {
+			usbcdc.txActive.Store(0)
+
+			// Avoid a missed wakeup: Write may append data while txActive is
+			// still set, causing kickTx to return without starting a transfer.
+			if usbcdc.tx.Used() == 0 {
+				return
+			}
+			if !usbcdc.txActive.CompareAndSwap(0, 1) {
+				return
+			}
+			continue
+		}
+
+		chunk := d1[:min(usb.EndpointPacketSize, len(d1))]
+		usbcdc.inflight.Store(uint32(len(chunk)))
+		machine.SendUSBInPacket(cdcEndpointIn, chunk)
 		return
 	}
-	chunk := d1[:min(usb.EndpointPacketSize, len(d1))]
-	usbcdc.inflight.Store(uint32(len(chunk)))
-	machine.SendUSBInPacket(cdcEndpointIn, chunk)
 }
 
 // WriteByte writes a byte of data to the USB CDC interface.

--- a/src/machine/usb/cdc/usbcdc.go
+++ b/src/machine/usb/cdc/usbcdc.go
@@ -143,10 +143,10 @@ func (usbcdc *USBCDC) sendFromRing() {
 
 			// Avoid a missed wakeup: Write may append data while txActive is
 			// still set, causing kickTx to return without starting a transfer.
-			if usbcdc.tx.Used() == 0 {
+			switch {
+			case usbcdc.tx.Used() == 0:
 				return
-			}
-			if !usbcdc.txActive.CompareAndSwap(0, 1) {
+			case !usbcdc.txActive.CompareAndSwap(0, 1):
 				return
 			}
 			continue


### PR DESCRIPTION
Fixes #5377.

This PR fixes a USB CDC TX race on RP2 targets when using `-scheduler=cores`.

The issue was reproduced on Raspberry Pi Pico / RP2040 with TinyGo 0.41.1.
RP2350 may be affected as well because it shares the RP2 USB backend and the
same USB CDC TX state machine.

## Cause

USB CDC TX is driven from two places:

- `Write()` via `kickTx()`
- the USB TX completion handler via `txhandler()`

The previous code used `inflight` both as:

- the number of bytes currently submitted to the USB IN endpoint
- an implicit guard for whether the TX pump is active

That is not sufficient on multicore targets.

With `-scheduler=cores`, `Write()` may run on one core while the USB TX
completion handler runs on another core. In that case, `kickTx()` can observe the
TX path as idle while `txhandler()` is still processing a completed packet and
chaining the next one.

That can allow concurrent or re-entrant calls into `sendFromRing()` /
`machine.SendUSBInPacket()` for the same USB IN endpoint, which can corrupt USB
CDC output.

## Fix

This PR adds a separate atomic `txActive` flag.

`txActive` represents ownership of the USB CDC TX pump. `inflight` remains only
the number of bytes currently submitted to the endpoint.

`kickTx()` now starts the TX pump only if it can acquire `txActive` with CAS.
The TX completion handler keeps TX pump ownership while chaining packets, and
ownership is released only when the TX ring is empty.

A final ring re-check is used when releasing ownership to avoid a missed wakeup
if `Write()` appends data while `txActive` is still set.

## Manual test

Test program:

```go
package main

import "time"

func main() {
	time.Sleep(2 * time.Second)

	println("start usb cdc tx stress")

	for i := 0; i < 1000; i++ {
		println("usb cdc tx test:", i, "abcdefghijklmnopqrstuvwxyz0123456789")
		time.Sleep(1 * time.Millisecond)
	}

	println("test finished")
}
```

Commands:

```sh
~/work/tinygo/build/tinygo flash -target=pico -scheduler=cores -monitor usbcdc_tx_stress.go
~/work/tinygo/build/tinygo flash -target=pico -scheduler=tasks -monitor usbcdc_tx_stress.go
```

Results:

```text
Before this fix:
- TinyGo 0.41.1 + -scheduler=cores: USB CDC output was corrupted
- TinyGo 0.41.1 + -scheduler=tasks: OK

After this fix:
- local dev build + -scheduler=cores: OK
- local dev build + -scheduler=tasks: OK
```

The `-scheduler=cores` test was repeated multiple times without observing
dropped or corrupted USB CDC output.