### PR TITLE
runtime: jump indirectly to longjmp on Xtensa

### DIFF
--- a/src/runtime/asm_xtensa.S
+++ b/src/runtime/asm_xtensa.S
@@ -21,6 +21,10 @@ __xtensa_libgcc_window_spill:
 #endif
 
 .section .text.tinygo_longjmp,"ax",@progbits
+// Literal data for l32r (must be at a lower address than the l32r).
+.balign 4
+.Llongjmp_addr:
+    .word longjmp
 .global tinygo_longjmp
 .type tinygo_longjmp, %function
 tinygo_longjmp:
@@ -30,5 +34,8 @@ tinygo_longjmp:
 #else
     movi a3, 1
 #endif
-    j longjmp
+    // j only reaches 128 KB (Xtensa ISA Reference Manual, J instruction) and
+    // longjmp can be further away. a8 is free to use in both ABIs.
+    l32r a8, .Llongjmp_addr
+    jx a8
 .size tinygo_longjmp, .-tinygo_longjmp


### PR DESCRIPTION
### What this fixes

`tinygo_longjmp` in `src/runtime/asm_xtensa.S` ends with `j longjmp`. The Xtensa
`J` instruction holds an 18-bit signed offset, thus it reaches only 128 KB.

picolibc's `setjmp.S` puts `longjmp` in the plain `.text` group of the linker
script, while all TinyGo code goes into the `.text.*` group after it. In a large
program the two are more than 128 KB apart and the link stops.

```
ld.lld: error: relocation R_XTENSA_SLOT0_OP out of range: -217201 is not in
[-131072, 131071]; references 'longjmp'
>>> referenced by asm_xtensa.S:33
```

This came in with #5653, which added panic recovery on Xtensa.

### How to see it

A small program links correctly, thus the smoke tests do not find this. The
example programs in the ESP smoke test are all below 15 KB.

A large program shows it. The `examples/ap` program in
[tinygo-org/espradio](https://github.com/tinygo-org/espradio) is 494 KB of code
on `xiao-esp32s3` and 530 KB on `esp32-mini32`. Both stop at the link step.

```
CGO_CFLAGS_ALLOW='-fno-short-enums' tinygo build -target=xiao-esp32s3 ./examples/ap/
```

### The change

Load the address of `longjmp` from a literal and jump to it with `jx`. The
literal carries an `R_XTENSA_32` relocation, which has no range limit.

The literal is placed by hand in the same section as the code. Automatic
literals go into a separate section, which this tree already records as a cause
of bad `l32r` offsets with LLVM 22 and lld. See the comments in
`src/device/esp/esp32.S` and `src/device/esp/esp32s3.S`. The same hand-placed
idiom is already used in `targets/esp32-interrupts.S` and
`targets/esp32s3-interrupts.S`.

The jump stays a jump. `tinygo_longjmp` has no `entry` instruction and runs in
the register window of its caller. A `call4` or `call8` would rotate the window
a second time and give `longjmp` bad arguments.

`a8` is free in both ABIs. In the windowed ABI it becomes `a0` of `longjmp`,
which `longjmp` overwrites at once from the jmp_buf. In the call0 ABI it is a
scratch register, and `longjmp` reads only `a2` and `a3`.

### Tests

- `make smoketest-esp` passes.
- `TestESP32QEMU` passes with Espressif QEMU, for `print.go` and `recover.go`.
- `testdata/recover.go` on ESP32-S3 hardware gives output identical to
  `testdata/recover.txt`.
- The two espradio programs above link, and the complete espradio smoke test
  passes on `xiao-esp32c3`, `xiao-esp32s3` and `esp32-mini32`.
- The relocation changes from `R_XTENSA_SLOT0_OP` to `R_XTENSA_32`, in the
  windowed ABI and in the call0 ABI.
