### PR TITLE
runtime, runtime/pprof: add Func.Entry and goroutine-label stubs

### DIFF
--- a/src/runtime/pprof/label.go
+++ b/src/runtime/pprof/label.go
@@ -1,0 +1,28 @@
+package pprof
+
+// TinyGo does not implement pprof goroutine labels, but callers such as
+// google.golang.org/grpc reference the label API. Provide inert stubs so they
+// compile: labels are simply not attached.
+
+import "context"
+
+// LabelSet is a set of profiling labels (unused under TinyGo).
+type LabelSet struct{}
+
+// Labels returns a LabelSet from key/value pairs. Inert under TinyGo.
+func Labels(args ...string) LabelSet { return LabelSet{} }
+
+// Label returns the value of the named label; always ("", false) under TinyGo.
+func Label(ctx context.Context, key string) (string, bool) { return "", false }
+
+// ForLabels iterates the labels on ctx; a no-op under TinyGo.
+func ForLabels(ctx context.Context, f func(key, value string) bool) {}
+
+// WithLabels returns ctx unchanged under TinyGo (labels are not stored).
+func WithLabels(ctx context.Context, labels LabelSet) context.Context { return ctx }
+
+// SetGoroutineLabels is a no-op under TinyGo.
+func SetGoroutineLabels(ctx context.Context) {}
+
+// Do calls f with ctx; labels are ignored under TinyGo.
+func Do(ctx context.Context, labels LabelSet, f func(context.Context)) { f(ctx) }

--- a/src/runtime/stack.go
+++ b/src/runtime/stack.go
@@ -15,6 +15,13 @@ func (f *Func) FileLine(pc uintptr) (file string, line int) {
 	return "", 0
 }
 
+// Entry returns the entry address of the function. Stubbed like the rest of
+// runtime.Func on TinyGo; provided so callers that reference it (e.g.
+// github.com/stretchr/testify/mock via FileLine(f.Entry())) compile.
+func (f *Func) Entry() uintptr {
+	return 0
+}
+
 func Caller(skip int) (pc uintptr, file string, line int, ok bool) {
 	return 0, "", 0, false
 }


### PR DESCRIPTION
Two source-compatibility fills, surfaced compiling larger Go programs under TinyGo:

- `runtime.Func.Entry`: stubbed like the rest of `runtime.Func`; testify's mock package calls `FileLine(f.Entry())`.
- `runtime/pprof` goroutine-label API (`Labels`, `Label`, `ForLabels`, `WithLabels`, `SetGoroutineLabels`, `Do`): inert stubs alongside the existing pprof stubs; google.golang.org/grpc references them. `Do` still calls `f` — labels are simply not attached.

Verified on linux/amd64: a program exercising all of the above builds and runs (`Entry` returns 0 like its siblings, `Do` invokes its function, `Label` reports absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i