### PR TITLE
ci: publish releases automatically on a tag push

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,9 +6,10 @@ on:
     branches:
       - dev
       - release
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: macos-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -59,7 +59,7 @@ jobs:
         run: make llvm-source
       - name: Save LLVM source cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -87,7 +87,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save LLVM build cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
         run: make llvm-source
       - name: Save LLVM source cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -108,7 +108,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save LLVM build cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
@@ -281,7 +281,7 @@ jobs:
         run: make llvm-source
       - name: Save LLVM source cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -308,7 +308,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save LLVM build cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build
@@ -390,7 +390,7 @@ jobs:
         run: make llvm-source
       - name: Save LLVM source cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -419,7 +419,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save LLVM build cache
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,9 +6,10 @@ on:
     branches:
       - dev
       - release
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: linux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+# Build and publish a GitHub Release when a version tag is pushed.
+#
+# This workflow does not build anything itself: it calls the regular Linux,
+# macOS and Windows workflows, which already produce every file a release
+# needs, and then collects their artifacts into a single draft release.
+#
+# The release is created as a draft on purpose, so the release notes can be
+# reviewed (and the CHANGELOG.md entry pasted in) before publishing.
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    # The release filenames are derived from goenv/version.go, not from the
+    # tag, so check they agree before spending an hour building everything.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Check the tag matches goenv/version.go
+        run: |
+          version=$(./.github/workflows/tinygo-extract-version.sh | cut -d= -f2-)
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match version $version in goenv/version.go"
+            exit 1
+          fi
+
+  linux:
+    needs: check-version
+    uses: ./.github/workflows/linux.yml
+  macos:
+    needs: check-version
+    uses: ./.github/workflows/build-macos.yml
+  windows:
+    needs: check-version
+    uses: ./.github/workflows/windows.yml
+
+  release:
+    needs: [linux, macos, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Download all release artifacts
+        # Every build job uploads with `archive: false`, which names the
+        # artifact after the file, so this leaves the release files (and
+        # nothing else) directly in dist/.
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Check all release files are present
+        # A build that silently stopped uploading must not result in a
+        # half-complete release, so list what is expected explicitly.
+        run: |
+          version=$(./.github/workflows/tinygo-extract-version.sh | cut -d= -f2-)
+          missing=0
+          for file in \
+              "tinygo$version.linux-amd64.tar.gz"  "tinygo_${version}_amd64.deb" \
+              "tinygo$version.linux-arm.tar.gz"    "tinygo_${version}_armhf.deb" \
+              "tinygo$version.linux-arm64.tar.gz"  "tinygo_${version}_arm64.deb" \
+              "tinygo$version.darwin-amd64.tar.gz" \
+              "tinygo$version.darwin-arm64.tar.gz" \
+              "tinygo$version.windows-amd64.zip"; do
+            if [ ! -f "dist/$file" ]; then
+              echo "::error::missing release file $file"
+              missing=1
+            fi
+          done
+          ls -l dist
+          exit $missing
+      - name: Create the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # GitHub computes a SHA-256 digest for every asset it stores, but
+          # only exposes it through the API, so say how to read it. These notes
+          # are prepended to the notes GitHub generates from the commit log.
+          notes=$(cat <<EOF
+          ## Verifying downloads
+
+          GitHub records a SHA-256 digest for every asset below. To print them:
+
+              gh release view $GITHUB_REF_NAME --repo $GITHUB_REPOSITORY --json assets --jq '.assets[] | "\(.digest)  \(.name)"'
+          EOF
+          )
+          prerelease=
+          case "$GITHUB_REF_NAME" in
+            *-alpha*|*-beta*|*-rc*) prerelease=--prerelease ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" \
+            --draft \
+            --verify-tag \
+            $prerelease \
+            --title "$GITHUB_REF_NAME" \
+            --notes "$notes" \
+            --generate-notes \
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,14 @@ jobs:
       - name: Download all release artifacts
         # Every build job uploads with `archive: false`, which names the
         # artifact after the file, so this leaves the release files (and
-        # nothing else) directly in dist/.
+        # nothing else) directly in dist/. skip-decompress matters for the
+        # Windows release, which is itself a .zip: without it the download
+        # would helpfully unpack the release instead of keeping the file.
         uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
