### PR TITLE
compiler: exclude generic methods from runtime method sets

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -60,6 +60,9 @@ func TestCompiler(t *testing.T) {
 	if goMinor >= 21 {
 		tests = append(tests, testCase{"go1.21.go", "", ""})
 	}
+	if goMinor >= 27 {
+		tests = append(tests, testCase{"go1.27.go", "", ""})
+	}
 
 	for _, tc := range tests {
 		name := tc.file

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -136,6 +136,16 @@ func (c *compilerContext) pkgPathPtr(pkgpath string) llvm.Value {
 	return pkgPathPtr
 }
 
+// isGenericMethod returns true for a method that has its own type parameters
+// (independent of any type parameters on its receiver), e.g. the N method in
+// "func (r *Rand) N[Int intType](n Int) Int { ... }". Like the reflect
+// package, such methods are excluded from runtime method sets: they aren't
+// instantiated, so their signature can't be represented in a type code, and
+// they can never satisfy an interface method anyway.
+func isGenericMethod(fn *types.Func) bool {
+	return fn.Signature().TypeParams().Len() > 0
+}
+
 // getTypeCode returns a reference to a type code.
 // A type code is a pointer to a constant global that describes the type.
 // This function returns a pointer to the 'kind' field (which might not be the
@@ -157,6 +167,9 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 	// For an interface type, it returns the number of exported and unexported methods.
 	var numMethods int
 	for method := range ms.Methods() {
+		if isGenericMethod(method.Obj().(*types.Func)) {
+			continue
+		}
 		if isInterface || method.Obj().Exported() {
 			numMethods++
 		}
@@ -205,7 +218,11 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 		// Compute the method set value for types that support methods.
 		var methods []*types.Func
 		for method := range ms.Methods() {
-			methods = append(methods, method.Obj().(*types.Func))
+			fn := method.Obj().(*types.Func)
+			if isGenericMethod(fn) {
+				continue
+			}
+			methods = append(methods, fn)
 		}
 		methodSetType := types.NewStruct([]*types.Var{
 			types.NewVar(token.NoPos, nil, "length", types.Typ[types.Uintptr]),
@@ -961,6 +978,9 @@ func (c *compilerContext) getTypeMethodSet(typ types.Type) llvm.Value {
 		// Create method set.
 		var signatures, wrappers []llvm.Value
 		for method := range ms.Methods() {
+			if isGenericMethod(method.Obj().(*types.Func)) {
+				continue
+			}
 			signatureGlobal := c.getMethodSignature(method.Obj().(*types.Func))
 			signatures = append(signatures, signatureGlobal)
 			fn := c.program.MethodValue(method)
@@ -975,7 +995,7 @@ func (c *compilerContext) getTypeMethodSet(typ types.Type) llvm.Value {
 
 		// Construct global value.
 		globalValue := c.ctx.ConstStruct([]llvm.Value{
-			llvm.ConstInt(c.uintptrType, uint64(ms.Len()), false),
+			llvm.ConstInt(c.uintptrType, uint64(len(signatures)), false),
 			llvm.ConstArray(c.dataPtrType, signatures),
 			c.ctx.ConstStruct(wrappers, false),
 		}, false)

--- a/compiler/interface.go
+++ b/compiler/interface.go
@@ -155,24 +155,25 @@ func (c *compilerContext) getTypeCode(typ types.Type) llvm.Value {
 	typ = types.Unalias(typ)
 
 	ms := c.program.MethodSets.MethodSet(typ)
-	hasMethodSet := ms.Len() != 0
 	_, isInterface := typ.Underlying().(*types.Interface)
-	if isInterface {
-		hasMethodSet = false
-	}
 
 	// As defined in https://pkg.go.dev/reflect#Type:
 	// NumMethod returns the number of methods accessible using Method.
 	// For a non-interface type, it returns the number of exported methods.
 	// For an interface type, it returns the number of exported and unexported methods.
 	var numMethods int
+	var hasMethodSet bool
 	for method := range ms.Methods() {
 		if isGenericMethod(method.Obj().(*types.Func)) {
 			continue
 		}
+		hasMethodSet = true
 		if isInterface || method.Obj().Exported() {
 			numMethods++
 		}
+	}
+	if isInterface {
+		hasMethodSet = false
 	}
 
 	// Short-circuit all the global pointer logic here for pointers to pointers.

--- a/compiler/testdata/go1.27.go
+++ b/compiler/testdata/go1.27.go
@@ -1,0 +1,24 @@
+package main
+
+// genericMethod has both a regular method and a "generic method": a method
+// with its own type parameter, independent of any type parameter on the
+// receiver. This is a Go 1.27 feature (see math/rand/v2.Rand.N for a
+// real-world example). Boxing such a value into an interface must not try to
+// encode the generic method's type-parameterized signature into a type code.
+type genericMethod struct{}
+
+func (t genericMethod) Regular(n int) int { return n }
+
+func (t genericMethod) GenericParam[X int | int64](n X) X { return n }
+
+// onlyGenericMethod's only method is generic, so its runtime type must have
+// an empty method set (hasMethodSet must become false, not just numMethods).
+type onlyGenericMethod struct{}
+
+func (t onlyGenericMethod) GenericParam[X int | int64](n X) X { return n }
+
+func useGenericMethods() (any, any) {
+	var g genericMethod
+	var o onlyGenericMethod
+	return any(g), any(o)
+}

--- a/compiler/testdata/go1.27.ll
+++ b/compiler/testdata/go1.27.ll
@@ -1,0 +1,67 @@
+; ModuleID = 'go1.27.go'
+source_filename = "go1.27.go"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-wasi"
+
+%runtime.structField = type { ptr, ptr }
+%runtime._interface = type { ptr, ptr }
+
+@"reflect/types.signature:Regular:func:{basic:int}{basic:int}" = linkonce_odr constant i8 0, align 1
+@"reflect/types.type:named:main.genericMethod" = linkonce_odr constant { ptr, i8, i16, ptr, ptr, ptr, { i32, [1 x ptr] }, [19 x i8] } { ptr @"named:main.genericMethod$methodset", i8 122, i16 -32767, ptr getelementptr ({ ptr, i8, i16, ptr, { i32, [1 x ptr] } }, ptr @"reflect/types.type:pointer:named:main.genericMethod", i32 0, i32 1), ptr @"reflect/types.type:struct:{}", ptr @"reflect/types.type.pkgpath:main", { i32, [1 x ptr] } { i32 1, [1 x ptr] [ptr @"reflect/types.signature:Regular:func:{basic:int}{basic:int}"] }, [19 x i8] c"main.genericMethod\00" }, align 4
+@"reflect/types.type.pkgpath:main" = linkonce_odr unnamed_addr constant [5 x i8] c"main\00", align 1
+@"reflect/types.type:pointer:named:main.genericMethod" = linkonce_odr constant { ptr, i8, i16, ptr, { i32, [1 x ptr] } } { ptr @"pointer:named:main.genericMethod$methodset", i8 -43, i16 -32767, ptr getelementptr ({ ptr, i8, i16, ptr, ptr, ptr, { i32, [1 x ptr] }, [19 x i8] }, ptr @"reflect/types.type:named:main.genericMethod", i32 0, i32 1), { i32, [1 x ptr] } { i32 1, [1 x ptr] [ptr @"reflect/types.signature:Regular:func:{basic:int}{basic:int}"] } }, align 4
+@"reflect/methods.Regular:func:{basic:int}{basic:int}" = linkonce_odr constant i8 0, align 1
+@"main$string" = internal unnamed_addr constant [18 x i8] c"main.genericMethod", align 1
+@"main$string.1" = internal unnamed_addr constant [7 x i8] c"Regular", align 1
+@"pointer:named:main.genericMethod$methodset" = linkonce_odr unnamed_addr constant { i32, [1 x ptr], { ptr } } { i32 1, [1 x ptr] [ptr @"reflect/methods.Regular:func:{basic:int}{basic:int}"], { ptr } { ptr @"(*main.genericMethod).Regular" } }
+@"reflect/types.type:struct:{}" = linkonce_odr constant { i8, i16, ptr, ptr, i32, i16, [0 x %runtime.structField] } { i8 90, i16 0, ptr @"reflect/types.type:pointer:struct:{}", ptr @"reflect/types.type.pkgpath.empty", i32 0, i16 0, [0 x %runtime.structField] zeroinitializer }, align 4
+@"reflect/types.type.pkgpath.empty" = linkonce_odr unnamed_addr constant [1 x i8] zeroinitializer, align 1
+@"reflect/types.type:pointer:struct:{}" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:struct:{}" }, align 4
+@"named:main.genericMethod$methodset" = linkonce_odr unnamed_addr constant { i32, [1 x ptr], { ptr } } { i32 1, [1 x ptr] [ptr @"reflect/methods.Regular:func:{basic:int}{basic:int}"], { ptr } { ptr @"(main.genericMethod).Regular$invoke" } }
+@"reflect/types.type:named:main.onlyGenericMethod" = linkonce_odr constant { i8, i16, ptr, ptr, ptr, [23 x i8] } { i8 122, i16 0, ptr @"reflect/types.type:pointer:named:main.onlyGenericMethod", ptr @"reflect/types.type:struct:{}", ptr @"reflect/types.type.pkgpath:main", [23 x i8] c"main.onlyGenericMethod\00" }, align 4
+@"reflect/types.type:pointer:named:main.onlyGenericMethod" = linkonce_odr constant { i8, i16, ptr } { i8 -43, i16 0, ptr @"reflect/types.type:named:main.onlyGenericMethod" }, align 4
+
+declare void @runtime.trackPointer(ptr nocapture readonly, ptr, ptr) #0
+
+; Function Attrs: nounwind
+define hidden void @main.init(ptr %context) unnamed_addr #1 {
+entry:
+  ret void
+}
+
+; Function Attrs: nounwind
+define hidden i32 @"(main.genericMethod).Regular"(i32 %n, ptr %context) unnamed_addr #1 {
+entry:
+  ret i32 %n
+}
+
+; Function Attrs: nounwind
+define hidden { %runtime._interface, %runtime._interface } @main.useGenericMethods(ptr %context) unnamed_addr #1 {
+entry:
+  %stackalloc = alloca i8, align 1
+  call void @runtime.trackPointer(ptr nonnull getelementptr inbounds nuw (i8, ptr @"reflect/types.type:named:main.genericMethod", i32 4), ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr nonnull @"reflect/types.type:named:main.onlyGenericMethod", ptr nonnull %stackalloc, ptr undef) #2
+  call void @runtime.trackPointer(ptr null, ptr nonnull %stackalloc, ptr undef) #2
+  ret { %runtime._interface, %runtime._interface } { %runtime._interface { ptr getelementptr ({ ptr, i8, i16, ptr, ptr, ptr, { i32, [1 x ptr] }, [19 x i8] }, ptr @"reflect/types.type:named:main.genericMethod", i32 0, i32 1), ptr null }, %runtime._interface { ptr @"reflect/types.type:named:main.onlyGenericMethod", ptr null } }
+}
+
+; Function Attrs: nounwind
+define linkonce_odr hidden i32 @"(*main.genericMethod).Regular"(ptr %t, i32 %n, ptr %context) unnamed_addr #1 {
+entry:
+  %stackalloc = alloca i8, align 1
+  call void @runtime.trackPointer(ptr %t, ptr nonnull %stackalloc, ptr undef) #2
+  %0 = call i32 @"(main.genericMethod).Regular"(i32 %n, ptr undef)
+  ret i32 %0
+}
+
+; Function Attrs: nounwind
+define linkonce_odr i32 @"(main.genericMethod).Regular$invoke"(ptr %0, i32 %1, ptr %2) unnamed_addr #1 {
+entry:
+  %ret = call i32 @"(main.genericMethod).Regular"(i32 %1, ptr %2)
+  ret i32 %ret
+}
+
+attributes #0 = { "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
+attributes #1 = { nounwind "target-features"="+bulk-memory,+bulk-memory-opt,+call-indirect-overlong,+mutable-globals,+nontrapping-fptoint,+sign-ext,-multivalue,-reference-types" }
+attributes #2 = { nounwind }


### PR DESCRIPTION
Go 1.27 promoted "generic methods" (methods with their own type parameters, independent of any type parameters on the receiver) out of the GenericMethods experiment, e.g.:

    func (r *Rand) N[Int intType](n Int) Int

Boxing a value of a type with such a method into an interface caused tinygo to panic while building the runtime type's method table:

    getTypeCode -> getMethodSetValue -> getTypeCodeName

getTypeCodeName's type switch has no case for *types.TypeParam, and a generic method's Signature carries the method's own type parameters in its parameter/result types (e.g. "Int" above), so encoding it into a type code name panicked with "unknown type: <param name>".

This affected any package using math/rand/v2.Rand.N, including much of the math/rand/v2 test suite, since printing or otherwise boxing a *Rand into an interface is common.

Upstream reflect deliberately excludes generic methods from Type.NumMethod()/Type.Method() (they can't be instantiated implicitly, and a generic method can never satisfy an interface method), so mirror that behavior: add isGenericMethod, which checks whether a method's Signature has its own type parameters, and skip such methods when building the runtime method count, method set value, and method set in compiler/interface.go.

Fixes a panic isolated to:

    package main

    type T struct{}

    func (t T) M[X int](n X) X { return n }

    func main() {
    	var t T
    	var i interface{} = t
    	_ = i
    }