### PR TITLE
ci: split assert-test-linux into jobs that run at the same time

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -276,17 +276,125 @@ jobs:
       - run: make gen-device -j4
       - name: Test TinyGo
         run: make ASSERT=1 test
-      - name: Build TinyGo
+      - name: Check Go code formatting
+        run: make fmt-check lint
+
+  assert-build-linux:
+    # Build TinyGo with LLVM assertions enabled and publish it for the jobs
+    # below, so that they do not have to build it again. The tarball is not a
+    # release file, thus its name does not hold the version.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - uses: ./.github/actions/setup-llvm
+        with:
+          # assert-test-linux saves the cache. This job only reads it, so that
+          # the two jobs do not write the same key.
+          save-cache: "false"
+      - name: Restore Binaryen
+        uses: actions/cache/restore@v5
+        id: cache-binaryen
+        with:
+          key: binaryen-linux-asserts-v1
+          path: build/wasm-opt
+      - name: Build Binaryen
+        if: steps.cache-binaryen.outputs.cache-hit != 'true'
+        run: make binaryen
+      - run: make gen-device -j4
+      - name: Build TinyGo release tarball
         run: |
-          make ASSERT=1
-          echo "$(pwd)/build" >> $GITHUB_PATH
+          make release ASSERT=1 -j4
+          cp -p build/release.tar.gz /tmp/tinygo-asserts.linux-amd64.tar.gz
+      - name: Publish TinyGo build
+        uses: actions/upload-artifact@v7
+        with:
+          name: tinygo-asserts.linux-amd64.tar.gz
+          path: /tmp/tinygo-asserts.linux-amd64.tar.gz
+          archive: false
+
+  assert-stdlib-test-linux:
+    # Test the standard library with the assertions build.
+    runs-on: ubuntu-24.04
+    needs: assert-build-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v8
+        with:
+          name: tinygo-asserts.linux-amd64.tar.gz
+      - name: Extract TinyGo build
+        run: |
+          mkdir -p ~/lib
+          tar -C ~/lib -xf tinygo-asserts.linux-amd64.tar.gz
+          ln -s ~/lib/tinygo/bin/tinygo ~/go/bin/tinygo
       - name: Test stdlib packages
         run: make tinygo-test
+
+  assert-smoketest-linux:
+    # The smoke test, the wasm tests, and the baremetal tests, with the
+    # assertions build.
+    runs-on: ubuntu-24.04
+    needs: assert-build-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends \
+              libgcrypt20 \
+              libpixman-1-0 \
+              libsdl2-2.0-0 \
+              libslirp0 \
+              qemu-system-arm \
+              qemu-system-riscv32 \
+              qemu-user \
+              simavr
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.1'
+          cache: true
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Install wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: "29.0.1"
+      - name: Setup `wasm-tools`
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+      - name: Download TinyGo build
+        uses: actions/download-artifact@v8
+        with:
+          name: tinygo-asserts.linux-amd64.tar.gz
+      - name: Extract TinyGo build
+        run: |
+          mkdir -p ~/lib
+          tar -C ~/lib -xf tinygo-asserts.linux-amd64.tar.gz
+          ln -s ~/lib/tinygo/bin/tinygo ~/go/bin/tinygo
       - run: make smoketest-quick
       - run: make wasmtest
       - run: make tinygo-test-baremetal
-      - name: Check Go code formatting
-        run: make fmt-check lint
   build-linux-cross:
     # Build ARM Linux binaries, ready for release.
     # This intentionally uses an older Linux image, so that we compile against


### PR DESCRIPTION
Independent of #5663 and #5664. It touches only `.github/workflows/linux.yml`.

## Problem

`assert-test-linux` is the longest job of the Linux workflow. It ran everything one after the other. Step times from [run 34466667108](https://github.com/tinygo-org/tinygo/actions/runs/34466667108), where the job took 31m26s:

| step | time |
| --- | --- |
| setup, which is checkout, apt, tools, LLVM, and Binaryen | 3m35s |
| make gen-device -j4 | 1m06s |
| make ASSERT=1 test | 12m30s |
| make ASSERT=1 | 32s |
| make tinygo-test | 8m21s |
| make smoketest-quick | 2m27s |
| make wasmtest | 46s |
| make tinygo-test-baremetal | 2m26s |
| make fmt-check lint | 45s |

Everything after `make ASSERT=1` only needs the built compiler, thus those steps can run in jobs at the same time.

## Change

Four jobs in place of one. This is the pattern that `test-linux-build` and `smoketest-linux` already use with `build-linux`.

| job | work | needs |
| --- | --- | --- |
| `assert-build-linux` | `make release ASSERT=1`, publishes the tarball | - |
| `assert-test-linux` | `make ASSERT=1 test` and `make fmt-check lint` | - |
| `assert-stdlib-test-linux` | `make tinygo-test` | assert-build-linux |
| `assert-smoketest-linux` | `make smoketest-quick`, `make wasmtest`, `make tinygo-test-baremetal` | assert-build-linux |

`assert-build-linux` and `assert-test-linux` start at the same time.

`ASSERT` only sets `-DLLVM_ENABLE_ASSERTIONS` for the LLVM build, see `make/config.mk` line 52. The assertions come from the `llvm-build-22-linux-ubuntu-24.04-asserts-v1` cache that `setup-llvm` restores, thus the tarball that `assert-build-linux` publishes has them.

The tarball is named `tinygo-asserts.linux-amd64.tar.gz`. It is not a release file, thus its name does not hold the version. `release.yml` looks for release files by exact file name, thus it does not take this one.

## Measured result

All jobs pass. Times from [run 34519948547](https://github.com/tinygo-org/tinygo/actions/runs/34519948547), rebased on dev after #5663 and #5664:

| job | time |
| --- | --- |
| assert-build-linux | 6m16s |
| assert-test-linux (at the same time) | 19m53s |
| assert-stdlib-test-linux | 6m16s + 9m36s = 15m52s |
| assert-smoketest-linux | 6m16s + 10m25s = 16m41s |
| **critical path** | **19m53s** |

Down from 31m26s, which is the time of the job with #5663 already in it. Thus
the two changes do not count the same saving twice.

`assert-test-linux` sets the critical path now. It holds `make ASSERT=1 test`,
which this pull request does not change.

## Note

Only `assert-test-linux` saves the LLVM cache. `assert-build-linux` reads it. On an `llvm-version.txt` bump the cache is cold and both jobs build LLVM at the same time. The wall clock is not worse, but those runs cost extra runner minutes. The Binaryen cache works the same way.
