### PR TITLE
runtime: add fast path for non-blocking single-state select

### DIFF
--- a/compiler/channel.go
+++ b/compiler/channel.go
@@ -80,6 +80,108 @@ func (b *builder) createChanClose(ch llvm.Value) {
 	b.createRuntimeInvoke("chanClose", []llvm.Value{ch}, "")
 }
 
+// createNonBlockingSelect emits IR for a non-blocking select with one channel case.
+func (b *builder) createNonBlockingSelect(expr *ssa.Select) llvm.Value {
+	state := expr.States[0]
+	ch := b.getValue(state.Chan, state.Pos)
+
+	resultType := b.ctx.StructType([]llvm.Type{
+		b.ctx.Int32Type(),
+		b.ctx.Int1Type(),
+	}, false)
+
+	var selected llvm.Value
+	selectOk := llvm.ConstInt(b.ctx.Int1Type(), 1, false)
+
+	switch state.Dir {
+	case types.SendOnly:
+		sendValue := b.getValue(state.Send, state.Pos)
+		valueType := b.getLLVMType(state.Send.Type())
+		isZeroSize := b.targetData.TypeAllocSize(valueType) == 0
+
+		valuePtr := llvm.ConstNull(b.dataPtrType)
+		var valueAlloca, valueAllocaSize llvm.Value
+
+		if !isZeroSize {
+			valueAlloca, valueAllocaSize = b.createTemporaryAlloca(
+				valueType,
+				"select.send.value",
+			)
+			b.CreateStore(sendValue, valueAlloca)
+			valuePtr = valueAlloca
+		}
+
+		selected = b.createRuntimeCall(
+			"chanTrySend",
+			[]llvm.Value{ch, valuePtr},
+			"select.sent",
+		)
+
+		if !isZeroSize {
+			b.emitLifetimeEnd(valueAlloca, valueAllocaSize)
+		}
+
+	case types.RecvOnly:
+		valueType := b.getLLVMType(
+			state.Chan.Type().Underlying().(*types.Chan).Elem(),
+		)
+		isZeroSize := b.targetData.TypeAllocSize(valueType) == 0
+
+		// getChanSelectResult loads the received value later.
+		recvbuf := llvm.Undef(b.dataPtrType)
+		runtimeRecvbuf := llvm.ConstNull(b.dataPtrType)
+
+		if !isZeroSize {
+			recvbuf, _ = b.createTemporaryAlloca(
+				valueType,
+				"select.recvbuf",
+			)
+			runtimeRecvbuf = recvbuf
+		}
+		results := b.createRuntimeCall(
+			"chanTryRecv",
+			[]llvm.Value{ch, runtimeRecvbuf},
+			"select.recv",
+		)
+
+		selected = b.CreateExtractValue(results, 0, "select.received")
+		recvOk := b.CreateExtractValue(results, 1, "select.recv.ok")
+		selectOk = b.CreateSelect(
+			selected,
+			recvOk,
+			llvm.ConstInt(b.ctx.Int1Type(), 1, false),
+			"select.ok",
+		)
+
+		if b.selectRecvBuf == nil {
+			b.selectRecvBuf = make(map[*ssa.Select]llvm.Value)
+		}
+		b.selectRecvBuf[expr] = recvbuf
+
+	default:
+		panic("unreachable")
+	}
+
+	selectedIndex := llvm.ConstInt(b.ctx.Int32Type(), 0, false)
+	defaultIndex := llvm.ConstInt(
+		b.ctx.Int32Type(),
+		math.MaxUint32,
+		false,
+	)
+
+	selectIndex := b.CreateSelect(
+		selected,
+		selectedIndex,
+		defaultIndex,
+		"select.index",
+	)
+
+	result := llvm.Undef(resultType)
+	result = b.CreateInsertValue(result, selectIndex, 0, "")
+	result = b.CreateInsertValue(result, selectOk, 1, "")
+	return result
+}
+
 // createSelect emits all IR necessary for a select statements. That's a
 // non-trivial amount of code because select is very complex to implement.
 func (b *builder) createSelect(expr *ssa.Select) llvm.Value {
@@ -100,6 +202,10 @@ func (b *builder) createSelect(expr *ssa.Select) llvm.Value {
 			retval = b.CreateInsertValue(retval, llvm.ConstInt(b.intType, 0xffffffffffffffff, true), 0, "")
 			return retval // {-1, false}
 		}
+	}
+
+	if !expr.Blocking && len(expr.States) == 1 {
+		return b.createNonBlockingSelect(expr)
 	}
 
 	const maxSelectStates = math.MaxUint32 >> 2

