### PR TITLE
ci: fix sizediff check by updating to go 1.25, which is the new minimum version

### DIFF
--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Add GOBIN to $PATH
         run: |
           echo "$HOME/go/bin" >> $GITHUB_PATH
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '~1.25'
       - name: Checkout
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
This PR fixes the sizediff check by updating to Go 1.25, which is the new minimum version for TinyGo.