### PR TITLE
machine: add USBDevice.Attach and USBDevice.Detach

### DIFF
--- a/src/machine/machine_atsamd21_usb.go
+++ b/src/machine/machine_atsamd21_usb.go
@@ -68,6 +68,20 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	dev.initcomplete = true
 }
 
+// Attach connects the device to the USB bus, allowing the host to detect and
+// enumerate it. It can be used together with Detach to delay enumeration
+// until the USB configuration (device identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	sam.USB_DEVICE.CTRLB.ClearBits(sam.USB_DEVICE_CTRLB_DETACH)
+}
+
+// Detach disconnects the device from the USB bus. To the host this appears
+// as if the device was unplugged. A subsequent Attach makes the host
+// enumerate the device again.
+func (dev *USBDevice) Detach() {
+	sam.USB_DEVICE.CTRLB.SetBits(sam.USB_DEVICE_CTRLB_DETACH)
+}
+
 func handlePadCalibration() {
 	// Load Pad Calibration data from non-volatile memory
 	// This requires registers that are not included in the SVD file.

--- a/src/machine/machine_atsamd21_usb.go
+++ b/src/machine/machine_atsamd21_usb.go
@@ -51,7 +51,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	sam.USB_DEVICE.CTRLB.SetBits(sam.USB_DEVICE_CTRLB_SPDCONF_FS << sam.USB_DEVICE_CTRLB_SPDCONF_Pos)
 
 	// attach
-	sam.USB_DEVICE.CTRLB.ClearBits(sam.USB_DEVICE_CTRLB_DETACH)
+	dev.Attach()
 
 	// enable interrupt for end of reset
 	sam.USB_DEVICE.INTENSET.SetBits(sam.USB_DEVICE_INTENSET_EORST)

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -51,7 +51,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	sam.USB_DEVICE.CTRLB.SetBits(sam.USB_DEVICE_CTRLB_SPDCONF_FS << sam.USB_DEVICE_CTRLB_SPDCONF_Pos)
 
 	// attach
-	sam.USB_DEVICE.CTRLB.ClearBits(sam.USB_DEVICE_CTRLB_DETACH)
+	dev.Attach()
 
 	// enable interrupt for end of reset
 	sam.USB_DEVICE.INTENSET.SetBits(sam.USB_DEVICE_INTENSET_EORST)

--- a/src/machine/machine_atsamd51_usb.go
+++ b/src/machine/machine_atsamd51_usb.go
@@ -71,6 +71,20 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	dev.initcomplete = true
 }
 
+// Attach connects the device to the USB bus, allowing the host to detect and
+// enumerate it. It can be used together with Detach to delay enumeration
+// until the USB configuration (device identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	sam.USB_DEVICE.CTRLB.ClearBits(sam.USB_DEVICE_CTRLB_DETACH)
+}
+
+// Detach disconnects the device from the USB bus. To the host this appears
+// as if the device was unplugged. A subsequent Attach makes the host
+// enumerate the device again.
+func (dev *USBDevice) Detach() {
+	sam.USB_DEVICE.CTRLB.SetBits(sam.USB_DEVICE_CTRLB_DETACH)
+}
+
 func handlePadCalibration() {
 	// Load Pad Calibration data from non-volatile memory
 	// This requires registers that are not included in the SVD file.

--- a/src/machine/machine_esp32c3_usb.go
+++ b/src/machine/machine_esp32c3_usb.go
@@ -67,6 +67,11 @@ func (dev *USBDevice) SetStallEPOut(ep uint32)   {}
 func (dev *USBDevice) ClearStallEPIn(ep uint32)  {}
 func (dev *USBDevice) ClearStallEPOut(ep uint32) {}
 
+// Attach and Detach are no-ops: the USB Serial/JTAG controller has no
+// software-controlled soft-connect, it is always attached to the bus.
+func (dev *USBDevice) Attach() {}
+func (dev *USBDevice) Detach() {}
+
 // initUSB is intentionally empty — the interp phase evaluates init()
 // functions at compile time and cannot access hardware registers.
 // Actual hardware setup is deferred to the first Configure() call.

--- a/src/machine/machine_esp32c6_usb.go
+++ b/src/machine/machine_esp32c6_usb.go
@@ -66,6 +66,11 @@ func (dev *USBDevice) SetStallEPOut(ep uint32)   {}
 func (dev *USBDevice) ClearStallEPIn(ep uint32)  {}
 func (dev *USBDevice) ClearStallEPOut(ep uint32) {}
 
+// Attach and Detach are no-ops: the USB Serial/JTAG controller has no
+// software-controlled soft-connect, it is always attached to the bus.
+func (dev *USBDevice) Attach() {}
+func (dev *USBDevice) Detach() {}
+
 // initUSB is intentionally empty — the interp phase evaluates init()
 // functions at compile time and cannot access hardware registers.
 // Actual hardware setup is deferred to the first Configure() call.

--- a/src/machine/machine_esp32xx_usb.go
+++ b/src/machine/machine_esp32xx_usb.go
@@ -67,6 +67,11 @@ func (dev *USBDevice) SetStallEPOut(ep uint32)   {}
 func (dev *USBDevice) ClearStallEPIn(ep uint32)  {}
 func (dev *USBDevice) ClearStallEPOut(ep uint32) {}
 
+// Attach and Detach are no-ops: the USB Serial/JTAG controller has no
+// software-controlled soft-connect, it is always attached to the bus.
+func (dev *USBDevice) Attach() {}
+func (dev *USBDevice) Detach() {}
+
 // initUSB is intentionally empty — the interp phase evaluates init()
 // functions at compile time and cannot access hardware registers.
 // Actual hardware setup is deferred to the first Configure() call.

--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -89,6 +89,21 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	dev.initcomplete = true
 }
 
