### PR TITLE
runntime/interrupt.Checkpoint: add warning that this is hard to use

### DIFF
--- a/src/runtime/interrupt/checkpoint.go
+++ b/src/runtime/interrupt/checkpoint.go
@@ -20,6 +20,10 @@ package interrupt
 //	if c.Saved() {
 //		c.Jump()
 //	}
+//
+// Warning: only use this in special runtime code! If it is used from a normal
+// goroutine, and the scheduler switches to a different goroutine, havoc will
+// ensure.
 type Checkpoint struct {
 	jumpSP uintptr
 	jumpPC uintptr


### PR DESCRIPTION
Realized this while looking through the code: there is no way to use this safely when the scheduler is involved. It can only be used safely with a `wfe` or similar (part of scheduler code).