### PR TITLE
CI: go back to free runners

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -19,11 +19,11 @@ jobs:
         # macos-14: arm64 (oldest supported version as of 18-11-2025)
         # macos-15-intel: amd64 (last intel version to be supported by github runners)
         # See https://github.com/actions/runner-images/issues/13046
-        os: [macos-14, macos-15-large]
+        os: [macos-14, macos-15-intel]
         include:
           - os: macos-14
             goarch: arm64
-          - os: macos-15-large
+          - os: macos-15-intel
             goarch: amd64
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-compat:
-    runs-on: ubuntu-22.04-better # this must be a specific version for the apt install below
+    runs-on: ubuntu-22.04 # this must be a specific version for the apt install below
     env:
       # Oldest versions currently supported by TinyGo
       LLVM: "15"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   push_to_registry:
     name: build-push-dev
-    runs-on: ubuntu-24-04-better
+    runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
     # Build Linux binaries, ready for release.
     # This runs inside an Alpine Linux container so we can more easily create a
     # statically linked binary.
-    runs-on: ubuntu-24-04-better
+    runs-on: ubuntu-latest
     container:
       image: golang:1.26-alpine
     outputs:
@@ -132,7 +132,7 @@ jobs:
           archive: false
   test-linux-build:
     # Test the binaries built in the build-linux job by running the smoke tests.
-    runs-on: ubuntu-24-04-better
+    runs-on: ubuntu-latest
     needs: build-linux
     steps:
       - name: Checkout
@@ -166,7 +166,7 @@ jobs:
   assert-test-linux:
     # Run all tests that can run on Linux, with LLVM assertions enabled to catch
     # potential bugs.
-    runs-on: ubuntu-24-04-better
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: windows-2022-better
+    runs-on: windows-2022
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache/restore@v5
         id: cache-llvm-source
         with:
-          key: llvm-source-20-windows-v2
+          key: llvm-source-20-windows-v3
           path: |
             llvm-project/clang/lib/Headers
             llvm-project/clang/include
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache/restore@v5
         id: cache-llvm-build
         with:
-          key: llvm-build-20-windows-v3
+          key: llvm-build-20-windows-v4
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -121,7 +121,7 @@ jobs:
           archive: false
 
   smoke-test-windows:
-    runs-on: windows-2022-better
+    runs-on: windows-2022
     needs: build-windows
     steps:
       - name: Configure pagefile
@@ -154,7 +154,7 @@ jobs:
         run: make smoketest TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
   stdlib-test-windows:
-    runs-on: windows-2022-better
+    runs-on: windows-2022
     needs: build-windows
     steps:
       - name: Configure pagefile
@@ -180,7 +180,7 @@ jobs:
         run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
   stdlib-wasi-test-windows:
-    runs-on: windows-2022-better
+    runs-on: windows-2022
     needs: build-windows
     steps:
       - name: Configure pagefile


### PR DESCRIPTION
Due to recent changes at Github, we have to go back to the free community runners. :crying_cat_face: 