### PR TITLE
fix: correctly calculate RAM/bss size on ESP32xx

### DIFF
--- a/builder/sizes.go
+++ b/builder/sizes.go
@@ -501,8 +501,9 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 						Align:   section.Addralign,
 						Type:    memoryStack,
 					})
-				} else {
-					// Regular .bss section.
+				} else if section.Flags&elf.SHF_WRITE != 0 {
+					// Regular .bss section. Zero-initialized RAM is always
+					// writable, so require SHF_WRITE here.
 					sections = append(sections, memorySection{
 						Address: section.Addr,
 						Size:    section.Size,
@@ -510,6 +511,11 @@ func loadProgramSize(path string, packagePathMap map[string]string) (*programSiz
 						Type:    memoryBSS,
 					})
 				}
+				// Other (non-writable) SHT_NOBITS sections are address-space
+				// placeholders that occupy no RAM, such as the ESP linker
+				// script's .irom_dummy / .rodata_dummy sections which reserve
+				// the flash-mapped XIP virtual address ranges. They must not be
+				// counted as bss/RAM usage.
 			} else if section.Type == elf.SHT_PROGBITS && section.Flags&elf.SHF_EXECINSTR != 0 {
 				// .text
 				sections = append(sections, memorySection{


### PR DESCRIPTION
This fixes a problem in the builder when calculating the sizes for RAM/bss sections on ESP32xx processors.

A SHT_NOBITS section was unconditionally treated as .bss (RAM) unless it was the stack. The ESP linker scripts emit non-writable SHT_NOBITS sections (.irom_dummy / .rodata_dummy) that merely reserve the flash-mapped XIP virtual address ranges and occupy no RAM. Counting them inflated the reported bss/RAM usage.

Before:
```
$ tinygo flash -target xiao-esp32c3 -size short -monitor ./examples/scan
   code    data     bss |   flash     ram
 460852    9140  182894 |  469992  192034
```

After:
```
$ tinygo flash -target xiao-esp32c3 -size short -monitor ./examples/scan
   code    data     bss |   flash     ram
 460852    9140   59204 |  469992   68344
```