### PR TITLE
fix: move esp32s3 based device to inside of XTENSA build section

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-compat:
-    runs-on: ubuntu-22.04 # this must be a specific version for the apt install below
+    runs-on: ubuntu-22.04-better # this must be a specific version for the apt install below
     env:
       # Oldest versions currently supported by TinyGo
       LLVM: "15"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -975,6 +975,8 @@ ifneq ($(XTENSA), 0)
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=esp32s3-supermini   	examples/adc
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=esp32s3-box-3       examples/blinky1
+	@$(MD5SUM) test.bin
 endif
     # esp32c3-supermini
 	$(TINYGO) build -size short -o test.bin -target=esp32c3-supermini	    examples/blinky1
@@ -999,8 +1001,6 @@ endif
 	$(TINYGO) build -size short -o test.bin -target=esp32-c3-devkit-rust-1 examples/blinky1
 	@$(MD5SUM) test.bin
 	$(TINYGO) build -size short -o test.bin -target=esp32c3-12f         examples/blinky1
-	@$(MD5SUM) test.bin
-	$(TINYGO) build -size short -o test.bin -target=esp32s3-box-3       examples/blinky1
 	@$(MD5SUM) test.bin
 
 	$(TINYGO) build -size short -o test.bin -target=makerfabs-esp32c3spi35 examples/machinetest


### PR DESCRIPTION
This PR is to fix the CI by moving the recently added `esp32s3` based device to inside of XTENSA build section.

It also adds a second commit to switch the `compat` build to use a larger Github runner, since it was both slow and also flaky due to that slowness.