+          skip-decompress: true
       - name: Check all release files are present
         # A build that silently stopped uploading must not result in a
         # half-complete release, so list what is expected explicitly.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,9 +6,10 @@ on:
     branches:
       - dev
       - release
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: windows-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
         run: make llvm-source
       - name: Save cached LLVM source
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
           path: |
@@ -81,7 +81,7 @@ jobs:
           find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
       - name: Save cached LLVM build
         uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-build.outputs.cache-hit != 'true' && github.ref_type != 'tag'
         with:
           key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
           path: llvm-build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -119,3 +119,31 @@ the following command (for example in ~/lib):
 TinyGo will get extracted to a `tinygo` directory. You can then call it with:
 
     ./tinygo/bin/tinygo
+
+## Publish a release
+
+Releases are built and published by the `Release` workflow
+(`.github/workflows/release.yml`), which runs when a `v*` tag is pushed. There
+is no need to build or upload anything by hand.
+
+ 1. On the `dev` branch, set `const version` in `goenv/version.go` to the new
+    version (without a `v` prefix) and update `CHANGELOG.md`.
+ 2. Merge `dev` into the `release` branch.
+ 3. Tag the release and push the tag:
+
+        git tag v0.42.0
+        git push origin v0.42.0
+
+    The tag must match `goenv/version.go`; the workflow refuses to build
+    otherwise, because the release filenames are derived from that constant.
+ 4. The workflow runs the full Linux, macOS and Windows workflows, so
+    everything that ships is also tested, and then collects their artifacts
+    into a **draft** release: tarballs for linux/darwin, a zip for Windows, and
+    Debian packages for linux.
+ 5. Review the generated release notes, paste in the `CHANGELOG.md` entry, and
+    publish the draft.
+
+GitHub records a SHA-256 digest for every published asset. It is not shown on
+the release page, but it can be read with:
+
+    gh release view v0.42.0 --json assets --jq '.assets[] | "\(.digest)  \(.name)"'


### PR DESCRIPTION
Hello! CI already builds everything a release needs, but publishing is still
manual — download the nine artifacts from the run, create the release, attach
them by hand. This automates that.

**What it does.** Pushing a `v*` tag runs the Linux, macOS and Windows
workflows via `workflow_call`, so what ships is what was tested, then collects
their artifacts into a **draft** release — draft on purpose, so you still
review the notes and paste in the CHANGELOG entry before publishing.

It checks the tag against `goenv/version.go` before starting the builds, since
the asset filenames come from that constant rather than from the tag. And it
checks all nine files actually arrived, so a build that quietly stops uploading
can't produce a half-complete release. That check earned its place immediately:
the first run failed on it, because the Windows release is itself a `.zip` and
`download-artifact` unpacked it instead of keeping the file.

No checksum file: GitHub records a SHA-256 digest for every asset itself. The
release notes just say how to print them.

**Caching.** Tag runs no longer *save* the LLVM caches. Caches are scoped to
the ref that creates them: a tag run can restore from the default branch, but
anything it saves lands in a scope named after that one tag and no later run
can ever read it — not another tag, not the default branch. On my fork the
first release run left 25 entries totalling 2.6 GB stranded that way. Since
eviction is by least recent access, a release that missed the cache could push
out the default-branch entries every other run depends on. Restore is
untouched, which is where the benefit is.

**Other changes to the existing workflows** are small — a `workflow_call`
trigger, and their concurrency groups no longer use `github.workflow`. Inside a
called workflow that context is the caller's, so all three would land in the
same group and cancel each other; the literals evaluate to the same string as
before for pull request and push runs.

**Tested end to end** on my fork: https://github.com/yohimik/tinygo/actions/runs/33208158272
All 23 jobs green, nine assets on a draft release, and every published asset's
digest matches the digest of the artifact its build job produced. (That run
predates a rebase onto current `dev`; the change set is identical.)

<img width="939" height="633" alt="image" src="https://github.com/user-attachments/assets/350d5002-beff-4561-89fe-d55793299874" />

Let me know if anything should change — naming, draft vs. published, the notes
wording, any of it.
