### PR TITLE
gba: add bios interrupt flags

### DIFF
--- a/src/device/gba/gba.go
+++ b/src/device/gba/gba.go
@@ -85,6 +85,9 @@ var (
 	SIO = (*SIO_Type)(unsafe.Add(unsafe.Pointer(REG_BASE), uintptr(0x0134)))
 
 	INTERRUPT = (*INTERRUPT_Type)(unsafe.Add(unsafe.Pointer(REG_BASE), uintptr(0x0200)))
+
+	// BIOS interrupt flags
+	BIOS_IF = (*volatile.Register16)(unsafe.Pointer(uintptr(0x03007FF8)))
 )
 
 // Main memory sections

--- a/src/runtime/interrupt/interrupt_gameboyadvance.go
+++ b/src/runtime/interrupt/interrupt_gameboyadvance.go
@@ -23,6 +23,7 @@ func handleInterrupt() {
 	for i := 0; i < 14; i++ {
 		if flags&(1<<uint(i)) != 0 {
 			gba.INTERRUPT.IF.Set(1 << uint(i)) // acknowledge interrupt
+			gba.BIOS_IF.Set(1 << uint(i)) // acknowledge interrupt for BIOS
 			callInterruptHandler(i)
 		}
 	}

--- a/src/runtime/interrupt/interrupt_gameboyadvance.go
+++ b/src/runtime/interrupt/interrupt_gameboyadvance.go
@@ -23,7 +23,7 @@ func handleInterrupt() {
 	for i := 0; i < 14; i++ {
 		if flags&(1<<uint(i)) != 0 {
 			gba.INTERRUPT.IF.Set(1 << uint(i)) // acknowledge interrupt
-			gba.BIOS_IF.Set(1 << uint(i)) // acknowledge interrupt for BIOS
+			gba.BIOS_IF.Set(1 << uint(i))      // acknowledge interrupt for BIOS
 			callInterruptHandler(i)
 		}
 	}


### PR DESCRIPTION
Adds a new GBA register for interrupt flags, the register is equivalent
to the IF register, but is intended for BIOS functions.

Acknowledging the interrupts with this register allows us to use BIOS
halt functions such as VBlankIntrWait and IntrWait, which we can use to
get rid of busy loops in the GBA code.

Example code:
```go
func vblank(interrupt.Interrupt) {}

func main() {
        // enable vblank interrupt
        gba.DISP.DISPSTAT.ReplaceBits(1, 1, 3)
        // setup a vblank handler
        interrupt.New(machine.IRQ_VBLANK, vblank).Enable()
        for {
                if gba.DISP.VCOUNT.Get() > 160 {
                        println("vblanking")
                } else {
                        println("busy loop")
                }

                // uncomment to get rid of the busy loop
                // call VBlankIntrWait
                // arm.SVCall0(0x05 << 16)
        }
}

```
