### PR TITLE
runtime: implement weak.runtime_makeStrongFromWeak

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -108,6 +108,7 @@ func TestBuild(t *testing.T) {
 	}
 	if minor >= 24 {
 		tests = append(tests, "typealias.go")
+		tests = append(tests, "weak.go")
 	}
 
 	if *testTarget != "" {

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -139,6 +139,13 @@ func registerWeakPointer(ptr unsafe.Pointer) unsafe.Pointer {
 	return ptr
 }
 
+//go:linkname makeStrongFromWeak weak.runtime_makeStrongFromWeak
+func makeStrongFromWeak(ptr unsafe.Pointer) unsafe.Pointer {
+	// Weak pointers are not weak here. registerWeakPointer above returns the
+	// pointer that it got, so the value stays and this is the identity too.
+	return ptr
+}
+
 var godebugUpdate func(string, string)
 
 //go:linkname godebug_setUpdate internal/godebug.setUpdate

--- a/testdata/weak.go
+++ b/testdata/weak.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"runtime"
+	"weak"
+)
+
+type value struct {
+	n int
+}
+
+func main() {
+	v := &value{n: 42}
+	p := weak.Make(v)
+	if got := p.Value(); got == nil {
+		println("weak pointer lost its value")
+	} else {
+		println("weak value:", got.n)
+	}
+	runtime.KeepAlive(v)
+}

--- a/testdata/weak.txt
+++ b/testdata/weak.txt
@@ -1,0 +1,1 @@
+weak value: 42


### PR DESCRIPTION
Superseded by #5698. The problem is tracked in #5693.

Closed on 17 September 2026 with a request for an issue first. The replacement uses the same patch, rebased on 18 September onto `dev` at `93940cb6`. Its description contains the scope, dependencies, and test status.
