### PR TITLE
cli: add basic probe-rs support

### DIFF
--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -539,7 +539,7 @@ func (c *Config) Programmer() (method, openocdInterface string) {
 	case "openocd", "msd", "command", "adb":
 		// The -programmer flag only specifies the flash method.
 		return c.Options.Programmer, c.Target.OpenOCDInterface
-	case "bmp":
+	case "bmp", "probe-rs":
 		// The -programmer flag only specifies the flash method.
 		return c.Options.Programmer, ""
 	default:

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -67,6 +67,7 @@ type TargetSpec struct {
 	ADBPreCommands   []string `json:"adb-pre-commands,omitempty"`
 	ADBPushRemote    string   `json:"adb-push-remote,omitempty"`
 	ADBPostCommands  []string `json:"adb-post-commands,omitempty"`
+	ProbeRSChip      string   `json:"probe-rs-chip,omitempty"`
 	CodeModel        string   `json:"code-model,omitempty"`
 	RelocationModel  string   `json:"relocation-model,omitempty"`
 	WITPackage       string   `json:"wit-package,omitempty"`

--- a/main.go
+++ b/main.go
@@ -394,7 +394,7 @@ func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 		fileExt = filepath.Ext(config.Target.FlashFilename)
 	case "openocd":
 		fileExt = ".hex"
-	case "bmp":
+	case "bmp", "probe-rs":
 		fileExt = ".elf"
 	case "adb":
 		fileExt = ".hex"
@@ -528,6 +528,16 @@ func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 		}
 		args := []string{"-ex", "target extended-remote " + bmpGDBPort, "-ex", "monitor swdp_scan", "-ex", "attach 1", "-ex", "load", filepath.ToSlash(result.Binary)}
 		cmd := executeCommand(config.Options, gdb, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			return &commandError{"failed to flash", result.Binary, err}
+		}
+	case "probe-rs":
+		// TODO: this halts the target after flashing.
+		// See: https://github.com/probe-rs/probe-rs/discussions/4005
+		cmd := executeCommand(config.Options, "probe-rs", "download", "--chip="+config.Target.ProbeRSChip, "--verify", result.Binary)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		err = cmd.Run()
@@ -691,6 +701,21 @@ func Debug(debugger, pkgName string, ocdOutput bool, options *compileopts.Option
 			w := &ColorWriter{
 				Out:    colorable.NewColorableStderr(),
 				Prefix: "openocd: ",
+				Color:  TermColorYellow,
+			}
+			daemon.Stdout = w
+			daemon.Stderr = w
+		}
+	case "probe-rs":
+		port = ":1337"
+		gdbCommands = append(gdbCommands, "monitor halt", "load", "monitor reset halt")
+
+		daemon = executeCommand(config.Options, "probe-rs", "gdb", "--chip="+config.Target.ProbeRSChip)
+		if ocdOutput {
+			// Make it clear which output is from the daemon.
+			w := &ColorWriter{
+				Out:    colorable.NewColorableStderr(),
+				Prefix: "probe-rs: ",
 				Color:  TermColorYellow,
 			}
 			daemon.Stdout = w

--- a/targets/stm32l0x1.json
+++ b/targets/stm32l0x1.json
@@ -13,6 +13,7 @@
         "src/device/stm32/stm32l0x1.s"
     ],
     "flash-method": "openocd",
+    "probe-rs-chip": "STM32L031G6Ux",
     "openocd-interface": "cmsis-dap",
     "openocd-target": "stm32l0"
 }


### PR DESCRIPTION
OpenOCD can be somewhat outdated. `probe-rs` is a more modern tool written in Rust with many interesting features, like built-in RTT logging support.

This commit just adds basic support, to be able to flash devices with probe-rs and debug them. It also adds probe-rs support for a single chip (the STM32L0x1 series).