### PR TITLE
builder: suggest GOTOOLCHAIN and -go-compatibility when the host Go is too new

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -38,6 +38,13 @@ func NewConfig(options *compileopts.Options) (*compileopts.Config, error) {
 		if gorootMajor != 1 || gorootMinor < minorMin || gorootMinor > minorMax {
 			// Note: when this gets updated, also update the Go compatibility matrix:
 			// https://github.com/tinygo-org/tinygo-site/blob/dev/content/docs/reference/go-compat-matrix.md
+			if gorootMajor == 1 && gorootMinor > minorMax {
+				// A too-new Go toolchain is the common case right after a Go
+				// release: point at Go's own toolchain switching, which lets
+				// the user build with a supported toolchain without
+				// downgrading their installation.
+				return nil, fmt.Errorf("requires go version 1.%d through 1.%d, got go%d.%d (to use a supported toolchain without downgrading, set GOTOOLCHAIN=go1.%d.x; to skip this check, use -go-compatibility=false)", minorMin, minorMax, gorootMajor, gorootMinor, minorMax)
+			}
 			return nil, fmt.Errorf("requires go version 1.%d through 1.%d, got go%d.%d", minorMin, minorMax, gorootMajor, gorootMinor)
 		}
 	}


### PR DESCRIPTION
The window between a Go release and the TinyGo release that supports it is when most users hit the version gate (for example go1.27 with TinyGo 0.41.x), and the error gives no way forward.

Both escape hatches already exist: `GOTOOLCHAIN=go1.<max>.x` makes the go command download and run a supported toolchain — TinyGo follows it transparently, verified with `GOTOOLCHAIN=go1.26.0 tinygo version` reporting the switched toolchain — and `-go-compatibility=false` (v0.40.0, #5075) skips the check outright. This mentions both in the too-new case, so the gap between releases self-serves instead of requiring a Go downgrade. The too-old case keeps the plain message.

Message-only change; `go build ./builder` passes.