### PR TITLE
compiler,runtime: call fcntl through a C wrapper on darwin

### DIFF
--- a/compiler/syscall.go
+++ b/compiler/syscall.go
@@ -529,6 +529,11 @@ func (b *builder) createDarwinFuncPCABI0Call(instr *ssa.CallCommon) llvm.Value {
 		// in C.
 		name = "syscall_libc_open"
 	}
+	if name == "fcntl" {
+		// Same for fcntl(), whose third parameter is variadic. See
+		// src/runtime/os_darwin.c for what goes wrong without the wrapper.
+		name = "syscall_libc_fcntl"
+	}
 	if b.GOARCH == "amd64" {
 		if name == "fdopendir" || name == "readdir_r" {
 			// Hack to support amd64, which needs the $INODE64 suffix.

--- a/src/os/fcntl_test.go
+++ b/src/os/fcntl_test.go
@@ -1,0 +1,72 @@
+//go:build (darwin || linux) && !baremetal && !tinygo.wasm && !nintendoswitch
+
+package os_test
+
+import (
+	. "os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fcntl takes its third parameter through a variadic list, so the call needs
+// the C wrapper in src/runtime/os_darwin.c on darwin.
+
+// F_SETFL must reach fcntl with the value that the caller gave it. A read on
+// an empty pipe returns EAGAIN when the descriptor is non-blocking, and blocks
+// when the flag did not arrive.
+func TestFcntlSetNonblock(t *testing.T) {
+	var fds [2]int
+	if err := syscall.Pipe(fds[:]); err != nil {
+		t.Fatalf("Pipe failed: %v", err)
+	}
+	defer syscall.Close(fds[0])
+	defer syscall.Close(fds[1])
+
+	if err := syscall.SetNonblock(fds[0], true); err != nil {
+		t.Fatalf("SetNonblock failed: %v", err)
+	}
+
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 1)
+		n, err := syscall.Read(fds[0], buf)
+		done <- result{n, err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != syscall.EAGAIN {
+			t.Errorf("wanted EAGAIN from a read on an empty non-blocking pipe, got %d, %v", r.n, r.err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the read blocked, so the descriptor is still blocking")
+	}
+}
+
+// The pointer commands go through the same wrapper as the int commands. A
+// F_GETLK on a file that nobody locked reports F_UNLCK.
+func TestFcntlGetLock(t *testing.T) {
+	f, err := CreateTemp(t.TempDir(), "fcntl")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	defer f.Close()
+
+	lk := syscall.Flock_t{
+		Type:   syscall.F_RDLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    0,
+	}
+	if err := syscall.FcntlFlock(f.Fd(), syscall.F_GETLK, &lk); err != nil {
+		t.Fatalf("FcntlFlock(F_GETLK) failed: %v", err)
+	}
+	if lk.Type != syscall.F_UNLCK {
+		t.Errorf("wanted F_UNLCK on an unlocked file, got %d", lk.Type)
+	}
+}

--- a/src/runtime/os_darwin.c
+++ b/src/runtime/os_darwin.c
@@ -3,6 +3,7 @@
 // This file is included in the build, despite the //go:build line above.
 
 #include <fcntl.h>
+#include <stdint.h>
 
 // Wrapper function because 'open' is a variadic function and variadic functions
 // use a different (incompatible) calling convention on darwin/arm64.
@@ -10,6 +11,18 @@
 // syscall.libc_open_trampoline function.
 int syscall_libc_open(const char *pathname, int flags, mode_t mode) {
     return open(pathname, flags, mode);
+}
+
+// Wrapper function for 'fcntl', whose third parameter is variadic as well.
+// A call through a plain three-argument function pointer makes the callee read
+// that argument from the stack, which holds an unrelated value.
+//
+// The argument is a uintptr_t so that the pointer commands reached through
+// syscall.fcntlPtr use the same wrapper. Both spellings share
+// libc_fcntl_trampoline, and on a little-endian target the int commands read
+// the low half of the same stack slot.
+int syscall_libc_fcntl(int fd, int cmd, uintptr_t arg) {
+    return fcntl(fd, cmd, arg);
 }
 
 // The following functions are called by the runtime because Go can't call


### PR DESCRIPTION
Status: closed in favor of the earlier and broader #5612. The tests remain available for that PR. The evidence below is historical.

# compiler,runtime: call fcntl through a C wrapper on darwin


## What this does

The third parameter of `fcntl` is variadic, and on darwin/arm64 a variadic
argument goes on the stack and not in a register. A call to libc `fcntl` through
a plain three-argument function pointer thus makes the callee read that argument
from an unrelated stack slot. `open()` already has a C wrapper in
`src/runtime/os_darwin.c` for the same reason, and this adds the matching one
for `fcntl`.

The wrapper takes the argument as a `uintptr_t` so that the pointer commands
reached through `syscall.fcntlPtr` use it too. Both spellings go through
`libc_fcntl_trampoline`, and on a little-endian target the int commands read the
low half of the same stack slot.

## Why it matters

The failure is quiet. `fcntl(fd, F_SETFD, FD_CLOEXEC)` sets the flag or does
not, which depends on the stack contents, so the result is the same for one
binary and different between binaries. `syscall.CloseOnExec` is the main caller,
so when it fails, every descriptor of the program goes into every process that
it starts, and a child that holds a copy of the write end of a pipe keeps that
pipe from a report of EOF.

## Evidence

Measured on macOS 26.6 arm64 before this change.

- `fcntl(fd, F_DUPFD, 100)` returns EINVAL.
- Three `F_SETFL` calls with 0x4, 0x0 and 0x8 all leave `F_GETFL` reading 0x48.

Two tests are added to `src/os/fcntl_test.go`. The `os` package is already in
`TEST_PACKAGES_FAST`, so both run in the linux and the macOS CI jobs with no
makefile change.

| Test | What it covers |
| --- | --- |
| `TestFcntlSetNonblock` | `F_SETFL` round trip. A read on an empty non-blocking pipe must return EAGAIN. It fails on darwin before this change. |
| `TestFcntlGetLock` | The pointer command path. `F_GETLK` on an unlocked file must report `F_UNLCK`. |

Both pass on macOS 26.6 arm64 with this change. Linux is unaffected, because it
does not use the darwin trampoline path, and the tests are a regression guard
there.

A downstream product also ships binaries built with a fork that carries this
change, in the published release dispat v1.4.0.
<https://github.com/yohimik/dispat/releases/tag/services%2Fdispat%2Fv1.4.0>

## Scope

- `compiler/syscall.go` only changes `createDarwinFuncPCABI0Call`, so no other
  target sees a difference.
- No API change.

## Related

This is a prerequisite for correct process creation on darwin. `os.Pipe` on
darwin has no `pipe2`, so it must mark both ends close-on-exec with `fcntl`.

## Related pull requests

Each open PR in this series has a separate change. A dependency is not a copied commit.

- #5630 fixes RWMutex handover.
- #5631 is closed in favor of #5530, owned by @0pcom. The fork still uses the tested #5631 implementation until a replacement is checked.
- #5632 is closed in favor of #5612, owned by @neomantra. #5612 covers both stdlib and x/sys Darwin trampolines.
- #5633 provides the weak-pointer runtime hook.
- #5634 provides process spawning and process state. Darwin also needs #5612 and #5636. Concurrent use needs #5630.
- #5635 selects software TLS on hosted Linux and Darwin. It needs #5633. The overlapping #5645 is under discussion with @0pcom.
- #5636 provides the Darwin socket and process link symbols. It does not include process or TLS implementation changes.

In tinygo-org/net

- tinygo-org/net#72 restores HTTP redirects. It shares http/client.go with the timeout work in tinygo-org/net#67, so the two changes need integration review.
- tinygo-org/net#73 preserves DNS not-found errors.
- tinygo-org/net#74 adds Darwin host netdev support. It shares the host netdev with tinygo-org/net#77. Linux epoll and Darwin support must remain separate.
- tinygo-org/net#75 supplies Darwin trust roots to the HTTP client.
- tinygo-org/net#77 owns Linux cancellation and deadline work, tinygo-org/net#80 owns port-zero reporting, and tinygo-org/net#79 owns HTTP server TLS. These are separate contributors' changes, not completed parts of this series.
- tinygo-org/net#78 adds client API fields and related compatibility methods.

Full Darwin networking also needs the merged net changes and a later src/net pin update. No upstream merge or current full-suite pass is implied by this list.
