### PR TITLE
Add Waveshare RP2350-PiZero board

### DIFF
--- a/make/smoketest.mk
+++ b/make/smoketest.mk
@@ -321,6 +321,8 @@ smoketest-rp2xxx: | build/smoke
 	@$(MD5SUM) $(SMOKE_OUT).hex
 	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=tufty2350          examples/blinky1
 	@$(MD5SUM) $(SMOKE_OUT).hex
+	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=waveshare-rp2350-pizero examples/blinky1
+	@$(MD5SUM) $(SMOKE_OUT).hex
 	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=metro-rp2350        examples/blinky1
 	@$(MD5SUM) $(SMOKE_OUT).hex
 	$(TINYGO) build -size short -o $(SMOKE_OUT).hex -target=waveshare-rp2040-tiny examples/echo

--- a/src/machine/board_waveshare-rp2350-pizero.go
+++ b/src/machine/board_waveshare-rp2350-pizero.go
@@ -1,0 +1,110 @@
+//go:build waveshare_rp2350_pizero
+
+// This file contains the pin mappings for the Waveshare RP2350-PiZero board.
+//
+// Waveshare RP2350-PiZero uses the Raspberry Pi RP2350B chip.
+//
+// - https://www.waveshare.com/wiki/RP2350-PiZero
+// - https://github.com/raspberrypi/pico-sdk/blob/master/src/boards/include/boards/waveshare_rp2350_pizero.h
+package machine
+
+// GPIO pins
+const (
+	GP0  Pin = GPIO0
+	GP1  Pin = GPIO1
+	GP2  Pin = GPIO2
+	GP3  Pin = GPIO3
+	GP4  Pin = GPIO4
+	GP5  Pin = GPIO5
+	GP6  Pin = GPIO6
+	GP7  Pin = GPIO7
+	GP8  Pin = GPIO8
+	GP9  Pin = GPIO9
+	GP10 Pin = GPIO10
+	GP11 Pin = GPIO11
+	GP12 Pin = GPIO12
+	GP13 Pin = GPIO13
+	GP14 Pin = GPIO14
+	GP15 Pin = GPIO15
+	GP16 Pin = GPIO16
+	GP17 Pin = GPIO17
+	GP18 Pin = GPIO18
+	GP19 Pin = GPIO19
+	GP20 Pin = GPIO20
+	GP21 Pin = GPIO21
+	GP22 Pin = GPIO22
+	GP23 Pin = GPIO23
+	GP24 Pin = GPIO24
+	GP25 Pin = GPIO25
+	GP26 Pin = GPIO26
+	GP27 Pin = GPIO27
+	GP28 Pin = GPIO28
+	GP29 Pin = GPIO29
+	GP30 Pin = GPIO30
+	GP31 Pin = GPIO31
+	GP32 Pin = GPIO32
+	GP33 Pin = GPIO33
+	GP34 Pin = GPIO34
+	GP35 Pin = GPIO35
+	GP36 Pin = GPIO36
+	GP37 Pin = GPIO37
+	GP38 Pin = GPIO38
+	GP39 Pin = GPIO39
+	GP40 Pin = GPIO40
+	GP41 Pin = GPIO41
+	GP42 Pin = GPIO42
+	GP43 Pin = GPIO43
+	GP44 Pin = GPIO44
+	GP45 Pin = GPIO45
+	GP46 Pin = GPIO46
+	GP47 Pin = GPIO47
+
+	// The Pico SDK board header defines no default LED pin.
+	LED Pin = NoPin
+
+	// Onboard crystal oscillator frequency, in MHz.
+	xoscFreq = 12 // MHz
+)
+
+// I2C default pins
+const (
+	I2C0_SDA_PIN = NoPin
+	I2C0_SCL_PIN = NoPin
+
+	I2C1_SDA_PIN = GP2
+	I2C1_SCL_PIN = GP3
+)
+
+// SPI default pins
+const (
+	SPI0_SCK_PIN = NoPin
+	SPI0_SDO_PIN = NoPin
+	SPI0_SDI_PIN = NoPin
+
+	SPI1_SCK_PIN = GPIO10
+	SPI1_SDO_PIN = GPIO11 // Tx
+	SPI1_SDI_PIN = GPIO12 // Rx
+)
+
+// UART pins
+const (
+	UART0_TX_PIN = GPIO0
+	UART0_RX_PIN = GPIO1
+	UART1_TX_PIN = GPIO4
+	UART1_RX_PIN = GPIO5
+	UART_TX_PIN  = UART1_TX_PIN
+	UART_RX_PIN  = UART1_RX_PIN
+)
+
+var DefaultUART = UART1
+
+// USB identifiers
+const (
+	usb_STRING_PRODUCT      = "RP2350-PiZero"
+	usb_STRING_MANUFACTURER = "Waveshare"
+)
+
+var (
+	usb_VID uint16 = 0x2e8a
+	usb_PID uint16 = 0x000f
+)

--- a/targets/waveshare-rp2350-pizero.json
+++ b/targets/waveshare-rp2350-pizero.json
@@ -1,0 +1,10 @@
+{
+    "inherits": [
+        "rp2350b"
+    ],
+    "build-tags": ["waveshare_rp2350_pizero"],
+    "ldflags": [
+        "--defsym=__flash_size=16M"
+    ],
+    "default-stack-size": 8192
+}


### PR DESCRIPTION
The Waveshare RP2350-PiZero is useful as a first-class TinyGo target for projects that use this RP2350B board. This adds a concrete target and machine pin map so users can build for it directly with `-target waveshare-rp2350-pizero`.

This target inherits from `rp2350b`, sets the board build tag and 16 MB flash size, and adds RP2350B GPIO aliases plus the Pico SDK default UART1, I2C1, and SPI1 pins. `LED` is set to `NoPin` because the Pico SDK board header does not define `PICO_DEFAULT_LED_PIN`, and the Arduino-Pico variant does not define `PIN_LED`.

Validation:
- `LLVM_CONFIG=/opt/homebrew/opt/llvm@20/bin/llvm-config go test -tags=llvm20 ./compileopts -run 'TestLoadTarget|TestGetTargetSpecs'`
- `PATH=/opt/homebrew/opt/lld@20/bin:$PATH LLVM_CONFIG=/opt/homebrew/opt/llvm@20/bin/llvm-config go run -tags=llvm20 . build -target waveshare-rp2350-pizero -o /tmp/waveshare-rp2350-pizero-empty.uf2 examples/empty`
- `PATH=/opt/homebrew/opt/lld@20/bin:$PATH LLVM_CONFIG=/opt/homebrew/opt/llvm@20/bin/llvm-config go run -tags=llvm20 . build -target waveshare-rp2350-pizero -o /tmp/waveshare-rp2350-pizero-blinky1.uf2 examples/blinky1`