### PR TITLE
runtime: prevent timer starvation in cores scheduler

### DIFF
--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -195,18 +195,6 @@ func run() {
 
 func scheduler(_ bool) {
 	for mainExited.Load() == 0 {
-		// Check for ready-to-run tasks.
-		if runnable := runqueue.Pop(); runnable != nil {
-			// Resume it now.
-			setCurrentTask(runnable)
-			runnable.RunState = task.RunStateRunning
-			schedulerLock.Unlock() // unlock before resuming, Pause() will lock again
-			runnable.Resume()
-			setCurrentTask(nil)
-
-			continue
-		}
-
 		var now timeUnit
 		if sleepQueue != nil || timerQueue != nil {
 			now = ticks()
@@ -251,6 +239,18 @@ func scheduler(_ bool) {
 				}
 				continue
 			}
+		}
+
+		// Check for ready-to-run tasks.
+		if runnable := runqueue.Pop(); runnable != nil {
+			// Resume it now.
+			setCurrentTask(runnable)
+			runnable.RunState = task.RunStateRunning
+			schedulerLock.Unlock() // unlock before resuming, Pause() will lock again
+			runnable.Resume()
+			setCurrentTask(nil)
+
+			continue
 		}
 
 		// At this point, there are no runnable tasks anymore.


### PR DESCRIPTION
This PR fixes an issue in `scheduler=cores` where expired sleeping tasks and timers may never be processed while runnable tasks remain continuously available.

This issue was found while investigating #4988.

## Problem and Fix

The issue was caused by the fixed processing priority in the cores scheduler.

Before this change, ordinary runnable tasks had the highest priority. When a runnable task was found, the scheduler executed it and immediately returned to the beginning of the scheduler loop. As a result, if the run queue remained continuously non-empty, the scheduler never reached the code that checks for expired sleeping tasks and timers.

The previous priority order was:

```text
runnable tasks > expired sleeping tasks > expired timers
```

Therefore, even while ordinary goroutines continued to run, the following operations could be starved indefinitely:

* Resuming from `time.Sleep`
* Callbacks registered with `time.AfterFunc`
* Other operations using the sleep queue or timer queue

This PR moves the existing `runqueue.Pop()` block after the checks for expired sleeping tasks and timers.

The new priority order is:

```text
expired sleeping tasks > expired timers > runnable tasks
```

The scheduler now processes work in the following order:

1. Check for an expired sleeping task
2. Check for an expired timer
3. Check the ordinary run queue
4. If no runnable task exists, wait until the next deadline or interrupt

No new scheduler state or queue operations are introduced. This change only modifies the evaluation order of the existing operations.

## Reproducer

The following reproducer demonstrates the `time.Sleep` starvation:

**a13_cores_sleep_starvation.go**
<details>

```go
package main

import (
        "runtime"
        "sync/atomic"
        "time"
)

var started [2]uint32

func worker(id int) {
        atomic.StoreUint32(&started[id], 1)

        for {
                runtime.Gosched()
        }
}

func waitStarted(id int) {
        for atomic.LoadUint32(&started[id]) == 0 {
                runtime.Gosched()
        }
}

func main() {
        time.Sleep(2 * time.Second)

        println("start worker0")
        go worker(0)
        waitStarted(0)

        println("before sleep with one worker")
        time.Sleep(time.Millisecond)
        println("after sleep with one worker")

        println("start worker1")
        go worker(1)
        waitStarted(1)

        println("before sleep with two workers")
        time.Sleep(time.Millisecond)
        println("after sleep with two workers")

        println("completed")
}
```
</details>


Before this fix, it stopped after:

```text
start worker0
before sleep with one worker
after sleep with one worker
start worker1
before sleep with two workers
```

The same program completed normally with `scheduler=tasks`:

```text
start worker0
before sleep with one worker
after sleep with one worker
start worker1
before sleep with two workers
after sleep with two workers
completed
```

The following bounded reproducer demonstrates timer starvation:


**a15_cores_timer_bounded.go**

<details>

```go
package main

import (
        "runtime"
        "sync/atomic"
        "time"
)

const attempts = 100_000

var (
        started [2]uint32
        fired   uint32
)

func worker(id int) {
        atomic.StoreUint32(&started[id], 1)

        for {
                runtime.Gosched()
        }
}

func waitStarted(id int) {
        for atomic.LoadUint32(&started[id]) == 0 {
                runtime.Gosched()
        }
}

func main() {
        time.Sleep(2 * time.Second)

        println("start worker0")
        go worker(0)
        waitStarted(0)

        println("start worker1")
        go worker(1)
        waitStarted(1)

        println("start timer")
        time.AfterFunc(time.Millisecond, func() {
                atomic.StoreUint32(&fired, 1)
        })

        for n := 1; n <= attempts; n++ {
                if atomic.LoadUint32(&fired) != 0 {
                        println("timer fired", n)
                        println("completed")
                        return
                }

                runtime.Gosched()

                if n%10_000 == 0 {
                        println("main progress", n)
                }
        }

        println("timer did not fire")
}

```
</details>

Before this fix, the main goroutine successfully resumed from `runtime.Gosched()` 100,000 times, but the timer callback was never executed:

```text
main progress 90000
main progress 100000
timer did not fire
```

This confirms that neither the scheduler nor the main goroutine was stopped. Only sleep and timer processing was being starved.

## Verification

The following results were verified on RP2040.

### Before the fix

* `scheduler=cores`

  * `time.Sleep` did not resume while runnable tasks continuously occupied both cores
  * Callbacks registered with `time.AfterFunc` were not executed
* `scheduler=tasks`

  * The same tests completed normally

### After the fix

* `scheduler=cores`

  * `time.Sleep` resumed while runnable tasks continuously occupied both cores
  * Callbacks registered with `time.AfterFunc` were executed
* `scheduler=tasks`

  * Continued to complete normally
* `-gc=conservative`

  * Completed normally
* `-gc=leaking`

  * Completed normally

After the fix, `a13_cores_sleep_starvation.go` completed as follows:

```text
start worker0
before sleep with one worker
after sleep with one worker
start worker1
before sleep with two workers
after sleep with two workers
completed
```

After the fix, `a15_cores_timer_bounded.go` also completed normally:

```text
start worker0
start worker1
start timer
timer fired 70
completed
```

I also checked for starvation in the opposite direction using:


**a17_cores_runqueue_starvation.go**
<details>

```go
package main

import (
        "runtime"
        "time"
)

func main() {
        time.Sleep(2 * time.Second)

        ticker := time.NewTicker(time.Nanosecond)
        defer ticker.Stop()

        println("ticker started")

        for n := 1; n <= 100_000; n++ {
                runtime.Gosched()

                if n%10_000 == 0 {
                        println("main progress", n)
                }
        }

        println("completed")
}
```

</details>

This test runs a ticker with a period of 1ns while allowing the main goroutine to make 100,000 iterations.

It completed normally with both `scheduler=cores` and `scheduler=tasks`:

```text
main progress 90000
main progress 100000
completed
```

Finally, I reran the original stress test containing ADC readers and allocation workers:


**main.go**
<details>

```go
package main

import (
        "machine"
        "runtime"
        "sync/atomic"
        "time"
)

const (
        allocationWorkers = 2
        liveSlots         = 16
        maxAllocation     = 512
)

var (
        adc0 = machine.ADC{Pin: machine.ADC0}
        adc1 = machine.ADC{Pin: machine.ADC1}

        adc0Reads uint32
        adc1Reads uint32
        allocs    uint32

        adc0Last uint32
        adc1Last uint32

        keep [allocationWorkers][liveSlots][]byte
)

func adcWorker(adc machine.ADC, reads, last *uint32) {
        var count uint32

        for {
                value := adc.Get()

                atomic.StoreUint32(last, uint32(value))
                atomic.AddUint32(reads, 1)

                count++
                if count&0xff == 0 {
                        runtime.Gosched()
                }
        }
}

func allocationWorker(worker int) {
        var sequence uint32

        for {
                size := 16 + int(sequence%maxAllocation)
                buf := make([]byte, size)
                for i := 0; i < len(buf); i += 64 {
                        buf[i] = byte(sequence + uint32(i))
                }
                buf[len(buf)-1] = byte(sequence >> 8)

                slot := int(sequence % liveSlots)
                keep[worker][slot] = buf

                sequence++
                atomic.AddUint32(&allocs, 1)
                if sequence&0x3f == 0 {
                        runtime.Gosched()
                }
        }
}

func stage(name string) {
        println("starting:", name)

        time.Sleep(time.Second)

        println("started:", name)
}

func main() {
        machine.InitADC()

        if err := adc0.Configure(machine.ADCConfig{}); err != nil {
                panic(err)
        }
        if err := adc1.Configure(machine.ADCConfig{}); err != nil {
                panic(err)
        }

        led := machine.LED
        led.Configure(machine.PinConfig{Mode: machine.PinOutput})
        led.Low()

        time.Sleep(2 * time.Second)

        println("issue-4988 staged stress start")

        go adcWorker(adc0, &adc0Reads, &adc0Last)
        stage("adc0")

        go adcWorker(adc1, &adc1Reads, &adc1Last)
        stage("adc1")

        go allocationWorker(0)
        stage("allocator0")

        go allocationWorker(1)
        stage("allocator1")

        println("all workers started")

        var (
                seconds  uint32
                ledState bool
        )

        for {
                time.Sleep(time.Second)

                seconds++
                ledState = !ledState
                led.Set(ledState)

                println(
                        "alive",
                        seconds,
                        "adc0", atomic.LoadUint32(&adc0Reads),
                        "value0", atomic.LoadUint32(&adc0Last),
                        "adc1", atomic.LoadUint32(&adc1Reads),
                        "value1", atomic.LoadUint32(&adc1Last),
                        "allocs", atomic.LoadUint32(&allocs),
                )
        }
}
```

</details>

With the original `scheduler=cores` implementation, the main goroutine did not resume from `time.Sleep` after the first allocator was started. After this fix, all workers started successfully, and the ADC read and allocation counters continued to increase:

```text
starting: allocator0
started: allocator0
starting: allocator1
started: allocator1
all workers started
alive 1 ...
alive 2 ...
alive 3 ...
alive 4 ...
```
