### PR TITLE
runtime: fix leaking GC build with cores scheduler

### DIFF
--- a/src/runtime/gc_stack_cores.go
+++ b/src/runtime/gc_stack_cores.go
@@ -1,4 +1,4 @@
-//go:build scheduler.cores
+//go:build scheduler.cores && (gc.conservative || gc.precise || gc.boehm)
 
 package runtime
 


### PR DESCRIPTION
Fix the build with `-scheduler=cores -gc=leaking`.

`gc_stack_cores.go` was included for the leaking GC, causing duplicate definitions and an undefined reference.

Limit it to GCs that perform stack scanning.

## Testing

```
tinygo build -target=pico -scheduler=cores -gc=leaking .
tinygo build -target=pico -scheduler=cores -gc=conservative .
tinygo build -target=pico -scheduler=cores -gc=precise .
```
