### PR TITLE
esp32: fix pullup/pulldown on RTC GPIO pins

### DIFF
--- a/src/machine/machine_esp32.go
+++ b/src/machine/machine_esp32.go
@@ -112,6 +112,11 @@ func (p Pin) configure(config PinConfig, signal uint32) {
 	// Configure the pad with the given IO mux configuration.
 	p.mux().Set(muxConfig)
 
+	// Internal pull resistors for pins with RTC function ignore
+	// the IO_MUX_GPIO0_FUN_WPU and IO_MUX_GPIO0_FUN_WPD bits set
+	// above and are instead controlled by the RTC_IO registers.
+	p.configureRTCPull(config.Mode)
+
 	switch config.Mode {
 	case PinOutput:
 		// Set the 'output enable' bit.
@@ -290,6 +295,60 @@ func (p Pin) mux() *volatile.Register32 {
 		return &esp.IO_MUX.GPIO24
 	default:
 		return nil
+	}
+}
+
+// configureRTCPull applies the pullup/pulldown setting to a pin.
+// This mirrors ESP-IDF:
+// https://github.com/espressif/esp-idf/blob/08e0d30/components/esp_driver_gpio/src/gpio.c#L283
+// https://github.com/espressif/esp-idf/blob/08e0d30/components/esp_hal_gpio/esp32/rtc_io_periph.c#L57
+// https://github.com/espressif/esp-idf/blob/08e0d30/components/esp_hal_gpio/esp32/include/hal/rtc_io_ll.h#L175
+func (p Pin) configureRTCPull(mode PinMode) {
+	var rue, rde uint32
+	switch mode {
+	case PinInputPullup:
+		rue = 1
+	case PinInputPulldown:
+		rde = 1
+	}
+
+	switch p {
+	case 0:
+		esp.RTC_IO.SetTOUCH_PAD1_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD1_RDE(rde)
+	case 2:
+		esp.RTC_IO.SetTOUCH_PAD2_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD2_RDE(rde)
+	case 4:
+		esp.RTC_IO.SetTOUCH_PAD0_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD0_RDE(rde)
+	case 12:
+		esp.RTC_IO.SetTOUCH_PAD5_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD5_RDE(rde)
+	case 13:
+		esp.RTC_IO.SetTOUCH_PAD4_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD4_RDE(rde)
+	case 14:
+		esp.RTC_IO.SetTOUCH_PAD6_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD6_RDE(rde)
+	case 15:
+		esp.RTC_IO.SetTOUCH_PAD3_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD3_RDE(rde)
+	case 25:
+		esp.RTC_IO.SetPAD_DAC1_PDAC1_RUE(rue)
+		esp.RTC_IO.SetPAD_DAC1_PDAC1_RDE(rde)
+	case 26:
+		esp.RTC_IO.SetPAD_DAC2_PDAC2_RUE(rue)
+		esp.RTC_IO.SetPAD_DAC2_PDAC2_RDE(rde)
+	case 27:
+		esp.RTC_IO.SetTOUCH_PAD7_RUE(rue)
+		esp.RTC_IO.SetTOUCH_PAD7_RDE(rde)
+	case 32:
+		esp.RTC_IO.SetXTAL_32K_PAD_X32P_RUE(rue)
+		esp.RTC_IO.SetXTAL_32K_PAD_X32P_RDE(rde)
+	case 33:
+		esp.RTC_IO.SetXTAL_32K_PAD_X32N_RUE(rue)
+		esp.RTC_IO.SetXTAL_32K_PAD_X32N_RDE(rde)
 	}
 }
 


### PR DESCRIPTION
Fixes #3477

## Issue

Pins with RTC function ignore the `IO_MUX_GPIO0_FUN_WPU` and `IO_MUX_GPIO0_FUN_WPD` bits, so `PinInputPullup` and `PinInputPulldown` did nothing.

The issue is that these pins (with RTC function, see [ESP32 TRM](https://documentation.espressif.com/esp32_technical_reference_manual_en.pdf) table 6.11-1) have their pull configuration controlled instead by the `RTC_IO` registers.

## Fix

The `Pin.Configure` function now calls `configureRTCPull` to set `RUE` and `RDE` (pullup and pulldown, respectively) bits in `RTC_IO` mapping the GPIO to RTC as shown in table 6.11-1 in the TRM shared above and also mirroring ESP-IDF [esp_hal_gpio/esp32/rtc_io_periph.c#L57](https://github.com/espressif/esp-idf/blob/08e0d30/components/esp_hal_gpio/esp32/rtc_io_periph.c#L57).

## Testing

Tested on an ESP32 development board ([exact model](https://robocraze.com/products/nodemcu-32-wifi-bluetooth-esp32-development-board30-pin)) by configuring pullup and then pulldown with nothing connected and confirmed the level through `Pin.Get` and also by measuring the voltage.

You can use the test script referenced in the original issue #3477 to validate the fix. Or something like this that checks all pins with this issue:

```go
package main

import (
	"machine"
	"time"
)

// 22 is a non-RTC control pin.
var pins = []machine.Pin{22, 4, 12, 13, 14, 15, 25, 26, 27, 32, 33}

func read(p machine.Pin, mode machine.PinMode) bool {
	p.Configure(machine.PinConfig{Mode: mode})
	time.Sleep(20 * time.Millisecond)
	return p.Get()
}

func main() {
	time.Sleep(2 * time.Second)
	for {
		println("pin pullup pulldown pass")
		pass := 0
		for _, p := range pins {
			up := read(p, machine.PinInputPullup)
			down := read(p, machine.PinInputPulldown)
			ok := up && !down
			if ok {
				pass++
			}
			println(int(p), up, down, ok)
		}
		println("passed", pass, "of", len(pins))
		println()
		time.Sleep(3 * time.Second)
	}
}
```