### PR TITLE
wasm: keep one pending scheduler wakeup instead of leaking a timer chain

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -270,15 +270,24 @@
 
 					// func sleepTicks(timeout int64)
 					"runtime.sleepTicks": (timeout) => {
-						// Do not sleep, only reactivate scheduler after the given timeout.
-						setTimeout(() => {
+						// Do not sleep, only reactivate the scheduler after the given
+						// timeout, keeping exactly one pending wakeup.
+						const ms = Number(timeout) / 1e6;
+						const due = Date.now() + ms;
+						if (this._scheduledWakeup !== undefined) {
+							if (this._scheduledWakeupDue <= due) return;
+							clearTimeout(this._scheduledWakeup);
+						}
+						this._scheduledWakeupDue = due;
+						this._scheduledWakeup = setTimeout(() => {
+							this._scheduledWakeup = undefined;
 							if (this.exited) return;
 							try {
 								this._inst.exports.go_scheduler();
 							} catch (e) {
 								if (e !== wasmExit) throw e;
 							}
-						}, Number(timeout) / 1e6);
+						}, ms);
 					},
 
 					// func finalizeRef(v ref)
@@ -489,6 +498,12 @@
 			this._ids = new Map();  // mapping from JS values to reference ids
 			this._idPool = [];      // unused ids that have been garbage collected
 			this.exited = false;    // whether the Go program has exited
+			// A wakeup left pending by a previous run would otherwise suppress the
+			// first one this run asks for, and the scheduler would never start.
+			if (this._scheduledWakeup !== undefined) {
+				clearTimeout(this._scheduledWakeup);
+				this._scheduledWakeup = undefined;
+			}
 			this.exitCode = 0;
 			// syscall/js.handleEvent reads _pendingEvent and returns early only when
 			// it IsNull(). Leaving it `undefined` is not null, so handleEvent falls


### PR DESCRIPTION
`sleepTicks` armed a fresh `setTimeout` on every call and never cancelled the
previous one. Its callback calls `go_scheduler()`, which re-enters the
cooperative scheduler, which calls `sleepTicks` again whenever it finds nothing
runnable but something sleeping (`scheduler_cooperative.go:258`, and `:285` on
wasmexport return). So each armed timer replaces itself indefinitely, and every
JS→Go callback that reaches the scheduler starts another such chain. Nothing
cancels one, so the pending count grows without bound.

The scheduler only ever needs one pending wakeup — the earliest deadline. This
tracks it and drops any request that is no sooner than what is already armed.
`run()` also clears a wakeup left over from a previous run, which would
otherwise suppress the first one the new run asks for.

Measured in Chrome with the same wasm binary both times — 50 sleeping goroutines
and a `requestAnimationFrame` loop — counting `setTimeout` calls per second:

| | t+3s | t+20s | t+40s |
|---|---|---|---|
| before | 487/sec | 1,498/sec | 2,509/sec |
| after | 9/sec | 5/sec | 5/sec |

A larger application reached ~2,800/sec inside a minute. Go-side timing is
unaffected — a goroutine sleeping in a loop still advances exactly 3s over 3s of
wall clock — and frame pacing is unchanged at ~59fps with the animation
rendering correctly.

Only `targets/wasm_exec.js` changes, so there is no Go code to `make fmt`; I
verified the file parses and exercised it in a browser rather than running the
full suite.

Fixes #5621
