### PR TITLE
runtime: make arrays and struct field hashes order dependent

### DIFF
--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -807,13 +807,13 @@ func hashmapInterfaceHash(itf interface{}, seed uintptr) uint32 {
 	case reflectlite.Array:
 		var hash uint32
 		for i := 0; i < x.Len(); i++ {
-			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)), seed)
+			hash = (hash * 31) ^ hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)), seed)
 		}
 		return hash
 	case reflectlite.Struct:
 		var hash uint32
 		for i := 0; i < x.NumField(); i++ {
-			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)), seed)
+			hash = (hash * 31) ^ hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)), seed)
 		}
 		return hash
 	default:


### PR DESCRIPTION
Tweak the hash to ensure that `[1, 2]` has a different hash value from `[2, 1]`