### PR TITLE
machine/usb: support bidirectional endpoints by dynamic registration

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3817, 299, 0, 2252},
 		{"microbit", "examples/serial", 2820, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7330, 1550, 120, 7248},
+		{"wioterminal", "examples/pininterrupt", 7902, 1650, 132, 7472},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3817, 299, 0, 2252},
 		{"microbit", "examples/serial", 2820, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7902, 1650, 132, 7472},
+		{"wioterminal", "examples/pininterrupt", 7930, 1650, 132, 7472},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/machine/machine_atsamd21_usb.go
+++ b/src/machine/machine_atsamd21_usb.go
@@ -23,19 +23,6 @@ const (
 	NumberOfUSBEndpoints = 8
 )
 
-var (
-	endPoints = []uint32{
-		usb.CONTROL_ENDPOINT:  usb.ENDPOINT_TYPE_CONTROL,
-		usb.CDC_ENDPOINT_ACM:  (usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointIn),
-		usb.CDC_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_BULK | usb.EndpointOut),
-		usb.CDC_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_BULK | usb.EndpointIn),
-		usb.HID_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_DISABLE), // Interrupt In
-		usb.HID_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_DISABLE), // Interrupt Out
-		usb.MIDI_ENDPOINT_IN:  (usb.ENDPOINT_TYPE_DISABLE), // Bulk In
-		usb.MIDI_ENDPOINT_OUT: (usb.ENDPOINT_TYPE_DISABLE), // Bulk Out
-	}
-)
-
 // Configure the USB peripheral. The config is here for compatibility with the UART interface.
 func (dev *USBDevice) Configure(config UARTConfig) {
 	if dev.initcomplete {

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -23,19 +23,6 @@ const (
 	NumberOfUSBEndpoints = 8
 )
 
-var (
-	endPoints = []uint32{
-		usb.CONTROL_ENDPOINT:  usb.ENDPOINT_TYPE_CONTROL,
-		usb.CDC_ENDPOINT_ACM:  (usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointIn),
-		usb.CDC_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_BULK | usb.EndpointOut),
-		usb.CDC_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_BULK | usb.EndpointIn),
-		usb.HID_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_DISABLE), // Interrupt In
-		usb.HID_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_DISABLE), // Interrupt Out
-		usb.MIDI_ENDPOINT_IN:  (usb.ENDPOINT_TYPE_DISABLE), // Bulk In
-		usb.MIDI_ENDPOINT_OUT: (usb.ENDPOINT_TYPE_DISABLE), // Bulk Out
-	}
-)
-
 // Configure the USB peripheral. The config is here for compatibility with the UART interface.
 func (dev *USBDevice) Configure(config UARTConfig) {
 	if dev.initcomplete {

--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -22,17 +22,6 @@ var (
 	epinen      uint32
 	epouten     uint32
 	easyDMABusy volatile.Register8
-
-	endPoints = []uint32{
-		usb.CONTROL_ENDPOINT:  usb.ENDPOINT_TYPE_CONTROL,
-		usb.CDC_ENDPOINT_ACM:  (usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointIn),
-		usb.CDC_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_BULK | usb.EndpointOut),
-		usb.CDC_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_BULK | usb.EndpointIn),
-		usb.HID_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_DISABLE), // Interrupt In
-		usb.HID_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_DISABLE), // Interrupt Out
-		usb.MIDI_ENDPOINT_IN:  (usb.ENDPOINT_TYPE_DISABLE), // Bulk In
-		usb.MIDI_ENDPOINT_OUT: (usb.ENDPOINT_TYPE_DISABLE), // Bulk Out
-	}
 )
 
 // enterCriticalSection is used to protect access to easyDMA - only one thing

--- a/src/machine/machine_rp2_usb.go
+++ b/src/machine/machine_rp2_usb.go
@@ -16,17 +16,6 @@ var (
 		data   []byte
 		pid    uint32
 	}
