### PR TITLE
builder: retry cached archive renames on Windows

### DIFF
--- a/builder/library.go
+++ b/builder/library.go
@@ -218,7 +218,7 @@ func (l *Library) load(config *compileopts.Config, tmpdir string) (job *compileJ
 				return err
 			}
 			// Store this archive in the cache.
-			return os.Rename(f.Name(), archiveFilePath)
+			return robustRename(f.Name(), archiveFilePath)
 		},
 	}
 

--- a/builder/robustio_other.go
+++ b/builder/robustio_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package builder
+
+import "os"
+
+func robustRename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/builder/robustio_windows.go
+++ b/builder/robustio_windows.go
@@ -1,0 +1,44 @@
+package builder
+
+import (
+	"errors"
+	"math/rand"
+	"os"
+	"syscall"
+	"time"
+)
+
+const robustRenameTimeout = 2 * time.Second
+
+func robustRename(oldpath, newpath string) error {
+	var bestErr error
+	start := time.Now()
+	nextSleep := time.Millisecond
+	for {
+		err := os.Rename(oldpath, newpath)
+		if err == nil || !isEphemeralRenameError(err) {
+			return err
+		}
+		if bestErr == nil {
+			bestErr = err
+		}
+		if d := time.Since(start) + nextSleep; d >= robustRenameTimeout {
+			return bestErr
+		}
+		time.Sleep(nextSleep)
+		nextSleep += time.Duration(rand.Int63n(int64(nextSleep)))
+	}
+}
+
+func isEphemeralRenameError(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.Errno(2), // ERROR_FILE_NOT_FOUND
+			syscall.Errno(5),  // ERROR_ACCESS_DENIED
+			syscall.Errno(32): // ERROR_SHARING_VIOLATION
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Got tired of seeing my builds fail on Windows for reasons like:

```
--- FAIL: TestErrors (0.00s)
    --- FAIL: TestErrors/linker-ramoverflow#cortex-m-qemu (31.39s)
        errors_test.go:91: expected error:
            > program uses too much static RAM on this chip (RAM overflowed by {{[0-9]+}} bytes)
            got:
            > rename C:\Users\runneradmin\AppData\Local\tinygo\picolibc-thumbv7m-unknown-unknown-eabi-cortex-m3\libc.a.tmp1585239900 C:\Users\runneradmin\AppData\Local\tinygo\picolibc-thumbv7m-unknown-unknown-eabi-cortex-m3\lib.a: Access is denied.
no Go files in D:\a\tinygo\tinygo\tests\testing
FAIL
exit status 1
FAIL	github.com/tinygo-org/tinygo	241.168s
make: *** [GNUmakefile:321: test] Error 1
Error: Process completed with exit code 2.
```

My guess here is that tinygo is hitting the same problems that required BigGo to introduce the `robustio` package, which does retries. Atomic renames are not so atomic on Windows where antivirus or other processes can hold locks on files and require a retry.

There's likely other place that could use this treatment (or maybe use https://pkg.go.dev/github.com/rogpeppe/go-internal/robustio), but I think this one rename is to blame?