### PR TITLE
machine: add I2C support for ESP32-C6

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -963,6 +963,8 @@ ifneq ($(XTENSA), 0)
 	# xiao-esp32c6
 	$(TINYGO) build -size short -o test.bin -target=xiao-esp32c6      	examples/blinky1
 	@$(MD5SUM) test.bin
+	$(TINYGO) build -size short -o test.bin -target=xiao-esp32c6   		examples/blinkm
+	@$(MD5SUM) test.bin
 	# xiao-esp32s3
 	$(TINYGO) build -size short -o test.bin -target=xiao-esp32s3   		examples/blinky1
 	@$(MD5SUM) test.bin

--- a/src/machine/i2c.go
+++ b/src/machine/i2c.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || rp2350 || mimxrt1062 || (esp32c3 && !m5stamp_c3) || esp32 || esp32s3
+//go:build !baremetal || atmega || nrf || sam || stm32 || fe310 || k210 || rp2040 || rp2350 || mimxrt1062 || (esp32c3 && !m5stamp_c3) || esp32 || esp32c6 || esp32s3
 
 package machine
 

--- a/src/machine/machine_esp32c3_i2c.go
+++ b/src/machine/machine_esp32c3_i2c.go
@@ -19,3 +19,10 @@ var (
 		useExt1: false,
 	}
 )
+
+// enableI2C0PeriphClock enables the I2C0 peripheral clock via SYSTEM.
+func enableI2C0PeriphClock() {
+	esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(1)
+	esp.SYSTEM.SetPERIP_CLK_EN0_I2C_EXT0_CLK_EN(1)
+	esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(0)
+}

--- a/src/machine/machine_esp32c6_i2c.go
+++ b/src/machine/machine_esp32c6_i2c.go
@@ -1,0 +1,37 @@
+//go:build esp32c6
+
+package machine
+
+import (
+	"device/esp"
+)
+
+// GPIO matrix signal indices for I2C0 on ESP32-C6.
+const (
+	I2CEXT0_SCL_OUT_IDX = 45
+	I2CEXT0_SDA_OUT_IDX = 46
+)
+
+var (
+	I2C0 = &I2C{
+		Bus:     esp.I2C0,
+		funcSCL: I2CEXT0_SCL_OUT_IDX,
+		funcSDA: I2CEXT0_SDA_OUT_IDX,
+		useExt1: false,
+	}
+)
+
+// enableI2C0PeriphClock enables the I2C0 peripheral clock via PCR.
+func enableI2C0PeriphClock() {
+	// Enable the APB/bus clock for the I2C0 registers and pulse the reset.
+	esp.PCR.SetI2C0_CONF_I2C0_CLK_EN(1)
+	esp.PCR.SetI2C0_CONF_I2C0_RST_EN(1)
+	esp.PCR.SetI2C0_CONF_I2C0_RST_EN(0)
+
+	// On the ESP32-C6 the I2C functional (source) clock is gated and selected
+	// in PCR.
+	// Select the XTAL (40 MHz) source and enable the clock gate, otherwise SCL
+	// is never driven and no bytes are clocked onto the bus.
+	esp.PCR.SetI2C_SCLK_CONF_I2C_SCLK_SEL(i2cClkSource)
+	esp.PCR.SetI2C_SCLK_CONF_I2C_SCLK_EN(1)
+}

--- a/src/machine/machine_esp32s3_i2c.go
+++ b/src/machine/machine_esp32s3_i2c.go
@@ -33,3 +33,10 @@ func initI2CExt1Clock() {
 	esp.SYSTEM.SetPERIP_CLK_EN0_I2C_EXT1_CLK_EN(1)
 	esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT1_RST(0)
 }
+
+// enableI2C0PeriphClock enables the I2C0 peripheral clock via SYSTEM.
+func enableI2C0PeriphClock() {
+	esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(1)
+	esp.SYSTEM.SetPERIP_CLK_EN0_I2C_EXT0_CLK_EN(1)
+	esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(0)
+}

--- a/src/machine/machine_esp32xx_i2c.go
+++ b/src/machine/machine_esp32xx_i2c.go
@@ -1,4 +1,4 @@
-//go:build (esp32c3 || esp32s3) && !m5stamp_c3
+//go:build (esp32c3 || esp32c6 || esp32s3) && !m5stamp_c3
 
 package machine
 
@@ -53,9 +53,7 @@ func (i2c *I2C) Configure(config I2CConfig) error {
 //go:inline
 func (i2c *I2C) initClock(config I2CConfig) {
 	if !i2c.useExt1 {
-		esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(1)
-		esp.SYSTEM.SetPERIP_CLK_EN0_I2C_EXT0_CLK_EN(1)
-		esp.SYSTEM.SetPERIP_RST_EN0_I2C_EXT0_RST(0)
+		enableI2C0PeriphClock()
 	} else {
 		initI2CExt1Clock()
 	}


### PR DESCRIPTION
Generalize the shared esp32xx I2C implementation to also cover the ESP32-C6 and add the chip-specific code.

Tested on the Xiao-ESP32C6 using a SSD1306 display.