### PR TITLE
runtime, testing: support Goexit, SkipNow, FailNow

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -410,6 +410,7 @@ TEST_PACKAGES_LINUX := \
 	context \
 	crypto/aes \
 	crypto/des \
+	crypto/ecdh \
 	crypto/hmac \
 	debug/dwarf \
 	debug/plan9obj \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -490,10 +490,12 @@ report-stdlib-tests-pass:
 ifeq ($(uname),Darwin)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_DARWIN)
 TEST_IOFS := true
+TEST_ENCODING_XML := true
 endif
 ifeq ($(uname),Linux)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_LINUX)
 TEST_IOFS := true
+TEST_ENCODING_XML := true
 endif
 ifeq ($(OS),Windows_NT)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_WINDOWS)
@@ -509,7 +511,10 @@ TEST_ADDITIONAL_FLAGS ?=
 tinygo-test:
 	@# TestExtraMethods: used by many crypto packages and uses reflect.Type.Method which is not implemented.
 	@# TestParseAndBytesRoundTrip/P256/Generic: needs Goexit to run defers on wasm.
-	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(filter-out encoding/xml,$(TEST_PACKAGES_HOST)) $(TEST_PACKAGES_SLOW)
+ifeq ($(TEST_ENCODING_XML),true)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) -stack-size=16MB encoding/xml
+endif
 	@# io/fs requires os.ReadDir, not yet supported on windows or wasi. It also
 	@# requires a large stack-size. Hence, io/fs is only run conditionally.
 	@# For more details, see the comments on issue #3143.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -508,7 +508,7 @@ TEST_ADDITIONAL_FLAGS ?=
 .PHONY: tinygo-test
 tinygo-test:
 	@# TestExtraMethods: used by many crypto packages and uses reflect.Type.Method which is not implemented.
