### PR TITLE
runtime: lock the timer queue when resetTimer mutates timer fields

### DIFF
--- a/src/runtime/scheduler_cooperative.go
+++ b/src/runtime/scheduler_cooperative.go
@@ -147,6 +147,21 @@ func addSleepTask(t *task.Task, duration timeUnit) {
 // queue already.
 // This function is very similar to addSleepTask but for timerQueue instead of
 // sleepQueue.
+// lockTimerQueue and unlockTimerQueue guard direct mutation of a timer's
+// when/period fields from outside the normal addTimer/removeTimer/reAddTimer
+// path (see resetTimer in time.go). On this scheduler there's no real
+// parallelism, so disabling interrupts is enough to make the pair of writes
+// atomic with respect to a timer callback running from an interrupt handler.
+var timerQueueLockMask interrupt.State
+
+func lockTimerQueue() {
+	timerQueueLockMask = interrupt.Disable()
+}
+
+func unlockTimerQueue() {
+	interrupt.Restore(timerQueueLockMask)
+}
+
 func addTimer(tim *timerNode) {
 	mask := interrupt.Disable()
 	timerQueueAdd(tim)

--- a/src/runtime/scheduler_cores.go
+++ b/src/runtime/scheduler_cores.go
@@ -99,6 +99,17 @@ func NumCPU() int {
 	return numCPU
 }
 
+// lockTimerQueue and unlockTimerQueue guard direct mutation of a timer's
+// when/period fields from outside the normal addTimer/removeTimer/reAddTimer
+// path (see resetTimer in time.go), using the same lock those functions use.
+func lockTimerQueue() {
+	schedulerLock.Lock()
+}
+
+func unlockTimerQueue() {
+	schedulerLock.Unlock()
+}
+
 func addTimer(tn *timerNode) {
 	schedulerLock.Lock()
 	timerQueueAdd(tn)

--- a/src/runtime/scheduler_none.go
+++ b/src/runtime/scheduler_none.go
@@ -59,6 +59,14 @@ func NumCPU() int {
 	return 1
 }
 
+// lockTimerQueue and unlockTimerQueue guard direct mutation of a timer's
+// when/period fields from outside the normal addTimer/removeTimer/reAddTimer
+// path (see resetTimer in time.go). Timers aren't supported at all without a
+// scheduler (addTimer below panics), so there's nothing to synchronize here.
+func lockTimerQueue() {}
+
+func unlockTimerQueue() {}
+
 func addTimer(tim *timerNode) {
 	runtimePanic("timers not supported without a scheduler")
 }

--- a/src/runtime/scheduler_threads.go
+++ b/src/runtime/scheduler_threads.go
@@ -115,6 +115,17 @@ func timerRunner() {
 	}
 }
 
+// lockTimerQueue and unlockTimerQueue guard direct mutation of a timer's
+// when/period fields from outside the normal addTimer/removeTimer/reAddTimer
+// path (see resetTimer in time.go), using the same lock those functions use.
+func lockTimerQueue() {
+	timerQueueLock.Lock()
+}
+
+func unlockTimerQueue() {
+	timerQueueLock.Unlock()
+}
+
 func addTimer(tim *timerNode) {
 	timerQueueLock.Lock()
 

--- a/src/runtime/time.go
+++ b/src/runtime/time.go
@@ -58,8 +58,15 @@ func resetTimer(t *timeTimer, when, period int64) bool {
 	if n == nil {
 		n = new(timerNode)
 	}
+	// A periodic timer's underlying *timer can still be referenced by a
+	// second timerNode while its callback is running (see reAddTimer and
+	// timerCallback), so t.timer.when/period must be mutated under the
+	// same lock every other writer and reader of those fields uses, not
+	// just left as a plain unsynchronized store.
+	lockTimerQueue()
 	t.timer.when = when
 	t.timer.period = period
+	unlockTimerQueue()
 	n.timer = &t.timer
 	n.callback = timerCallback
 	addTimer(n)


### PR DESCRIPTION
## Summary

`resetTimer`'s fast path for a periodic timer still firing on another goroutine allocates a fresh `timerNode` that points at the same shared `*timer` as the node currently running its callback. Every place that reads or writes that timer's `when`/`period` fields while it can be firing concurrently takes the scheduler's timer lock first: `reAddTimer` does, and the two reads in the threads scheduler's `timerRunner` do too. `resetTimer`'s own writes to `t.timer.when` and `t.timer.period` were the one place that didn't, an unsynchronized store racing against those lock-protected accesses.

Update #5469

That issue is a nil pointer dereference during a fuzz-style repeat of the context tests, and #5470 already fixed one instance of this same "accessed outside the lock" pattern in `timerRunner`. This closes another surviving instance of it: `resetTimer`'s writes now go through the same lock via two new functions, `lockTimerQueue`/`unlockTimerQueue`, implemented per scheduler (the real lock for threads and cores, interrupt disable/restore for the cooperative scheduler, and a no-op for `scheduler.none`, where timers are unsupported entirely).

## Test plan

I wasn't able to reproduce the original crash directly. It's rare enough that the issue itself needed a repeated loop to hit it, and a targeted stress test hammering `Ticker.Reset` concurrently with active firing (16 tickers, 3 goroutines each, several minutes total across both the original and patched runtime) didn't trigger it either way.

What I can confirm:
- The data race is real and reproducible by inspection: the write in `resetTimer` has no lock while every other writer and reader of the same fields has one.
- `gofmt` is clean on all changed files.
- The fix doesn't introduce any deadlock or regression: `context` package tests pass, and the same targeted stress test ran clean (no hangs, no crashes) against the patched runtime.

Happy to add a regression test if there's a preferred pattern for timing-dependent runtime races in this codebase, since a deterministic one isn't straightforward given how narrow the window is.