--- a/compiler/testdata/channel.go
+++ b/compiler/testdata/channel.go
@@ -23,3 +23,48 @@ func selectZeroRecv(ch1 chan int, ch2 chan struct{}) {
 	default:
 	}
 }
+
+func selectNonBlockingSend(ch chan int, value int) bool {
+	select {
+	case ch <- value:
+		return true
+	default:
+		return false
+	}
+}
+
+func selectNonBlockingRecv(ch chan int) (int, bool, bool) {
+	select {
+	case value, ok := <-ch:
+		return value, ok, true
+	default:
+		return 0, false, false
+	}
+}
+
+func selectNonBlockingZeroSend(ch chan struct{}) bool {
+	select {
+	case ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func selectNonBlockingZeroRecv(ch chan struct{}) (bool, bool) {
+	select {
+	case _, ok := <-ch:
+		return ok, true
+	default:
+		return false, false
+	}
+}
+
+func selectBlocking(ch1, ch2 chan int) (int, bool) {
+	select {
+	case value, ok := <-ch1:
+		return value, ok
+	case value, ok := <-ch2:
+		return value, ok
+	}
+}

--- a/compiler/testdata/channel.ll
+++ b/compiler/testdata/channel.ll
@@ -3,10 +3,16 @@ source_filename = "channel.go"
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-wasi"
 
+%runtime._string = type { ptr, i32 }
 %runtime.channelOp = type { ptr, ptr, i32, ptr }
 %runtime.chanSelectState = type { ptr, ptr }
 
-declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+@"main$string" = internal unnamed_addr constant [31 x i8] c"blocking select matched no case", align 1
+@"main$pack" = internal unnamed_addr constant { %runtime._string } { %runtime._string { ptr @"main$string", i32 31 } }
+@"reflect/types.type:basic:string" = linkonce_odr constant { i8, ptr } { i8 81, ptr @"reflect/types.type:pointer:basic:string" }, align 4
+@"reflect/types.type:pointer:basic:string" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:basic:string" }, align 4
+
+declare void @runtime.trackPointer(ptr readonly captures(none), ptr, ptr) #0
 
 ; Function Attrs: nounwind
 define hidden void @main.init(ptr %context) unnamed_addr #1 {
@@ -19,33 +25,33 @@ define hidden void @main.chanIntSend(ptr dereferenceable_or_null(36) %ch, ptr %c
 entry:
   %chan.op = alloca %runtime.channelOp, align 8
   %chan.value = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.value)
   store i32 3, ptr %chan.value, align 4
-  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.op)
   call void @runtime.chanSend(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.op, ptr undef) #3
-  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
-  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.op)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.value)
   ret void
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #2
+declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 
 declare void @runtime.chanSend(ptr dereferenceable_or_null(36), ptr, ptr dereferenceable_or_null(16), ptr) #0
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #2
+declare void @llvm.lifetime.end.p0(ptr captures(none)) #2
 
 ; Function Attrs: nounwind
 define hidden void @main.chanIntRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
 entry:
   %chan.op = alloca %runtime.channelOp, align 8
   %chan.value = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %chan.value)
-  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.value)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.op)
   %0 = call i1 @runtime.chanRecv(ptr %ch, ptr nonnull %chan.value, ptr nonnull %chan.op, ptr undef) #3
-  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %chan.value)
-  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.value)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.op)
   ret void
 }
 
