### PR TITLE
ci: split the macOS jobs, and test only the host on the intel runner

### DIFF
--- a/.github/actions/setup-llvm-macos/action.yml
+++ b/.github/actions/setup-llvm-macos/action.yml
@@ -1,0 +1,65 @@
+name: Set up LLVM on macOS
+description: Restore or build LLVM
+
+inputs:
+  os:
+    description: Runner image name, used in the cache key
+    required: true
+  save-cache:
+    description: Save LLVM caches after a cache miss
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore LLVM source cache
+      uses: actions/cache/restore@v5
+      id: cache-llvm-source
+      with:
+        key: llvm-source-22-${{ inputs.os }}-v1-${{ hashFiles('llvm-version.txt') }}
+        path: |
+          llvm-project/clang/lib/Headers
+          llvm-project/clang/include
+          llvm-project/compiler-rt
+          llvm-project/lld/include
+          llvm-project/llvm/include
+    - name: Download LLVM source
+      if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+      shell: bash
+      run: make llvm-source
+    - name: Save LLVM source cache
+      uses: actions/cache/save@v5
+      if: inputs.save-cache == 'true' && steps.cache-llvm-source.outputs.cache-hit != 'true'
+      with:
+        key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
+        path: |
+          llvm-project/clang/lib/Headers
+          llvm-project/clang/include
+          llvm-project/compiler-rt
+          llvm-project/lld/include
+          llvm-project/llvm/include
+    - name: Restore LLVM build cache
+      uses: actions/cache/restore@v5
+      id: cache-llvm-build
+      with:
+        key: llvm-build-22-${{ inputs.os }}-v1-${{ hashFiles('llvm-version.txt') }}
+        path: llvm-build
+    - name: Build LLVM
+      if: steps.cache-llvm-build.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # fetch LLVM source
+        rm -rf llvm-project
+        make llvm-source
+        # install dependencies
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
+        # build!
+        make llvm-build
+        find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
+    - name: Save LLVM build cache
+      uses: actions/cache/save@v5
+      if: inputs.save-cache == 'true' && steps.cache-llvm-build.outputs.cache-hit != 'true'
+      with:
+        key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
+        path: llvm-build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   build-macos:
+    # Build the release tarball. The jobs below download it, so that they do not
+    # have to build the compiler again.
     name: build-macos
     strategy:
       matrix:
@@ -42,62 +44,13 @@ jobs:
         with:
           go-version: '1.27.1'
           cache: true
-      - name: Restore LLVM source cache
-        uses: actions/cache/restore@v5
-        id: cache-llvm-source
+      - uses: ./.github/actions/setup-llvm-macos
         with:
-          key: llvm-source-22-${{ matrix.os }}-v1-${{ hashFiles('llvm-version.txt') }}
-          path: |
-            llvm-project/clang/lib/Headers
-            llvm-project/clang/include
-            llvm-project/compiler-rt
-            llvm-project/lld/include
-            llvm-project/llvm/include
-      - name: Download LLVM source
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
-        run: make llvm-source
-      - name: Save LLVM source cache
-        uses: actions/cache/save@v5
-        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.cache-llvm-source.outputs.cache-primary-key }}
-          path: |
-            llvm-project/clang/lib/Headers
-            llvm-project/clang/include
-            llvm-project/compiler-rt
-            llvm-project/lld/include
-            llvm-project/llvm/include
-      - name: Restore LLVM build cache
-        uses: actions/cache/restore@v5
-        id: cache-llvm-build
-        with:
-          key: llvm-build-22-${{ matrix.os }}-v1-${{ hashFiles('llvm-version.txt') }}
-          path: llvm-build
-      - name: Build LLVM
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
-        run: |
-          # fetch LLVM source
-          rm -rf llvm-project
-          make llvm-source
-          # install dependencies
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
-          # build!
-          make llvm-build
-          find llvm-build -name CMakeFiles -prune -exec rm -r '{}' \;
-      - name: Save LLVM build cache
-        uses: actions/cache/save@v5
-        if: steps.cache-llvm-build.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.cache-llvm-build.outputs.cache-primary-key }}
-          path: llvm-build
+          os: ${{ matrix.os }}
       - name: make gen-device
         run: make -j3 gen-device
-      - name: Test TinyGo
-        run: make test GOTESTFLAGS="-only-current-os"
       - name: Build TinyGo release tarball
         run: make release -j3
-      - name: Test stdlib packages
-        run: make tinygo-test
       - name: Make release artifact
         run: cp -p build/release.tar.gz build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
       - name: Publish release artifact
@@ -106,8 +59,113 @@ jobs:
           name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
           path: build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
           archive: false
