### PR TITLE
testing: avoid Goexit without unwind support

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1981,7 +1981,7 @@ func (b *builder) createFunctionCall(instr *ssa.CallCommon) (llvm.Value, error) 
 	if fn := instr.StaticCallee(); fn != nil {
 		// Direct function call, either to a named or anonymous (directly
 		// applied) function call. If it is anonymous, it may be a closure.
-		name := fn.RelString(nil)
+		name := b.getFunctionInfo(fn).linkName
 		switch {
 		case name == "device.Asm" || name == "device/arm.Asm" || name == "device/arm64.Asm" || name == "device/avr.Asm" || name == "device/riscv.Asm":
 			return b.createInlineAsm(instr.Args)

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+	_ "unsafe"
 )
 
 // Testing flags.
@@ -215,7 +216,10 @@ func (c *common) Failed() bool {
 func (c *common) FailNow() {
 	c.Fail()
 	c.finished = true
-	runtime.Goexit()
+	if supportsRecover() {
+		runtime.Goexit()
+	}
+	c.Error("FailNow is incomplete, requires runtime.Goexit()")
 }
 
 // log generates the output.
@@ -287,12 +291,18 @@ func (c *common) Skipf(format string, args ...any) {
 func (c *common) SkipNow() {
 	c.skip()
 	c.finished = true
-	runtime.Goexit()
+	if supportsRecover() {
+		runtime.Goexit()
+	}
+	c.Error("SkipNow is incomplete, requires runtime.Goexit()")
 }
 
 func (c *common) skip() {
 	c.skipped = true
 }
+
+//go:linkname supportsRecover runtime.supportsRecover
+func supportsRecover() bool
 
 // Skipped reports whether the test was skipped.
 func (c *common) Skipped() bool {


### PR DESCRIPTION
In #5493 I made fail/skip work by implementing `Goexit`. But I forgot that on some platforms, unwiding doesn't work, and so the impact of my implementing `Goexit` in the cooperative scheduler means a deadlock for Wasm and so on.

Restore the error for now.