+// Attach connects the device to the USB bus by enabling the DP pull-up,
+// allowing the host to detect and enumerate it. It can be used together with
+// Detach to delay enumeration until the USB configuration (device
+// identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	nrf.USBD.USBPULLUP.Set(1)
+}
+
+// Detach disconnects the device from the USB bus by disabling the DP pull-up.
+// To the host this appears as if the device was unplugged. A subsequent
+// Attach makes the host enumerate the device again.
+func (dev *USBDevice) Detach() {
+	nrf.USBD.USBPULLUP.Set(0)
+}
+
 func handleUSBIRQ(interrupt.Interrupt) {
 	if nrf.USBD.EVENTS_SOF.Get() == 1 {
 		nrf.USBD.EVENTS_SOF.Set(0)

--- a/src/machine/machine_nrf52840_usb.go
+++ b/src/machine/machine_nrf52840_usb.go
@@ -22,6 +22,11 @@ var (
 	epinen      uint32
 	epouten     uint32
 	easyDMABusy volatile.Register8
+
+	// usbDetached keeps the device detached from the bus after Detach: the
+	// USB IRQ handler re-enables the DP pull-up on every power-ready event,
+	// which would otherwise silently undo a Detach.
+	usbDetached bool
 )
 
 // enterCriticalSection is used to protect access to easyDMA - only one thing
@@ -94,6 +99,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 // Detach to delay enumeration until the USB configuration (device
 // identifiers, classes, ...) is complete.
 func (dev *USBDevice) Attach() {
+	usbDetached = false
 	nrf.USBD.USBPULLUP.Set(1)
 }
 
@@ -101,6 +107,7 @@ func (dev *USBDevice) Attach() {
 // To the host this appears as if the device was unplugged. A subsequent
 // Attach makes the host enumerate the device again.
 func (dev *USBDevice) Detach() {
+	usbDetached = true
 	nrf.USBD.USBPULLUP.Set(0)
 }
 
@@ -118,7 +125,9 @@ func handleUSBIRQ(interrupt.Interrupt) {
 
 			// Configure control endpoint
 			initEndpoint(0, usb.ENDPOINT_TYPE_CONTROL)
-			nrf.USBD.USBPULLUP.Set(1)
+			if !usbDetached {
+				nrf.USBD.USBPULLUP.Set(1)
+			}
 
 			usbConfiguration = 0
 		}

--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -43,7 +43,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 		rp.USBCTRL_REGS_INTE_SETUP_REQ)
 
 	// Present full speed device by enabling pull up on DP
-	rp.USBCTRL_REGS.SIE_CTRL.SetBits(rp.USBCTRL_REGS_SIE_CTRL_PULLUP_EN)
+	dev.Attach()
 }
 
 // Attach connects the device to the USB bus by enabling the DP pull-up,

--- a/src/machine/machine_rp2040_usb.go
+++ b/src/machine/machine_rp2040_usb.go
@@ -46,6 +46,21 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	rp.USBCTRL_REGS.SIE_CTRL.SetBits(rp.USBCTRL_REGS_SIE_CTRL_PULLUP_EN)
 }
 
