### PR TITLE
begin debugging gvisor crash

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1354,6 +1354,15 @@ func (b *builder) createFunctionStart(intrinsic bool) {
 // diagnostic.
 func (b *builder) createFunction() {
 	b.createFunctionStart(false)
+	// createFunctionStart returns early (leaving blockInfo unset) when it hits
+	// an error such as a redeclared symbol. Don't plow into the block loop and
+	// panic on an empty blockInfo — the error was already recorded.
+	if b.blockInfo == nil {
+		// TINYGO-DEBUG: surface the redeclaration collision.
+		fmt.Printf("TINYGO-DEBUG skipping fn (redeclared/errored): %s  pkg=%s\n",
+			b.fn.RelString(nil), b.fn.Pkg.Pkg.Path())
+		return
+	}
 
 	// Fill blocks with instructions.
 	for _, block := range b.fn.DomPreorder() {


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0

goroutine 946 [running]:
github.com/tinygo-org/tinygo/compiler.(*builder).createFunction(0x1582243c4700)
        /home/pato/Documents/src/tg/tinygo/compiler/compiler.go:1364 +0xd65
github.com/tinygo-org/tinygo/compiler.(*compilerContext).createPackage(0x158244e5a000, {0x158205119600?}, 0x158206fc0680)
        /home/pato/Documents/src/tg/tinygo/compiler/compiler.go:934 +0x985
github.com/tinygo-org/tinygo/compiler.CompilePackage({0x1581e30ec990?, 0x58?}, 0x1581e30fc780, 0x158206fc0680, {0x0?}, 0x30d701?, 0xf9?)
        /home/pato/Documents/src/tg/tinygo/compiler/compiler.go:334 +0x445
github.com/tinygo-org/tinygo/builder.Build.func3(0x158209a2ec60)
        /home/pato/Documents/src/tg/tinygo/builder/build.go:405 +0x1eb
github.com/tinygo-org/tinygo/builder.runJob(0x158209a2ec60, 0x1581ef37cbd0)
        /home/pato/Documents/src/tg/tinygo/builder/jobs.go:212 +0x4d
created by github.com/tinygo-org/tinygo/builder.runJobs in goroutine 1
        /home/pato/Documents/src/tg/tinygo/builder/jobs.go:113 +0x6bd
 ```
 
<details><summary>Claude findings</summary>


**Symptom:** `panic: runtime error: index out of range [0] with length 0` at
`compiler/compiler.go:1364` (`b.blockInfo[block.Index]`), no function named.

**Root cause:** [`createFunctionStart`](/home/pato/Documents/src/tg/tinygo/compiler/compiler.go#L1165)
returns early when a symbol is redeclared (`!b.llvmFn.IsDeclaration()` →
`b.addError(...)` → `return`) **without** populating `b.blockInfo`.
[`createFunction`](/home/pato/Documents/src/tg/tinygo/compiler/compiler.go#L1355)
did not check for that and plowed into the block loop, indexing an empty slice →
panic. The panic **hid** the genuine `... redeclared in this program` error.

**Local fix (in `$TINYGOROOT/compiler/compiler.go`):** clear `b.blockInfo` before
`createFunctionStart`, and after it return early when `b.blockInfo == nil`.
Currently also prints a `TINYGO-DEBUG` line naming the skipped function — remove
that before upstreaming.

**Upstreamable to tinygo** independently of netbird: a redeclared symbol should
produce a clean compile error, not a compiler panic.

## 2. TinyGo codegen bug — gvisor stateify hooks "redeclared" (NOT fixed)

With the panic gone, the real errors surface:
```
gvisor/pkg/tcpip/stack/save_restore.go:26  (*Stack).beforeSave redeclared in this program
gvisor/pkg/tcpip/stack/save_restore.go:51  (*Stack).afterLoad  redeclared in this program
+ tcp.ReceiveErrors / tcp.SendErrors / tcp.Endpoint : beforeSave/afterLoad (same)
```

**Key fact:** each of these is defined **exactly once** in gvisor's Go source
(verified in `save_restore.go`) and compiles fine under **standard Go** (the
62 MB go-wasm build works). So this is **not** a Go-level duplicate — **TinyGo
emits the LLVM symbol twice** for these methods. They are gvisor `stateify`
save/restore hooks (`beforeSave()`, `afterLoad(context.Context)`), invoked by
gvisor's reflection-based state framework. Something about how TinyGo handles
these (interface-satisfaction wrapper vs direct method, or a linkname/state
autogen interaction) double-defines them.

**Status:** needs a minimal reproducer + upstream tinygo issue. This is likely
the *first* of many gvisor walls (gvisor is unsafe/linkname/reflection-heavy and
not a realistic TinyGo target as a whole). **Recommendation: do NOT chase full
gvisor-on-tinygo** — see #3.

</details>