### PR TITLE
make: skip slow stdlib tests on macOS

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -192,11 +192,19 @@ report-stdlib-tests-pass:
 	join -a1 -a2 - $(jointmp).portable
 	@rm $(jointmp).*
 
+# These packages take minutes to test on macOS. See issue #5659.
+# encoding/xml is not listed here because TEST_ENCODING_XML controls it.
+TEST_PACKAGES_SKIP_DARWIN = \
+	archive/zip \
+	index/suffixarray \
+	$(nil)
+
 # Standard library packages that pass tests quickly on the current platform
 ifeq ($(uname),Darwin)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_DARWIN)
+TEST_PACKAGES_SKIP_HOST := $(TEST_PACKAGES_SKIP_DARWIN)
 TEST_IOFS := true
-TEST_ENCODING_XML := true
+TEST_ENCODING_XML := false
 endif
 ifeq ($(uname),Linux)
 TEST_PACKAGES_HOST := $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_LINUX)
@@ -219,7 +227,7 @@ tinygo-test:
 	@# TestParseAndBytesRoundTrip/P256/Generic: needs Goexit to run defers on wasm.
 	@# TestUnmarshalNestingLimit{Slice,Struct}: encoding/asn1 nesting limit added in
 	@# https://github.com/golang/go/commit/6a6d115f9a7422b2fa081ba6f567eefb4a099462
-	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(filter-out encoding/xml,$(TEST_PACKAGES_HOST)) $(TEST_PACKAGES_SLOW)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(filter-out encoding/xml $(TEST_PACKAGES_SKIP_HOST),$(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW))
 ifeq ($(TEST_ENCODING_XML),true)
 	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) -stack-size=16MB encoding/xml
 endif


### PR DESCRIPTION
The `Test stdlib packages` step (`make tinygo-test`) is slow on the macOS runners. Three standard library packages use most of the time.

Run times measured in [run 30306484647](https://github.com/tinygo-org/tinygo/actions/runs/30306484647), macos-15-intel / macos-14:

| package | macos-15-intel | macos-14 |
| --- | --- | --- |
| archive/zip | 351s | 139s |
| index/suffixarray | 147s | 57s |
| encoding/xml | 131s | 104s |
| all other packages together | 126s | 34s |

This pull request skips these three packages on macOS only. Linux CI continues to test them, thus test coverage stays. The step should go down from 17m34s to about 5 minutes on macos-15-intel, and from 8m13s to about 2.5 minutes on macos-14.

Put the packages back in the macOS test set when #5659 is corrected.
