### PR TITLE
esp32: remove incorrect `!readLast` check

### DIFF
--- a/src/machine/machine_esp32_i2c.go
+++ b/src/machine/machine_esp32_i2c.go
@@ -242,7 +242,6 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 	timeoutNS := int64(timeoutMS) * 1000000
 	needAddress := true
 	needRestart := false
-	readLast := false
 	var readTo []byte
 	for cmdIdx, reg := 0, &i2c.Bus.COMD0; cmdIdx < len(cmd); {
 		c := &cmd[cmdIdx]
@@ -310,7 +309,6 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 			}
 
 			if split {
-				readLast = true
 				reg.Set(i2cCMD_READLAST | 1)
 				reg = nextAddress(reg)
 				readTo = c.data[c.head : c.head+bytes+1] // read bytes + 1 last byte
@@ -342,7 +340,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 				}
 			}
 			switch {
-			case mask&esp.I2C_INT_STATUS_ACK_ERR_INT_ST_Msk != 0 && !readLast:
+			case mask&esp.I2C_INT_STATUS_ACK_ERR_INT_ST_Msk != 0:
 				return errI2CAckExpected
 			case mask&esp.I2C_INT_STATUS_TIME_OUT_INT_ST_Msk != 0:
 				// timeout leaves the bus in an undefined state, reset

--- a/src/machine/machine_esp32xx_i2c.go
+++ b/src/machine/machine_esp32xx_i2c.go
@@ -186,7 +186,6 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 	timeoutNS := int64(timeoutMS) * 1000000
 	needAddress := true
 	needRestart := false
-	readLast := false
 	var readTo []byte
 	for cmdIdx, reg := 0, &i2c.Bus.COMD0; cmdIdx < len(cmd); {
 		c := &cmd[cmdIdx]
@@ -254,7 +253,6 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 				reg = nextAddress(reg)
 			}
 			if split {
-				readLast = true
 				reg.Set(i2cCMD_READLAST | 1)
 				reg = nextAddress(reg)
 				readTo = c.data[c.head : c.head+bytes+1] // read bytes + 1 last byte
@@ -285,7 +283,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 				}
 			}
 			switch {
-			case mask&esp.I2C_INT_STATUS_NACK_INT_ST_Msk != 0 && !readLast:
+			case mask&esp.I2C_INT_STATUS_NACK_INT_ST_Msk != 0:
 				return errI2CAckExpected
 			case mask&esp.I2C_INT_STATUS_TIME_OUT_INT_ST_Msk != 0:
 				if readTo != nil {


### PR DESCRIPTION
Fixes #5584

As described in the issue, the `&& !readLast` check discarded the address NACK on reads of 32 bytes or fewer. Only `i2cCMD_WRITE` sets `ack_check_en`, so the address WRITE is the only command in a read that can set `ACK_ERR`, so this check is unnecessary.

`readLast` is also removed as it is not used anywhere else other than this check.

Tested on an ESP32-D0WD-V3:

- reads from a device that is present still succeed
- reads from an absent address now return `errI2CAckExpected`
- values read back are unchanged

You can use the same script in the issue to run the test with any I2C device(s).