### PR TITLE
targets/esp32*: add espradio tag for convenience

### DIFF
--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -3,7 +3,7 @@
 	"inheritable-only": true,
 	"cpu": "esp32",
 	"features": "+atomctl,+bool,+clamps,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+minmax,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed",
-	"build-tags": ["esp32", "esp"],
+	"build-tags": ["esp32", "esp", "espradio"],
 	"scheduler": "tasks",
 	"serial": "uart",
 	"linker": "ld.lld",

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -6,7 +6,8 @@
 	"features": "+32bit,+c,+m,+zmmul,-relax",
 	"build-tags": [
 		"esp32c3",
-		"esp"
+		"esp",
+		"espradio"
 	],
 	"serial": "usb",
 	"rtlib": "compiler-rt",

--- a/targets/esp32s3.json
+++ b/targets/esp32s3.json
@@ -3,7 +3,7 @@
 	"inheritable-only": true,
 	"cpu": "esp32s3",
 	"features": "+atomctl,+bool,+clamps,+coprocessor,+debug,+density,+div32,+esp32s3,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+minmax,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed",
-	"build-tags": ["esp32s3", "esp"],
+	"build-tags": ["esp32s3", "esp", "espradio"],
 	"scheduler": "tasks",
 	"serial": "usb",
 	"linker": "ld.lld",


### PR DESCRIPTION
This add the `espradio` build tag to all ESP32C3, ESP32S3, and ESP32 boards, since they all have support for wireless communication using espradio. This just makes it to people do not have to remember to use the build tag, the same as we have done with both `ninafw` and `cyw43439` build tags.

Before:
```bash
tinygo flash -target xiao-esp32c3 -tags espradio -monitor ./examples/heartrate
```

With this PR:
```bash
tinygo flash -target xiao-esp32c3 -monitor ./examples/heartrate
```