### PR TITLE
builder: add strlen to wasm builtins

### DIFF
--- a/builder/wasmbuiltins.go
+++ b/builder/wasmbuiltins.go
@@ -43,11 +43,11 @@ var libWasmBuiltins = Library{
 	sourceDir: func() string { return filepath.Join(goenv.Get("TINYGOROOT"), "lib/wasi-libc") },
 	librarySources: func(target string, _ bool) ([]string, error) {
 		return []string{
-			// memory builtins needed for llvm.memcpy.*, llvm.memmove.*, and
-			// llvm.memset.* LLVM intrinsics.
+			// Memory builtins needed for LLVM intrinsics and library calls.
 			"libc-top-half/musl/src/string/memcpy.c",
 			"libc-top-half/musl/src/string/memmove.c",
 			"libc-top-half/musl/src/string/memset.c",
+			"libc-top-half/musl/src/string/strlen.c",
 
 			// exp, exp2, and log are needed for LLVM math builtin functions
 			// like llvm.exp.*.

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -23,8 +23,9 @@ import (
 // builder.Library struct but that's hard to do since we want to know the
 // library path in advance in several places).
 var libVersions = map[string]int{
-	"musl":  3,
-	"bdwgc": 2,
+	"musl":         3,
+	"bdwgc":        2,
+	"wasmbuiltins": 1,
 }
 
 // Config keeps all configuration affecting the build in a single struct.

--- a/make/smoketest.mk
+++ b/make/smoketest.mk
@@ -573,9 +573,10 @@ smoketest-riscv: | build/smoke
 smoketest-wasm: SMOKE_OUT = build/smoke/wasm
 smoketest-wasm: | build/smoke
 ifneq ($(WASM), 0)
-	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm               examples/wasm/export
-	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm               examples/wasm/main
-	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm-unknown       examples/hello-wasm-unknown
+	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm                examples/wasm/export
+	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm                examples/wasm/main
+	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm-unknown        examples/hello-wasm-unknown
+	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm-unknown -opt=2 ./testdata/wasm-unknown-opt
 endif
 
 smoketest-flags: SMOKE_OUT = build/smoke/flags

--- a/testdata/wasm-unknown-opt/main.go
+++ b/testdata/wasm-unknown-opt/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "reflect"
+
+type value struct {
+	Field int
+}
+
+//go:wasmexport typeNameLength
+func typeNameLength() uint32 {
+	return uint32(len(reflect.TypeOf(value{}).String()))
+}
+
+func main() {
+}


### PR DESCRIPTION
LLVM 22 can replace string-scanning loops with calls to strlen during optimization. Add the implementation to wasmbuiltins and invalidate cached archives.

I hit this while trying to bump dprint-plugin-gofumpt to Go 1.27 via a `dev` docker image.