### PR TITLE
Some garbage collector fixes

### DIFF
--- a/src/runtime/gc_blocks.go
+++ b/src/runtime/gc_blocks.go
@@ -510,7 +510,7 @@ func realloc(ptr unsafe.Pointer, size uintptr) unsafe.Pointer {
 	lastBlock := firstBlock.findHead()
 
 	// Calculate the size of the original allocation body.
-	oldSize := uintptr(lastBlock-firstBlock)*blocksPerStateByte + (bytesPerBlock - unsafe.Sizeof(objHeader{}))
+	oldSize := uintptr(lastBlock-firstBlock)*bytesPerBlock + (bytesPerBlock - unsafe.Sizeof(objHeader{}))
 
 	if size <= oldSize {
 		// The requested size is less than the old size.

--- a/src/runtime/gc_leaking.go
+++ b/src/runtime/gc_leaking.go
@@ -47,8 +47,14 @@ func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
 	gcTotalAlloc += uint64(size)
 	gcMallocs++
 	heapptr += size
-	for heapptr >= heapEnd {
+	if heapptr < addr {
+		// The allocation size overflowed the heap pointer.
+		runtimePanic("out of memory")
+	}
+	for heapptr > heapEnd {
 		// Try to increase the heap and check again.
+		// Use > instead of >= because an allocation that exactly
+		// ends at heapEnd is still within heap boundaries.
 		if growHeap() {
 			continue
 		}

--- a/src/runtime/gc_stack_cores.go
+++ b/src/runtime/gc_stack_cores.go
@@ -43,6 +43,12 @@ func gcMarkReachable() {
 		gcPauseCore(i)
 	}
 
+	// Busy-wait until all the other cores are ready.
+	for gcScanState.Load() != numCPU {
+		spinLoopWait()
+	}
+	gcScanState.Store(0)
+
 	// Scan the stack(s) of the current core.
 	scanCurrentStack()
 	if !task.OnSystemStack() {
@@ -52,13 +58,6 @@ func gcMarkReachable() {
 
 	// Scan globals.
 	findGlobals(markRoots)
-
-	// Busy-wait until all the other cores are ready. They certainly should be,
-	// after the scanning we did above.
-	for gcScanState.Load() != numCPU {
-		spinLoopWait()
-	}
-	gcScanState.Store(0)
 
 	// Signal each core in turn that they can scan the stack.
 	for i := uint32(0); i < numCPU; i++ {


### PR DESCRIPTION
Mostly correctness fixes, but the issue with `cores` scheduler may cause unexpected crashes during GC mark phase.

- fixed incorrect previous size calculation in block realloc, causing potential data loss on growing reallocs.
- fixed incorrect comparison, causing a premature OOM on the leaking alloc (rather improbable though).
- correctly pause all cores during the GC mark phase, preventing a data race.