### PR TITLE
compiler: disambiguate generic instance link names with local type args

### DIFF
--- a/compiler/goroutine.go
+++ b/compiler/goroutine.go
@@ -97,7 +97,7 @@ func (b *builder) createGo(instr *ssa.Go) {
 		funcType = b.getLLVMFunctionType(instr.Call.Value.Type().Underlying().(*types.Signature))
 		params = append(params, context, funcPtr)
 		hasContext = true
-		prefix = b.fn.RelString(nil)
+		prefix = b.getFunctionInfo(b.fn).linkName
 	}
 
 	paramBundle := b.emitPointerPack(params)
@@ -139,7 +139,7 @@ func (b *builder) createWasmExport() {
 	// Declare the exported function.
 	paramTypes := b.llvmFnType.ParamTypes()
 	exportedFnType := llvm.FunctionType(b.llvmFnType.ReturnType(), paramTypes[:len(paramTypes)-1], false)
-	exportedFn := llvm.AddFunction(b.mod, b.fn.RelString(nil)+suffix, exportedFnType)
+	exportedFn := llvm.AddFunction(b.mod, b.getFunctionInfo(b.fn).linkName+suffix, exportedFnType)
 	b.addStandardAttributes(exportedFn)
 	llvmutil.AppendToGlobal(b.mod, "llvm.used", exportedFn)
 	exportedFn.AddFunctionAttr(b.ctx.CreateStringAttribute("wasm-export-name", b.info.wasmExport))

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -323,6 +323,12 @@ func (c *compilerContext) getFunctionInfo(f *ssa.Function) functionInfo {
 		linkName: f.RelString(nil),
 	}
 
+	// RelString is not unique for local type arguments, so add a suffix
+	// when needed.
+	if suffix := c.localTypeArgsSuffix(f); suffix != "" {
+		info.linkName += suffix
+	}
+
 	// Check for a few runtime functions that are treated specially.
 	if info.linkName == "runtime.wasmEntryReactor" && c.BuildMode == "c-shared" {
 		info.linkName = "_initialize"
@@ -345,6 +351,26 @@ func (c *compilerContext) getFunctionInfo(f *ssa.Function) functionInfo {
 
 	c.functionInfos[f] = info
 	return info
+}
+
+func (c *compilerContext) localTypeArgsSuffix(f *ssa.Function) string {
+	typeArgs := f.TypeArgs()
+	if len(typeArgs) == 0 {
+		return ""
+	}
+	var hasLocal bool
+	parts := make([]string, len(typeArgs))
+	for i, ta := range typeArgs {
+		name, isLocal := c.getTypeCodeName(ta)
+		if isLocal {
+			hasLocal = true
+		}
+		parts[i] = name
+	}
+	if !hasLocal {
+		return ""
+	}
+	return "$localtype:" + strings.Join(parts, ",")
 }
 
 // parsePragmas is used by getFunctionInfo to parse function pragmas such as

--- a/testdata/localtypes.go
+++ b/testdata/localtypes.go
@@ -115,6 +115,72 @@ func doublyNestedInGeneric[T any]() (any, checker) {
 	return v, c
 }
 
+// issue4931Item's layout depends on T, so sharing generic function
+// bodies across different local T declarations is observable.
+type issue4931Item[T any] struct {
+	_      T
+	Labels []int
+}
+
+func issue4931Run[T any](input <-chan issue4931Item[T]) int {
+	item := <-input
+	return len(item.Labels)
+}
+
+func issue4931A() int {
+	type T struct{ _ [1]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Run(items)
+}
+
+func issue4931B() int {
+	type T struct{ _ [0]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Run(items)
+}
+
+func issue4931Pair[A, B any](input <-chan issue4931Item[A]) int {
+	item := <-input
+	return len(item.Labels)
+}
+
+func issue4931PairA() int {
+	type T struct{ _ [1]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Pair[T, int](items)
+}
+
+func issue4931PairB() int {
+	type T struct{ _ [0]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Pair[T, int](items)
+}
+
+type issue4931Runner[T any] struct{}
+
+func (issue4931Runner[T]) run(input <-chan issue4931Item[T]) int {
+	item := <-input
+	return len(item.Labels)
+}
+
+func issue4931MethodA() int {
+	type T struct{ _ [1]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Runner[T]{}.run(items)
+}
+
+func issue4931MethodB() int {
+	type T struct{ _ [0]any }
+	items := make(chan issue4931Item[T], 1)
+	items <- issue4931Item[T]{Labels: nil}
+	return issue4931Runner[T]{}.run(items)
+}
+
 func expect(name string, ok bool) {
 	if ok {
 		println("ok:", name)
@@ -226,4 +292,12 @@ func main() {
 	expect("doublyNestedInGeneric[string].Y accepts own", dnsC(dns))
 	expect("doublyNestedInGeneric[int].Y rejects [string].Y", !dniC(dns))
 	expect("doublyNestedInGeneric[string].Y rejects [int].Y", !dnsC(dni))
+
+	// Issue 4931: generic instances with local type args must not share bodies.
+	println("issue4931A labels:", issue4931A())
+	println("issue4931B labels:", issue4931B())
+	println("issue4931PairA labels:", issue4931PairA())
+	println("issue4931PairB labels:", issue4931PairB())
+	println("issue4931MethodA labels:", issue4931MethodA())
+	println("issue4931MethodB labels:", issue4931MethodB())
 }

--- a/testdata/localtypes.txt
+++ b/testdata/localtypes.txt
@@ -41,3 +41,9 @@ ok: doublyNestedInGeneric[int].Y accepts own
 ok: doublyNestedInGeneric[string].Y accepts own
 ok: doublyNestedInGeneric[int].Y rejects [string].Y
 ok: doublyNestedInGeneric[string].Y rejects [int].Y
+issue4931A labels: 0
+issue4931B labels: 1
+issue4931PairA labels: 0
+issue4931PairB labels: 1
+issue4931MethodA labels: 0
+issue4931MethodB labels: 1

--- a/testdata/localtypes.txt
+++ b/testdata/localtypes.txt
@@ -42,8 +42,8 @@ ok: doublyNestedInGeneric[string].Y accepts own
 ok: doublyNestedInGeneric[int].Y rejects [string].Y
 ok: doublyNestedInGeneric[string].Y rejects [int].Y
 issue4931A labels: 0
-issue4931B labels: 1
+issue4931B labels: 0
 issue4931PairA labels: 0
-issue4931PairB labels: 1
+issue4931PairB labels: 0
 issue4931MethodA labels: 0
-issue4931MethodB labels: 1
+issue4931MethodB labels: 0


### PR DESCRIPTION
Fixes #4931

This adds in a suffix to linknames so that local types do not alias each other.