### PR TITLE
compiler: support //go:linknamestd pragma

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -515,7 +515,7 @@ func (c *compilerContext) parsePragmas(info *functionInfo, f *ssa.Function) {
 			info.inline = inlineHint
 		case "//go:noinline":
 			info.inline = inlineNone
-		case "//go:linkname":
+		case "//go:linkname", "//go:linknamestd":
 			if len(parts) != 3 || parts[1] != f.Name() {
 				continue
 			}

--- a/compiler/testdata/pragma.go
+++ b/compiler/testdata/pragma.go
@@ -35,6 +35,12 @@ func withLinkageName1() {
 //go:linkname withLinkageName2 somepkg.someFunction2
 func withLinkageName2()
 
+// Import a function from a different package using go:linknamestd (the standard
+// library variant of go:linkname introduced in Go 1.27).
+//
+//go:linknamestd withLinkageNameStd somepkg.someFunctionStd
+func withLinkageNameStd()
+
 // Function has an 'inline hint', similar to the inline keyword in C.
 //
 //go:inline

--- a/compiler/testdata/pragma.ll
+++ b/compiler/testdata/pragma.ll
@@ -33,6 +33,8 @@ entry:
 
 declare void @somepkg.someFunction2(ptr) #0
 
+declare void @somepkg.someFunctionStd(ptr) #0
+
 ; Function Attrs: inlinehint nounwind
 define hidden void @main.inlineFunc(ptr %context) unnamed_addr #3 {
 entry:


### PR DESCRIPTION
Go 1.27 introduced the //go:linknamestd directive, a standard-library variant of //go:linkname that does not require importing "unsafe". The iter package switched to it for referencing runtime.newcoro and runtime.coroswitch, which caused "linker could not find symbol iter.newcoro / iter.coroswitch" errors when building with Go 1.27.

Handle //go:linknamestd the same as //go:linkname, bypassing the unsafe import requirement, and add test coverage in the pragma compiler test.