### PR TITLE
sizediff: skip "go:" lines printed by the Go toolchain

### DIFF
--- a/tools/sizediff
+++ b/tools/sizediff
@@ -23,17 +23,19 @@ class Comparison:
 def readSizes(path):
     sizes = []
     lines = open(path).readlines()
+    command = None
     for i in range(len(lines)):
-        if not lines[i].strip().startswith('code '):
-            continue
-        # found a size header
-        code, data, bss, flash, ram = map(int, lines[i+1].replace("|", "").split())
-        command = lines[i-1].strip()
-        sizes.append({
-            'command': command,
-            'flash':   flash,
-            'ram':     ram
-        })
+        if lines[i].strip().startswith('tinygo build'):
+            command = lines[i].strip()
+        elif lines[i].strip().startswith('code '):
+            # found a size header
+            code, data, bss, flash, ram = map(int, lines[i+1].replace("|", "").split())
+            sizes.append({
+                'command': command,
+                'flash':   flash,
+                'ram':     ram
+            })
+            command = None # make sure we don't accidentally miss a 'tinygo build' line
     return sizes
 
 def main():


### PR DESCRIPTION
This should fix lines like the following in the sizediff CI action:

```
not the same command!
    tinygo build -size short -o ./build/test.hex -target=feather-rp2040 ./examples/adafruit4650
    go: downloading tinygo.org/x/tinyfont v0.3.0
not the same command!
    tinygo build -size short -o ./build/test.hex -target=pico ./examples/tmc5160/main.go
    go: downloading golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
not the same command!
    tinygo build -size short -o ./build/test.hex -target=nano-rp2040 -stack-size 8kb ./examples/net/websocket/dial/
    go: downloading golang.org/x/net v0.33.0
not the same command!
    tinygo build -size short -o ./build/test.hex -target=nano-rp2040 -stack-size 8kb ./examples/net/mqttclient/natiu/
    go: downloading github.com/soypat/natiu-mqtt v0.5.1
not the same command!
    tinygo build -size short -o ./build/test.hex -target=wioterminal -stack-size 8kb ./examples/net/mqttclient/paho/
    go: downloading github.com/eclipse/paho.mqtt.golang v1.2.0
```