### PR TITLE
make: allow updating LLVM sources

### DIFF
--- a/make/llvm.mk
+++ b/make/llvm.mk
@@ -78,13 +78,16 @@ endif
 # Pinned in llvm-version.txt. Branch tinygo_22.x of tinygo-org/llvm-project.
 LLVM_REVISION = $(shell cat llvm-version.txt)
 
-$(LLVM_PROJECTDIR)/llvm:
-	git init $(LLVM_PROJECTDIR)
+llvm-source: ## Get or update LLVM sources
+	@if [ ! -e "$(LLVM_PROJECTDIR)/.git" ]; then \
+	  git init $(LLVM_PROJECTDIR); \
+	fi
 	cd $(LLVM_PROJECTDIR) && \
-	  git remote add origin https://github.com/tinygo-org/llvm-project && \
+	  if ! git remote get-url origin >/dev/null 2>&1; then \
+	    git remote add origin https://github.com/tinygo-org/llvm-project; \
+	  fi && \
 	  git fetch --depth=1 origin $(LLVM_REVISION) && \
 	  git checkout FETCH_HEAD
-llvm-source: $(LLVM_PROJECTDIR)/llvm ## Get LLVM sources
 
 # Configure LLVM.
 TINYGO_SOURCE_DIR=$(shell pwd)


### PR DESCRIPTION
I've frequently wanted to be able to update the local clone of llvm to the expected version; until now I've just been deleting it and rebuilding, replying on ccache to make it not as slow as a fresh build.

Maybe there's a better way but I think fetching and checking out should be good.