-	@# TestParseAndBytesRoundTrip/P256/Generic: relies on t.Skip() which is not implemented
+	@# TestParseAndBytesRoundTrip/P256/Generic: needs Goexit to run defers on wasm.
 	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW)
 	@# io/fs requires os.ReadDir, not yet supported on windows or wasi. It also
 	@# requires a large stack-size. Hence, io/fs is only run conditionally.

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,9 +42,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 3765, 307, 0, 2260},
-		{"microbit", "examples/serial", 2824, 368, 8, 2256},
-		{"wioterminal", "examples/pininterrupt", 8041, 1663, 132, 7488},
+		{"hifive1b", "examples/echo", 3771, 309, 0, 2260},
+		{"microbit", "examples/serial", 2832, 368, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 8053, 1663, 132, 7488},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/builder/sizes_test.go
+++ b/builder/sizes_test.go
@@ -42,9 +42,9 @@ func TestBinarySize(t *testing.T) {
 	// This is a small number of very diverse targets that we want to test.
 	tests := []sizeTest{
 		// microcontrollers
-		{"hifive1b", "examples/echo", 3699, 297, 0, 2252},
-		{"microbit", "examples/serial", 2736, 356, 8, 2248},
-		{"wioterminal", "examples/pininterrupt", 7960, 1652, 132, 7480},
+		{"hifive1b", "examples/echo", 3765, 307, 0, 2260},
+		{"microbit", "examples/serial", 2824, 368, 8, 2256},
+		{"wioterminal", "examples/pininterrupt", 8041, 1663, 132, 7488},
 
 		// TODO: also check wasm. Right now this is difficult, because
 		// wasm binaries are run through wasm-opt and therefore the

--- a/compiler/defer.go
+++ b/compiler/defer.go
@@ -116,8 +116,8 @@ func (b *builder) createLandingPad() {
 func (b *builder) createCheckpoint(ptr llvm.Value) llvm.Value {
 	// Construct inline assembly equivalents of setjmp.
 	// The assembly works as follows:
-	//   * All registers (both callee-saved and caller saved) are clobbered
-	//     after the inline assembly returns.
+	//   * Registers are either clobbered or, on 386, saved for longjmp to
+	//     restore if the ABI requires them to survive calls.
 	//   * The assembly stores the address just past the end of the assembly
 	//     into the jump buffer.
 	//   * The return value (eax, rax, r0, etc) is set to zero in the inline
@@ -130,8 +130,12 @@ func (b *builder) createCheckpoint(ptr llvm.Value) llvm.Value {
 		asmString = `
 xorl %eax, %eax
 movl $$1f, 4(%ebx)
+movl %ebx, 8(%ebx)
+movl %esi, 12(%ebx)
+movl %edi, 16(%ebx)
+movl %ebp, 20(%ebx)
 1:`
-		constraints = "={eax},{ebx},~{ebx},~{ecx},~{edx},~{esi},~{edi},~{ebp},~{xmm0},~{xmm1},~{xmm2},~{xmm3},~{xmm4},~{xmm5},~{xmm6},~{xmm7},~{fpsr},~{fpcr},~{flags},~{dirflag},~{memory}"
+		constraints = "={eax},{ebx},~{ecx},~{edx},~{xmm0},~{xmm1},~{xmm2},~{xmm3},~{xmm4},~{xmm5},~{xmm6},~{xmm7},~{fpsr},~{fpcr},~{flags},~{dirflag},~{memory}"
 		// This doesn't include the floating point stack because TinyGo uses
 		// newer floating point instructions.
 	case "x86_64":

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -3,7 +3,7 @@ source_filename = "defer.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv7m-unknown-unknown-eabi"
 
-%runtime.deferFrame = type { ptr, ptr, [0 x ptr], ptr, i8, %runtime._interface, ptr, i1 }
+%runtime.deferFrame = type { ptr, ptr, [0 x ptr], ptr, i8, %runtime._interface, ptr }
 %runtime._interface = type { ptr, ptr }
 
 ; Function Attrs: nounwind
@@ -111,9 +111,9 @@ rundefers.end3:                                   ; preds = %rundefers.loophead6
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare ptr @llvm.stacksave.p0() #2
 
-declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(32), ptr, ptr) #1
+declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(28), ptr, ptr) #1
 
-declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(32), ptr) #1
+declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(28), ptr) #1
 
 ; Function Attrs: nounwind
 define internal void @"main.deferSimple$1"(ptr %context) unnamed_addr #0 {

--- a/compiler/testdata/defer-cortex-m-qemu.ll
+++ b/compiler/testdata/defer-cortex-m-qemu.ll
@@ -3,7 +3,7 @@ source_filename = "defer.go"
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "thumbv7m-unknown-unknown-eabi"
 
-%runtime.deferFrame = type { ptr, ptr, [0 x ptr], ptr, i8, %runtime._interface, ptr }
+%runtime.deferFrame = type { ptr, ptr, [0 x ptr], ptr, i8, %runtime._interface, ptr, i1 }
 %runtime._interface = type { ptr, ptr }
 
 ; Function Attrs: nounwind
@@ -111,9 +111,9 @@ rundefers.end3:                                   ; preds = %rundefers.loophead6
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
 declare ptr @llvm.stacksave.p0() #2
 
-declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(28), ptr, ptr) #1
+declare void @runtime.setupDeferFrame(ptr dereferenceable_or_null(32), ptr, ptr) #1
 
-declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(28), ptr) #1
+declare void @runtime.destroyDeferFrame(ptr dereferenceable_or_null(32), ptr) #1
 
 ; Function Attrs: nounwind
 define internal void @"main.deferSimple$1"(ptr %context) unnamed_addr #0 {

--- a/main_test.go
+++ b/main_test.go
@@ -937,20 +937,36 @@ func TestGoexitCrash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	output := &bytes.Buffer{}
-	_, err = buildAndRun("testdata/goexit.go", config, output, nil, nil, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
-		cmd.Stdout = nil
-		cmd.Stderr = nil
-		data, err := cmd.CombinedOutput()
-		output.Write(data)
-		return err
-	})
-	if err == nil {
-		t.Fatal("program unexpectedly exited successfully")
-	}
-	const want = "panic: panic after Goexit"
-	if !strings.Contains(output.String(), want) {
-		t.Fatalf("output does not contain %q:\n%s", want, output.String())
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{"main", "all goroutines are asleep - deadlock!"},
+		{"deadlock", "all goroutines are asleep - deadlock!"},
+		{"exit", "all goroutines are asleep - deadlock!"},
+		{"main-other", "all goroutines are asleep - deadlock!"},
+		{"in-panic", "all goroutines are asleep - deadlock!"},
+		{"panic", "panic: panic after Goexit"},
+		{"recovered-panic", "all goroutines are asleep - deadlock!"},
+		{"recover-before-panic", "all goroutines are asleep - deadlock!"},
+		{"recover-before-panic-loop", "all goroutines are asleep - deadlock!"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			_, err = buildAndRun("testdata/goexit.go", config, output, []string{tc.name}, nil, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+				cmd.Stdout = nil
+				cmd.Stderr = nil
+				data, err := cmd.CombinedOutput()
+				output.Write(data)
+				return err
+			})
+			if err == nil {
+				t.Fatal("program unexpectedly exited successfully")
+			}
+			if !strings.Contains(output.String(), tc.want) {
+				t.Fatalf("output does not contain %q:\n%s", tc.want, output.String())
+			}
+		})
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -467,6 +467,12 @@ func runTestWithConfig(name string, t *testing.T, options compileopts.Options, c
 		options.Directory = path
 		pkgName = "."
 	}
