### PR TITLE
machine: add GP aliases for waveshare-rp2040-zero

### DIFF
--- a/src/machine/board_waveshare-rp2040-zero.go
+++ b/src/machine/board_waveshare-rp2040-zero.go
@@ -41,6 +41,40 @@ const (
 	D29 Pin = GPIO29
 )
 
+// GPIO pin aliases
+const (
+	GP0  Pin = GPIO0
+	GP1  Pin = GPIO1
+	GP2  Pin = GPIO2
+	GP3  Pin = GPIO3
+	GP4  Pin = GPIO4
+	GP5  Pin = GPIO5
+	GP6  Pin = GPIO6
+	GP7  Pin = GPIO7
+	GP8  Pin = GPIO8
+	GP9  Pin = GPIO9
+	GP10 Pin = GPIO10
+	GP11 Pin = GPIO11
+	GP12 Pin = GPIO12
+	GP13 Pin = GPIO13
+	GP14 Pin = GPIO14
+	GP15 Pin = GPIO15
+	GP16 Pin = GPIO16
+	GP17 Pin = GPIO17
+	GP18 Pin = GPIO18
+	GP19 Pin = GPIO19
+	GP20 Pin = GPIO20
+	GP21 Pin = GPIO21
+	GP22 Pin = GPIO22
+	GP23 Pin = GPIO23
+	GP24 Pin = GPIO24
+	GP25 Pin = GPIO25
+	GP26 Pin = GPIO26
+	GP27 Pin = GPIO27
+	GP28 Pin = GPIO28
+	GP29 Pin = GPIO29
+)
+
 // Analog pins
 const (
 	A0 Pin = D26


### PR DESCRIPTION
Add GP0-GP29 aliases for the Waveshare RP2040-Zero board.

The Pico board definitions already provide GP aliases for RP2040 GPIO pins. This change adds the same style of aliases to Waveshare RP2040-Zero while keeping the existing D0-D29 aliases unchanged.