### PR TITLE
fix: monitor flag on flash now respects port

### DIFF
--- a/main.go
+++ b/main.go
@@ -588,7 +588,7 @@ func Flash(pkgName, port, outpath string, options *compileopts.Options) error {
 		return fmt.Errorf("unknown flash method: %s", flashMethod)
 	}
 	if options.Monitor {
-		return Monitor(result.Executable, "", config)
+		return Monitor(result.Executable, port, config)
 	}
 	return nil
 }


### PR DESCRIPTION
Ran into this with multiple boards connected. Flashing with the `-port` flag and the `-monitor` flag resulted in the monitor operation still searching for a port instead of using the one passed in.