### PR TITLE
add CGO_CFLAGS support

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -151,6 +151,8 @@ func Get(name string) string {
 			panic("could not find cache dir: " + err.Error())
 		}
 		return filepath.Join(dir, "tinygo")
+	case "CGO_CFLAGS":
+		return os.Getenv("CGO_CFLAGS")
 	case "CGO_ENABLED":
 		// Always enable CGo. It is required by a number of targets, including
 		// macOS and the rp2040.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -508,6 +508,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags(true)...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
+		initialCFlags = append(initialCFlags, goenv.Get("CGO_CFLAGS"))
 		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.config.GOOS())
 		p.CFlags = append(initialCFlags, cflags...)
 		p.CGoHeaders = headerCode

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -508,7 +508,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags(true)...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
-		initialCFlags = append(initialCFlags, goenv.Get("CGO_CFLAGS"))
+		initialCFlags = append(initialCFlags, strings.Fields(goenv.Get("CGO_CFLAGS"))...)
 		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.config.GOOS())
 		p.CFlags = append(initialCFlags, cflags...)
 		p.CGoHeaders = headerCode

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/google/shlex"
 	"github.com/tinygo-org/tinygo/cgo"
 	"github.com/tinygo-org/tinygo/compileopts"
 	"github.com/tinygo-org/tinygo/goenv"
@@ -508,7 +509,11 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		var initialCFlags []string
 		initialCFlags = append(initialCFlags, p.program.config.CFlags(true)...)
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
-		initialCFlags = append(initialCFlags, strings.Fields(goenv.Get("CGO_CFLAGS"))...)
+		cgoCFlags, err := shlex.Split(goenv.Get("CGO_CFLAGS"))
+		if err != nil {
+			return nil, err
+		}
+		initialCFlags = append(initialCFlags, cgoCFlags...)
 		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.config.GOOS())
 		p.CFlags = append(initialCFlags, cflags...)
 		p.CGoHeaders = headerCode

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -511,7 +511,7 @@ func (p *Package) parseFiles() ([]*ast.File, error) {
 		initialCFlags = append(initialCFlags, "-I"+p.Dir)
 		cgoCFlags, err := shlex.Split(goenv.Get("CGO_CFLAGS"))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to split CGO_CFLAGS: %w", err)
 		}
 		initialCFlags = append(initialCFlags, cgoCFlags...)
 		generated, headerCode, cflags, ldflags, accessedFiles, errs := cgo.Process(files, p.program.workingDir, p.ImportPath, p.program.fset, initialCFlags, p.program.config.GOOS())


### PR DESCRIPTION
Allow CGO_CFLAGS to be set when running tinygo. Usually needed for specifying alternative libc includes.