### PR TITLE
machine/usb: fix truncated USB string descriptor when host requests short maxLen

### DIFF
--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -44,7 +44,7 @@ func TestBinarySize(t *testing.T) {
 		// microcontrollers
 		{"hifive1b", "examples/echo", 3817, 299, 0, 2252},
 		{"microbit", "examples/serial", 2820, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7286, 1534, 120, 7248},
+		{"wioterminal", "examples/pininterrupt", 7330, 1550, 120, 7248},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -196,17 +196,18 @@ func sendDescriptorString(data string, maxLen uint16) {
 
 	// Clamp the length.
 	maxEncBytes := min(len(usb_trans_buffer), len(udd_ep_control_cache_buffer), int(maxLen))
-	data = data[:min(len(data), (maxEncBytes-2)/2)]
-
 	// Write the header.
-	buf := usb_trans_buffer[:2*len(data)+2]
+	buf := usb_trans_buffer[:min(2*len(data)+2, maxEncBytes)]
 	hdr, body := buf[:2], buf[2:]
-	hdr[0] = byte(len(buf))
+
+	// hdr[0] (bLength) should convey the "original total string length" before being limited by the host's maxLen.
+	hdr[0] = byte(2*len(data) + 2)
 	hdr[1] = descriptor.TypeString
 
 	// Convert the string to UTF16.
 	// NOTE: Using range here would cause the length to disagree when multibyte codepoints are present.
-	for i := 0; i < len(data); i++ {
+	limit := min(len(data), len(body)/2)
+	for i := 0; i < limit; i++ {
 		body[2*i] = byte(data[i])
 		body[2*i+1] = 0
 	}


### PR DESCRIPTION
### Description

This PR fixes a bug where the USB string descriptor initialization fails depending on the host's USB stack behavior. 

When a host (e.g., Windows or certain OS architectures) initially requests only the first few bytes of a string descriptor (typically a `maxLen` of 2 or 4 bytes) to determine its total size, the previous implementation permanently truncated the source `data` string itself. 

As a result:
1. `hdr[0]` (`bLength`) incorrectly reported the truncated size (e.g., `4` bytes) instead of the actual total descriptor length (e.g., `24` bytes).
2. The host was misled into thinking the device had an extremely short string descriptor and subsequently aborted the remaining setup sequence (such as fetching trailing string bytes or executing the final `SET INTERFACE` requests).

### Changes

- Removed the destructive slicing of the source `data` string (`data = data[:min(...)]`).
- Changed the transmission buffer (`buf`) slicing to safely clamp to `maxEncBytes` without affecting the original string's length calculation.
- Ensured `hdr[0]` (`bLength`) always conveys the original total size of the descriptor so the host can correctly request the remainder of the payload.
- Added a safety bounds check (`limit`) to the UTF-16 conversion loop to prevent any buffer overruns.