-
-	endPoints = []uint32{
-		usb.CONTROL_ENDPOINT:  usb.ENDPOINT_TYPE_CONTROL,
-		usb.CDC_ENDPOINT_ACM:  (usb.ENDPOINT_TYPE_INTERRUPT | usb.EndpointIn),
-		usb.CDC_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_BULK | usb.EndpointOut),
-		usb.CDC_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_BULK | usb.EndpointIn),
-		usb.HID_ENDPOINT_IN:   (usb.ENDPOINT_TYPE_DISABLE), // Interrupt In
-		usb.HID_ENDPOINT_OUT:  (usb.ENDPOINT_TYPE_DISABLE), // Interrupt Out
-		usb.MIDI_ENDPOINT_IN:  (usb.ENDPOINT_TYPE_DISABLE), // Bulk In
-		usb.MIDI_ENDPOINT_OUT: (usb.ENDPOINT_TYPE_DISABLE), // Bulk Out
-	}
 )
 
 func initEndpoint(ep, config uint32) {

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -14,9 +14,21 @@ type USBDevice struct {
 	InitEndpointComplete bool
 }
 
+type usbEndpointEntry struct {
+	Endpoint uint32
+	Config   uint32
+}
+
 var (
 	USBDev = &USBDevice{}
 	USBCDC Serialer
+
+	endPoints = []usbEndpointEntry{
+		{
+			Endpoint: usb.CONTROL_ENDPOINT,
+			Config:   usb.ENDPOINT_TYPE_CONTROL,
+		},
+	}
 )
 
 func initUSB() {
@@ -277,8 +289,11 @@ func handleStandardSetup(setup usb.Setup) bool {
 
 	case usb.SET_CONFIGURATION:
 		if setup.BmRequestType&usb.REQUEST_RECIPIENT == usb.REQUEST_DEVICE {
-			for i := 1; i < len(endPoints); i++ {
-				initEndpoint(uint32(i), endPoints[i])
+			for _, entry := range endPoints {
+				if entry.Endpoint == usb.CONTROL_ENDPOINT {
+					continue
+				}
+				initEndpoint(uint32(entry.Endpoint), entry.Config)
 			}
 
 			usbConfiguration = setup.WValueL
@@ -359,12 +374,18 @@ func ConfigureUSBEndpoint(desc descriptor.Descriptor, epSettings []usb.EndpointC
 
 	for _, ep := range epSettings {
 		if ep.IsIn {
-			endPoints[ep.Index] = uint32(ep.Type | usb.EndpointIn)
+			endPoints = append(endPoints, usbEndpointEntry{
+				Endpoint: uint32(ep.Index),
+				Config:   uint32(ep.Type | usb.EndpointIn),
+			})
 			if ep.TxHandler != nil {
 				usbTxHandler[ep.Index] = ep.TxHandler
 			}
 		} else {
-			endPoints[ep.Index] = uint32(ep.Type | usb.EndpointOut)
+			endPoints = append(endPoints, usbEndpointEntry{
+				Endpoint: uint32(ep.Index),
+				Config:   uint32(ep.Type | usb.EndpointOut),
+			})
 			if ep.RxHandler != nil {
 				usbRxHandler[ep.Index] = func(b []byte) bool {
 					ep.RxHandler(b)


### PR DESCRIPTION
This change is for enabling bidirectional endpoints.

Before the change, the endPoints could only be configured as either In or Out for the same endpoint. This change removes that restriction.
By merging this change, the modifications in #5405 will work properly.

The tests were conducted in the following environment. I have verified that HID works using the actual examples/hid-keyboard. Furthermore, I have confirmed that it functions correctly even when HID_ENDPOINT_IN is changed to a different number, or when it is defined in a bidirectional format.

- rp2040
  - waveshare-rp2040-zero
- rp2350
  - pico2
- atsamd51
  - wioterminal
- atsamd21
  - qtpy
- nrf52840
  - feathre-nrf52840

~~I didn't have it on hand, so I would appreciate it if someone could test it. I think it should be fine as long as the hid-keyboard works.~~
I found a Pico 2, so I was able to confirm that it works correctly on the RP2350 as well.