### PR TITLE
compiler: implement go:cgo_import_dynamic and lower Darwin cgo import trampolines (#5604)

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -88,6 +88,7 @@ type compilerContext struct {
 	diagnostics      []error
 	functionInfos    map[*ssa.Function]functionInfo
 	astComments      map[string]*ast.CommentGroup
+	cgoImportDynamic map[string]string // //go:cgo_import_dynamic local name -> remote symbol
 	embedGlobals     map[string][]*loader.EmbedFile
 	pkg              *types.Package
 	loaderPkg        *loader.Package // current package being compiled (for AST access)
@@ -100,14 +101,15 @@ type compilerContext struct {
 // importantly with a newly created LLVM context and module.
 func newCompilerContext(moduleName string, machine llvm.TargetMachine, config *Config, dumpSSA bool) *compilerContext {
 	c := &compilerContext{
-		Config:        config,
-		DumpSSA:       dumpSSA,
-		difiles:       make(map[string]llvm.Metadata),
-		ditypes:       make(map[types.Type]llvm.Metadata),
-		machine:       machine,
-		targetData:    machine.CreateTargetData(),
-		functionInfos: map[*ssa.Function]functionInfo{},
-		astComments:   map[string]*ast.CommentGroup{},
+		Config:           config,
+		DumpSSA:          dumpSSA,
+		difiles:          make(map[string]llvm.Metadata),
+		ditypes:          make(map[types.Type]llvm.Metadata),
+		machine:          machine,
+		targetData:       machine.CreateTargetData(),
+		functionInfos:    map[*ssa.Function]functionInfo{},
+		astComments:      map[string]*ast.CommentGroup{},
+		cgoImportDynamic: map[string]string{},
 	}
 
 	c.ctx = llvm.NewContext()
@@ -3670,6 +3672,11 @@ func (b *builder) createConvert(typeFrom, typeTo types.Type, value llvm.Value, p
 // which can all be directly lowered to IR. However, there is also the channel
 // receive operator which is handled in the runtime directly.
 func (b *builder) createUnOp(unop *ssa.UnOp) (llvm.Value, error) {
+	if unop.Op == token.MUL {
+		if value := b.createDarwinCgoImportDynamicLoad(unop); !value.IsNil() {
+			return value, nil
+		}
+	}
 	x := b.getValue(unop.X, getPos(unop))
 	switch unop.Op {
 	case token.NOT: // !x

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -198,6 +198,26 @@ func TestDarwinCgoImportDynamic(t *testing.T) {
 	if !strings.Contains(ir, "ptrtoint (ptr @syscall_libc_ioctl to i64)") {
 		t.Error("variadic ioctl import was not routed through its fixed-signature wrapper")
 	}
+	for _, remote := range []string{"open", "openat", "fcntl"} {
+		if !strings.Contains(ir, "ptrtoint (ptr @syscall_libc_"+remote+" to i64)") {
+			t.Errorf("variadic %s import was not routed through its fixed-signature wrapper", remote)
+		}
+		if strings.Contains(ir, "declare void @"+remote+"()") {
+			t.Errorf("variadic %s import was declared directly instead of using its wrapper", remote)
+		}
+	}
+	if !strings.Contains(ir, "ptrtoint (ptr @remote_nolib to i64)") {
+		t.Error("cgo_import_dynamic without a library operand was not honored")
+	}
+	if !strings.Contains(ir, "ptrtoint (ptr @libc_self to i64)") {
+		t.Error("cgo_import_dynamic without a remote symbol did not default to the local symbol")
+	}
+	if !strings.Contains(ir, "load i32, ptr @main.libc_badtype_trampoline_addr") {
+		t.Error("load of a non-uintptr trampoline global was replaced instead of being left alone")
+	}
+	if strings.Contains(ir, "@bad_remote") {
+		t.Error("a declaration was created for the remote symbol of a non-uintptr trampoline global")
+	}
 }
 
 // normalizeIR canonicalizes LLVM-version-specific IR spellings for comparison

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -174,6 +174,32 @@ func TestOptimizedLargeAggregateABI(t *testing.T) {
 	}
 }
 
+func TestDarwinCgoImportDynamic(t *testing.T) {
+	options := &compileopts.Options{GOOS: "darwin", GOARCH: "arm64"}
+	mod, errs := testCompilePackage(t, options, "cgo-import-dynamic.go")
+	if len(errs) != 0 {
+		for _, err := range errs {
+			t.Error(err)
+		}
+		return
+	}
+	defer mod.Dispose()
+
+	ir := mod.String()
+	if !strings.Contains(ir, `declare void @"remote$INODE64"()`) {
+		t.Error("missing external declaration for cgo_import_dynamic remote symbol")
+	}
+	if !strings.Contains(ir, `ptrtoint (ptr @"remote$INODE64" to i64)`) {
+		t.Error("trampoline address load was not replaced with the remote symbol address")
+	}
+	if strings.Contains(ir, "load i64, ptr @main.libc_test_trampoline_addr") {
+		t.Error("trampoline address global was loaded instead of using the remote symbol address")
+	}
+	if !strings.Contains(ir, "ptrtoint (ptr @syscall_libc_ioctl to i64)") {
+		t.Error("variadic ioctl import was not routed through its fixed-signature wrapper")
+	}
+}
+
 // normalizeIR canonicalizes LLVM-version-specific IR spellings for comparison
 // and when regenerating golden files.
 func normalizeIR(s string) string {

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -773,11 +773,25 @@ func (c *compilerContext) loadASTComments(pkg *loader.Package) {
 		// cgo_import_dynamic directives are file-level pragmas. Darwin's
 		// generated syscall wrappers use the local symbol to name an assembly
 		// trampoline and the remote symbol to name the actual dylib function.
+		// Like the gc compiler, accept all three operand forms:
+		//
+		//	//go:cgo_import_dynamic local [remote ["library"]]
+		//
+		// The remote symbol defaults to the local symbol when omitted. The
+		// library operand is not needed here (the linker resolves the symbol
+		// against the libraries it already links) and is ignored, so a library
+		// path containing spaces does not break parsing. A repeated local
+		// symbol keeps the last remote symbol, matching gc's behavior of
+		// simply recording each directive.
 		for _, group := range file.Comments {
 			for _, comment := range group.List {
 				parts := strings.Fields(comment.Text)
-				if len(parts) == 4 && parts[0] == "//go:cgo_import_dynamic" {
-					c.cgoImportDynamic[parts[1]] = parts[2]
+				if len(parts) >= 2 && parts[0] == "//go:cgo_import_dynamic" {
+					local, remote := parts[1], parts[1]
+					if len(parts) >= 3 {
+						remote = parts[2]
+					}
+					c.cgoImportDynamic[local] = remote
 				}
 			}
 		}

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -763,10 +763,25 @@ func (c *compilerContext) fileForFunc(f *ssa.Function) *ast.File {
 	return nil
 }
 
-// loadASTComments loads comments on globals from the AST, for use later in the
-// program. In particular, they are required for //go:extern pragmas on globals.
+// loadASTComments loads comments from the AST that cannot be read on demand
+// while compiling a function, for use later in the program. This covers doc
+// comments on globals (required for //go:extern pragmas) and free-standing
+// file-level //go:cgo_import_dynamic directives, which are not attached to any
+// declaration and apply to the whole package.
 func (c *compilerContext) loadASTComments(pkg *loader.Package) {
 	for _, file := range pkg.Files {
+		// cgo_import_dynamic directives are file-level pragmas. Darwin's
+		// generated syscall wrappers use the local symbol to name an assembly
+		// trampoline and the remote symbol to name the actual dylib function.
+		for _, group := range file.Comments {
+			for _, comment := range group.List {
+				parts := strings.Fields(comment.Text)
+				if len(parts) == 4 && parts[0] == "//go:cgo_import_dynamic" {
+					c.cgoImportDynamic[parts[1]] = parts[2]
+				}
+			}
+		}
+
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.GenDecl:

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -524,11 +524,10 @@ func (b *builder) createDarwinFuncPCABI0Call(instr *ssa.CallCommon) llvm.Value {
 
 	// Extract the libc function name.
 	name := strings.TrimPrefix(strings.TrimSuffix(calledFn.Name(), "_trampoline"), "libc_")
-	if name == "open" {
-		// Special case: open() is a variadic function and can't be called like
-		// a regular function. Therefore, we need to use a wrapper implemented
-		// in C.
-		name = "syscall_libc_open"
+	if wrapper, ok := darwinVariadicImports[name]; ok {
+		// Variadic functions can't be called like a regular function, so use a
+		// wrapper implemented in C. See the comment on darwinVariadicImports.
+		name = wrapper
 	}
 	if b.GOARCH == "amd64" {
 		if name == "fdopendir" || name == "readdir_r" {
@@ -542,16 +541,18 @@ func (b *builder) createDarwinFuncPCABI0Call(instr *ssa.CallCommon) llvm.Value {
 	return b.createDarwinImportedFunctionAddr(name)
 }
 
-// darwinVariadicImports maps the variadic libc functions imported with
-// //go:cgo_import_dynamic on Darwin to fixed-signature C wrappers defined in
+// darwinVariadicImports maps the variadic libc functions imported by Darwin
+// syscall wrappers to fixed-signature C wrappers defined in
 // src/runtime/os_darwin.c. The syscall engine calls an imported address
 // through a fixed-signature function pointer (tinygo_syscallX and friends in
 // src/runtime/os_darwin.c), which passes every argument in a register. A
 // variadic callee, however, takes its variadic arguments from the stack on
 // darwin/arm64, so calling one of these functions directly makes it read
-// garbage arguments (the direct ioctl call observably failed with EFAULT).
-// The same problem is solved the same way for the standard library's open in
-// createDarwinFuncPCABI0Call above.
+// garbage arguments (a direct ioctl call observably failed with EFAULT, and
+// a direct fcntl(F_SETFL) wrote garbage flags). This applies to both
+// trampoline flavors: the standard library's function-based pattern
+// (createDarwinFuncPCABI0Call above) and the address-global pattern used by
+// golang.org/x/sys (createDarwinCgoImportDynamicLoad below).
 //
 // The set comes from cross-referencing the symbols that darwin's generated
 // syscall wrappers import (the //go:cgo_import_dynamic directives in

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -538,16 +538,50 @@ func (b *builder) createDarwinFuncPCABI0Call(instr *ssa.CallCommon) llvm.Value {
 		}
 	}
 
-	// Obtain the C function.
-	// Use a simple function (no parameters or return value) because all we need
-	// is the address of the function.
+	return b.createDarwinImportedFunctionAddr(name)
+}
+
+// Lower a load from a Darwin libc trampoline address global. Packages such as
+// golang.org/x/sys/unix declare globals named libc_*_trampoline_addr and use
+// assembly to initialize them to trampolines for symbols imported with
+// //go:cgo_import_dynamic. TinyGo cannot compile that assembly, so use the
+// imported dylib symbol directly, just like createDarwinFuncPCABI0Call does for
+// the standard library's function-based trampoline pattern.
+func (b *builder) createDarwinCgoImportDynamicLoad(unop *ssa.UnOp) llvm.Value {
+	if b.GOOS != "darwin" {
+		return llvm.Value{}
+	}
+
+	global, ok := unop.X.(*ssa.Global)
+	if !ok {
+		return llvm.Value{}
+	}
+	const suffix = "_trampoline_addr"
+	if !strings.HasPrefix(global.Name(), "libc_") || !strings.HasSuffix(global.Name(), suffix) {
+		return llvm.Value{}
+	}
+
+	local := strings.TrimSuffix(global.Name(), suffix)
+	remote, ok := b.cgoImportDynamic[local]
+	if !ok {
+		return llvm.Value{}
+	}
+	if remote == "ioctl" {
+		// ioctl is variadic, which uses an incompatible calling convention on
+		// darwin/arm64. Route it through the fixed-signature C wrapper.
+		remote = "syscall_libc_ioctl"
+	}
+
+	return b.createDarwinImportedFunctionAddr(remote)
+}
+
+func (b *builder) createDarwinImportedFunctionAddr(name string) llvm.Value {
+	// The signature does not matter: the declaration is only used for its
+	// address, which is passed to a syscall implementation as a uintptr.
 	llvmFn := b.mod.NamedFunction(name)
 	if llvmFn.IsNil() {
 		llvmFnType := llvm.FunctionType(b.ctx.VoidType(), nil, false)
 		llvmFn = llvm.AddFunction(b.mod, name, llvmFnType)
 	}
-
-	// Cast the function pointer to a uintptr (because that's what
-	// abi.FuncPCABI0 returns).
 	return b.CreatePtrToInt(llvmFn, b.uintptrType, "")
 }

--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -4,6 +4,7 @@ package compiler
 // compiler builtins.
 
 import (
+	"go/types"
 	"strconv"
 	"strings"
 
@@ -541,6 +542,30 @@ func (b *builder) createDarwinFuncPCABI0Call(instr *ssa.CallCommon) llvm.Value {
 	return b.createDarwinImportedFunctionAddr(name)
 }
 
+// darwinVariadicImports maps the variadic libc functions imported with
+// //go:cgo_import_dynamic on Darwin to fixed-signature C wrappers defined in
+// src/runtime/os_darwin.c. The syscall engine calls an imported address
+// through a fixed-signature function pointer (tinygo_syscallX and friends in
+// src/runtime/os_darwin.c), which passes every argument in a register. A
+// variadic callee, however, takes its variadic arguments from the stack on
+// darwin/arm64, so calling one of these functions directly makes it read
+// garbage arguments (the direct ioctl call observably failed with EFAULT).
+// The same problem is solved the same way for the standard library's open in
+// createDarwinFuncPCABI0Call above.
+//
+// The set comes from cross-referencing the symbols that darwin's generated
+// syscall wrappers import (the //go:cgo_import_dynamic directives in
+// zsyscall_darwin_*.go, both in golang.org/x/sys/unix and in the standard
+// library) against their Darwin SDK declarations: of those imports, exactly
+// open(2), openat(2), fcntl(2), and ioctl(2) are declared variadic (see
+// sys/fcntl.h and sys/ioctl.h, or lib/macos-minimal-sdk's copies).
+var darwinVariadicImports = map[string]string{
+	"fcntl":  "syscall_libc_fcntl",
+	"ioctl":  "syscall_libc_ioctl",
+	"open":   "syscall_libc_open",
+	"openat": "syscall_libc_openat",
+}
+
 // Lower a load from a Darwin libc trampoline address global. Packages such as
 // golang.org/x/sys/unix declare globals named libc_*_trampoline_addr and use
 // assembly to initialize them to trampolines for symbols imported with
@@ -560,16 +585,20 @@ func (b *builder) createDarwinCgoImportDynamicLoad(unop *ssa.UnOp) llvm.Value {
 	if !strings.HasPrefix(global.Name(), "libc_") || !strings.HasSuffix(global.Name(), suffix) {
 		return llvm.Value{}
 	}
+	// The replacement value is a ptrtoint to uintptr, so only replace loads of
+	// uintptr-typed globals; the trampoline address pattern always uses plain
+	// uintptr variables. Anything else keeps its normal load.
+	if basic, ok := global.Type().(*types.Pointer).Elem().Underlying().(*types.Basic); !ok || basic.Kind() != types.Uintptr {
+		return llvm.Value{}
+	}
 
 	local := strings.TrimSuffix(global.Name(), suffix)
 	remote, ok := b.cgoImportDynamic[local]
 	if !ok {
 		return llvm.Value{}
 	}
-	if remote == "ioctl" {
-		// ioctl is variadic, which uses an incompatible calling convention on
-		// darwin/arm64. Route it through the fixed-signature C wrapper.
-		remote = "syscall_libc_ioctl"
+	if wrapper, ok := darwinVariadicImports[remote]; ok {
+		remote = wrapper
 	}
 
 	return b.createDarwinImportedFunctionAddr(remote)

--- a/compiler/testdata/cgo-import-dynamic.go
+++ b/compiler/testdata/cgo-import-dynamic.go
@@ -2,9 +2,21 @@ package main
 
 var libc_test_trampoline_addr uintptr
 var libc_ioctl_trampoline_addr uintptr
+var libc_open_trampoline_addr uintptr
+var libc_openat_trampoline_addr uintptr
+var libc_fcntl_trampoline_addr uintptr
+var libc_nolib_trampoline_addr uintptr
+var libc_self_trampoline_addr uintptr
+var libc_badtype_trampoline_addr uint32
 
 //go:cgo_import_dynamic libc_test remote$INODE64 "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_open open "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_openat openat "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_fcntl fcntl "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_nolib remote_nolib
+//go:cgo_import_dynamic libc_self
+//go:cgo_import_dynamic libc_badtype bad_remote "/usr/lib/libSystem.B.dylib"
 
 func loadImportedFunctionAddress() uintptr {
 	return libc_test_trampoline_addr
@@ -12,4 +24,28 @@ func loadImportedFunctionAddress() uintptr {
 
 func loadImportedIoctlAddress() uintptr {
 	return libc_ioctl_trampoline_addr
+}
+
+func loadImportedOpenAddress() uintptr {
+	return libc_open_trampoline_addr
+}
+
+func loadImportedOpenatAddress() uintptr {
+	return libc_openat_trampoline_addr
+}
+
+func loadImportedFcntlAddress() uintptr {
+	return libc_fcntl_trampoline_addr
+}
+
+func loadImportedNoLibraryAddress() uintptr {
+	return libc_nolib_trampoline_addr
+}
+
+func loadImportedSelfAddress() uintptr {
+	return libc_self_trampoline_addr
+}
+
+func loadImportedBadTypeAddress() uint32 {
+	return libc_badtype_trampoline_addr
 }

--- a/compiler/testdata/cgo-import-dynamic.go
+++ b/compiler/testdata/cgo-import-dynamic.go
@@ -1,0 +1,15 @@
+package main
+
+var libc_test_trampoline_addr uintptr
+var libc_ioctl_trampoline_addr uintptr
+
+//go:cgo_import_dynamic libc_test remote$INODE64 "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_ioctl ioctl "/usr/lib/libSystem.B.dylib"
+
+func loadImportedFunctionAddress() uintptr {
+	return libc_test_trampoline_addr
+}
+
+func loadImportedIoctlAddress() uintptr {
+	return libc_ioctl_trampoline_addr
+}

--- a/src/runtime/os_darwin.c
+++ b/src/runtime/os_darwin.c
@@ -21,6 +21,31 @@ int syscall_libc_ioctl(uintptr_t fd, uintptr_t request, uintptr_t arg) {
     return ioctl((int)fd, request, (void *)arg);
 }
 
+// Wrappers for the remaining variadic libc functions that darwin syscall
+// wrappers import with //go:cgo_import_dynamic (see darwinVariadicImports in
+// compiler/syscall.go): of the symbols imported by the generated
+// zsyscall_darwin_*.go files in golang.org/x/sys/unix and the standard
+// library, exactly open, openat, fcntl, and ioctl are declared variadic in
+// the Darwin SDK headers (sys/fcntl.h and sys/ioctl.h). The tinygo_syscall*
+// functions below call through fixed-signature function pointers that pass
+// every argument in a register, while a variadic callee takes its variadic
+// arguments from the stack on darwin/arm64, so each of these needs a
+// fixed-signature wrapper. The uintptr_t parameters match the uintptr
+// arguments the Go syscall engine passes.
+
+// fcntl's third argument is an int for some commands and a pointer for
+// others; passing the raw pointer-sized value covers both.
+int syscall_libc_fcntl(uintptr_t fd, uintptr_t cmd, uintptr_t arg) {
+    return fcntl((int)fd, (int)cmd, (void *)arg);
+}
+
+// openat is invoked by x/sys through syscall6 with six arguments, the last
+// two of which are zero padding; the two extra register arguments are
+// harmless to a four-parameter callee.
+int syscall_libc_openat(uintptr_t dirfd, uintptr_t pathname, uintptr_t flags, uintptr_t mode) {
+    return openat((int)dirfd, (const char *)pathname, (int)flags, (mode_t)mode);
+}
+
 // The following functions are called by the runtime because Go can't call
 // function pointers directly.
 

--- a/src/runtime/os_darwin.c
+++ b/src/runtime/os_darwin.c
@@ -4,12 +4,21 @@
 
 #include <fcntl.h>
 
+extern int ioctl(int fd, unsigned long request, ...);
+
 // Wrapper function because 'open' is a variadic function and variadic functions
 // use a different (incompatible) calling convention on darwin/arm64.
 // This function is referenced from the compiler, when it sees a
 // syscall.libc_open_trampoline function.
 int syscall_libc_open(const char *pathname, int flags, mode_t mode) {
     return open(pathname, flags, mode);
+}
+
+// Wrapper for ioctl, which is variadic just like open and therefore also uses
+// an incompatible calling convention on darwin/arm64. Use uintptr_t arguments
+// to match the fixed-signature call made by tinygo_syscall below.
+int syscall_libc_ioctl(uintptr_t fd, uintptr_t request, uintptr_t arg) {
+    return ioctl((int)fd, request, (void *)arg);
 }
 
 // The following functions are called by the runtime because Go can't call


### PR DESCRIPTION
As noted in #5604, this was worked through with LLM.  It adds parsing of the `go:cgo_import_dynamic` directive and implementation for Darwin. 

The other  Tinygo-supported platform that *could* use this is OpenBSD, but is more important for Darwin.  It targets `loadASTComments` generally because these directives are not necessarily attached to a function/module/etc; the comment there explains it.

The following description of the PR is LLM-generated from our journey; it is verbose but comprehensive.    I have read it and I have reviewed all the submitted code, both humanually and with multiple LLMs.   Thanks for the review.

----

## Summary

Extend TinyGo's existing Darwin stdlib trampoline lowering to the variable-based pattern used by `golang.org/x/sys/unix` and `internal/syscall/unix`, and route all four variadic libc imports (`open`, `openat`, `fcntl`, `ioctl`) through fixed-signature wrappers on both trampoline paths.

Fixes #5604.
Fixes #5365.
Builds on #5401.
The companion `_ioctl`/`___sincos_stret` stubs ([macos-minimal-sdk#5](https://github.com/tinygo-org/macos-minimal-sdk/pull/5)) are already in `dev` via the macos-minimal-sdk v0.1.0 submodule update.

## Problem

Darwin syscall wrappers generated by x/sys declare globals such as `libc_ioctl_trampoline_addr` and associate them with dylib symbols using file-level `//go:cgo_import_dynamic` pragmas. TinyGo does not compile the assembly that initializes those globals, so the existing libc syscall engine receives address zero and crashes before `main` in Bubble Tea programs.

TinyGo already avoids the equivalent assembly trampoline for the standard library: `createDarwinFuncPCABI0Call` recognizes `abi.FuncPCABI0(libc_*_trampoline)` and substitutes the address of an external libc declaration. This change applies that same lowering to the x/sys global-load pattern.

That existing stdlib lowering also carries a silent bug of its own: among its variadic imports it routes only `open` through a fixed-signature wrapper, so stdlib `fcntl`, `ioctl`, and `openat` calls corrupt their variadic arguments on darwin/arm64. This PR fixes that too, since the new lowering needs the same wrapper set anyway.

## Scope

This is a targeted implementation of the `//go:cgo_import_dynamic` pattern used by Darwin's generated syscall wrappers, not general cross-platform support for the directive. Although the file-level metadata is parsed during compilation, the `libc_*_trampoline_addr` symbol-address substitution is restricted to `GOOS=darwin`; non-Darwin targets retain their existing behavior.

Upstream Go also uses `//go:cgo_import_dynamic` on platforms such as OpenBSD, AIX, Solaris, and illumos. Supporting those platforms, the directive's library operand, other use patterns, and platform-specific linking or calling conventions remains out of scope.

## Implementation

- Parse the local and remote symbol metadata from file-level `//go:cgo_import_dynamic` pragmas into a package-local map for Darwin trampoline lowering, accepting the same one-, two-, and three-operand forms as the gc compiler (`local [remote ["library"]]`); the remote symbol defaults to the local one and the library operand is ignored (the linker already resolves against libSystem).
- On Darwin, replace loads of matching uintptr-typed `libc_*_trampoline_addr` globals with `ptrtoint` of an external declaration for the pragma's remote symbol. Globals of any other type keep their normal load.
- Preserve remote names verbatim, including amd64 `$INODE64` variants.
- Route the variadic imports through fixed-signature C wrappers via a shared `darwinVariadicImports` table. Of the symbols Darwin's generated syscall wrappers import (`zsyscall_darwin_*.go` in x/sys and the standard library), exactly `open`, `openat`, `fcntl`, and `ioctl` are variadic. The syscall engine calls imported addresses through fixed-signature function pointers (`tinygo_syscallX` and friends) that pass every argument in a register, while a variadic callee reads its variadic arguments from the stack on darwin/arm64, so direct calls silently receive garbage in the variadic slot (observed: `EFAULT` from `ioctl`; `unix.Open` creating files with mode 0 instead of the requested mode).
- In a separate commit, point the existing stdlib `FuncPCABI0` trampoline lowering (`createDarwinFuncPCABI0Call`) at the same table, replacing its `open`-only special case. This fixes the pre-existing silent bug on the stdlib path: `syscall.SetNonblock` (fcntl `F_SETFL` with the new flags in the variadic slot) observably wrote garbage file flags on darwin/arm64, and the stdlib `ioctl` and `openat` trampolines were equally unsound.
- Extend the focused compiler IR test: pragma parsing including the short directive forms, exact remote-symbol preservation, load replacement, wrapper routing for all four variadic imports (with no direct declarations for them), and the non-uintptr-global guard.

The companion `_ioctl` and `___sincos_stret` stub additions landed upstream in [macos-minimal-sdk#5](https://github.com/tinygo-org/macos-minimal-sdk/pull/5) and reached `dev` with the macos-minimal-sdk v0.1.0 submodule update, so this branch (rebased onto that dev) builds and links darwin x/sys programs out of the box with no SDK changes of its own. No new stubs are needed for `open`, `openat`, or `fcntl` — those symbols are already in the stock stub list, and their prototypes come from the SDK's `sys/fcntl.h`.

## Verification

- `go test -tags llvm22 ./compiler -count=1`
- 11-line `golang.org/x/sys/unix.IoctlGetTermios` repro under a PTY: returned a populated termios value and `<nil>`.
- `github.com/charmbracelet/x/term.IsTerminal` under a PTY: `true`.
- `term.MakeRaw` and `term.Restore` under a PTY: both `<nil>`.
- Bubble Tea `examples/spinner`: initialized, rendered animated frames, and exited on `q`.
- Bubble Tea `examples/list-default`: initialized, rendered the list UI, and exited on `q`.
- Variadic-slot checks (x/sys path), asserting values that travel through the variadic parameter: `unix.Open` with mode `0o640` created the file with mode `640` exactly, `unix.FcntlInt(F_DUPFD, 50)` returned fd `50`, and `unix.Openat` with mode `0o600` created mode `600` exactly. The pre-fix compiler produced mode `0`, fd `49`, and mode `41` on the same program — the silent-corruption failure mode.
- Variadic-slot check (stdlib `FuncPCABI0` path): `syscall.SetNonblock(fd, true)` followed by an `F_GETFL` readback yields flags exactly `0o4` (`O_NONBLOCK`), and a read from the empty pipe returns `EAGAIN` immediately. Without the `FuncPCABI0` change, the same program showed garbage flags (`0o20000110`), `O_NONBLOCK` unset, and the read blocked forever; the blocking read was also reproduced on stock `dev` at f71b6305 with a stdlib-only variant.

No startup panic or `os/signal`/SIGWINCH failure surfaced in this ladder.

## Context

This is the actual current Darwin-native root cause behind #5365. It is the "class 2" failure described by @mparrett in #4794 and is independent of the public `syscall.Syscall*` API discussed there.

An earlier attempt in #5403 made public `syscall.Syscall*` calls work by lowering syscall numbers directly to raw Darwin kernel instructions. That was a separate route which bypassed Darwin's libc-based dispatch and was never used by the x/sys/Bubble Tea call chain.

After #5401 made x/sys's private linknames resolve, the failing program reached TinyGo's existing `syscall.syscalln`/`syscall.rawsyscalln` libc dispatcher with the correct `ioctl` arguments but a zero function pointer. The dispatcher was not broken; the assembly-generated bridge that supplied its libc function pointer was missing. This change supplies that address and lets x/sys use TinyGo's existing libc path as intended.

This does not implement public `syscall.Syscall*`-by-number on Darwin, nor does it guarantee that every libc symbol is already present in the macOS minimal SDK.