+
+  test-macos:
+    # The compiler test suite. It needs LLVM, thus it cannot use the release
+    # tarball. It restores the LLVM cache and runs at the same time as
+    # build-macos. Only build-macos saves that cache.
+    name: test-macos
+    strategy:
+      matrix:
+        os: [macos-14, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Dependencies
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu binaryen
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - uses: ./.github/actions/setup-llvm-macos
+        with:
+          os: ${{ matrix.os }}
+          save-cache: "false"
+      - name: make gen-device
+        run: make -j3 gen-device
+      - name: Test TinyGo
+        run: make test GOTESTFLAGS="-only-current-os"
+
+  stdlib-test-macos:
+    # Test the standard library, compiled and run on the host itself.
+    name: stdlib-test-macos
+    needs: build-macos
+    strategy:
+      matrix:
+        os: [macos-14, macos-15-intel]
+        include:
+          - os: macos-14
+            goarch: arm64
+          - os: macos-15-intel
+            goarch: amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Extract TinyGo version
+        id: version
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v8
+        with:
+          name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
+          path: build/
+      - name: Unpack TinyGo build
+        run: tar -xzf build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz -C build
+      - name: Test stdlib packages
+        run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
+
+  smoke-test-macos:
+    # Cross compilation gives the same result on every host. Thus only one macOS
+    # runner does the full set, and the other one does the host dependent part
+    # plus a canary. See the smoketest-linux comment in linux.yml.
+    name: smoke-test-macos
+    needs: build-macos
+    strategy:
+      matrix:
+        os: [macos-14, macos-15-intel]
+        include:
+          - os: macos-14
+            goarch: arm64
+            smoketest: smoketest-quick
+          - os: macos-15-intel
+            goarch: amd64
+            smoketest: smoketest-host
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Dependencies
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install binaryen
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Extract TinyGo version
+        id: version
+        run: ./.github/workflows/tinygo-extract-version.sh | tee -a "$GITHUB_OUTPUT"
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v8
+        with:
+          name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
+          path: build/
+      - name: Unpack TinyGo build
+        run: tar -xzf build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz -C build
       - name: Smoke tests
-        run: make smoketest-quick TINYGO=$(PWD)/build/tinygo
+        run: make ${{ matrix.smoketest }} TINYGO=$(PWD)/build/tinygo/bin/tinygo
+
   test-macos-homebrew:
     name: homebrew-install
     runs-on: macos-latest

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -118,10 +118,17 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v8
         with:
-          name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
+          # An artifact uploaded with "archive: false" takes the name of the
+          # file, not the name given to upload-artifact. See the comment on
+          # "Collect the release files" in release.yml.
+          name: tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
           path: build/
+          skip-decompress: true
       - name: Unpack TinyGo build
-        run: tar -xzf build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz -C build
+        run: |
+          tarball=$(find build -type f -name 'tinygo*.darwin-*.tar.gz' | head -1)
+          test -n "$tarball"
+          tar -xzf "$tarball" -C build
       - name: Test stdlib packages
         run: make tinygo-test TINYGO=$(PWD)/build/tinygo/bin/tinygo
 
@@ -159,10 +166,17 @@ jobs:
       - name: Download TinyGo build
         uses: actions/download-artifact@v8
         with:
-          name: darwin-${{ matrix.goarch }}-double-zipped-${{ steps.version.outputs.version }}
+          # An artifact uploaded with "archive: false" takes the name of the
+          # file, not the name given to upload-artifact. See the comment on
+          # "Collect the release files" in release.yml.
+          name: tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz
           path: build/
+          skip-decompress: true
       - name: Unpack TinyGo build
-        run: tar -xzf build/tinygo${{ steps.version.outputs.version }}.darwin-${{ matrix.goarch }}.tar.gz -C build
+        run: |
+          tarball=$(find build -type f -name 'tinygo*.darwin-*.tar.gz' | head -1)
+          test -n "$tarball"
+          tar -xzf "$tarball" -C build
       - name: Smoke tests
         run: make ${{ matrix.smoketest }} TINYGO=$(PWD)/build/tinygo/bin/tinygo
 

--- a/make/smoketest.mk
+++ b/make/smoketest.mk
@@ -606,16 +606,35 @@ ifneq ($(OS),Windows_NT)
 	$(TINYGO) build -o $(SMOKE_OUT).elf -gc=leaking -scheduler=none examples/serial
 endif
 
+# The host dependent part of the quick smoke test, plus a canary that shows cross
+# compilation works from this host. Cross compilation gives the same result on
+# every host, thus a second runner of the same OS only needs this part.
+.PHONY: smoketest-host
+smoketest-host: SMOKE_OUT = build/smoke/host
+smoketest-host: testchdir | build/smoke
+	$(TINYGO) version
+	$(TINYGO) targets > /dev/null
+	# regression test for #2892
+	cd tests/testing/recurse && ($(TINYGO) test ./... > recurse.log && cat recurse.log && test $$(wc -l < recurse.log) = 2 && rm recurse.log)
+ifneq ($(OS),Windows_NT)
+	# TODO: this does not yet work on Windows. Somehow, unused functions are
+	# not garbage collected.
+	$(TINYGO) build -o $(SMOKE_OUT).elf -gc=leaking -scheduler=none examples/serial
+endif
+	# canary, nrf52 Cortex-M4
+	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=pca10040            examples/blinky1
+	@$(MD5SUM) $(SMOKE_OUT).hex
+ifneq ($(WASM), 0)
+	# canary, wasm
+	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm               examples/wasm/main
+endif
+
 # A representative board for each processor architecture. This answers the
 # question "can TinyGo build a binary for each architecture" at a fraction of
 # the cost of the full smoke test, which runs separately on Linux.
 .PHONY: smoketest-quick
 smoketest-quick: SMOKE_OUT = build/smoke/quick
-smoketest-quick: testchdir | build/smoke
-	$(TINYGO) version
-	$(TINYGO) targets > /dev/null
-	# regression test for #2892
-	cd tests/testing/recurse && ($(TINYGO) test ./... > recurse.log && cat recurse.log && test $$(wc -l < recurse.log) = 2 && rm recurse.log)
+smoketest-quick: smoketest-host | build/smoke
 	# nrf51, Cortex-M0
 	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=microbit            examples/microbit-blink
 	@$(MD5SUM) $(SMOKE_OUT).hex
@@ -691,9 +710,4 @@ ifneq ($(WASM), 0)
 	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm              examples/wasm/main
 	# wasm without a host, so without any imports
 	$(TINYGO) build -size short -o $(SMOKE_OUT).wasm -target=wasm-unknown      examples/hello-wasm-unknown
-endif
-ifneq ($(OS),Windows_NT)
-	# TODO: this does not yet work on Windows. Somehow, unused functions are
-	# not garbage collected.
-	$(TINYGO) build -o $(SMOKE_OUT).elf -gc=leaking -scheduler=none examples/serial
 endif


### PR DESCRIPTION
Stacked on #5663. Review that one first. The base of this pull request is `stdlib-test-short`, thus the diff shows only the change of this pull request.

## Problem

`build-macos` on macos-15-intel was the critical path of CI at 1h21m44s in [run 34445433537](https://github.com/tinygo-org/tinygo/actions/runs/34445433537), against 41m58s for the longest Linux job and 27m49s for Windows.

Two causes.

**One job did everything in sequence.** gen-device, `make test`, `make release`, `make tinygo-test`, and `make smoketest-quick`, one after the other.

**The intel runner repeated work that does not depend on the host.** It is about 3x slower than macos-14 on every step, and most of `smoketest-quick` is cross compilation. `linux.yml` already states the rule: "The result does not depend on the host OS, so the other jobs build a representative board for each architecture with smoketest-quick."

## Change

**Four jobs, the same pattern as `windows.yml`:**

| job | work |
| --- | --- |
| `build-macos` | gen-device, `make release`, publish the tarball |
| `test-macos` | `make test`, restores the LLVM cache, runs at the same time as `build-macos` |
| `stdlib-test-macos` | `make tinygo-test`, downloads the tarball |
| `smoke-test-macos` | the smoke test, downloads the tarball |

The LLVM steps move to a new `setup-llvm-macos` composite action with a `save-cache` input, the same shape as the existing `setup-llvm` action. Only `build-macos` saves the cache, thus there is no write race.

**New `smoketest-host` target.** It holds the host dependent part of `smoketest-quick`, which is `testchdir`, `tinygo version`, `tinygo targets`, the #2892 recurse test, and the `-gc=leaking` build, plus a Cortex-M and a wasm canary that show cross compilation works from this host. `smoketest-quick` now depends on it, thus the recipe is not duplicated. macos-15-intel runs `smoketest-host`, macos-14 keeps the full `smoketest-quick`.

## Measured result

All jobs pass. Times from [run 34466829734](https://github.com/tinygo-org/tinygo/actions/runs/34466829734), on top of #5663:

| job | macos-15-intel | macos-14 |
| --- | --- | --- |
| build-macos | 10m19s | 4m25s |
| test-macos (at the same time as build-macos) | 17m36s | 9m34s |
| stdlib-test-macos | 17m35s | 7m06s |
| smoke-test-macos | 3m18s | 4m24s |
| **critical path** | **~28m** | **~12m** |

The intel critical path is `build-macos` plus `stdlib-test-macos`, which is 10m19s plus 17m35s. Down from 1h21m44s on dev, and from 48m05s with #5663 alone.

The smoke test on intel goes from 16m35s to 3m21s.

## Coverage

The intel runner still tests darwin/amd64 with `make test GOTESTFLAGS=-only-current-os`, `make tinygo-test`, and `smoketest-host`, and it still publishes the darwin-amd64 tarball. It no longer repeats the cross compilation that macos-14, Linux, and Windows already do.

`make -n smoketest-quick` lists every build it listed before. The only difference is that pca10040 and wasm are each built twice, once as the canary and once in the full set. The second build is a compiler cache hit.

## Note

On an `llvm-version.txt` bump the LLVM cache is cold and `build-macos` and `test-macos` both build LLVM. They run at the same time, thus the wall clock is not worse, but those runs cost extra runner minutes.

`needs:` on a matrix job waits for the whole matrix, thus the macos-14 test jobs wait for the macos-15-intel build. That does not make the critical path longer, because the intel jobs set it.

This pull request replaces #5661, which could not change its base branch because GitHub had made it part of a stack.
