### PR TITLE
make: run the slowest stdlib tests with -short

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -211,6 +211,17 @@ endif
 TEST_SKIP_FLAG := -skip='TestExtraMethods|TestParseAndBytesRoundTrip/P256/Generic|TestAsValidation|TestUnmarshalNestingLimitSlice|TestUnmarshalNestingLimitStruct'
 TEST_ADDITIONAL_FLAGS ?=
 
+# These packages spend almost all of their test time in a few tests that Go
+# marks as long running. -short omits those tests and keeps the rest.
+# encoding/xml gets the same treatment on its own line below.
+# See https://github.com/tinygo-org/tinygo/issues/5659
+TEST_PACKAGES_SHORT = \
+	archive/zip \
+	index/suffixarray \
+	$(nil)
+
+TEST_PACKAGES_SHORT_HOST := $(filter $(TEST_PACKAGES_SHORT),$(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW))
+
 # Test known-working standard library packages.
 # TODO: parallelize, and only show failing tests (no implied -v flag).
 .PHONY: tinygo-test
@@ -219,9 +230,12 @@ tinygo-test:
 	@# TestParseAndBytesRoundTrip/P256/Generic: needs Goexit to run defers on wasm.
 	@# TestUnmarshalNestingLimit{Slice,Struct}: encoding/asn1 nesting limit added in
 	@# https://github.com/golang/go/commit/6a6d115f9a7422b2fa081ba6f567eefb4a099462
-	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(filter-out encoding/xml,$(TEST_PACKAGES_HOST)) $(TEST_PACKAGES_SLOW)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) $(filter-out encoding/xml $(TEST_PACKAGES_SHORT),$(TEST_PACKAGES_HOST) $(TEST_PACKAGES_SLOW))
+ifneq ($(TEST_PACKAGES_SHORT_HOST),)
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) -short $(TEST_PACKAGES_SHORT_HOST)
+endif
 ifeq ($(TEST_ENCODING_XML),true)
-	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) -stack-size=16MB encoding/xml
+	$(TINYGO) test $(TEST_ADDITIONAL_FLAGS) $(TEST_SKIP_FLAG) -short -stack-size=16MB encoding/xml
 endif
 	@# io/fs requires os.ReadDir, not yet supported on windows or wasi. It also
 	@# requires a large stack-size. Hence, io/fs is only run conditionally.


### PR DESCRIPTION
Fixes the slow standard library tests reported in #5659.

## Problem

Three packages use most of the time of `make tinygo-test` on every platform. Measured run times:

| package | macos-15-intel | macos-14 | linux (assert) |
| --- | --- | --- | --- |
| archive/zip | 808s | 174s | 245s |
| index/suffixarray | 251s | 60s | 87s |
| encoding/xml | 111s | 115s | 107s |

The step takes 32m28s on macos-15-intel and 13m06s on the Linux job.

## Cause

Almost all of that time is in a small number of tests that Go marks as long running with `testing.Short()`. For archive/zip two tests give 89% of the time:

| test | time |
| --- | --- |
| TestZip64LargeDirectory | 35.14s |
| TestZip64WriterCDGoldens | 28.24s |
| all other tests together | ~7.5s |

Both write more than 4GB through a writer.

## Change

Run these three packages with `-short`. Measured on Linux with a local build:

| package | full | -short | tests, full | -short passed | -short skipped |
| --- | --- | --- | --- | --- | --- |
| archive/zip | 70.87s | 0.110s | 54 | 47 | 7 |
| encoding/xml | 50.45s | 0.070s | 83 | 81 | 2 |
| index/suffixarray | 116.78s | 0.829s | 6 | 6 | 0 |

`-short` omits 9 tests of 143 and keeps the rest. index/suffixarray omits no test at all, because those tests make their input smaller in short mode instead of stopping.

The set of packages tested does not change. `make -n tinygo-test` gives the same 77 packages on Linux and macOS, and the same 62 on Windows, as before this pull request. Only the way three of them run is different.

## Result

Every platform gets the saving, and the packages keep their coverage. This is important for archive/zip and encoding/xml, because Linux is the only platform that tests them.

## Measured effect in CI

| job | dev | this pull request |
| --- | --- | --- |
| macOS build-macos (macos-15-intel) | 1h21m44s | 48m05s |
| macOS build-macos (macos-14) | 25m59s | 18m09s |
| Linux assert-test-linux | 41m58s | 31m26s |
| Windows stdlib-test-windows | 7m28s | 9m04s |

The Windows job is an exception in appearance only. Its runner was slower in that run, thus compress/flate, which this pull request does not change, went from 18.95s to 25.87s in the same job. index/suffixarray went from 66.8s to 0.95s, which is the expected result.

## Note

`-short` does not correct the speed itself. The omitted tests are the ones that move large amounts of data, thus the throughput problem behind #5659 is still there. Keep #5659 open.

The wasi and wasip2 targets still run index/suffixarray in full, through `TEST_PACKAGES_SLOW`. That can get the same treatment later if it is wanted.
