### PR TITLE
go.mod: update to go-llvm with changes to use context-aware wrappers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/tools v0.47.0
 	gopkg.in/yaml.v2 v2.4.0
 	tinygo.org/x/espflasher v0.7.1
-	tinygo.org/x/go-llvm v0.0.0-20260707200325-ddd595b68360
+	tinygo.org/x/go-llvm v0.0.0-20260721072906-185673ef46a5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -120,5 +120,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 tinygo.org/x/espflasher v0.7.1 h1:oJ+tt58QltP+c5+iHGRdCNNnVaXZ9yYXyWK/F747BVY=
 tinygo.org/x/espflasher v0.7.1/go.mod h1:a3l/4jOSMf9vhaPtEmGbCwtrC5oiZiNKx1i8jUkyyRI=
-tinygo.org/x/go-llvm v0.0.0-20260707200325-ddd595b68360 h1:BOGCjKGwPn2q54p/CNyfGzUDmqyi8YBSm3KlDheaTEU=
-tinygo.org/x/go-llvm v0.0.0-20260707200325-ddd595b68360/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=
+tinygo.org/x/go-llvm v0.0.0-20260721072906-185673ef46a5 h1:0PKRhM1INWAi7PdIng1BHMPTDaRcOmv1UymdTgZ76Jo=
+tinygo.org/x/go-llvm v0.0.0-20260721072906-185673ef46a5/go.mod h1:GFbusT2VTA4I+l4j80b17KFK+6whv69Wtny5U+T8RR0=


### PR DESCRIPTION
This PR is to update TinyGo to use the context-aware wrappers in LLVM added in https://github.com/tinygo-org/go-llvm/pull/76

In addition to calling the correct functions, it removes warnings like these:
```
# tinygo.org/x/go-llvm
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMIntPtrType’:
cgo-gcc-prolog:477:2: warning: ‘LLVMIntPtrType’ is deprecated [-Wdeprecated-declarations]
In file included from ../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:18,
                 from ../../../go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20260707200325-ddd595b68360/target.go:16:
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Target.h:234:41: note: declared here
  234 | LLVM_ATTRIBUTE_C_DEPRECATED(LLVMTypeRef LLVMIntPtrType(LLVMTargetDataRef TD),
      |                                         ^~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
# tinygo.org/x/go-llvm
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMAppendBasicBlock’:
cgo-gcc-prolog:285:2: warning: ‘LLVMAppendBasicBlock’ is deprecated [-Wdeprecated-declarations]
In file included from ../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:18,
                 from ../../../go/pkg/mod/tinygo.org/x/go-llvm@v0.0.0-20260707200325-ddd595b68360/ir.go:16:
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:3717:23: note: declared here
 3717 |     LLVMBasicBlockRef LLVMAppendBasicBlock(LLVMValueRef Fn, const char *Name),
      |                       ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMConstString’:
cgo-gcc-prolog:2925:2: warning: ‘LLVMConstString’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:2489:18: note: declared here
 2489 |     LLVMValueRef LLVMConstString(const char *Str, unsigned Length,
      |                  ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMConstStruct’:
cgo-gcc-prolog:2966:2: warning: ‘LLVMConstStruct’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:2538:18: note: declared here
 2538 |     LLVMValueRef LLVMConstStruct(LLVMValueRef *ConstantVals, unsigned Count,
      |                  ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMGetGlobalContext’:
cgo-gcc-prolog:4229:2: warning: ‘LLVMGetGlobalContext’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:593:44: note: declared here
  593 | LLVM_ATTRIBUTE_C_DEPRECATED(LLVMContextRef LLVMGetGlobalContext(void),
      |                                            ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMGetMDKindID’:
cgo-gcc-prolog:4597:2: warning: ‘LLVMGetMDKindID’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:669:14: note: declared here
  669 |     unsigned LLVMGetMDKindID(const char *Name, unsigned SLen),
      |              ^~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMInsertBasicBlock’:
cgo-gcc-prolog:5664:2: warning: ‘LLVMInsertBasicBlock’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:3739:23: note: declared here
 3739 |     LLVMBasicBlockRef LLVMInsertBasicBlock(LLVMBasicBlockRef InsertBeforeBB,
      |                       ^~~~~~~~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
cgo-gcc-prolog: In function ‘_cgo_2ad2ad839789_Cfunc_LLVMStructType’:
cgo-gcc-prolog:8039:2: warning: ‘LLVMStructType’ is deprecated [-Wdeprecated-declarations]
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Core.h:1580:17: note: declared here
 1580 |     LLVMTypeRef LLVMStructType(LLVMTypeRef *ElementTypes, unsigned ElementCount,
      |                 ^~~~~~~~~~~~~~
../../../work/tinygo/tinygo/llvm-project/llvm/include/llvm-c/Deprecated.h:29:3: note: in definition of macro ‘LLVM_ATTRIBUTE_C_DEPRECATED’
   29 |   decl __attribute__((deprecated))
      |   ^~~~
ok  	github.com/tinygo-org/tinygo/builder	48.021s
```

Leaving as draft until `go-llvm` itself is updated.