### PR TITLE
runtime: reserve 16GB of heap address space on 64-bit unix

### DIFF
--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -318,13 +318,24 @@ func procUnpin() {
 var heapSize uintptr = 128 * 1024 // small amount to start
 var heapMaxSize uintptr
 
+// heapMaxReserve is how much virtual address space to reserve for the heap:
+// 16GB (1<<34) on 64-bit targets and 1GB (1<<30) on 32-bit ones. The
+// reservation is not a commitment: pages cost physical RAM only when first
+// touched, and allocateHeap's halving loop still adapts if mmap refuses.
+// A flat 1GB cap on 64-bit made any single allocation approaching 1GB
+// (e.g. a scrypt key-derivation buffer with N=1<<20, r=8) fail regardless
+// of available system memory. Deriving the shift from TargetBits keeps the
+// constant within uintptr range on 32-bit targets, where a plain 16GB
+// literal would not compile even in a dead branch.
+const heapMaxReserve = 1 << (30 + 4*(TargetBits/64))
+
 var heapStart, heapEnd uintptr
 
 func allocateHeap() {
 	// Allocate a large chunk of virtual memory. Because it is virtual, it won't
 	// really be allocated in RAM. Memory will only be allocated when it is
 	// first touched.
-	heapMaxSize = 1 * 1024 * 1024 * 1024 // 1GB for the entire heap
+	heapMaxSize = heapMaxReserve
 	for {
 		addr := mmap(nil, heapMaxSize, flag_PROT_READ|flag_PROT_WRITE, flag_MAP_PRIVATE|flag_MAP_ANONYMOUS, -1, 0)
 		if addr == unsafe.Pointer(^uintptr(0)) {


### PR DESCRIPTION
allocateHeap caps the heap at 1GB for all targets, so with `-gc=conservative` or `-gc=precise` any single allocation approaching 1GB fails with out of memory regardless of available system RAM. The real case that hit this: a scrypt key-derivation buffer (N=1<<20, r=8 → 1GiB) in the skycoin wallet, on a machine with 16GB free.

Reserve 16GB of virtual address space on 64-bit targets instead. The mmap is a *reservation*, not a commitment: pages cost physical memory only when first touched, and the existing halve-on-failure loop still adapts when the map is refused. 32-bit targets keep the 1GB cap unchanged. This is the direction the `growHeap` comment already points at: *"If we run out of memory, we should consider increasing heapMaxSize on 64-bit systems."*

Verified on linux/amd64 with `-gc=conservative`:
- before: `make([]byte, 1536<<20)` → `fatal error: out of memory` (15GB RAM free)
- after: the same allocation succeeds and is fully usable (touched and read back across the whole range)

One behavioral note, stated for the record: under the blocks GC on 64-bit hosts the practical limit becomes actual system memory — matching the boehm default and big Go — so true exhaustion surfaces as OS memory pressure rather than a fatal error at an arbitrary 1GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i