### PR TITLE
syscall: remove sliceHeader, use unsafe.SliceData more

### DIFF
--- a/src/syscall/env_libc.go
+++ b/src/syscall/env_libc.go
@@ -66,8 +66,7 @@ func Getenv(key string) (value string, found bool) {
 	for size := uintptr(0); ; size++ {
 		v := *(*byte)(unsafe.Pointer(ptr))
 		if v == 0 {
-			src := *(*[]byte)(unsafe.Pointer(&sliceHeader{buf: raw, len: size, cap: size}))
-			return string(src), true
+			return string(unsafe.Slice(raw, size)), true
 		}
 		ptr += unsafe.Sizeof(byte(0))
 	}

--- a/src/syscall/syscall_libc.go
+++ b/src/syscall/syscall_libc.go
@@ -6,12 +6,6 @@ import (
 	"unsafe"
 )
 
-type sliceHeader struct {
-	buf *byte
-	len uintptr
-	cap uintptr
-}
-
 func Close(fd int) (err error) {
 	if libc_close(int32(fd)) < 0 {
 		err = getErrno()
@@ -58,8 +52,7 @@ func Fsync(fd int) (err error) {
 
 func Readlink(path string, p []byte) (n int, err error) {
 	data := cstring(path)
-	buf, count := splitSlice(p)
-	n = libc_readlink(&data[0], buf, uint(count))
+	n = libc_readlink(&data[0], unsafe.SliceData(p), uint(len(p)))
 	if n < 0 {
 		err = getErrno()
 	}
@@ -262,11 +255,6 @@ func cstring(s string) []byte {
 	copy(data, s)
 	// final byte should be zero from the initial allocation
 	return data
-}
-
-func splitSlice(p []byte) (buf *byte, len uintptr) {
-	slice := (*sliceHeader)(unsafe.Pointer(&p))
-	return slice.buf, slice.len
 }
 
 // These two functions are provided by the runtime.

--- a/src/syscall/syscall_libc_default.go
+++ b/src/syscall/syscall_libc_default.go
@@ -2,6 +2,8 @@
 
 package syscall
 
+import "unsafe"
+
 // These are the default Read/Write/Pread/Pwrite implementations for
 // libc-backed wasm targets that do NOT have the cooperative scheduler
 // + wasip1 netpoll integration. They are simple pass-throughs to the
@@ -12,8 +14,7 @@ package syscall
 // that park the goroutine on EAGAIN; see syscall_libc_wasip1.go.
 
 func Write(fd int, p []byte) (n int, err error) {
-	buf, count := splitSlice(p)
-	n = libc_write(int32(fd), buf, uint(count))
+	n = libc_write(int32(fd), unsafe.SliceData(p), uint(len(p)))
 	if n < 0 {
 		err = getErrno()
 	}
@@ -21,8 +22,7 @@ func Write(fd int, p []byte) (n int, err error) {
 }
 
 func Read(fd int, p []byte) (n int, err error) {
-	buf, count := splitSlice(p)
-	n = libc_read(int32(fd), buf, uint(count))
+	n = libc_read(int32(fd), unsafe.SliceData(p), uint(len(p)))
 	if n < 0 {
 		err = getErrno()
 	}
@@ -30,8 +30,7 @@ func Read(fd int, p []byte) (n int, err error) {
 }
 
 func Pread(fd int, p []byte, offset int64) (n int, err error) {
-	buf, count := splitSlice(p)
-	n = libc_pread(int32(fd), buf, uint(count), offset)
+	n = libc_pread(int32(fd), unsafe.SliceData(p), uint(len(p)), offset)
 	if n < 0 {
 		err = getErrno()
 	}
@@ -39,8 +38,7 @@ func Pread(fd int, p []byte, offset int64) (n int, err error) {
 }
 
 func Pwrite(fd int, p []byte, offset int64) (n int, err error) {
-	buf, count := splitSlice(p)
-	n = libc_pwrite(int32(fd), buf, uint(count), offset)
+	n = libc_pwrite(int32(fd), unsafe.SliceData(p), uint(len(p)), offset)
 	if n < 0 {
 		err = getErrno()
 	}

--- a/src/syscall/syscall_libc_wasip1.go
+++ b/src/syscall/syscall_libc_wasip1.go
@@ -4,7 +4,7 @@ package syscall
 
 import (
 	"internal/task"
-	_ "unsafe" // for go:linkname
+	"unsafe"
 )
 
 // pollMode constants must mirror runtime/netpoll_wasip1.go's pollRead/
@@ -26,9 +26,8 @@ func runtime_netpoll_done(pd uintptr)
 // goroutine until the cooperative scheduler's pollIO wakes us, then
 // retry. EINTR retries immediately without parking.
 func Write(fd int, p []byte) (n int, err error) {
-	buf, count := splitSlice(p)
 	for {
-		n = libc_write(int32(fd), buf, uint(count))
+		n = libc_write(int32(fd), unsafe.SliceData(p), uint(len(p)))
 		if n >= 0 {
 			return
 		}
@@ -45,9 +44,8 @@ func Write(fd int, p []byte) (n int, err error) {
 }
 
 func Read(fd int, p []byte) (n int, err error) {
-	buf, count := splitSlice(p)
 	for {
-		n = libc_read(int32(fd), buf, uint(count))
+		n = libc_read(int32(fd), unsafe.SliceData(p), uint(len(p)))
 		if n >= 0 {
 			return
 		}
@@ -64,9 +62,8 @@ func Read(fd int, p []byte) (n int, err error) {
 }
 
 func Pread(fd int, p []byte, offset int64) (n int, err error) {
-	buf, count := splitSlice(p)
 	for {
-		n = libc_pread(int32(fd), buf, uint(count), offset)
+		n = libc_pread(int32(fd), unsafe.SliceData(p), uint(len(p)), offset)
 		if n >= 0 {
 			return
 		}
@@ -83,9 +80,8 @@ func Pread(fd int, p []byte, offset int64) (n int, err error) {
 }
 
 func Pwrite(fd int, p []byte, offset int64) (n int, err error) {
-	buf, count := splitSlice(p)
 	for {
-		n = libc_pwrite(int32(fd), buf, uint(count), offset)
+		n = libc_pwrite(int32(fd), unsafe.SliceData(p), uint(len(p)), offset)
 		if n >= 0 {
 			return
 		}


### PR DESCRIPTION
This is what I meant in https://github.com/tinygo-org/tinygo/pull/5387#issuecomment-4471615146; this local slice type doesn't need to exist.