### PR TITLE
build: statically link MinGW runtime in LLVM tools on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache/restore@v5
         id: cache-llvm-build
         with:
-          key: llvm-build-20-windows-v4
+          key: llvm-build-20-windows-v5
           path: llvm-build
       - name: Build LLVM
         if: steps.cache-llvm-build.outputs.cache-hit != 'true'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -142,6 +142,9 @@ ifeq ($(OS),Windows_NT)
 
     # PIC needs to be disabled for libclang to work.
     LLVM_OPTION += -DLLVM_ENABLE_PIC=OFF
+    # Statically link the C++ and GCC runtime into LLVM tools so they don't
+    # depend on MinGW DLLs that may not be on PATH when executed during the build.
+    LLVM_OPTION += '-DCMAKE_EXE_LINKER_FLAGS=-static-libgcc -static-libstdc++'
 
     CGO_CPPFLAGS += -DCINDEX_NO_EXPORTS
     CGO_LDFLAGS += -static -static-libgcc -static-libstdc++


### PR DESCRIPTION
This PR is to fix the WIndows build by statically linking MinGW runtime in LLVM tools on Windows.

Looks like the latest version of the Windows runner changed the configuration.