### PR TITLE
loader: avoid race condition when loading package list

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -245,7 +245,7 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"internal/cm/":                false,
 		"internal/futex/":             false,
 		"internal/fuzz/":              false,
-		"internal/itoa":               false,
+		"internal/itoa/":              false,
 		"internal/reflectlite/":       false,
 		"internal/gclayout":           false,
 		"internal/task/":              false,


### PR DESCRIPTION
I was seeing bad error messages... but only some of the time. So I went digging. Eventually I traced it to this one bug, probably introduced in https://github.com/tinygo-org/tinygo/pull/5290.

This is not just a visual issue, this is actually a bug in TinyGo that will result in non-reproducible binaries and random behavior differences (perhaps also random code size differences).