@@ -55,9 +61,9 @@ declare i1 @runtime.chanRecv(ptr dereferenceable_or_null(36), ptr, ptr dereferen
 define hidden void @main.chanZeroSend(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
 entry:
   %chan.op = alloca %runtime.channelOp, align 8
-  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.op)
   call void @runtime.chanSend(ptr %ch, ptr null, ptr nonnull %chan.op, ptr undef) #3
-  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.op)
   ret void
 }
 
@@ -65,9 +71,9 @@ entry:
 define hidden void @main.chanZeroRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
 entry:
   %chan.op = alloca %runtime.channelOp, align 8
-  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.start.p0(ptr nonnull %chan.op)
   %0 = call i1 @runtime.chanRecv(ptr %ch, ptr null, ptr nonnull %chan.op, ptr undef) #3
-  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %chan.op)
+  call void @llvm.lifetime.end.p0(ptr nonnull %chan.op)
   ret void
 }
 
@@ -77,7 +83,7 @@ entry:
   %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
   %select.send.value = alloca i32, align 4
   store i32 1, ptr %select.send.value, align 4
-  call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %select.states.alloca)
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.states.alloca)
   store ptr %ch1, ptr %select.states.alloca, align 4
   %select.states.alloca.repack1 = getelementptr inbounds nuw i8, ptr %select.states.alloca, i32 4
   store ptr %select.send.value, ptr %select.states.alloca.repack1, align 4
@@ -86,7 +92,7 @@ entry:
   %.repack3 = getelementptr inbounds nuw i8, ptr %select.states.alloca, i32 12
   store ptr null, ptr %.repack3, align 4
   %select.result = call { i32, i1 } @runtime.chanSelect(ptr undef, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr null, i32 0, i32 0, ptr undef) #3
-  call void @llvm.lifetime.end.p0(i64 16, ptr nonnull %select.states.alloca)
+  call void @llvm.lifetime.end.p0(ptr nonnull %select.states.alloca)
   %1 = extractvalue { i32, i1 } %select.result, 0
   %2 = icmp eq i32 %1, 0
   br i1 %2, label %select.done, label %select.next
@@ -103,6 +109,132 @@ select.body:                                      ; preds = %select.next
 }
 
 declare { i32, i1 } @runtime.chanSelect(ptr, ptr, i32, i32, ptr, i32, i32, ptr) #0
