### PR TITLE
os: add File.Chown on the unix path

### DIFF
--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -163,6 +163,17 @@ func (f *File) Truncate(size int64) (err error) {
 	return Truncate(f.name, size)
 }
 
+// Chown changes the numeric uid and gid of the named file.
+// A uid or gid of -1 means to not change that value.
+// If there is an error, it will be of type *PathError.
+func (f *File) Chown(uid, gid int) error {
+	if f.handle == nil {
+		return ErrClosed
+	}
+
+	return Chown(f.name, uid, gid)
+}
+
 func (f *File) chmod(mode FileMode) error {
 	if f.handle == nil {
 		return ErrClosed


### PR DESCRIPTION
`os.File.Chown` is missing on unix targets, so code calling it fails to compile even though `os.Chown` (the path-based form) is present and the syscall is already available.

This adds the method on the unix path, delegating to the same syscall the package-level function uses.

Verified by building TinyGo.