+// Attach connects the device to the USB bus by enabling the DP pull-up,
+// allowing the host to detect and enumerate it. It can be used together with
+// Detach to delay enumeration until the USB configuration (device
+// identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	rp.USBCTRL_REGS.SIE_CTRL.SetBits(rp.USBCTRL_REGS_SIE_CTRL_PULLUP_EN)
+}
+
+// Detach disconnects the device from the USB bus by disabling the DP pull-up.
+// To the host this appears as if the device was unplugged. A subsequent
+// Attach makes the host enumerate the device again.
+func (dev *USBDevice) Detach() {
+	rp.USBCTRL_REGS.SIE_CTRL.ClearBits(rp.USBCTRL_REGS_SIE_CTRL_PULLUP_EN)
+}
+
 func handleUSBIRQ(intr interrupt.Interrupt) {
 	status := rp.USBCTRL_REGS.INTS.Get()
 

--- a/src/machine/machine_rp2350_usb.go
+++ b/src/machine/machine_rp2350_usb.go
@@ -43,7 +43,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 		rp.USB_INTE_SETUP_REQ)
 
 	// Present full speed device by enabling pull up on DP
-	rp.USB.SIE_CTRL.SetBits(rp.USB_SIE_CTRL_PULLUP_EN)
+	dev.Attach()
 
 	// 12.7.2 Disable phy isolation
 	rp.USB.SetMAIN_CTRL_PHY_ISO(0x0)

--- a/src/machine/machine_rp2350_usb.go
+++ b/src/machine/machine_rp2350_usb.go
@@ -49,6 +49,21 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	rp.USB.SetMAIN_CTRL_PHY_ISO(0x0)
 }
 
+// Attach connects the device to the USB bus by enabling the DP pull-up,
+// allowing the host to detect and enumerate it. It can be used together with
+// Detach to delay enumeration until the USB configuration (device
+// identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	rp.USB.SIE_CTRL.SetBits(rp.USB_SIE_CTRL_PULLUP_EN)
+}
+
+// Detach disconnects the device from the USB bus by disabling the DP pull-up.
+// To the host this appears as if the device was unplugged. A subsequent
+// Attach makes the host enumerate the device again.
+func (dev *USBDevice) Detach() {
+	rp.USB.SIE_CTRL.ClearBits(rp.USB_SIE_CTRL_PULLUP_EN)
+}
+
 func handleUSBIRQ(intr interrupt.Interrupt) {
 	status := rp.USB.INTS.Get()
 

--- a/src/machine/machine_stm32_otgfs_usb.go
+++ b/src/machine/machine_stm32_otgfs_usb.go
@@ -254,7 +254,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	otgPower.PCGCCTL.Set(0)
 
 	// Soft-disconnect now (after CSRST reset DCTL to its default connected state).
-	otgDevice.DCTL.SetBits(dctlSDIS)
+	dev.Detach()
 
 	// ---- 7. Configure data FIFOs --------------------------------------------
 
@@ -311,7 +311,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 
 	// ---- 12. Connect to host (clear soft-disconnect) -----------------------
 
-	otgDevice.DCTL.ClearBits(dctlSDIS)
+	dev.Attach()
 
 	dev.initcomplete = true
 }

--- a/src/machine/machine_stm32_otgfs_usb.go
+++ b/src/machine/machine_stm32_otgfs_usb.go
@@ -316,6 +316,21 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	dev.initcomplete = true
 }
 
+// Attach connects the device to the USB bus by releasing soft disconnect,
+// allowing the host to detect and enumerate it. It can be used together with
+// Detach to delay enumeration until the USB configuration (device
+// identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	otgDevice.DCTL.ClearBits(dctlSDIS)
+}
+
+// Detach disconnects the device from the USB bus by asserting soft
+// disconnect. To the host this appears as if the device was unplugged. A
+// subsequent Attach makes the host enumerate the device again.
+func (dev *USBDevice) Detach() {
+	otgDevice.DCTL.SetBits(dctlSDIS)
+}
+
 // handleUSBIRQ is the OTG FS interrupt handler, dispatching on GINTSTS bits.
 func handleUSBIRQ(intr interrupt.Interrupt) {
 	status := stm32.OTG_FS_GLOBAL.GINTSTS.Get() &

--- a/src/machine/machine_stm32h7_usb.go
+++ b/src/machine/machine_stm32h7_usb.go
@@ -206,7 +206,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 
 	// Stay soft-disconnected until configuration is complete; CSRST left
 	// DCTL at its default "connected" state.
-	usbOTG.DCTL.SetBits(DCTL_SDIS)
+	dev.Detach()
 
 	// 5. Force device mode now that the core is out of reset. The mode
 	// change takes effect only after up to 25 ms (RM0433); poll GINTSTS.CMOD
@@ -265,7 +265,7 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	dev.initcomplete = true
 
 	// Release soft-disconnect: pulls D+ high, making device visible to host.
-	usbOTG.DCTL.ClearBits(DCTL_SDIS)
+	dev.Attach()
 }
 
 // Attach connects the device to the USB bus by releasing soft disconnect,