+
+; Function Attrs: nounwind
+define hidden i1 @main.selectNonBlockingSend(ptr dereferenceable_or_null(36) %ch, i32 %value, ptr %context) unnamed_addr #1 {
+entry:
+  %select.send.value = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.send.value)
+  store i32 %value, ptr %select.send.value, align 4
+  %select.sent = call i1 @runtime.chanTrySend(ptr %ch, ptr nonnull %select.send.value, ptr undef) #3
+  call void @llvm.lifetime.end.p0(ptr nonnull %select.send.value)
+  br i1 %select.sent, label %select.body, label %select.next
+
+select.body:                                      ; preds = %entry
+  ret i1 true
+
+select.next:                                      ; preds = %entry
+  ret i1 false
+}
+
+declare i1 @runtime.chanTrySend(ptr dereferenceable_or_null(36), ptr, ptr) #0
+
+; Function Attrs: nounwind
+define hidden { i32, i1, i1 } @main.selectNonBlockingRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
+entry:
+  %select.recvbuf = alloca i32, align 4
+  %stackalloc = alloca i8, align 1
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.recvbuf)
+  %select.recv = call { i1, i1 } @runtime.chanTryRecv(ptr %ch, ptr nonnull %select.recvbuf, ptr undef) #3
+  %select.received = extractvalue { i1, i1 } %select.recv, 0
+  call void @runtime.trackPointer(ptr nonnull %select.recvbuf, ptr nonnull %stackalloc, ptr undef) #3
+  br i1 %select.received, label %select.body, label %select.next
+
+select.body:                                      ; preds = %entry
+  %select.recv.ok = extractvalue { i1, i1 } %select.recv, 1
+  %select.received1 = load i32, ptr %select.recvbuf, align 4
+  %0 = insertvalue { i32, i1, i1 } zeroinitializer, i32 %select.received1, 0
+  %1 = insertvalue { i32, i1, i1 } %0, i1 %select.recv.ok, 1
+  %2 = insertvalue { i32, i1, i1 } %1, i1 true, 2
+  ret { i32, i1, i1 } %2
+
+select.next:                                      ; preds = %entry
+  ret { i32, i1, i1 } zeroinitializer
+}
+
+declare { i1, i1 } @runtime.chanTryRecv(ptr dereferenceable_or_null(36), ptr, ptr) #0
+
+; Function Attrs: nounwind
+define hidden i1 @main.selectNonBlockingZeroSend(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
+entry:
+  %select.sent = call i1 @runtime.chanTrySend(ptr %ch, ptr null, ptr undef) #3
+  br i1 %select.sent, label %select.body, label %select.next
+
+select.body:                                      ; preds = %entry
+  ret i1 true
+
+select.next:                                      ; preds = %entry
+  ret i1 false
+}
+
+; Function Attrs: nounwind
+define hidden { i1, i1 } @main.selectNonBlockingZeroRecv(ptr dereferenceable_or_null(36) %ch, ptr %context) unnamed_addr #1 {
+entry:
+  %select.recv = call { i1, i1 } @runtime.chanTryRecv(ptr %ch, ptr null, ptr undef) #3
+  %select.received = extractvalue { i1, i1 } %select.recv, 0
+  br i1 %select.received, label %select.body, label %select.next
+
+select.body:                                      ; preds = %entry
+  %select.recv.ok = extractvalue { i1, i1 } %select.recv, 1
+  %0 = insertvalue { i1, i1 } zeroinitializer, i1 %select.recv.ok, 0
+  %1 = insertvalue { i1, i1 } %0, i1 true, 1
+  ret { i1, i1 } %1
+
+select.next:                                      ; preds = %entry
+  ret { i1, i1 } zeroinitializer
+}
+
+; Function Attrs: nounwind
+define hidden { i32, i1 } @main.selectBlocking(ptr dereferenceable_or_null(36) %ch1, ptr dereferenceable_or_null(36) %ch2, ptr %context) unnamed_addr #1 {
+entry:
+  %select.block.alloca = alloca [2 x %runtime.channelOp], align 8
+  %select.states.alloca = alloca [2 x %runtime.chanSelectState], align 8
+  %select.recvbuf.alloca = alloca [4 x i8], align 4
+  %stackalloc = alloca i8, align 1
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.recvbuf.alloca)
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.states.alloca)
+  store ptr %ch1, ptr %select.states.alloca, align 4
+  %select.states.alloca.repack4 = getelementptr inbounds nuw i8, ptr %select.states.alloca, i32 4
+  store ptr null, ptr %select.states.alloca.repack4, align 4
+  %0 = getelementptr inbounds nuw i8, ptr %select.states.alloca, i32 8
+  store ptr %ch2, ptr %0, align 4
+  %.repack6 = getelementptr inbounds nuw i8, ptr %select.states.alloca, i32 12
+  store ptr null, ptr %.repack6, align 4
+  call void @llvm.lifetime.start.p0(ptr nonnull %select.block.alloca)
+  %select.result = call { i32, i1 } @runtime.chanSelect(ptr nonnull %select.recvbuf.alloca, ptr nonnull %select.states.alloca, i32 2, i32 2, ptr nonnull %select.block.alloca, i32 2, i32 2, ptr undef) #3
+  call void @llvm.lifetime.end.p0(ptr nonnull %select.block.alloca)
+  call void @llvm.lifetime.end.p0(ptr nonnull %select.states.alloca)
+  call void @runtime.trackPointer(ptr nonnull %select.recvbuf.alloca, ptr nonnull %stackalloc, ptr undef) #3
+  %1 = extractvalue { i32, i1 } %select.result, 0
+  %2 = icmp eq i32 %1, 0
+  br i1 %2, label %select.body, label %select.next
+
+select.body:                                      ; preds = %entry
+  %select.received = load i32, ptr %select.recvbuf.alloca, align 4
+  %3 = extractvalue { i32, i1 } %select.result, 1
+  %4 = insertvalue { i32, i1 } zeroinitializer, i32 %select.received, 0
+  %5 = insertvalue { i32, i1 } %4, i1 %3, 1
+  ret { i32, i1 } %5
+
+select.next:                                      ; preds = %entry
+  %6 = icmp eq i32 %1, 1
+  br i1 %6, label %select.body1, label %select.next2
+
+select.body1:                                     ; preds = %select.next
+  %select.received3 = load i32, ptr %select.recvbuf.alloca, align 4
+  %7 = extractvalue { i32, i1 } %select.result, 1
+  %8 = insertvalue { i32, i1 } zeroinitializer, i32 %select.received3, 0
+  %9 = insertvalue { i32, i1 } %8, i1 %7, 1
+  ret { i32, i1 } %9
+
+select.next2:                                     ; preds = %select.next
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:basic:string", ptr nonnull %stackalloc, ptr undef) #3
+  call void @runtime.trackPointer(ptr nonnull @"main$pack", ptr nonnull %stackalloc, ptr undef) #3
+  call void @runtime._panic(ptr nonnull @"reflect/types.type:basic:string", ptr nonnull @"main$pack", ptr undef) #3
+  unreachable
+}
+
+declare void @runtime._panic(ptr, ptr, ptr) #0
 
 attributes #0 = { "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
 attributes #1 = { nounwind "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -344,6 +344,51 @@ func chanRecv(ch *channel, value unsafe.Pointer, op *channelOp) bool {
 	return t.DataUint32() != chanOperationClosed
 }
 