+	isWebAssembly := strings.HasPrefix(options.Target, "wasi") ||
+		strings.HasPrefix(options.Target, "wasm") ||
+		strings.HasPrefix(options.GOARCH, "wasm")
+	if name == "testing.go" && isWebAssembly {
+		expectedOutputPath = TESTDATA + "/testing-wasm.txt"
+	}
 
 	config, err := builder.NewConfig(&options)
 	if err != nil {
@@ -919,6 +925,32 @@ func checkOutputData(t *testing.T, expectedOutput, actual []byte) {
 	if !bytes.Equal(actual, expectedOutput) {
 		t.Errorf("output did not match (expected %d bytes, got %d bytes):", len(expectedOutput), len(actual))
 		t.Error(string(Diff("expected", expectedOutput, "actual", actual)))
+	}
+}
+
+func TestGoexitCrash(t *testing.T) {
+	t.Parallel()
+
+	options := optionsFromTarget("", sema)
+	config, err := builder.NewConfig(&options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := &bytes.Buffer{}
+	_, err = buildAndRun("testdata/goexit.go", config, output, nil, nil, time.Minute, func(cmd *exec.Cmd, result builder.BuildResult) error {
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		data, err := cmd.CombinedOutput()
+		output.Write(data)
+		return err
+	})
+	if err == nil {
+		t.Fatal("program unexpectedly exited successfully")
+	}
+	const want = "panic: panic after Goexit"
+	if !strings.Contains(output.String(), want) {
+		t.Fatalf("output does not contain %q:\n%s", want, output.String())
 	}
 }
 

--- a/src/internal/task/task_asyncify.go
+++ b/src/internal/task/task_asyncify.go
@@ -51,6 +51,7 @@ type stackState struct {
 // The new goroutine is immediately started.
 func start(fn uintptr, args unsafe.Pointer, stackSize uintptr) {
 	t := &Task{}
+	addLiveTask(t)
 	t.state.initialize(fn, args, stackSize)
 	scheduleTask(t)
 }

--- a/src/internal/task/task_exit.go
+++ b/src/internal/task/task_exit.go
@@ -1,0 +1,42 @@
+//go:build scheduler.tasks || scheduler.asyncify || scheduler.cores
+
+package task
+
+import "sync/atomic"
+
+var (
+	mainTask           *Task
+	liveTasks          uint32
+	mainExitedByGoexit uint32
+)
+
+func addLiveTask(t *Task) {
+	if mainTask == nil {
+		mainTask = t
+	}
+	atomic.AddUint32(&liveTasks, 1)
+}
+
+// Exit exits the current task because runtime.Goexit was called.
+func Exit() {
+	exit(true)
+}
+
+func exit(goexit bool) {
+	t := Current()
+	remaining := atomic.AddUint32(&liveTasks, ^uint32(0))
+	if t == mainTask {
+		if goexit {
+			if remaining == 0 {
+				runtimePanic("all goroutines are asleep - deadlock!")
+			}
+			atomic.StoreUint32(&mainExitedByGoexit, 1)
+		}
+	} else if atomic.LoadUint32(&mainExitedByGoexit) != 0 && remaining == 0 {
+		runtimePanic("all goroutines are asleep - deadlock!")
+	}
+
+	// TODO: explicitly free the stack after switching back to the scheduler.
+	Pause()
+	runtimePanic("unreachable")
+}

--- a/src/internal/task/task_stack.go
+++ b/src/internal/task/task_stack.go
@@ -33,8 +33,7 @@ type state struct {
 
 //export tinygo_task_exit
 func taskExit() {
-	// TODO: explicitly free the stack after switching back to the scheduler.
-	Pause()
+	exit(false)
 }
 
 // initialize the state and prepare to call the specified function with the specified argument bundle.
@@ -73,6 +72,7 @@ var startTask [0]uint8
 // The new goroutine is scheduled to run later.
 func start(fn uintptr, args unsafe.Pointer, stackSize uintptr) {
 	t := &Task{}
+	addLiveTask(t)
 	t.state.initialize(fn, args, stackSize)
 	scheduleTask(t)
 }

--- a/src/internal/task/task_threads.c
+++ b/src/internal/task/task_threads.c
@@ -145,6 +145,11 @@ void* tinygo_task_current(void) {
     return current_task;
 }
 
+// Exit the current thread.
+void tinygo_task_exit(void) {
+    pthread_exit(NULL);
+}
+
 // Send a signal to cause the task to pause for the GC mark phase.
 void tinygo_task_send_gc_signal(pthread_t thread) {
     pthread_kill(thread, taskPauseSignal);

--- a/src/internal/task/task_threads.go
+++ b/src/internal/task/task_threads.go
@@ -43,7 +43,9 @@ var mainTask Task
 
 // Queue of tasks (see QueueNext) that currently exist in the program.
 var activeTasks = &mainTask
+var activeTaskCount uint32 = 1
 var activeTaskLock PMutex
+var mainExitedByGoexit bool
 
 func OnSystemStack() bool {
 	runtimePanic("todo: task.OnSystemStack")
@@ -95,9 +97,6 @@ func (t *Task) Resume() {
 	t.state.pauseSem.Post()
 }
 
-// otherGoroutines is the total number of live goroutines minus one.
-var otherGoroutines uint32
-
 // Start a new OS thread.
 func start(fn uintptr, args unsafe.Pointer, stackSize uintptr) {
 	t := &Task{}
@@ -117,7 +116,7 @@ func start(fn uintptr, args unsafe.Pointer, stackSize uintptr) {
 	}
 	t.state.QueueNext = activeTasks
 	activeTasks = t
-	otherGoroutines++
+	activeTaskCount++
 	activeTaskLock.Unlock()
 }
 
@@ -127,6 +126,12 @@ func taskExited(t *Task) {
 		println("*** exit:", t.state.id)
 	}
 
+	if exit(t) {
+		runtimePanic("all goroutines are asleep - deadlock!")
+	}
+}
+
+func exit(t *Task) bool {
 	// Remove from the queue.
 	// TODO: this can be made more efficient by using a doubly linked list.
 	activeTaskLock.Lock()
@@ -135,16 +140,46 @@ func taskExited(t *Task) {
 		if *q == t {
 			*q = t.state.QueueNext
 			found = true
+			activeTaskCount--
 			break
 		}
 	}
-	otherGoroutines--
+	deadlocked := mainExitedByGoexit && activeTaskCount == 0
 	activeTaskLock.Unlock()
 
 	// Sanity check.
 	if !found {
 		runtimePanic("taskExited failed")
 	}
+	return deadlocked
+}
+
+func otherTasks(current *Task) uint32 {
+	if activeTaskCount == 0 {
+		return 0
+	}
+	return activeTaskCount - 1
+}
+
+// Exit exits the current task. If this is the main task and there are no other
+// goroutines, it reports a deadlock.
+func Exit() {
+	t := Current()
+	if t == &mainTask {
+		activeTaskLock.Lock()
+		noOtherTasks := otherTasks(t) == 0
+		if !noOtherTasks {
+			mainExitedByGoexit = true
+		}
+		activeTaskLock.Unlock()
+		if noOtherTasks {
+			runtimePanic("all goroutines are asleep - deadlock!")
+		}
+	}
+	if exit(t) {
+		runtimePanic("all goroutines are asleep - deadlock!")
+	}
+	tinygo_task_exit()
 }
 
 // scanWaitGroup is used to wait on until all threads have finished the current state transition.
@@ -206,7 +241,7 @@ func GCStopWorldAndScan() {
 		gcState.Store(gcStateStopped)
 
 		// Set the number of threads to wait for.
-		scanWaitGroup = initWaitGroup(otherGoroutines)
+		scanWaitGroup = initWaitGroup(otherTasks(current))
 
 		// Pause all other threads.
 		for t := activeTasks; t != nil; t = t.state.QueueNext {
@@ -242,7 +277,7 @@ func GCResumeWorld() {
 	}
 
 	// Set the wait group to track resume progress.
-	scanWaitGroup = initWaitGroup(otherGoroutines)
+	scanWaitGroup = initWaitGroup(otherTasks(Current()))
 
 	// Set the state to resumed.
 	gcState.Store(gcStateResumed)
@@ -303,6 +338,9 @@ func tinygo_task_init(t *Task, thread *threadID, numCPU *int32)
 //
 //go:linkname tinygo_task_start tinygo_task_start
 func tinygo_task_start(fn uintptr, args unsafe.Pointer, t *Task, thread *threadID, stackTop *uintptr, stackSize uintptr) int32
+
+//go:linkname tinygo_task_exit tinygo_task_exit
+func tinygo_task_exit()
 
 // Pause the thread by sending it a signal.
 //

--- a/src/runtime/arch_386.go
+++ b/src/runtime/arch_386.go
@@ -5,7 +5,7 @@ const GOARCH = "386"
 // The bitness of the CPU (e.g. 8, 32, 64).
 const TargetBits = 32
 
-const deferExtraRegs = 0
+const deferExtraRegs = 4
 
 const callInstSize = 5 // "call someFunction" is 5 bytes
 

--- a/src/runtime/asm_386.S
+++ b/src/runtime/asm_386.S
@@ -43,6 +43,10 @@ tinygo_longjmp:
     // Note: the code we jump to assumes eax is set to a non-zero value if we
     // jump from here.
     movl 4(%esp), %eax
+    movl 8(%eax), %ebx
+    movl 12(%eax), %esi
+    movl 16(%eax), %edi
+    movl 20(%eax), %ebp
     movl 0(%eax), %esp // jumpSP
     movl 4(%eax), %eax // jumpPC (stash in volatile register)
     jmpl *%eax

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -41,6 +41,7 @@ type deferFrame struct {
 	Panicking  panicState                     // not panicking, panicking, or in Goexit
 	PanicValue interface{}                    // panic value, might be nil for panic(nil) for example
 	DeferPtr   unsafe.Pointer                 // head of the stack-allocated defer list
+	Goexit     bool                           // whether Goexit is still pending after a recovered deferred panic
 }
 
 type panicState uint8
@@ -57,7 +58,7 @@ func _panic(message interface{}) {
 }
 
 func panicOrGoexit(message interface{}, panicking panicState) {
-	if panicStrategy() == tinygo.PanicStrategyTrap {
+	if panicking != panicGoexit && panicStrategy() == tinygo.PanicStrategyTrap {
 		trap()
 	}
 	// Note: recover is not supported inside interrupts.
@@ -65,6 +66,9 @@ func panicOrGoexit(message interface{}, panicking panicState) {
 	if supportsRecover() && !interrupt.In() {
 		frame := (*deferFrame)(task.Current().DeferFrame)
 		if frame != nil {
+			if panicking == panicGoexit {
+				frame.Goexit = true
+			}
 			frame.PanicValue = message
 			frame.Panicking = panicking
 			tinygo_longjmp(frame)
@@ -138,6 +142,7 @@ func setupDeferFrame(frame *deferFrame, jumpSP unsafe.Pointer) {
 	frame.JumpSP = jumpSP
 	frame.Panicking = panicFalse
 	frame.DeferPtr = nil
+	frame.Goexit = false
 	currentTask.DeferFrame = unsafe.Pointer(frame)
 }
 
@@ -153,6 +158,11 @@ func destroyDeferFrame(frame *deferFrame) {
 		// We're still panicking!
 		// Re-raise the panic now.
 		panicOrGoexit(frame.PanicValue, frame.Panicking)
+	}
+	if frame.Goexit {
+		// A deferred function panicked during Goexit, and that panic was
+		// recovered. Continue the original Goexit instead of returning.
+		panicOrGoexit(nil, panicGoexit)
 	}
 }
 

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -38,17 +38,15 @@ type deferFrame struct {
 	JumpPC     unsafe.Pointer                 // pc to return to
 	ExtraRegs  [deferExtraRegs]unsafe.Pointer // extra registers (depending on the architecture)
 	Previous   *deferFrame                    // previous recover buffer pointer
-	Panicking  panicState                     // not panicking, panicking, or in Goexit
+	Panicking  panicState                     // panic/Goexit state
 	PanicValue interface{}                    // panic value, might be nil for panic(nil) for example
 	DeferPtr   unsafe.Pointer                 // head of the stack-allocated defer list
-	Goexit     bool                           // whether Goexit is still pending after a recovered deferred panic
 }
 
 type panicState uint8
 
 const (
-	panicFalse panicState = iota
-	panicTrue
+	panicTrue panicState = 1 << iota
 	panicGoexit
 )
 
@@ -66,10 +64,10 @@ func panicOrGoexit(message interface{}, panicking panicState) {
 	if supportsRecover() && !interrupt.In() {
 		frame := (*deferFrame)(task.Current().DeferFrame)
 		if frame != nil {
-			if panicking == panicGoexit {
-				frame.Goexit = true
-			}
 			frame.PanicValue = message
+			if panicking&panicTrue != 0 {
+				panicking |= frame.Panicking & panicGoexit
+			}
 			frame.Panicking = panicking
 			tinygo_longjmp(frame)
 			// unreachable
@@ -103,7 +101,7 @@ func runtimePanicAt(addr unsafe.Pointer, msg string) {
 			// Use the normal panic mechanism so that this runtime error
 			// can be recovered with recover().
 			frame.PanicValue = plainError(msg)
-			frame.Panicking = panicTrue
+			frame.Panicking = panicTrue | (frame.Panicking & panicGoexit)
 			tinygo_longjmp(frame)
 			// unreachable
 		}
@@ -140,9 +138,8 @@ func setupDeferFrame(frame *deferFrame, jumpSP unsafe.Pointer) {
 	currentTask := task.Current()
 	frame.Previous = (*deferFrame)(currentTask.DeferFrame)
 	frame.JumpSP = jumpSP
-	frame.Panicking = panicFalse
+	frame.Panicking = 0
 	frame.DeferPtr = nil
-	frame.Goexit = false
 	currentTask.DeferFrame = unsafe.Pointer(frame)
 }
 
@@ -154,12 +151,12 @@ func setupDeferFrame(frame *deferFrame, jumpSP unsafe.Pointer) {
 //go:nobounds
 func destroyDeferFrame(frame *deferFrame) {
 	task.Current().DeferFrame = unsafe.Pointer(frame.Previous)
-	if frame.Panicking != panicFalse {
+	if frame.Panicking&panicTrue != 0 {
 		// We're still panicking!
 		// Re-raise the panic now.
-		panicOrGoexit(frame.PanicValue, frame.Panicking)
+		panicOrGoexit(frame.PanicValue, panicTrue)
 	}
-	if frame.Goexit {
+	if frame.Panicking&panicGoexit != 0 {
 		// A deferred function panicked during Goexit, and that panic was
 		// recovered. Continue the original Goexit instead of returning.
 		panicOrGoexit(nil, panicGoexit)
@@ -194,15 +191,15 @@ func _recover(useParentFrame bool) interface{} {
 		// already), but instead from the previous frame.
 		frame = frame.Previous
 	}
-	if frame != nil && frame.Panicking != panicFalse {
-		if frame.Panicking == panicGoexit {
+	if frame != nil && frame.Panicking != 0 {
+		if frame.Panicking&panicTrue == 0 {
 			// Special value that indicates we're exiting the goroutine using
 			// Goexit(). Therefore, make this recover call a no-op.
 			return nil
 		}
 		// Only the first call to recover returns the panic value. It also stops
 		// the panicking sequence, hence setting panicking to false.
-		frame.Panicking = panicFalse
+		frame.Panicking &^= panicTrue
 		return frame.PanicValue
 	}
 	// Not panicking, so return a nil interface.

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -78,7 +78,7 @@ func panicOrGoexit(message interface{}, panicking panicState) {
 	if panicking == panicGoexit {
 		// Call to Goexit() instead of a panic.
 		// Exit the goroutine instead of printing a panic message.
-		deadlock()
+		goexit()
 	}
 	printstring("panic: ")
 	printitf(message)

--- a/src/runtime/runtime_windows.go
+++ b/src/runtime/runtime_windows.go
@@ -2,9 +2,6 @@ package runtime
 
 import "unsafe"
 
-//export abort
-func abort()
-
 //export exit
 func libc_exit(code int)
 
@@ -130,6 +127,11 @@ func os_runtime_args() []string {
 
 func putchar(c byte) {
 	libc_putchar(int(c))
+}
+
+func abort() {
+	libc_exit(1)
+	trap()
 }
 
 var heapSize uintptr = 128 * 1024 // small amount to start

--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -54,6 +54,10 @@ func deadlock() {
 	panic("unreachable")
 }
 
+func goexit() {
+	task.Exit()
+}
+
 // Add this task to the end of the run queue.
 func scheduleTask(t *task.Task) {
 	runqueue.Push(t)

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -32,6 +32,10 @@ func deadlock() {
 	trap()
 }
 
+func goexit() {
+	task.Exit()
+}
+
 // Mark the given task as ready to resume.
 // This is allowed even if the task isn't paused yet, but will pause soon.
 func scheduleTask(t *task.Task) {

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -42,6 +42,10 @@ func deadlock() {
 	runtimePanic("all goroutines are asleep - deadlock!")
 }
 
+func goexit() {
+	deadlock()
+}
+
 func scheduleTask(t *task.Task) {
 	// Pause() will panic, so this should not be reachable.
 }

--- a/src/runtime/scheduler_threads.go
+++ b/src/runtime/scheduler_threads.go
@@ -40,8 +40,11 @@ func sleep(duration int64) {
 }
 
 func deadlock() {
-	// TODO: exit the thread via pthread_exit.
 	task.Pause()
+}
+
+func goexit() {
+	task.Exit()
 }
 
 func scheduleTask(t *task.Task) {

--- a/src/testing/benchmark.go
+++ b/src/testing/benchmark.go
@@ -193,7 +193,12 @@ func (b *B) run1() bool {
 			ctx.maxLen = n + 8 // Add additional slack to avoid too many jumps in size.
 		}
 	}
-	b.runN(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.runN(1)
+	}()
+	<-done
 	return !b.hasSub
 }
 
@@ -209,8 +214,12 @@ func (b *B) run() {
 }
 
 func (b *B) doBench() BenchmarkResult {
-	// in upstream, this uses a goroutine
-	b.launch()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.launch()
+	}()
+	<-done
 	return b.result
 }
 

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -214,9 +214,8 @@ func (c *common) Failed() bool {
 // current goroutine).
 func (c *common) FailNow() {
 	c.Fail()
-
 	c.finished = true
-	c.Error("FailNow is incomplete, requires runtime.Goexit()")
+	runtime.Goexit()
 }
 
 // log generates the output.
@@ -288,7 +287,7 @@ func (c *common) Skipf(format string, args ...interface{}) {
 func (c *common) SkipNow() {
 	c.skip()
 	c.finished = true
-	c.Error("SkipNow is incomplete, requires runtime.Goexit()")
+	runtime.Goexit()
 }
 
 func (c *common) skip() {
@@ -480,19 +479,19 @@ type InternalTest struct {
 }
 
 func tRunner(t *T, fn func(t *T)) {
+	t.start = time.Now()
 	defer func() {
+		t.duration += time.Since(t.start) // TODO: capture cleanup time, too.
 		t.runCleanup()
+		t.report() // Report after all subtests have finished.
+		if t.parent != nil && !t.hasSub {
+			t.setRan()
+		}
 	}()
 
 	// Run the test.
-	t.start = time.Now()
 	fn(t)
-	t.duration += time.Since(t.start) // TODO: capture cleanup time, too.
-
-	t.report() // Report after all subtests have finished.
-	if t.parent != nil && !t.hasSub {
-		t.setRan()
-	}
+	t.finished = true
 }
 
 // Run runs f as a subtest of t called name. It waits until the subtest is finished
@@ -524,7 +523,12 @@ func (t *T) Run(name string, f func(t *T)) bool {
 		fmt.Fprintf(t.output, "=== RUN   %s\n", sub.name)
 	}
 
-	tRunner(&sub, f)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tRunner(&sub, f)
+	}()
+	<-done
 	return !sub.failed
 }
 

--- a/testdata/goexit.go
+++ b/testdata/goexit.go
@@ -1,0 +1,10 @@
+package main
+
+import "runtime"
+
+func main() {
+	defer func() {
+		panic("panic after Goexit")
+	}()
+	runtime.Goexit()
+}

--- a/testdata/goexit.go
+++ b/testdata/goexit.go
@@ -1,10 +1,80 @@
 package main
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+	"time"
+)
 
 func main() {
-	defer func() {
-		panic("panic after Goexit")
-	}()
-	runtime.Goexit()
+	switch os.Args[1] {
+	case "main":
+		runtime.Goexit()
+	case "deadlock":
+		f := func() {
+			for i := 0; i < 10; i++ {
+			}
+		}
+		go f()
+		go f()
+		runtime.Goexit()
+	case "exit":
+		go func() {
+			time.Sleep(time.Millisecond)
+		}()
+		i := 0
+		runtime.SetFinalizer(&i, func(p *int) {})
+		runtime.GC()
+		runtime.Goexit()
+	case "main-other":
+		go func() {
+			println("other goroutine ran")
+		}()
+		runtime.Goexit()
+	case "in-panic":
+		go func() {
+			defer func() {
+				runtime.Goexit()
+			}()
+			panic("panic before Goexit")
+		}()
+		runtime.Goexit()
+	case "panic":
+		defer func() {
+			panic("panic after Goexit")
+		}()
+		runtime.Goexit()
+	case "recovered-panic":
+		defer func() {
+			defer func() {
+				recover()
+			}()
+			panic("recovered panic after Goexit")
+		}()
+		runtime.Goexit()
+	case "recover-before-panic":
+		defer func() {
+			if recover() == nil {
+				panic("bad recover")
+			}
+		}()
+		defer func() {
+			panic("panic during Goexit")
+		}()
+		runtime.Goexit()
+	case "recover-before-panic-loop":
+		for i := 0; i < 2; i++ {
+			defer func() {
+			}()
+		}
+		defer func() {
+			if recover() == nil {
+				panic("bad recover")
+			}
+		}()
+		defer func() {
+			panic("panic during Goexit")
+		}()
+		runtime.Goexit()
+	}
 }

--- a/testdata/recover.go
+++ b/testdata/recover.go
@@ -158,6 +158,71 @@ func runtimeGoexit() {
 		runtime.Goexit()
 	}()
 	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runtimeGoexitRecoveredPanic()
+		println("unreachable after Goexit helper")
+	}()
+	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runtimeGoexitNestedRecoveredPanic()
+		println("unreachable after nested Goexit helper")
+	}()
+	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runtimeGoexitLoopDefers()
+		println("unreachable after loop Goexit helper")
+	}()
+	wg.Wait()
+}
+
+func runtimeGoexitRecoveredPanic() {
+	defer func() {
+		if r := recover(); r != nil {
+			printitf("Goexit recovered deferred panic:", r)
+		}
+	}()
+	defer func() {
+		panic("panic during Goexit")
+	}()
+	runtime.Goexit()
+}
+
+func runtimeGoexitNestedRecoveredPanic() {
+	defer func() {
+		defer func() {
+			if r := recover(); r != nil {
+				printitf("Goexit nested recovered deferred panic:", r)
+			}
+		}()
+		panic("nested panic during Goexit")
+	}()
+	runtime.Goexit()
+}
+
+func runtimeGoexitLoopDefers() {
+	for i := 0; i < 2; i++ {
+		defer func() {
+			println("Goexit loop defer")
+		}()
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			printitf("Goexit loop recovered deferred panic:", r)
+		}
+	}()
+	defer func() {
+		panic("loop panic during Goexit")
+	}()
+	runtime.Goexit()
 }
 
 // Test that a repanic inside a deferred function propagates correctly

--- a/testdata/recover.txt
+++ b/testdata/recover.txt
@@ -33,6 +33,11 @@ indirect recover returned: indirect panic
 
 # runtime.Goexit
 Goexit deferred function, recover is nil: true
+Goexit recovered deferred panic: panic during Goexit
+Goexit nested recovered deferred panic: nested panic during Goexit
+Goexit loop recovered deferred panic: loop panic during Goexit
+Goexit loop defer
+Goexit loop defer
 
 # repanic
 inner, repanicking

--- a/testdata/testing-wasm.txt
+++ b/testdata/testing-wasm.txt
@@ -11,8 +11,6 @@
             c
         failed
         after failed
-    --- FAIL: TestBar/Bar4 (0.00s)
-        fatal
     log Bar end
 --- FAIL: TestAllLowercase (0.00s)
     --- FAIL: TestAllLowercase/BETA (0.00s)

--- a/testdata/testing.go
+++ b/testdata/testing.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -25,11 +26,21 @@ func TestBar(t *testing.T) {
 		t.Log("after failed")
 	})
 	t.Run("Bar3", func(t *testing.T) {})
+	if runtime.GOARCH != "wasm" {
+		t.Run("Bar4", func(t *testing.T) {
+			t.Fatal("fatal")
+			t.Log("after fatal")
+		})
+		t.Run("Bar5", func(t *testing.T) {
+			t.SkipNow()
+			t.Error("after skip")
+		})
+	}
 	t.Log("log Bar end")
 }
 
 func TestAllLowercase(t *testing.T) {
-	names := []string {
+	names := []string{
 		"alpha",
 		"BETA",
 		"gamma",


### PR DESCRIPTION
In #5438 I expanded out panic/recover behavior to cover a lot of (all?) cases.

I forgot about `Goexit`.

This PR adds support for it, including the work to make it exit pthreads.