### PR TITLE
machine: optimize RTT initialization

### DIFF
--- a/src/machine/serial-rtt.go
+++ b/src/machine/serial-rtt.go
@@ -71,16 +71,18 @@ type rttSerial struct {
 	rttControlBlock
 }
 
+var terminalByteString = []byte("Terminal\x00")
+
 func (s *rttSerial) Configure(config UARTConfig) error {
 	s.maxNumUpBuffers = rttMaxNumUpBuffers
 	s.maxNumDownBuffers = rttMaxNumDownBuffers
 
-	s.buffersUp[0].name = &[]byte("Terminal\x00")[0]
+	s.buffersUp[0].name = &terminalByteString[0]
 	s.buffersUp[0].buffer = &rttBufferUpData[0]
 	s.buffersUp[0].bufferSize = rttBufferSizeUp
 	s.buffersUp[0].flags = rttModeNoBlockSkip
 
-	s.buffersDown[0].name = &[]byte("Terminal\x00")[0]
+	s.buffersDown[0].name = &terminalByteString[0]
 	s.buffersDown[0].buffer = &rttBufferDownData[0]
 	s.buffersDown[0].bufferSize = rttBufferSizeDown
 	s.buffersDown[0].flags = rttModeNoBlockSkip


### PR DESCRIPTION
This converts the heap allocation to a statically allocated string when using `-serial=rtt`. This is useful for me, since it reduces binary size and makes it possible to use `-gc=none` (which would previously result in a linker error).