+// chanTrySend attempts a non-blocking send to ch. It reports whether the send
+// completed.
+func chanTrySend(ch *channel, value unsafe.Pointer) bool {
+	if ch == nil {
+		return false
+	}
+
+	mask := interrupt.Disable()
+	ch.lock.Lock()
+
+	sent, wake := ch.trySend(value)
+
+	ch.lock.Unlock()
+	if wake != nil {
+		scheduleTask(wake)
+	}
+	interrupt.Restore(mask)
+
+	return sent
+}
+
+// chanTryRecv attempts a non-blocking receive from ch.
+//
+// received reports whether the receive completed. If received is true, ok has
+// the same meaning as the second result of a channel receive. If received is
+// false, ok is false.
+func chanTryRecv(ch *channel, value unsafe.Pointer) (received, ok bool) {
+	if ch == nil {
+		return false, false
+	}
+
+	mask := interrupt.Disable()
+	ch.lock.Lock()
+
+	received, ok, wake := ch.tryRecv(value)
+
+	ch.lock.Unlock()
+	if wake != nil {
+		scheduleTask(wake)
+	}
+	interrupt.Restore(mask)
+
+	return received, ok
+}
+
 // chanClose closes the given channel. If this channel has a receiver or is
 // empty, it closes the channel. Else, it panics.
 func chanClose(ch *channel) {


### PR DESCRIPTION
~~Fixes #4974.~~ Related to #4974.

**Status: this PR is an optimization, not the fix.** It started as a fix for the freeze in #4974, but further investigation showed the root cause is the waiter wake-up ordering in the common channel path — see #5513. A blocking multi-state select, which cannot take the fast path added here, still froze 3/3 on `dev`.

The #4974 reproducer did not freeze in testing with this PR because its select operation uses the fast path added here. However, this bypasses the underlying bug rather than fixing it. Therefore, this PR is related to #4974 but does not close it.

The fast path is still worth having on its own: the Go compiler applies the same optimization, lowering a select with a single channel operation and a default case to `selectnbsend` / `selectnbrecv` instead of going through the general select path.

This PR adds a fast path in `chanSelect` for non-blocking single-state selects.

For example:

```go
select {
case ch <- value:
default:
}
```

This form can lock at most one channel, so it does not need the global `chanSelectLock`, which is used to avoid deadlocks when multiple channels may be locked in different orders.

This fast path does not use `chanSelectLock`, and also avoids `lockAllStates` / `unlockAllStates`. Instead, when parallelism is enabled, it directly locks and unlocks the target channel.

`lockAllStates` / `unlockAllStates` use `channel.selectLocked`, and that state is protected by `chanSelectLock`. Therefore, simply skipping `chanSelectLock` while still using `lockAllStates` / `unlockAllStates` is not safe. The fast path avoids both.

## Background

*(Historical context — see the status note above for the current understanding.)*

#4974 reports a freeze on RP2040 with `-scheduler=cores` when using channels, goroutines, and timers together.

While investigating this issue, I found that a repeated single-channel select send with a default case can reproduce a freeze on RP2040/RP2350 with `-scheduler=cores`.

The minimized reproducer repeatedly sends from a timer goroutine using this form:

```go
select {
case ch <- struct{}{}:
    sentCount++
default:
    defaultCount++
}
```

A receiver goroutine continuously receives from the same channel.

At the time of freeze, the last report showed:

```text
sent == recv
default == 0
```

So the issue did not appear to be caused by entering the default branch. It looked related to the successful send path through `chanSelect` and the receiver wakeup path.

## Reproducer

I used `a03_nonblocking_select_send_large_buffer_receiver.go` as a minimized reproducer.

<details>

```
package main

import "time"

const maxRun = 3 * time.Minute

var sentCount uint32
var defaultCount uint32
var recvCount uint32

func main() {
        time.Sleep(1 * time.Second)

        start := time.Now()

        // Keep the large buffer from a02.
        // Add the receiver goroutine back to separate:
        //   receiver/wakeup effect
        // from:
        //   small buffer / default branch effect
        ch := make(chan struct{}, 1024)

        // Receiver goroutine.
        go func() {
                for range ch {
                        recvCount++
                }
        }()

        // Sender goroutine.
        // This keeps the non-blocking send with default case code path.
        go func() {
                var timer *time.Timer
                var timerC <-chan time.Time

                for {
                        if timer == nil {
                                timer = time.NewTimer(300 * time.Millisecond)
                                timerC = timer.C
                        } else {
                                timer.Stop()
                                timer.Reset(300 * time.Millisecond)
                        }

                        <-timerC

                        select {
                        case ch <- struct{}{}:
                                sentCount++
                        default:
                                defaultCount++
                        }
                }
        }()

        // Main goroutine.
        // Keep the same 30ms timer + frequent output pattern as a01/a02.
        var timer *time.Timer
        var timerC <-chan time.Time
        mainCount := uint32(0)

        for {
                if timer == nil {
                        timer = time.NewTimer(30 * time.Millisecond)
                        timerC = timer.C
                } else {
                        timer.Stop()
                        timer.Reset(30 * time.Millisecond)
                }

                <-timerC

                mainCount++
                print(".")

                if mainCount%333 == 0 {
                        print(" REPORT ms=", time.Since(start).Milliseconds(),
                                " main=", mainCount,
                                " sent=", sentCount,
                                " recv=", recvCount,
                                " default=", defaultCount,
                                "\n")
                }

                if time.Since(start) >= maxRun {
                        print(" DONE ms=", time.Since(start).Milliseconds(),
                                " main=", mainCount,
                                " sent=", sentCount,
                                " recv=", recvCount,
                                " default=", defaultCount,
                                "\n")
                        return
                }
        }
}

```

</details>

The important part is this single-state default select send:

```go
select {
case ch <- struct{}{}:
    sentCount++
default:
    defaultCount++
}
```

This form uses `runtime.chanSelect` and reproduced the freeze on RP2040/RP2350 with `-scheduler=cores`.

At the time of freeze, the report showed:

```text
sent == recv
default == 0
```

This suggests that the channel values were not being lost. Instead, progress appeared to stop around the successful `chanSelect` send path and receiver wakeup.

## Control case

I also used `a06_two_state_select_send_full_case.go` as a multi-state select control.

<details>

```
package main

import "time"

const maxRun = 3 * time.Minute

var sentCount uint32
var recvCount uint32
var otherCount uint32
var defaultCount uint32

func main() {
        time.Sleep(1 * time.Second)

        start := time.Now()

        ch := make(chan struct{}, 1024)
        otherCh := make(chan struct{}, 1)
        otherCh <- struct{}{}

        go func() {
                for range ch {
                        recvCount++
                }
        }()

        go func() {
                var timer *time.Timer
                var timerC <-chan time.Time

                for {
                        if timer == nil {
                                timer = time.NewTimer(300 * time.Millisecond)
                                timerC = timer.C
                        } else {
                                timer.Stop()
                                timer.Reset(300 * time.Millisecond)
                        }

                        <-timerC

                        select {
                        case ch <- struct{}{}:
                                sentCount++
                        case otherCh <- struct{}{}:
                                otherCount++
                        default:
                                defaultCount++
                        }
                }
        }()

        var timer *time.Timer
        var timerC <-chan time.Time
        mainCount := uint32(0)

        for {
                if timer == nil {
                        timer = time.NewTimer(30 * time.Millisecond)
                        timerC = timer.C
                } else {
                        timer.Stop()
                        timer.Reset(30 * time.Millisecond)
                }

                <-timerC

                mainCount++
                print(".")

                if mainCount%333 == 0 {
                        print(" REPORT ms=", time.Since(start).Milliseconds(),
                                " main=", mainCount,
                                " sent=", sentCount,
                                " recv=", recvCount,
                                " other=", otherCount,
                                " default=", defaultCount,
                                "\n")
                }

                if time.Since(start) >= maxRun {
                        print(" DONE ms=", time.Since(start).Milliseconds(),
                                " main=", mainCount,
                                " sent=", sentCount,
                                " recv=", recvCount,
                                " other=", otherCount,
                                " default=", defaultCount,
                                "\n")
                        return
                }
        }
}


```
</details>

The important part is:

```go
select {
case ch <- struct{}{}:
    sentCount++
case otherCh <- struct{}{}:
    otherCount++
default:
    defaultCount++
}
```

`otherCh` is pre-filled, so the second send case should normally not be selected.

This test is intended to check that the existing multi-state select path is not broken. With this PR, multi-state selects still use the existing `chanSelectLock` path.

## Investigation

I first tried skipping only `chanSelectLock` for single-state selects. However, while still using `lockAllStates` / `unlockAllStates`, the #4974 reproducer hit this panic:

```text
panic: sync: unlock of unlocked Mutex
```

This happened because `lockAllStates` / `unlockAllStates` use `channel.selectLocked`, and that state is protected by `chanSelectLock`.

Therefore, this PR adds a dedicated fast path for non-blocking single-state selects. This path avoids both `chanSelectLock` and `lockAllStates` / `unlockAllStates`, while still directly locking the channel when parallelism is enabled.

## Validation

### RP2040 / `-scheduler=cores`

* #4974 reproducer: ran for 5 minutes without freeze
* `a03` single-state default select reproducer: 3/3 completed
* `a06` multi-state select control: 3/3 completed

### RP2040 / `-scheduler=tasks`

* #4974 reproducer: ran for 5 minutes without freeze
* `a03` single-state default select reproducer: 1/1 completed
* `a06` multi-state select control: 1/1 completed

### RP2350 / `-scheduler=cores`

* `a03` single-state default select reproducer: 3/3 completed
* `a06` multi-state select control: 3/3 completed

### RP2350 / `-scheduler=tasks`

* `a03` single-state default select reproducer: 1/1 completed
* `a06` multi-state select control: 1/1 completed

## Before this change

* The `a03` reproducer repeatedly froze on RP2040.
* The `a03` reproducer also reproduced the freeze on RP2350.

## Notes
This change only adds a fast path for non-blocking single-state selects.

Multi-state selects continue to use the existing `chanSelectLock` path, so the existing protection against deadlocks from locking multiple channels in different orders is preserved.

The fast path still directly locks and unlocks the target channel when parallelism is enabled, so channel-level protection is preserved.
