### PR TITLE
main: don't mutate compile options in Test

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,6 +209,8 @@ func Build(pkgName, outpath string, config *compileopts.Config) error {
 // Test runs the tests in the given package. Returns whether the test passed and
 // possibly an error if the test failed to run.
 func Test(pkgName string, stdout, stderr io.Writer, options *compileopts.Options, outpath string) (bool, error) {
+	optionsCopy := *options
+	options = &optionsCopy
 	options.TestConfig.CompileTestBinary = true
 	config, err := builder.NewConfig(options)
 	if err != nil {


### PR DESCRIPTION
This function modifies TestConfig, but Test is called from multiple places, so can cause a data race. (and in the presence of races, all behavior bets are off).