### PR TITLE
ci: group make output

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -90,12 +90,12 @@ jobs:
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
-      - name: make gen-device
-        run: make -j3 gen-device
+      - name: Generate device files
+        run: make -j -O gen-device
       - name: Test TinyGo
         run: make test GOTESTFLAGS="-only-current-os"
       - name: Build TinyGo release tarball
-        run: make release -j3
+        run: make -j -O release
       - name: Test stdlib packages
         run: make tinygo-test
       - name: Make release artifact

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -67,6 +67,6 @@ jobs:
       - name: Build TinyGo
         run: go install -tags=llvm${{ env.LLVM }}
       - run: tinygo version
-      - run: make gen-device -j4
+      - run: make -j -O gen-device
       - run: go test -tags=llvm${{ env.LLVM }} -short -skip=TestErrors
       - run: make smoketest XTENSA=0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,7 +133,7 @@ jobs:
         run: make spell
       - name: Build TinyGo release
         run: |
-          make release deb -j3 STATIC=1
+          make -j -O release deb STATIC=1
           cp -p build/release.tar.gz /tmp/tinygo${{ steps.version.outputs.version }}.linux-amd64.tar.gz
           cp -p build/release.deb    /tmp/tinygo_${{ steps.version.outputs.version }}_amd64.deb
       - name: "Publish release artifact: tarball"
@@ -272,7 +272,7 @@ jobs:
       - name: Build Binaryen
         if: steps.cache-binaryen.outputs.cache-hit != 'true'
         run: make binaryen
-      - run: make gen-device -j4
+      - run: make -j -O gen-device
       - name: Test TinyGo
         run: make ASSERT=1 test
       - name: Build TinyGo

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -43,7 +43,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-      - run: make gen-device -j4
+      - run: make -j -O gen-device
       - name: Download drivers repo
         run: git clone https://github.com/tinygo-org/drivers.git
       - name: Save HEAD

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,14 +95,14 @@ jobs:
         run: |
           scoop config use_external_7zip true
           scoop install wasmtime@29.0.1
-      - name: make gen-device
-        run: make -j3 gen-device
+      - name: Generate device files
+        run: make -j -O gen-device
       - name: Test TinyGo
         shell: bash
         run: make test GOTESTFLAGS="-only-current-os"
       - name: Build TinyGo release tarball
         shell: bash
-        run: make build/release -j4
+        run: make -j -O build/release
       - name: Make release artifact
         shell: bash
         working-directory: build/release


### PR DESCRIPTION
Add the `-O` flag to request that output be grouped per-rule. This is a bit easier to read than having all output from parallel jobs mixed together. There is a small downside to this - make will not print the output until the job completes.

I also switched the `-j` flag to automatically select the correct build parallelism. This is a bit cleaner, and will update appropriately whenever we change builders.