--- a/src/machine/machine_stm32h7_usb.go
+++ b/src/machine/machine_stm32h7_usb.go
@@ -268,6 +268,21 @@ func (dev *USBDevice) Configure(config UARTConfig) {
 	usbOTG.DCTL.ClearBits(DCTL_SDIS)
 }
 
+// Attach connects the device to the USB bus by releasing soft disconnect,
+// allowing the host to detect and enumerate it. It can be used together with
+// Detach to delay enumeration until the USB configuration (device
+// identifiers, classes, ...) is complete.
+func (dev *USBDevice) Attach() {
+	usbOTG.DCTL.ClearBits(DCTL_SDIS)
+}
+
+// Detach disconnects the device from the USB bus by asserting soft
+// disconnect. To the host this appears as if the device was unplugged. A
+// subsequent Attach makes the host enumerate the device again.
+func (dev *USBDevice) Detach() {
+	usbOTG.DCTL.SetBits(DCTL_SDIS)
+}
+
 func initEndpoint(ep, config uint32) {
 	if ep == 0 {
 		// Control endpoint


### PR DESCRIPTION
This PR adds `machine.USBDev.Attach()` and `machine.USBDev.Detach()`, exposing
USB soft-connect control (the D+ pull-up) to user code.

**Motivation**

The USB device is attached to the bus automatically during startup, before
user code has had a chance to finish its USB configuration (`usb.VendorID` /
`usb.ProductID` / `usb.Product`, additional interfaces registered through
`machine.ConfigureUSBEndpoint`, ...). For composite devices such as keyboards
this means the host may enumerate a half-configured device: identifiers and
interfaces set from `main()` can arrive after the host has already read the
descriptors.

With this API, an application or library can stay detached until its
configuration is complete, so the host enumerates the finished device exactly
once:

```go
func init() {
      machine.USBDev.Detach() // stay invisible to the host for now
}

func main() {
      usb.Product = "my-keyboard"
      // ... register HID interfaces, set VID/PID, ...
      machine.USBDev.Attach() // now let the host enumerate
}
```

It can also be used to force re-enumeration without replugging the cable
(Detach() → Attach()).

Prior art

Soft-connect control is a well-established primitive in embedded USB stacks,
exposed for exactly these use cases (delaying enumeration until configuration
is complete, and forcing re-enumeration from software):

- Arduino: USBDevice.detach() / USBDevice.attach() (AVR and SAMD
cores).
- TinyUSB: tud_disconnect() / tud_connect().
- Zephyr: usb_dc_detach() / usb_dc_attach() in the device-controller
driver API.
- STM32 HAL: HAL_PCD_DevDisconnect() / HAL_PCD_DevConnect().

The Attach/Detach naming follows the USB specification's bus-state wording
(a device is "attached" to the bus), which is also where the SAMD register
bit name (CTRLB.DETACH) comes from — and matches the Arduino API, easing
migration for users coming from that ecosystem.

Implementation

One-register operation per chip family, following each reference manual:

```
┌────────────────────┬─────────────────────────────┐
│        Chip        │          Mechanism          │
├────────────────────┼─────────────────────────────┤
│ atsamd21, atsamd51 │ USB_DEVICE.CTRLB DETACH bit │
├────────────────────┼─────────────────────────────┤
│ nrf52840           │ USBD.USBPULLUP              │
├────────────────────┼─────────────────────────────┤
│ rp2040, rp2350     │ SIE_CTRL PULLUP_EN bit      │
└────────────────────┴─────────────────────────────┘
```

The ESP32 variants are not covered: their USB is a Serial/JTAG peripheral
with no equivalent soft-connect concept. Existing behavior is unchanged —
the methods are purely additive.

Testing

- Compile-tested a program calling both methods for all five chip families
(xiao-ble, xiao, wioterminal, pico, pico2).
- Verified on hardware with a XIAO nRF52840 Sense running a Vial keyboard
firmware (tinygo-keyboard)
that detaches in a package init() and attaches after configuration:
the host enumerates the device once, with the complete configuration
(CDC + keyboard/mouse/raw HID interfaces and a custom ProductID).**