### PR TITLE
Fix to allow -o flag to point to a directory :: #5548

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,8 +177,15 @@ func Build(pkgName, outpath string, config *compileopts.Config) error {
 				// Pick a default output path based on the main directory.
 				outpath = filepath.Base(result.MainDir) + config.DefaultBinaryExtension()
 			}
+		} else if fi, statErr := os.Stat(outpath); statErr == nil && fi.IsDir() {
+			var name string
+			if strings.HasSuffix(pkgName, ".go") {
+				name = filepath.Base(pkgName[:len(pkgName)-3]) + config.DefaultBinaryExtension()
+			} else {
+				name = filepath.Base(result.MainDir) + config.DefaultBinaryExtension()
+			}
+			outpath = filepath.Join(outpath, name)
 		}
-
 		if err := os.Rename(result.Binary, outpath); err != nil {
 			// Moving failed. Do a file copy.
 			inf, err := os.Open(result.Binary)


### PR DESCRIPTION
## What this does
Fixes `tinygo build -o <dir>/ ...` failing with `open <dir>/: is a directory`
when the target directory already exists.

## Why
`Build()` in main.go only derived a default binary name when `outpath == ""`.
If `outpath` was explicitly set but pointed to an existing directory, the
code fell straight to `os.Rename(result.Binary, outpath)`, which fails
since a directory can't be renamed-over/opened as a file.

## Fix
Added a check: if `outpath` is a directory, derive the same default binary
name used in the empty-outpath case, and place the binary inside that
directory — mirroring how `go build -o dir/` behaves for a package.

## Scope
Only handles the case where the directory already exists. If `-o somedir/`
is given and `somedir` doesn't exist yet, behavior is unchanged. Happy to
extend this in a follow-up if maintainers want that too.

## Testing
- `make test` passes locally
- Manually verified: existing directory (new behavior), explicit file path
  (unchanged), and no `-o` flag (unchanged)