### PR TITLE
Revert "runtime: make arrays and struct field hashes order dependent"

### DIFF
--- a/src/runtime/hashmap.go
+++ b/src/runtime/hashmap.go
@@ -807,13 +807,13 @@ func hashmapInterfaceHash(itf interface{}, seed uintptr) uint32 {
 	case reflectlite.Array:
 		var hash uint32
 		for i := 0; i < x.Len(); i++ {
-			hash = (hash * 31) ^ hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)), seed)
+			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Index(i)), seed)
 		}
 		return hash
 	case reflectlite.Struct:
 		var hash uint32
 		for i := 0; i < x.NumField(); i++ {
-			hash = (hash * 31) ^ hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)), seed)
+			hash ^= hashmapInterfaceHash(valueInterfaceUnsafe(x.Field(i)), seed)
 		}
 		return hash
 	default:


### PR DESCRIPTION
Reverts tinygo-org/tinygo#5581 by request of @dgryski 

> "struct and array hash function potentially now differs from the compiler generated one"
> "we probably need a test that creates a composite-type keyed map and tries to look up values with reflect"