### PR TITLE
rp2: allow SPI transmit-only without SDI

### DIFF
--- a/src/machine/machine_rp2_2040.go
+++ b/src/machine/machine_rp2_2040.go
@@ -130,11 +130,11 @@ func (spi *SPI) validPins(config SPIConfig) error {
 	var okSDI, okSDO, okSCK bool
 	switch spi.Bus {
 	case rp.SPI0:
-		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20
+		okSDI = config.SDI == NoPin || config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20
 		okSDO = config.SDO == 3 || config.SDO == 7 || config.SDO == 19 || config.SDO == 23
 		okSCK = config.SCK == 2 || config.SCK == 6 || config.SCK == 18 || config.SCK == 22
 	case rp.SPI1:
-		okSDI = config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28
+		okSDI = config.SDI == NoPin || config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28
 		okSDO = config.SDO == 11 || config.SDO == 15 || config.SDO == 27
 		okSCK = config.SCK == 10 || config.SCK == 14 || config.SCK == 26
 	}

--- a/src/machine/machine_rp2_2350a.go
+++ b/src/machine/machine_rp2_2350a.go
@@ -21,11 +21,11 @@ func (spi *SPI) validPins(config SPIConfig) error {
 	var okSDI, okSDO, okSCK bool
 	switch spi.Bus {
 	case rp.SPI0:
-		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20
+		okSDI = config.SDI == NoPin || config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20
 		okSDO = config.SDO == 3 || config.SDO == 7 || config.SDO == 19 || config.SDO == 23
 		okSCK = config.SCK == 2 || config.SCK == 6 || config.SCK == 18 || config.SCK == 22
 	case rp.SPI1:
-		okSDI = config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28
+		okSDI = config.SDI == NoPin || config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28
 		okSDO = config.SDO == 11 || config.SDO == 15 || config.SDO == 27
 		okSCK = config.SCK == 10 || config.SCK == 14 || config.SCK == 26
 	}

--- a/src/machine/machine_rp2_2350b.go
+++ b/src/machine/machine_rp2_2350b.go
@@ -55,11 +55,11 @@ func (spi *SPI) validPins(config SPIConfig) error {
 	var okSDI, okSDO, okSCK bool
 	switch spi.Bus {
 	case rp.SPI0:
-		okSDI = config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20 || config.SDI == 32 || config.SDI == 36
+		okSDI = config.SDI == NoPin || config.SDI == 0 || config.SDI == 4 || config.SDI == 16 || config.SDI == 20 || config.SDI == 32 || config.SDI == 36
 		okSDO = config.SDO == 3 || config.SDO == 7 || config.SDO == 19 || config.SDO == 23 || config.SDO == 35 || config.SDO == 39
 		okSCK = config.SCK == 2 || config.SCK == 6 || config.SCK == 18 || config.SCK == 22 || config.SCK == 34 || config.SCK == 38
 	case rp.SPI1:
-		okSDI = config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28 || config.SDI == 40 || config.SDI == 44
+		okSDI = config.SDI == NoPin || config.SDI == 8 || config.SDI == 12 || config.SDI == 24 || config.SDI == 28 || config.SDI == 40 || config.SDI == 44
 		okSDO = config.SDO == 11 || config.SDO == 15 || config.SDO == 27 || config.SDO == 31 || config.SDO == 43 || config.SDO == 47
 		okSCK = config.SCK == 10 || config.SCK == 14 || config.SCK == 26 || config.SCK == 30 || config.SCK == 42 || config.SCK == 46
 	}

--- a/src/machine/machine_rp2_spi.go
+++ b/src/machine/machine_rp2_spi.go
@@ -174,7 +174,9 @@ func (spi *SPI) Configure(config SPIConfig) error {
 	// SPI pin configuration
 	config.SCK.setFunc(fnSPI)
 	config.SDO.setFunc(fnSPI)
-	config.SDI.setFunc(fnSPI)
+	if config.SDI != NoPin {
+		config.SDI.setFunc(fnSPI)
+	}
 
 	return spi.initSPI(config)
 }


### PR DESCRIPTION
This allows SPI transmit-only configurations on RP2040/RP2350 with SDI set to machine.NoPin.

The RP2040/RP2350 SPI implementation already supports transmit-only SPI through spi.Tx(tx, nil), where only SDO is used and received data is ignored. However, Configure still required SDI to be a valid physical pin. As a result, SDI: machine.NoPin returned invalid SPI SDI pin, even for transmit-only SPI.

This change keeps SCK and SDO validation unchanged, allows SDI: machine.NoPin, and skips SDI pin configuration when NoPin is used.

This PR intentionally only covers the transmit-only case. It does not change SDO handling.

## Testing

Tested on Raspberry Pi Pico / RP2040:

```
SPI0: SCK=GP18, SDO=GP19, SDI=machine.NoPin: OK
SPI0: SCK=GP18, SDO=GP19, SDI=GP0: OK
SPI1: SCK=GP14, SDO=GP15, SDI=machine.NoPin: OK
SPI1: SCK=GP14, SDO=GP15, SDI=GP12: OK
SPI1 invalid SDI check: 
SDI=GP0 is still rejected
spi.Tx(tx, nil): OK
```
Tested on Raspberry Pi Pico 2 / RP2350A:

```
SPI0: SCK=GP18, SDO=GP19, SDI=machine.NoPin: OK
SPI0: SCK=GP18, SDO=GP19, SDI=GP0: OK
SPI1: SCK=GP14, SDO=GP15, SDI=machine.NoPin: OK
SPI1: SCK=GP14, SDO=GP15, SDI=GP12: OK
SPI1 invalid SDI check: SDI=GP0 is still rejected
spi.Tx(tx, nil): OK
```

### test code
RP2040 version:
<details>

```
//go:build rp2040

package main

import (
        "machine"
        "time"
)

func testSPI(name string, spi *machine.SPI, sck, sdo, sdi machine.Pin, sckName, sdoName, sdiName string) bool {
        println("test:", name)
        println("  SCK:", sckName, "SDO:", sdoName, "SDI:", sdiName)
        err := spi.Configure(machine.SPIConfig{Frequency: 100_000, SCK: sck, SDO: sdo, SDI: sdi, Mode: 0})
        if err != nil {
                println("FAIL configure:", err.Error())
                return false
        }
        println("OK configure")
        err = spi.Tx([]byte{0x00, 0x55, 0xAA, 0xFF}, nil)
        if err != nil {
                println("FAIL tx:", err.Error())
                return false
        }
        println("OK tx")
        return true
}

func testInvalidSPI(name string, spi *machine.SPI, sck, sdo, sdi machine.Pin, sckName, sdoName, sdiName string) bool {
        println("test invalid:", name)
        println("  SCK:", sckName, "SDO:", sdoName, "SDI:", sdiName)
        err := spi.Configure(machine.SPIConfig{Frequency: 100_000, SCK: sck, SDO: sdo, SDI: sdi, Mode: 0})
        if err == nil {
                println("FAIL invalid pin accepted")
                return false
        }
        println("OK invalid pin rejected:", err.Error())
        return true
}

func main() {
        time.Sleep(2 * time.Second)
        println("RP2040 SPI SDI test")

        ok := true
        ok = testSPI("SPI0 NoPin", machine.SPI0, machine.GP18, machine.GP19, machine.NoPin, "GP18", "GP19", "NoPin") && ok
        ok = testSPI("SPI0 valid SDI", machine.SPI0, machine.GP18, machine.GP19, machine.GP0, "GP18", "GP19", "GP0") && ok
        ok = testSPI("SPI1 NoPin", machine.SPI1, machine.GP14, machine.GP15, machine.NoPin, "GP14", "GP15", "NoPin") && ok
        ok = testSPI("SPI1 valid SDI", machine.SPI1, machine.GP14, machine.GP15, machine.GP12, "GP14", "GP15", "GP12") && ok
        ok = testInvalidSPI("SPI1 invalid SDI", machine.SPI1, machine.GP14, machine.GP15, machine.GP0, "GP14", "GP15", "GP0") && ok

        if ok {
                println("PASS")
        } else {
                println("FAIL")
        }
        for {
                time.Sleep(time.Second)
        }
}
```
</details>

RP2350 version:
<details>

```
//go:build rp2350 

package main

import (
        "machine"
        "time"
)

func testSPI(name string, spi *machine.SPI, sck, sdo, sdi machine.Pin, sckName, sdoName, sdiName string) bool {
        println("test:", name)
        println("  SCK:", sckName, "SDO:", sdoName, "SDI:", sdiName)
        err := spi.Configure(machine.SPIConfig{Frequency: 100_000, SCK: sck, SDO: sdo, SDI: sdi, Mode: 0})
        if err != nil {
                println("FAIL configure:", err.Error())
                return false
        }
        println("OK configure")
        err = spi.Tx([]byte{0x00, 0x55, 0xAA, 0xFF}, nil)
        if err != nil {
                println("FAIL tx:", err.Error())
                return false
        }
        println("OK tx")
        return true
}

func testInvalidSPI(name string, spi *machine.SPI, sck, sdo, sdi machine.Pin, sckName, sdoName, sdiName string) bool {
        println("test invalid:", name)
        println("  SCK:", sckName, "SDO:", sdoName, "SDI:", sdiName)
        err := spi.Configure(machine.SPIConfig{Frequency: 100_000, SCK: sck, SDO: sdo, SDI: sdi, Mode: 0})
        if err == nil {
                println("FAIL invalid pin accepted")
                return false
        }
        println("OK invalid pin rejected:", err.Error())
        return true
}

func main() {
        time.Sleep(2 * time.Second)
        println("RP2350A SPI SDI test")

        ok := true
        ok = testSPI("SPI0 NoPin", machine.SPI0, machine.GP18, machine.GP19, machine.NoPin, "GP18", "GP19", "NoPin") && ok
        ok = testSPI("SPI0 valid SDI", machine.SPI0, machine.GP18, machine.GP19, machine.GP0, "GP18", "GP19", "GP0") && ok
        ok = testSPI("SPI1 NoPin", machine.SPI1, machine.GP14, machine.GP15, machine.NoPin, "GP14", "GP15", "NoPin") && ok
        ok = testSPI("SPI1 valid SDI", machine.SPI1, machine.GP14, machine.GP15, machine.GP12, "GP14", "GP15", "GP12") && ok
        ok = testInvalidSPI("SPI1 invalid SDI", machine.SPI1, machine.GP14, machine.GP15, machine.GP0, "GP14", "GP15", "GP0") && ok

        if ok {
                println("PASS")
        } else {
                println("FAIL")
        }
        for {
                time.Sleep(time.Second)
        }
}
```
</details>