### PR TITLE
gba: add support for mGBA debugging

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -278,7 +278,7 @@ func ListSerialPorts() ([]SerialPortInfo, error) {
 	return serialPortInfo, nil
 }
 
-var addressMatch = regexp.MustCompile(`^panic: runtime error at 0x([0-9a-f]+): `)
+var addressMatch = regexp.MustCompile(`panic: runtime error at 0x([0-9a-f]+): `)
 
 // Extract the address from the "panic: runtime error at" message.
 func extractPanicAddress(line []byte) uint64 {

--- a/src/runtime/runtime_mgba.go
+++ b/src/runtime/runtime_mgba.go
@@ -1,14 +1,39 @@
-//go:build arm7tdmi && !mgbadebug
+//go:build gameboyadvance && mgbadebug
 
 package runtime
 
 import (
 	_ "runtime/interrupt" // make sure the interrupt handler is defined
+	"runtime/volatile"
 	"unsafe"
 )
 
+var (
+	// Setting this memory address to 0xC0DE enables mGBA's debug printing
+	debugEnable = (*volatile.Register16)(unsafe.Pointer(uintptr(0x4FFF780)))
+	// mGBA supports log levels from 0x100(fatal) to 0x104(debug)
+	logLevel uint16 = 0x104 // use the debug log level
+	// Once we are ready to output we set the debug flags register to logLevel
+	// mGBA will output the text and then clear the text buffer when set
+	debugFlags = (*volatile.Register16)(unsafe.Pointer(uintptr(0x4FFF700)))
+
+	textBuffer = (*[255]byte)(unsafe.Pointer(uintptr(0x4FFF600)))
+	index      = 0
+)
+
 func putchar(c byte) {
-	// dummy, TODO
+	if c == '\n' || index >= len(textBuffer) {
+		debugFlags.Set(logLevel)
+		index = 0
+
+		// mGBA automatically prints a new line so we can ignore it
+		if c == '\n' {
+			return
+		}
+	}
+
+	textBuffer[index] = c
+	index++
 }
 
 func getchar() byte {
@@ -42,6 +67,9 @@ var _edata [0]byte
 func main() {
 	// Initialize .data and .bss sections.
 	preinit()
+
+	// Enable mGBA debugging.
+	debugEnable.Set(0xC0DE)
 
 	// Run program.
 	run()


### PR DESCRIPTION
Implements `putchar` when `mgbadebug` build tag is set which outputs
text through the mGBA debugging output interface.

mGBA allows the games running in the emulator to output debug text
The process to do so is:
1. set 0x4FFF780 to value of 0xC0DE
2. write text in memory 0x4FFF600 to 0x4FFF700
3. set 0x4FFF700 to the desired log level value from 0x100 (fatal) to
0x104 (debug)

Once this is done mGBA will output the text in its logs view as well as
through stdout. (Setting the log level to fatal also produces a dialog
box with the text)

The text output in the CLI is prefixed with `[DEBUG] GBA Debug: ` so I
modified the regex used for address matching in panic messages to be
able to read the address when the output line doesn't start with
`panic`.

After the change
```go
func main() {
	println("hello world")
	// fake panic with an address in it for demo purposes
	panic("runtime error at 0x08000000: ")
}
```
results in output such as:
<img width="1414" height="256" alt="image" src="https://github.com/user-attachments/assets/15080088-1193-48bd-9523-923c5684fe84" />

This makes debugging much easier as panic messages are shown and we can also do
debug prints.