### PR TITLE
esp32: fix I2C timeouts on larger transfers

### DIFF
--- a/src/machine/machine_esp32_i2c.go
+++ b/src/machine/machine_esp32_i2c.go
@@ -242,6 +242,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 	timeoutNS := int64(timeoutMS) * 1000000
 	needAddress := true
 	needRestart := false
+	isRead := false
 	var readTo []byte
 	for cmdIdx, reg := 0, &i2c.Bus.COMD0; cmdIdx < len(cmd); {
 		c := &cmd[cmdIdx]
@@ -253,6 +254,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 			cmdIdx++
 
 		case i2cCMD_WRITE:
+			isRead = false
 			count := 32
 			if needAddress {
 				needAddress = false
@@ -266,15 +268,16 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 			reg.Set(i2cCMD_WRITE | uint32(32-count))
 			reg = nextAddress(reg)
 
-			if c.head < len(c.data) {
-				reg.Set(i2cCMD_END)
-				reg = nil
-			} else {
+			// A resuming segment must not overwrite the slot with END.
+			reg.Set(i2cCMD_END)
+			reg = nil
+			if c.head >= len(c.data) {
 				cmdIdx++
 			}
 			needRestart = true
 
 		case i2cCMD_READ:
+			isRead = true
 			if needAddress {
 				needAddress = false
 				i2c.Bus.SetDATA_FIFO_RDATA((uint32(addr)&0x7f)<<1 | 1)
@@ -308,10 +311,16 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 				reg = nextAddress(reg)
 			}
 
-			if split {
+			if split && bytes > 0 {
+				reg.Set(i2cCMD_END)
+				readTo = c.data[c.head : c.head+bytes]
+				reg = nil
+			} else if split {
 				reg.Set(i2cCMD_READLAST | 1)
 				reg = nextAddress(reg)
-				readTo = c.data[c.head : c.head+bytes+1] // read bytes + 1 last byte
+				reg.Set(i2cCMD_END)
+				readTo = c.data[c.head : c.head+1]
+				reg = nil
 				cmdIdx++
 			} else {
 				reg.Set(i2cCMD_END)
@@ -333,7 +342,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 				if nanotime() > end {
 					// timeout leaves the bus in an undefined state, reset
 					i2c.resetBus()
-					if readTo != nil {
+					if isRead {
 						return errI2CReadTimeout
 					}
 					return errI2CWriteTimeout
@@ -345,7 +354,7 @@ func (i2c *I2C) transmit(addr uint16, cmd []i2cCommand, timeoutMS int) error {
 			case mask&esp.I2C_INT_STATUS_TIME_OUT_INT_ST_Msk != 0:
 				// timeout leaves the bus in an undefined state, reset
 				i2c.resetBus()
-				if readTo != nil {
+				if isRead {
 					return errI2CReadTimeout
 				}
 				return errI2CWriteTimeout


### PR DESCRIPTION
Fixes #5673

The I2C controller has 16 command slots and 32 bytes of RAM. So it splits longer transfers into segments. A segment ends with `i2cCMD_END`, which suspends the transfer and holds the bus. And as mentioned in the [TRM section 21.3.5](https://documentation.espressif.com/esp32_technical_reference_manual_en.pdf):

> Note: When there are more than three segments, the address of an END command in the cmd should not be altered into another command by the next segment.

`transmit` resets `reg` to `COMD0` after every segment and does not clear the slots. The segment that finishes a read or a write does not end with `END`, so `i2cCMD_STOP` is programmed into the next slot instead.

For example:

```
segment 1         COMD0 RSTART   COMD1 WRITE   COMD2 END
middle segments   COMD0 WRITE    COMD1 END
final segment     COMD0 WRITE    COMD1 STOP
```

Up to 63 bytes, a write is two segments, so the final `STOP` at `COMD1` overwrites a `WRITE`. From 64 bytes (three segments or more), the final `STOP` overwrites the `END` left by the previous segment in `COMD1` (which the note above mentions not to do).

Reads fail at 32 bytes for another reason. A segment that reads 32 bytes NACKs the last with `i2cCMD_READLAST` and ends with `i2cCMD_STOP`, with no `i2cCMD_END`.

The fix is to ensure write segments always end with `i2cCMD_END`, so `i2cCMD_STOP` goes out alone at `COMD0`. Follows the same logic in ESP-IDF [i2c_master.c#L202-L204](https://github.com/espressif/esp-idf/blob/c712a0dde385d659a1470a136251980d31a70bc1/components/esp_driver_i2c/i2c_master.c#L202-L204).

> [!NOTE]
> All writes now use two segments. Each write ends with END and starts a transfer, then STOP starts a second transfer. A 1-byte write and CheckDevice change from one hardware start to two. ESP-IDF does the same.

Reads put the ACKed bytes and the final NACKed byte in separate segments. The `READLAST` segment now pulls one byte and ends with `END`. Also follows the same logic in ESP-IDF [i2c_master.c#L395-L396](https://github.com/espressif/esp-idf/blob/c712a0dde385d659a1470a136251980d31a70bc1/components/esp_driver_i2c/i2c_master.c#L395-L396).

An `isRead` flag replaces `readTo` because `STOP` is now in its own segment after `readTo` has been cleared.

Tested on an ESP32-D0WD-V3 with an SH1106 OLED.