### PR TITLE
crypto/tls: use Go's software TLS on the host target

### DIFF
--- a/loader/goroot.go
+++ b/loader/goroot.go
@@ -232,7 +232,6 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		"":                            true,
 		"crypto/":                     true,
 		"crypto/rand/":                false,
-		"crypto/tls/":                 false,
 		"crypto/x509/":                true,
 		"crypto/x509/internal/":       true,
 		"crypto/x509/internal/macos/": false,
@@ -277,6 +276,17 @@ func pathsToOverride(goMinor int, needsSyscallPackage bool) map[string]bool {
 		// since TinyGo targets never use FIPS jitter entropy.
 		paths["crypto/internal/entropy/"] = true
 		paths["crypto/internal/entropy/v1.0.0/"] = false
+	}
+
+	// crypto/tls: TinyGo's version is a thin wrapper around a netdev-provided
+	// (hardware/firmware-offloaded) TLS socket, which only makes sense on
+	// embedded/wasm targets that have such a netdev. On the host/native target
+	// (raw-syscall netdev, no TLS offload) there is no real TLS that way, so use
+	// Go's full software crypto/tls instead — leaving crypto/tls out of the
+	// overrides map makes the goroot link Go's implementation. needsSyscallPackage
+	// is true exactly for the embedded/wasm targets.
+	if needsSyscallPackage {
+		paths["crypto/tls/"] = false
 	}
 
 	if needsSyscallPackage {

--- a/src/runtime/runtime.go
+++ b/src/runtime/runtime.go
@@ -139,6 +139,14 @@ func registerWeakPointer(ptr unsafe.Pointer) unsafe.Pointer {
 	return ptr
 }
 
+//go:linkname makeStrongFromWeak weak.runtime_makeStrongFromWeak
+func makeStrongFromWeak(u unsafe.Pointer) unsafe.Pointer {
+	// Counterpart to registerWeakPointer above. Because weak pointers are never
+	// collected here (the "weak" handle is just the pointer itself), the
+	// referent is always still alive, so return it unchanged.
+	return u
+}
+
 var godebugUpdate func(string, string)
 
 //go:linkname godebug_setUpdate internal/godebug.setUpdate


### PR DESCRIPTION
TinyGo's crypto/tls is a thin wrapper around a netdev-provided (hardware/firmware-offloaded) TLS socket, which only exists on the embedded/wasm targets that have such a netdev. On the host/native target the netdev is raw syscalls with no TLS offload, so crypto/tls could never actually work there. Link Go's full software crypto/tls on the host instead, keyed off `needsSyscallPackage` (true exactly for the embedded/wasm targets, which keep the offload wrapper unchanged).

Go's crypto/tls needs one runtime hook TinyGo lacked: `weak.runtime_makeStrongFromWeak` (Go 1.24 weak pointers). Added next to the existing `registerWeakPointer` as a strong-reference no-op — weak pointers are never collected here, so the referent is always alive.

Verified on linux/amd64 (LLVM 22): a real TLS 1.3 handshake and HTTPS round trip entirely in-process — `tls.Client` against an `http.Server` behind a TLS listener over loopback — plus external `curl -k` against the same server. Pairs with tinygo-org/net#79 (`net/http.ListenAndServeTLS`/`ServeTLS`), but is independently useful for any crypto/tls client use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i