### PR TITLE
GNUmakefile: disable DWARF compression for CGo objects

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -193,7 +193,8 @@ NINJA_BUILD_TARGETS = clang llvm-config llvm-ar llvm-nm lld $(addprefix lib/lib,
 # For static linking.
 ifneq ("$(wildcard $(LLVM_BUILDDIR)/bin/llvm-config*)","")
     CGO_CPPFLAGS+=$(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --cppflags) -I$(abspath $(LLVM_BUILDDIR))/tools/clang/include -I$(abspath $(CLANG_SRC))/include -I$(abspath $(LLD_SRC))/include
-    CGO_CXXFLAGS=-std=c++17
+    CGO_CFLAGS=-gz=none
+    CGO_CXXFLAGS=-std=c++17 -gz=none
     CGO_LDFLAGS+=-L$(abspath $(LLVM_BUILDDIR)/lib) -lclang $(CLANG_LIBS) $(LLD_LIBS) $(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --ldflags --libs --system-libs $(LLVM_COMPONENTS)) -lstdc++ $(CGO_LDFLAGS_EXTRA)
 endif
 
@@ -310,7 +311,7 @@ check-nodejs-version:
 
 tinygo: ## Build the TinyGo compiler
 	@if [ ! -f "$(LLVM_BUILDDIR)/bin/llvm-config" ]; then echo "Fetch and build LLVM first by running:"; echo "  $(MAKE) llvm-source"; echo "  $(MAKE) $(LLVM_BUILDDIR)"; exit 1; fi
-	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GOENVFLAGS) $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags "byollvm osusergo" .
+	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GOENVFLAGS) $(GO) build -buildmode exe -o build/tinygo$(EXE) -tags "byollvm osusergo" .
 test: check-nodejs-version
 	CGO_CPPFLAGS="$(CGO_CPPFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" $(GO) test $(GOTESTFLAGS) -timeout=1h -buildmode exe -tags "byollvm osusergo" $(GOTESTPKGS)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -193,8 +193,13 @@ NINJA_BUILD_TARGETS = clang llvm-config llvm-ar llvm-nm lld $(addprefix lib/lib,
 # For static linking.
 ifneq ("$(wildcard $(LLVM_BUILDDIR)/bin/llvm-config*)","")
     CGO_CPPFLAGS+=$(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --cppflags) -I$(abspath $(LLVM_BUILDDIR))/tools/clang/include -I$(abspath $(CLANG_SRC))/include -I$(abspath $(LLD_SRC))/include
-    CGO_CFLAGS=-gz=none
-    CGO_CXXFLAGS=-std=c++17 -gz=none
+    CGO_CXXFLAGS=-std=c++17
+ifneq ($(uname),Windows_NT)
+    # Disable GCC DWARF compression: lld built without zlib cannot link
+    # object files with ELFCOMPRESS_ZLIB debug sections.
+    CGO_CFLAGS+=-gz=none
+    CGO_CXXFLAGS+=-gz=none
+endif
     CGO_LDFLAGS+=-L$(abspath $(LLVM_BUILDDIR)/lib) -lclang $(CLANG_LIBS) $(LLD_LIBS) $(shell $(LLVM_CONFIG_PREFIX) $(LLVM_BUILDDIR)/bin/llvm-config --ldflags --libs --system-libs $(LLVM_COMPONENTS)) -lstdc++ $(CGO_LDFLAGS_EXTRA)
 endif
 


### PR DESCRIPTION
## Problem

Building TinyGo with a locally-built lld that was compiled without zlib
support fails at link time:

    ld.lld: error: (.debug_info) is compressed with ELFCOMPRESS_ZLIB,
    but lld is not built with zlib support

Modern GCC compresses DWARF debug sections in object files by default
(`-gz=zlib`). When CGo hands those objects to lld for the final link,
lld rejects them if it was built without zlib.

## Fix

Add `-gz=none` to `CGO_CFLAGS` and `CGO_CXXFLAGS` to tell GCC not to
compress DWARF sections in CGo-compiled objects. Also thread
`CGO_CFLAGS` through the `tinygo` make target (it was previously
omitted from the explicit env var list).

This only affects builds that use a locally-built LLVM/lld (`byollvm`
tag). Distro-provided lld is typically built with zlib and is
unaffected.

Fixes #5379